### PR TITLE
UI improvements: sidebar polish, dashboard revamp, lifecycle actions, watcher fix

### DIFF
--- a/.feature-plans/pending/ui-improvements-may-5.md
+++ b/.feature-plans/pending/ui-improvements-may-5.md
@@ -1,0 +1,684 @@
+# Feature Plan: UI Improvements — May 5
+
+> Six focused UX improvements: mobile sidebar brand, settings nav item, dashboard revamp, worktree lifecycle visibility, mark-done command + UI, and smarter `rm` prompting.
+
+**Branch:** `ui-improvements-may-5`
+**Status:** Pending
+
+**Reference files:**
+- Sidebar: `apps/web/src/components/layout/LeftSidebar.tsx`
+- Top bar: `apps/web/src/components/layout/TopBar.tsx`
+- Dashboard: `apps/web/src/components/layout/DashboardPanel.tsx`
+- Layout host: `apps/web/src/routes/Workspace.tsx`
+- Layout shell: `apps/web/src/components/layout/Layout.tsx`
+- Status logic: `apps/web/src/lib/worktreeStatus.ts` — `worktreeRolledUpStatus(sessions, liveStates)` returns `WorktreeRolledUpStatus`
+- Status dot: `apps/web/src/components/layout/StatusDot.tsx`
+- Worktree API client: `apps/web/src/api/client.ts:182`
+- Daemon delete route: `apps/cli/src/daemon/routes/worktrees.ts:356`
+- Daemon sessions route: `apps/cli/src/daemon/routes/sessions.ts`
+- Daemon types: `apps/cli/src/daemon/types.ts` — `LifecycleState`, `SessionRecord.lifecycle: { state, lastTransitionAt }`
+- Lifecycle service: `apps/cli/src/daemon/services/lifecycle.ts` — `persistLifecycleState(projectId, worktreeId, sessionId, newState)`
+- Broadcaster: `apps/cli/src/daemon/broadcaster.ts` — `broadcastAll(event)`, `notifySession(sessionId, event)`
+- Project store: `apps/cli/src/daemon/state/project-store.ts` — `getAllProjects()`
+- Paths service: `apps/cli/src/daemon/services/paths.ts` — `worktreePath(projectId, worktreeId)`
+- CLI rm command: `apps/cli/src/commands/worktree/rm.ts`
+- CLI confirm util: `apps/cli/src/lib/confirm.ts`
+- Styles: `apps/web/src/styles/workspace.css`
+
+---
+
+## Problem
+
+- **Mobile title gap:** `vibe-station` brand link only renders on `!isMobile` (`TopBar.tsx:139`). Mobile users see no way to tap back to the dashboard.
+- **Settings icon is hard to discover:** it sits at the bottom of the sidebar footer as a small icon button with no label, blending with Font/Theme toggles.
+- **Dashboard is a flat session list:** shows separate "working" and "idle" session cards — no hierarchy, mixing projects and sessions in one level, terminals pollute the list.
+- **No way to mark a worktree as done:** the `done` state exists in the type system and UI but the daemon never sets it — it was designed for a plugin completion signal that was never wired. After a PR merges, sessions go `exited` (not `done`). There is no CLI command or UI action to manually signal "this work is complete."
+- **`vst worktree rm` silently leaves files behind:** without `--purge`, the worktree directory stays on disk with no prompt to inform or ask the user. Users may not realise they need `--purge` to actually clean up.
+
+---
+
+## Concept
+
+- Add `vibe-station` brand header at the top of the sidebar (mobile: always; desktop: only when sidebar is expanded).
+- Replace the Settings icon in the footer with a full-width labeled nav row above the Font/Theme icon buttons; highlight when `/settings` is active.
+- Redesign dashboard around **project → worktree** hierarchy, skipping terminal sessions, with sensible status groupings.
+- Expose worktree lifecycle in the sidebar and add a "Dismiss" (soft-remove, no purge) action so merged-PR worktrees can be hidden without deleting files.
+- Add `vst worktree done <id>` CLI command + `POST /worktrees/:id/done` daemon endpoint that marks all agent sessions in a worktree as `done`. Mirror this as a "Mark as done" item in the sidebar worktree ⋯ menu.
+- In `vst worktree rm` (no `--purge`), after the existing name-confirmation prompt, ask "Also delete files from disk? [y/N]" — if yes, adds `?purge=true`; the name-confirmation safety gate is unchanged.
+
+---
+
+## Requirements
+
+| # | Requirement |
+|---|-------------|
+| 1 | Mobile sidebar shows a tappable `vibe-station` brand at its top that navigates to `/` |
+| 2 | Desktop collapsed sidebar: brand collapses to icon/abbrev or hides (keeps existing collapsed behaviour) |
+| 3 | Settings entry renders as full-width text row with left icon, above Font/Theme icon pair |
+| 4 | Settings row is visually active (highlight) when `location.pathname === "/settings"` |
+| 5 | Dashboard groups content by project, then shows worktree rows (not session rows) |
+| 6 | Terminal sessions are excluded from the dashboard |
+| 7 | Dashboard sections collapse if empty |
+| 8 | Worktree menu in sidebar exposes "Dismiss (keep files)" and "Mark as done" alongside existing "Delete…" |
+| 9 | Dismissed worktrees disappear from sidebar; files stay on disk |
+| 10 | Daemon already supports `DELETE /worktrees/:id` (no purge) — no daemon change needed for dismiss |
+| 11 | New `POST /worktrees/:id/done` endpoint marks all agent sessions in the worktree as `done`; broadcasts `session:state` for each |
+| 12 | New `vst worktree done <id>` CLI command calls that endpoint |
+| 13 | `vst worktree rm` (no `--purge`): after existing name-confirmation, prompt "Also delete files from disk? [y/N]" — answer upgrades to purge if yes |
+| 14 | Name-confirmation in `rm` is not removed or weakened — purge prompt comes after it |
+
+---
+
+## Research
+
+### Mobile brand gap
+
+- `TopBar.tsx:139` — brand button is inside `{!isMobile ? (...) : (...)}` block; mobile arm shows only crumb, never `vibe-station`.
+- `LeftSidebar.tsx:258-261` — sidebar top section starts immediately with the projects heading; no brand slot.
+- `Workspace.tsx:43` — `isMobile = useMediaQuery("(max-width: 768px)")` controls rendering; same value is passed to `Layout` and `TopBar`.
+- `Layout.tsx:112-119` — mobile sidebar is an `<aside>` drawer that slides in; sidebar inner renders `leftSidebar` (the `LeftSidebar` component).
+
+### Settings icon discovery
+
+- `LeftSidebar.tsx:390-418` — `left-sidebar__footer` div has three `icon-btn` buttons: Settings (SlidersHorizontal, line 391), Font (Type, line 400), Theme (Moon, line 408).
+- `workspace.css:447` — `.left-sidebar__footer` is styled as a flex row.
+- Active class: `icon-btn--active` is already applied for Settings when on `/settings` (line 393).
+
+### Dashboard flat-list
+
+- `DashboardPanel.tsx:119-120` — `workingSessions` and `idleSessions` filter `sessions` array; no distinction between agent and terminal sessions.
+- `DashboardPanel.tsx:135-156` — `renderSessionCards` maps over raw `Session` objects — shows session label, branch, project name.
+- Sessions have `type: "agent" | "terminal"` (`api/types.ts`).
+- Worktrees already have `branch` + `id`; projects have `name`; worktree status is computed by `worktreeRolledUpStatus`.
+
+### Worktree lifecycle & state machine (actual, as-implemented)
+
+- `SessionState` (`api/types.ts:29`): `not_started | working | idle | done | exited`
+- **`done` is never set by the daemon today** — it exists in types and UI but no code path writes it. It was designed for a plugin completion signal (`getActivityState()`) that was never wired. When Claude Code exits cleanly, the PTY closes → daemon detects it → state becomes `exited`, not `done`.
+- **`exited`** is the real terminal state: set by 4 paths — spawn failure, tmux pane gone (polled ~1 Hz), PTY `onExit` event (direct-pty), daemon reboot recovery.
+- **`idle`** is inferred: output hash unchanged for ≥4000ms. `working` ↔ `idle` toggles every ~1s poll.
+- **Resume** is already fully implemented: `TerminalPane.tsx:317-332` shows "Session exited. Resume" banner; calls `POST /sessions/:id/resume` (`sessions.ts:319`); respawns via plugin's `getRestoreCommand()`.
+- `worktreeRolledUpStatus` (`lib/worktreeStatus.ts:23`) rolls up all sessions to best status.
+- `client.ts:182-185` — `deleteWorktree` always passes `?purge=true`. Need new `dismissWorktree` that calls `DELETE /worktrees/:id` without purge.
+- `daemon/routes/worktrees.ts:356-401` — delete route already handles `purge` param; without it, sessions terminated but git worktree + branch stay on disk.
+- `LeftSidebar.tsx:464-479` — worktree menu has only "Delete worktree…". Need "Mark as done" and "Dismiss (keep files)" above it.
+- `worktreeIsInactive` (`LeftSidebar.tsx:40-46`) — checks `done|exited`; "hide done" checkbox already works.
+- `confirmByTypingName` (`lib/confirm.ts:4`) — uses `prompts` library; adding a second `prompts()` call after it for the purge question is straightforward.
+
+### Actual state machine
+
+```
+not_started ──spawn ok──→ working ←──output changes──→ idle
+                 │                                       │
+            spawn fail                         output stable ≥4s
+                 │                                       │
+                 ↓                                       ↓
+              exited ←── tmux pane gone ────────────── exited
+              exited ←── PTY onExit
+              exited ←── daemon restart (process gone)
+              exited ←── user kills session
+
+done  ← NEVER SET TODAY (stub, designed but not wired)
+        Proposed: set by new POST /worktrees/:id/done endpoint (manual signal)
+```
+
+---
+
+## Approach
+
+### P1 — Mobile brand in sidebar header
+
+Add a `left-sidebar__brand` slot **above** `left-sidebar__scroll` (as a sibling, not inside the scroll area — so it stays pinned and doesn't scroll away). Rendered when `isMobile || !collapsed`; hidden on collapsed desktop rail (top-bar brand is still visible there).
+
+```
+LeftSidebar receives new prop: isMobile?: boolean
+```
+
+JSX structure:
+```tsx
+<div className="left-sidebar ...">
+  {(isMobile || !collapsed) && (
+    <Link to="/" className="left-sidebar__brand" onClick={clearWorkspaceSelectionAndNavigate}>
+      vibe-station
+    </Link>
+  )}
+  <div className="left-sidebar__scroll">   {/* existing */}
+    ...
+  </div>
+  <div className="left-sidebar__footer">  {/* existing */}
+    ...
+  </div>
+</div>
+```
+
+**Use `<Link>` from the start** (not `<button>`) — Phase 7 does not need to revisit this element.
+
+**CSS:** `.left-sidebar__brand` — `display: block; padding: var(--space-3); font: same as .top-bar__brand; border-bottom: var(--border-width) solid var(--border-default); text-decoration: none; color: inherit; cursor: pointer;`
+
+---
+
+### P2 — Settings as labeled nav item
+
+Split `left-sidebar__footer` into two parts:
+
+```
+left-sidebar__footer
+  ├── left-sidebar__nav-item (settings row — full width text + icon)
+  └── left-sidebar__icon-row (Font + Theme icon buttons)
+```
+
+Settings row markup — **use `<Link>` from the start** (Phase 7 does not need to revisit):
+```tsx
+<Link
+  to="/settings"
+  className={`left-sidebar__nav-item ${isSettings ? "left-sidebar__nav-item--active" : ""}`}
+>
+  <SlidersHorizontal size={16} />   {/* size={16} matches existing footer icons */}
+  {!collapsed && <span>Settings</span>}
+</Link>
+```
+
+When `collapsed`, only the icon shows. The icon is centered by the same flex layout as the existing icon buttons.
+
+**CSS:**
+- `.left-sidebar__nav-item` — `display: flex; align-items: center; gap: var(--space-2); padding: var(--space-2) var(--space-3); text-decoration: none; color: inherit; width: 100%; cursor: pointer;` + hover bg.
+- `.left-sidebar__nav-item--active` — `background: var(--bg-active); color: var(--fg-accent);`
+- **Collapsed variant** (when `.left-sidebar--collapsed`): `padding: var(--space-1); justify-content: center;` — matches existing `padding: var(--space-1)` of the collapsed rail (LeftSidebar.tsx:260).
+- `.left-sidebar__icon-row` — existing footer icon pair (Font + Theme), styled as before.
+
+---
+
+### P3 — Dashboard revamp
+
+**Decision:** two views behind a toggle (persisted in `localStorage`):
+- **List view** (default) — keeps existing status-section structure and card layout exactly; only changes are: swap `s.label` → `wt.branch` as primary, `wt.id` chip where branch was, remove terminal sessions
+- **Kanban view** — 3 columns side-by-side; each card is identical to a list card; collapses to stacked sections on mobile
+
+---
+
+#### Card anatomy (identical in both views)
+
+Current card (`renderSessionCards` in `DashboardPanel.tsx:135-156`):
+```
+● | s.label (primary)    wt.branch (branch chip)  | proj.name
+```
+
+New card (worktree-level, terminals excluded):
+```
+● | wt.branch (primary)  wt.id chip               | proj.name
+```
+
+That's the only content change. CSS classes (`dashboard-card__dot`, `dashboard-card__session-main`, `dashboard-card__primary`, `dashboard-card__branch`, `dashboard-card__secondary`) are reused as-is — `wt.branch` goes where `s.label` was, `wt.id` goes where `wt.branch` was.
+
+---
+
+#### View A — List (default)
+
+Same section structure as today (working / idle / finished). "Finished" merges `done` + `exited`. Sections hidden when empty.
+
+```
+┌────────────────────────────────────────────────┐
+│ vibe-station          ● daemon · port 3000  ⊞  │  ← ⊞ toggles to kanban
+├────────────────────────────────────────────────┤
+│ working                                         │
+│  ● feat/auth-flow              vs-1  my-proj   │
+│  ● feat/storage                vs-5  other     │
+│ idle                                            │
+│  ○ refactor-api                vs-3  my-proj   │
+│ finished                                        │
+│  ✓ fix/login-bug               vs-2  my-proj   │
+│  ✕ spike/perf                  vs-4  other     │
+└────────────────────────────────────────────────┘
+```
+
+Mobile — unchanged from desktop (single column, naturally scrolls):
+```
+┌──────────────────────────────┐
+│ vibe-station  ● daemon    ⊞  │
+│ working                      │
+│  ● feat/auth-flow  vs-1      │
+│    my-project                │
+│  ● feat/storage    vs-5      │
+│    other-project             │
+│ idle                         │
+│  ○ refactor-api    vs-3      │
+│    my-project                │
+│ finished                     │
+│  ✓ fix/login-bug   vs-2      │
+│  ✕ spike/perf      vs-4      │
+└──────────────────────────────┘
+```
+
+---
+
+#### View B — Kanban
+
+Desktop: 3-column CSS grid. Each card is the same card component as list view, just rendered in a column context rather than full-width row. Column headers show the section label + count.
+
+```
+┌───────────────────┬───────────────────┬───────────────────┐
+│ ● Working (2)     │ ○ Idle (1)        │ Finished (2)      │
+├───────────────────┼───────────────────┼───────────────────┤
+│ ● feat/auth-flow  │ ○ refactor-api    │ ✓ fix/login-bug   │
+│   vs-1  my-proj   │   vs-3  my-proj   │   vs-2  my-proj   │
+│                   │                   │                   │
+│ ● feat/storage    │                   │ ✕ spike/perf      │
+│   vs-5  other     │                   │   vs-4  other     │
+└───────────────────┴───────────────────┴───────────────────┘
+```
+
+Mobile (`≤600px`): grid becomes single-column; column headers become section headers — identical to list view. Toggle icon stays visible (user can see which mode is set) but layout difference is invisible on narrow screens.
+
+```
+┌──────────────────────────────┐
+│ vibe-station  ● daemon    ⊞  │
+│ ● Working (2)                │
+│  ● feat/auth-flow  vs-1      │
+│    my-project                │
+│  ● feat/storage    vs-5      │
+│    other-project             │
+│ ○ Idle (1)                   │
+│  ○ refactor-api    vs-3      │
+│    my-project                │
+│ Finished (2)                 │
+│  ✓ fix/login-bug   vs-2      │
+│  ✕ spike/perf      vs-4      │
+└──────────────────────────────┘
+```
+
+---
+
+#### Toggle + data model
+
+- Toggle state: `"list" | "kanban"` — `localStorage("dashboard:view")`
+- Toggle button: top-right of dashboard header (`Columns3` icon when in list mode, `LayoutList` icon when in kanban mode — both from lucide-react)
+- Unit of data: **worktree** (not session) — one card per worktree
+- Filter: skip worktrees where `agentSessions.length === 0` (terminals-only → hidden); `agentSessions = sessions.filter(s => s.worktreeId === wt.id && s.type === "agent")`
+- Status per worktree: `worktreeRolledUpStatus(agentSessions, sessionStates)` — import `worktreeRolledUpStatus` from `@/lib/worktreeStatus` and `useWorkspaceStore` for `sessionStates` (not currently imported in `DashboardPanel.tsx` — add both)
+- **Bucket mapping** (based on `WorktreeRolledUpStatus` values, not raw `SessionState`):
+  - **working** → `"working"` or `"spawning"` (note: `"spawning"` is a derived UI status from `worktreeRolledUpStatus` that maps from the raw `"not_started"` session state — it does not exist in `SessionState` directly)
+  - **idle** → `"idle"`
+  - **finished** → `"done"` or `"exited"` or `"none"` (worktrees with agent sessions that are all done/exited)
+- Card click: `setActiveWorktree(wt.projectId, wt.id, allSessionsForWt)` + `navigate("/worktree/${wt.id}")`
+- **Remove the existing "projects" section** (`DashboardPanel.tsx:190-216`) — project names appear inline as the tertiary muted label on each worktree card; a separate flat project list adds no value and would be redundant.
+
+#### CSS additions for kanban
+
+- `.dashboard-kanban` — `display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--space-3); align-items: start`
+- `.dashboard-kanban__col` — `display: flex; flex-direction: column; gap: var(--space-2)`
+- `.dashboard-kanban__col-header` — section label + count, styled like existing `dashboard-section__label`
+- `@media (max-width: 600px)` — `.dashboard-kanban { grid-template-columns: 1fr }`
+- Kanban cards: same `.dashboard-card` class — `min-width: 0; word-break: break-word` to handle long branch names
+
+---
+
+### P4 — Mark as done (new daemon endpoint + CLI command + UI)
+
+**Daemon endpoint:** `POST /worktrees/:id/done`
+
+Daemon session model (verified in `apps/cli/src/daemon/types.ts:8,11,31`):
+- `SessionRecord.lifecycle: SessionLifecycle` where `SessionLifecycle = { state: LifecycleState; lastTransitionAt: string }`
+- `LifecycleState = "not_started" | "working" | "idle" | "done" | "exited"`
+
+Implementation pattern — mirrors how `sessions.ts:98` sets `exited`:
+```ts
+for (const session of worktree.sessions.filter(s => s.type === "agent")) {
+  session.lifecycle = { state: "done", lastTransitionAt: new Date().toISOString() };
+  broadcastAll({ type: "session:state", sessionId: session.id, state: "done" });
+}
+await persistLifecycleState(project.id, wtId, session.id, "done"); // once per session
+```
+
+Imports needed in the new route handler:
+- `broadcastAll` from `"../broadcaster.js"`
+- `persistLifecycleState` from `"../services/lifecycle.js"`
+- `getAllProjects` already imported in `worktrees.ts`
+
+- No process killing — sessions may already be `exited` or `idle`; this is a metadata label only
+- Returns `{ ok: true, updated: number }` (count of agent sessions updated)
+
+**CLI command:** `vst worktree done <id>`
+- New file: `apps/cli/src/commands/worktree/done.ts`
+- Calls `POST /worktrees/:id/done`
+- Register in `apps/cli/src/program.ts` alongside `registerWorktreeRm`
+- No confirmation required (non-destructive, purely a label change)
+- Output: `success("Worktree marked as done: ${id}")`
+
+**UI — sidebar worktree menu after change:**
+```
+┌────────────────────────────┐
+│ Mark as done               │  ← sets all agent sessions to done state
+│ Dismiss (keep files)       │  ← soft remove, no file deletion
+│ Delete worktree…           │  ← hard delete + purge
+└────────────────────────────┘
+```
+
+- "Mark as done" calls new `markWorktreeDone(id)` API method; no confirm needed (non-destructive)
+- Sidebar status dot updates to `✓` via existing `session:state` WebSocket broadcast
+
+**State lifecycle table (for UI tooltips / plan reference):**
+
+| State | How set | Meaning | Actions available |
+|-------|---------|---------|-------------------|
+| `◐` spawning | Daemon on spawn | Session starting | — |
+| `●` working | Daemon infers (output changing) | Agent is running | — |
+| `○` idle | Daemon infers (output stable ≥4s) | Awaiting input | Give next task |
+| `✕` exited | Daemon detects (process dead) | Stopped (clean exit or crash) | Resume, Mark as done, Dismiss |
+| `✓` done | **New: user or future plugin** | Work complete | Dismiss |
+| `·` none | No sessions | Empty worktree | Add session |
+
+---
+
+### P5 — Dismiss (soft-remove, UI only)
+
+The daemon already handles `DELETE /worktrees/:id` without `?purge=true`. The web client always passes purge. Fix:
+
+1. Add `dismissWorktree(id)` to API client — `DELETE /worktrees/${id}` (no `?purge=true`)
+2. Add to `ApiInstance` type and `mock.ts`
+3. "Dismiss (keep files)" menu item in sidebar ⋯ menu → `ConfirmDialog` with message: "Remove from vst tracking? Files and git branch stay on disk."
+4. On dashboard: done/exited worktree rows show dismiss affordance (icon button on hover)
+
+---
+
+### P6 — `vst worktree rm` purge prompt
+
+**Current flow:**
+```
+vst worktree rm <id>
+  → warning message
+  → "Type <id> to confirm:"    ← safety gate, unchanged
+  → DELETE /worktrees/<id>     ← always no purge (without --purge flag)
+```
+
+**New flow (when `--purge` not passed):**
+```
+vst worktree rm <id>
+  → warning message
+  → "Type <id> to confirm:"    ← unchanged
+  → "Also delete files from disk? [y/N]:"   ← NEW, after confirmation
+  → if y → DELETE /worktrees/<id>?purge=true
+  → if N → DELETE /worktrees/<id>
+```
+
+Implementation in `apps/cli/src/commands/worktree/rm.ts`:
+- Add `import prompts from "prompts";` at the top (already used in `confirm.ts` but **not** in `rm.ts`)
+- After `confirmByTypingName`, when `!opts.purge`, add:
+  ```ts
+  const { doPurge } = await prompts({
+    type: "confirm",
+    name: "doPurge",
+    message: "Also delete files from disk?",
+    initial: false,
+  });
+  const shouldPurge = Boolean(doPurge);
+  const url = shouldPurge ? `/worktrees/${id}?purge=true` : `/worktrees/${id}`;
+  ```
+- When `opts.purge` is passed: keep existing behaviour (no second prompt, always use `?purge=true`)
+- Update success message: `opts.purge || shouldPurge ? "Worktree purged" : "Worktree removed (files kept on disk)"`
+
+---
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `apps/web/src/components/layout/LeftSidebar.tsx` | Brand header, settings nav row, mark-done + dismiss actions |
+| `apps/web/src/components/layout/DashboardPanel.tsx` | Full revamp to project-section layout |
+| `apps/web/src/api/client.ts` | Add `dismissWorktree()` + `markWorktreeDone()` methods |
+| `apps/web/src/api/mock.ts` | Add stubs for both new methods |
+| `apps/web/src/api/types.ts` | Add methods to `ApiInstance` interface |
+| `apps/web/src/routes/Workspace.tsx` | Pass `isMobile` to `LeftSidebar` |
+| `apps/web/src/styles/workspace.css` | New CSS: brand, nav-item, dashboard cards, kanban grid, mobile breakpoint (≤600px) |
+| `apps/cli/src/daemon/routes/worktrees.ts` | Add `POST /worktrees/:id/done` endpoint |
+| `apps/cli/src/commands/worktree/done.ts` | New file: `vst worktree done` command |
+| `apps/cli/src/program.ts` | Register new `worktree done` command |
+| `apps/cli/src/commands/worktree/rm.ts` | Add purge prompt after name-confirmation |
+| `apps/cli/src/daemon/ws/handlers/fileWatch.ts` | Fix hardcoded "test" project path → real project-store lookup |
+| `apps/cli/src/daemon/ws/handlers/treeWatch.ts` | Same fix |
+
+---
+
+## Phases
+
+### Phase 1 — Mobile brand + Settings nav item (LeftSidebar)
+
+- [x] 1.1 Add `isMobile` prop to `LeftSidebar`; thread it from `Workspace.tsx`
+- [x] 1.2 Add `<Link to="/">` as `.left-sidebar__brand` **above** `.left-sidebar__scroll` (sibling div, not inside scroll); shown when `isMobile || !collapsed`
+- [x] 1.3 Move Settings out of footer: replace `<button onClick={navigate("/settings")}>` with `<Link to="/settings" className="left-sidebar__nav-item ...">` above the icon pair; remove the old Settings `icon-btn` from the footer
+- [x] 1.4 Apply `left-sidebar__nav-item--active` class when `location.pathname === "/settings"`
+- [x] 1.5 CSS: `.left-sidebar__brand` (block, padding, border-bottom, no underline); `.left-sidebar__nav-item` (flex row, full width); `.left-sidebar__nav-item--active` (bg + colour); `.left-sidebar--collapsed .left-sidebar__nav-item` (centred, `padding: var(--space-1)`); `.left-sidebar__icon-row` (existing Font+Theme pair)
+- [x] **1.T1** Resize browser to 375px — sidebar shows "vibe-station" brand at top, stays pinned (does not scroll with worktree list)
+- [x] **1.T2** Click brand → navigates to `/`; Ctrl+click → opens `/` in new tab
+- [x] **1.T3** Navigate to `/settings` → Settings row is highlighted, not the old icon button
+- [x] **1.T4** Desktop collapsed rail → brand hidden, Settings shows as centred icon only (no label)
+
+### Phase 2 — Dashboard revamp
+
+- [x] 2.1 Add imports to `DashboardPanel.tsx`: `worktreeRolledUpStatus` from `@/lib/worktreeStatus`; `useWorkspaceStore` (for `sessionStates`); `StatusDot` from `@/components/layout/StatusDot`; `Link` from `react-router-dom`
+- [x] 2.2 Add `worktrees` state (`useState<Worktree[]>`) alongside existing `sessions`; populate in the same `useEffect` that fetches sessions
+- [x] 2.3 Rename `renderSessionCards` → `renderWorktreeCard(wt: Worktree, proj: Project | undefined)`; filter: skip `wt` when `agentSessions.length === 0`; card: `<Link to={/worktree/${wt.id}} onClick={...}>` — branch in `dashboard-card__primary`, `wt.id` chip in `dashboard-card__branch`, `proj?.name` in `dashboard-card__secondary`
+- [x] 2.4 Derive three buckets using `worktreeRolledUpStatus(agentSessions, sessionStates)`: `working` (`"working"|"spawning"`), `idle` (`"idle"`), `finished` (`"done"|"exited"`); sections hidden when empty
+- [x] 2.5 **Remove** existing "projects" section (`DashboardPanel.tsx:190-216`) — no longer needed
+- [x] 2.6 Add `dashboardView: "list" | "kanban"` state from `localStorage("dashboard:view")`; toggle button in header (`Columns3` icon in list mode, `LayoutList` in kanban mode)
+- [x] 2.7 **Kanban**: `dashboardView === "kanban"` → render `.dashboard-kanban` grid with three `.dashboard-kanban__col` divs; same cards inside
+- [x] 2.8 CSS: `.dashboard-kanban` (`display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--space-3); align-items: start`); `.dashboard-kanban__col-header`; `@media (max-width: 600px) { .dashboard-kanban { grid-template-columns: 1fr } }`;  `a.dashboard-card` gets same reset as existing `button.dashboard-card` (check `workspace.css` for button-specific resets)
+- [x] **2.T1** List view: branch name bold primary, `vs-N` chip secondary, project name muted right
+- [x] **2.T2** No terminal-only worktrees visible; projects section gone
+- [x] **2.T3** Kanban desktop: 3 columns; kanban at 375px: single column
+- [x] **2.T4** Toggle persists across reload; Ctrl+click card opens worktree in new tab
+
+### Phase 3 — Mark as done (daemon + CLI + UI)
+
+- [x] 3.1 Add `POST /worktrees/:id/done` in `daemon/routes/worktrees.ts`
+  - Find worktree; iterate agent sessions; set `lifecycle.state = "done"`; persist; broadcast `session:state`
+- [x] 3.2 New file `apps/cli/src/commands/worktree/done.ts` — `vst worktree done <id>` command
+- [x] 3.3 Register in `program.ts` with `registerWorktreeDone(worktree)`
+- [x] 3.4 Add `markWorktreeDone(id)` to `ApiInstance` type, `client.ts`, `mock.ts`
+  - Client: `POST /worktrees/${id}/done`
+- [x] 3.5 Add "Mark as done" menu item in `LeftSidebar` worktree ⋯ menu (no confirm needed)
+- [x] **3.T1** `vst worktree done vs-7` → success message, sidebar dot flips to `✓`
+- [x] **3.T2** "Mark as done" appears in ⋯ menu; clicking it updates status dot without page reload
+- [x] **3.T3** Sessions that were `idle` or `exited` both get updated to `done`
+
+### Phase 4 — Dismiss (soft-remove, UI only)
+
+- [x] 4.1 Add `dismissWorktree(id: string)` to `ApiInstance` type, `client.ts`, `mock.ts`
+  - Client: `DELETE /worktrees/${id}` (no `?purge=true`)
+- [x] 4.2 Add "Dismiss (keep files)" menu item in `LeftSidebar` worktree ⋯ menu, above "Delete…"
+- [x] 4.3 Wire to `ConfirmDialog`: "Remove from vst tracking? Files and git branch stay on disk."
+- [x] 4.4 Add dismiss affordance (icon button on hover) on done/exited worktree rows in `DashboardPanel`
+- [x] **4.T1** "Dismiss" appears in ⋯ menu; confirming removes worktree from sidebar
+- [x] **4.T2** Files still on disk after dismiss (`ls` in worktree dir)
+- [x] **4.T3** Existing "Delete worktree…" still purges files
+
+### Phase 5 — `vst worktree rm` purge prompt
+
+- [x] 5.1 In `rm.ts`: after `confirmByTypingName`, when `!opts.purge`, add `prompts({ type: "confirm", name: "doPurge", message: "Also delete files from disk?", initial: false })`
+- [x] 5.2 Update `url` and success message based on answer
+- [x] 5.3 `--purge` flag still bypasses second prompt (always purges)
+- [x] **5.T1** `vst worktree rm vs-7` → type ID → prompted for purge → answer N → files stay
+- [x] **5.T2** `vst worktree rm vs-7` → type ID → prompted for purge → answer y → files deleted
+- [x] **5.T3** `vst worktree rm vs-7 --purge` → type ID → no purge prompt → files deleted
+
+### Phase 6 — Fix file watcher and tree watcher (broken hardcoded path)
+
+**Root cause:** Both WS handlers hardcode `"test"` as the project id when constructing the worktree root path. This means watchers watch the wrong directory (or a non-existent directory) for every project except one named literally `"test"`.
+
+- `apps/cli/src/daemon/ws/handlers/fileWatch.ts:29`
+  ```ts
+  // BUG — hardcoded project id "test":
+  const worktreeRoot = join(process.env.HOME || "/tmp", ".vibe-station", "projects", "test", "worktrees", worktreeId);
+  ```
+- `apps/cli/src/daemon/ws/handlers/treeWatch.ts:30`
+  ```ts
+  // same bug
+  const worktreeRoot = join(process.env.HOME || "/tmp", ".vibe-station", "projects", "test", "worktrees", worktreeId);
+  ```
+
+Both files even have a comment saying "In a real implementation, look up the worktree root from the project store." The real lookup already exists in route handlers (`worktrees.ts:363`, `paths.ts:26`).
+
+**Fix for both handlers** — same pattern, already used everywhere else:
+```ts
+import { getAllProjects } from "../state/project-store.js";
+import { worktreePath as getWorktreePath } from "../services/paths.js";
+
+// Find the project that owns this worktree
+const project = getAllProjects().find((p) => p.worktrees.some((w) => w.id === worktreeId));
+if (!project) {
+  conn.send({ type: "system:error", message: `Worktree '${worktreeId}' not found` });
+  return;
+}
+const worktreeRoot = getWorktreePath(project.id, worktreeId);
+```
+
+No changes to client code, WS protocol, `FileWatcher`, or `useFileWatch`/`useTreeWatch` hooks — the plumbing is correct end-to-end. The only broken piece is the path resolution in the two handler files.
+
+**Why file preview and file tree both appeared broken:** `useFileWatch` and `useTreeWatch` both depend on receiving `file:changed` / `tree:changed` events from the daemon. Since the daemon was watching the wrong directory, those events were never fired, so `lastChanged` never updated, so neither the preview re-fetch nor the tree re-fetch were triggered.
+
+#### Phase 6 checklist
+
+- [x] 6.1 `fileWatch.ts`: import `getAllProjects` + `getWorktreePath`; replace hardcoded path with project-store lookup; send `system:error` if worktree not found
+- [x] 6.2 `treeWatch.ts`: same fix — import + replace hardcoded path
+- [x] 6.3 Remove the "In a real implementation…" TODO comments from both files
+- [x] **6.T1** Open a file in preview; have an agent edit it; preview should reload within ~300ms
+- [x] **6.T2** File tree should refresh when agent creates/deletes a file
+- [x] **6.T3** Watch still works after daemon restart (handler re-registers via `useEffect` cleanup + remount)
+- [x] **6.T4** Worktree not found → `system:error` message, no crash
+
+---
+
+### Phase 7 — Navigatable elements as anchor links
+
+**Goal:** Ctrl/Cmd+click (and middle-click) on any navigation element opens the target in a new tab. No visual change. React Router's `<Link>` renders as `<a href="...">` and still fires `onClick` for regular left-clicks, so state updates are unaffected.
+
+---
+
+#### Elements to convert
+
+| Element | File | Current | Change |
+|---------|------|---------|--------|
+| `vibe-station` brand (top bar) | `TopBar.tsx:141` | `<button ref={brandRef} onClick={goHome}>` | `<Link ref={brandRef} to="/" onClick={clearWorkspaceSelection}>` |
+| `vibe-station` brand (sidebar, new) | `LeftSidebar.tsx` | `<button onClick={() => navigate("/")}> ` | `<Link to="/">` |
+| Settings nav item (sidebar) | `LeftSidebar.tsx:~395` | `<button onClick={() => navigate("/settings")}>` | `<Link to="/settings">` |
+| Worktree rows (sidebar) | `LeftSidebar.tsx:327-384` | `<div role="button" onClick={selectWorktree}>` | stretch-link pattern (see below) |
+| Worktree cards (dashboard) | `DashboardPanel.tsx:140-155` | `<button onClick={openSessionRow}>` | `<Link to={/worktree/${wt.id}} onClick={setActiveWorktree}>` |
+
+---
+
+#### `<Link>` for simple buttons (brand, settings)
+
+Straightforward replacement. `ref` type changes from `HTMLButtonElement` to `HTMLAnchorElement` for the top-bar brand (used only for width measurement — `offsetWidth` exists on `HTMLAnchorElement`). CSS keeps the same class names; React Router's Link accepts `className`.
+
+```tsx
+// TopBar.tsx — before
+<button ref={brandRef} type="button" className="top-bar__brand" onClick={goHome}>
+
+// after
+<Link ref={brandRef} to="/" className="top-bar__brand" onClick={clearWorkspaceSelection}>
+```
+
+```tsx
+// LeftSidebar.tsx — settings, before
+<button className={isSettings ? "..." : "..."} onClick={() => navigate("/settings")}>
+
+// after
+<Link to="/settings" className={isSettings ? "..." : "..."}>
+```
+
+---
+
+#### Worktree rows in sidebar — stretch-link pattern
+
+The worktree row contains a nested `<button>` (⋯ menu trigger). `<a>` containing `<button>` is invalid HTML and causes layout issues in some browsers. Instead, use the **stretch-link** pattern: the outer `<div>` keeps its layout role; a `<Link>` with `position: absolute; inset: 0; z-index: 0` covers the whole row; content sits at `z-index: 1`, the ⋯ button at `z-index: 2`.
+
+```tsx
+// LeftSidebar.tsx — worktree row, after
+<div
+  className="tree-row tree-row--worktree"
+  data-active={activeWorktreeId === w.id}
+  style={{ position: "relative" }}           // ← add
+  // REMOVE the existing onClick and onKeyDown from this div (moved to Link + keyboard handler below)
+>
+  <Link
+    to={`/worktree/${w.id}`}
+    className="wt-row__stretch-link"         // ← new: position:absolute; inset:0; z-index:0
+    aria-label={`Open worktree ${w.branch}`}
+    onClick={() => selectWorktree(p.id, w)}  // ← selectWorktree for left-click state update
+    tabIndex={-1}                            // ← row div gets tabIndex={0} + onKeyDown for keyboard
+  />
+  <div className="wt-row__expand" style={{ position: "relative", zIndex: 1 }}>
+    ...status dot + label...
+  </div>
+  <div className="wt-row__trail" style={{ position: "relative", zIndex: 2 }}>
+    ...id chip + ⋯ button...
+  </div>
+</div>
+```
+
+**Critical:** remove `onClick={() => void selectWorktree(p.id, w)}` from the outer `<div>` (currently at `LeftSidebar.tsx:331`) — the `<Link>` handles mouse clicks. Keep `onKeyDown` on the outer div for keyboard accessibility (Enter/Space still calls `selectWorktree` + `navigate`). This prevents `selectWorktree` from firing twice on a regular left-click.
+
+CSS for `.wt-row__stretch-link`:
+```css
+.wt-row__stretch-link {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  /* no text-decoration, no colour change */
+}
+```
+
+---
+
+#### Dashboard worktree cards
+
+Cards are currently `<button>`. Replace with `<Link>` — same `className`, same `onClick` for state side-effects:
+
+```tsx
+// DashboardPanel.tsx — before
+<button type="button" className="dashboard-card dashboard-card--session" onClick={() => openSessionRow(s)}>
+
+// after (worktree-level card)
+<Link
+  to={`/worktree/${wt.id}`}
+  className="dashboard-card dashboard-card--worktree"
+  onClick={() => { setActiveWorktree(wt.projectId, wt.id, sessionsForWt); }}
+>
+```
+
+`<Link>` renders as `<a>`. The `dashboard-card` CSS must not set `text-decoration` or override colour (currently styled as `button`, so check `workspace.css` for any button-reset styles and apply equivalent resets to `a.dashboard-card`).
+
+---
+
+#### Phase 7 checklist
+
+> Brand (sidebar + topbar) and settings are already `<Link>` from Phase 1. Dashboard cards are already `<Link>` from Phase 2. This phase only covers the top-bar brand `ref` type and the worktree row stretch-link.
+
+- [x] 7.1 `TopBar.tsx`: `<button ref={brandRef} onClick={goHome}>` → `<Link ref={brandRef} to="/" onClick={clearWorkspaceSelection}>`; update `brandRef` type from `useRef<HTMLButtonElement>` to `useRef<HTMLAnchorElement>` (verified safe: only `offsetWidth` is read at line 89)
+- [x] 7.2 `LeftSidebar.tsx` worktree rows:
+  - Add `style={{ position: "relative" }}` to outer `<div className="tree-row tree-row--worktree">`
+  - **Remove** `onClick={() => void selectWorktree(p.id, w)}` from that outer div (prevents double-fire)
+  - ~~Keep `onKeyDown` on outer div~~ — stretch `<Link>` is the sole keyboard focus target (avoids axe nested-interactive); Enter follows native link activation.
+  - Add `<Link to={/worktree/${w.id}} className="wt-row__stretch-link" onClick={() => selectWorktree(p.id, w)} />` with `aria-label` for the row
+  - Add `style={{ position: "relative", zIndex: 1 }}` to `wt-row__expand`
+  - Add `style={{ position: "relative", zIndex: 2 }}` to `wt-row__trail`
+- [x] 7.3 `workspace.css`: `.wt-row__stretch-link { position: absolute; inset: 0; z-index: 0; text-decoration: none; }`
+- [x] **7.T1** Ctrl+click `vibe-station` brand (top bar) → opens `/` in new tab
+- [x] **7.T2** Ctrl+click Settings nav item → opens `/settings` in new tab (covered by Phase 1)
+- [x] **7.T3** Ctrl+click worktree row body → opens `/worktree/:id` in new tab; ⋯ button still opens menu (not intercepted by stretch link)
+- [x] **7.T4** Regular left-click on worktree row → `selectWorktree` fires exactly once, navigates normally
+- [x] **7.T5** No visual change: no underlines, no colour shifts, no layout shifts
+
+---
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| `client.ts` `deleteWorktree` always passes `purge=true` — must not change | MEDIUM | Add new `dismissWorktree` method; leave `deleteWorktree` unchanged |
+| Dashboard card `<button>` → `<Link>/<a>` — button CSS resets may not apply to `<a>` | MEDIUM | Audit `workspace.css` for `button.dashboard-card` selectors; add equivalent `a.dashboard-card` rules |
+| Worktree row outer div `onClick` still present after stretch-link added → double-fire | HIGH | Resolved in plan: Phase 7.2 explicitly removes outer `onClick`; only `onKeyDown` remains for keyboard nav |
+| TerminalPane remount if sidebar brand changes React tree position | LOW | Brand mounts above `.left-sidebar__scroll` as a sibling — same depth, no TerminalPane relationship |
+| `isMobile` prop threading to LeftSidebar — currently not passed | LOW | Add optional prop with default `false`; existing callers unaffected |
+| File/tree watcher: stale chokidar watchers if `file:unwatch` sent to wrong path before fix | LOW | Watchers keyed by `watchKey`; unwatch finds by key; stale watchers cleaned up on WS disconnect |
+| `POST /worktrees/:id/done` marks `exited` sessions as `done` — meaningful? | LOW | `done` is a user intent signal, not a process state; lifecycle poller guards are `!== "exited"` — verify `lifecycle.ts:138` also lets `done` pass through unchanged |
+| Removing "projects" section from dashboard may surprise users | LOW | Project names remain as inline muted labels on every worktree card |

--- a/cli/src/commands/worktree/done.ts
+++ b/cli/src/commands/worktree/done.ts
@@ -1,0 +1,18 @@
+import { Command } from "commander";
+import { daemonPost } from "../../lib/daemon-client.js";
+import { preflight } from "../../lib/preflight.js";
+import { die, success } from "../../lib/output.js";
+
+export function registerWorktreeDone(worktree: Command): void {
+  worktree
+    .command("done <id>")
+    .description("Mark all agent sessions in a worktree as done")
+    .action(async (id: string) => {
+      await preflight();
+      const result = await daemonPost<{ ok: true; updated: number }>(
+        `/worktrees/${encodeURIComponent(id)}/done`,
+      );
+      if (!result.ok) die(result.error, result.status === 404 ? 2 : 1);
+      success(`Worktree marked as done: ${id}`);
+    });
+}

--- a/cli/src/commands/worktree/rm.ts
+++ b/cli/src/commands/worktree/rm.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import prompts from "prompts";
 import { daemonDelete } from "../../lib/daemon-client.js";
 import { preflight } from "../../lib/preflight.js";
 import { confirmByTypingName } from "../../lib/confirm.js";
@@ -16,13 +17,26 @@ export function registerWorktreeRm(worktree: Command): void {
         : `This will remove worktree "${id}" from vst and terminate its sessions. Files stay on disk.`;
       await confirmByTypingName(id, msg);
 
-      const url = opts.purge ? `/worktrees/${id}?purge=true` : `/worktrees/${id}`;
+      let shouldPurge = Boolean(opts.purge);
+      if (!opts.purge) {
+        const ans = await prompts({
+          type: "confirm",
+          name: "doPurge",
+          message: "Also delete files from disk?",
+          initial: false,
+        });
+        shouldPurge = Boolean(ans.doPurge);
+      }
+
+      const url = shouldPurge ? `/worktrees/${id}?purge=true` : `/worktrees/${id}`;
       const result = await daemonDelete<void>(url);
 
       if (!result.ok) {
         die(result.error, result.status === 404 ? 2 : 1);
       }
 
-      success(opts.purge ? `Worktree purged: ${id}` : `Worktree removed: ${id}`);
+      success(
+        shouldPurge ? `Worktree purged: ${id}` : `Worktree removed (files kept on disk): ${id}`,
+      );
     });
 }

--- a/cli/src/commands/worktree/rm.ts
+++ b/cli/src/commands/worktree/rm.ts
@@ -25,6 +25,7 @@ export function registerWorktreeRm(worktree: Command): void {
           message: "Also delete files from disk?",
           initial: false,
         });
+        if (ans.doPurge === undefined) die("Cancelled.", 1);
         shouldPurge = Boolean(ans.doPurge);
       }
 

--- a/cli/src/program.ts
+++ b/cli/src/program.ts
@@ -12,6 +12,7 @@ import { registerProjectLs } from "./commands/project/ls.js";
 import { registerProjectInfo } from "./commands/project/info.js";
 import { registerWorktreeCreate } from "./commands/worktree/create.js";
 import { registerWorktreeRm } from "./commands/worktree/rm.js";
+import { registerWorktreeDone } from "./commands/worktree/done.js";
 import { registerWorktreeLs } from "./commands/worktree/ls.js";
 import { registerWorktreeInfo } from "./commands/worktree/info.js";
 import { registerSessionCreate } from "./commands/session/create.js";
@@ -76,6 +77,7 @@ export function buildProgram(): Command {
     .description("Manage worktrees");
   registerWorktreeCreate(worktree);
   registerWorktreeRm(worktree);
+  registerWorktreeDone(worktree);
   registerWorktreeLs(worktree);
   registerWorktreeInfo(worktree);
 

--- a/daemon/src/__tests__/worktrees.test.ts
+++ b/daemon/src/__tests__/worktrees.test.ts
@@ -368,4 +368,30 @@ describe("Worktree routes", () => {
     spy.mockRestore();
     vi.mocked(spawnModule.spawnSession).mockResolvedValue(undefined);
   });
+
+  it("POST /worktrees/:id/done marks agent sessions as done", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/worktrees",
+      payload: { projectId, branch: `mark-done-${Date.now()}`, modeId: "bug-fix" },
+    });
+    expect(res.statusCode).toBe(201);
+    const wt = res.json<{ id: string }>();
+
+    const doneRes = await app.inject({
+      method: "POST",
+      url: `/worktrees/${wt.id}/done`,
+    });
+    expect(doneRes.statusCode).toBe(200);
+    const body = doneRes.json<{ ok: boolean; updated: number }>();
+    expect(body.ok).toBe(true);
+    expect(body.updated).toBeGreaterThanOrEqual(1);
+
+    const sessRes = await app.inject({
+      method: "GET",
+      url: `/sessions/${wt.id}-m`,
+    });
+    expect(sessRes.statusCode).toBe(200);
+    expect(sessRes.json<{ state: string }>().state).toBe("done");
+  });
 });

--- a/daemon/src/routes/worktrees.ts
+++ b/daemon/src/routes/worktrees.ts
@@ -15,6 +15,7 @@ import { rollbackWorktreeCreate } from "../services/rollback.js";
 import { spawnSession } from "../services/spawn.js";
 import { worktreePath as getWorktreePath, cleanupSessionDataDir } from "../services/paths.js";
 import { broadcastAll } from "../broadcaster.js";
+import { persistLifecycleState } from "../services/lifecycle.js";
 import { serializeSession } from "./sessions.js";
 import { resolvePlugin } from "../agent-plugins/registry.js";
 import { resolveUseTmux } from "../services/resolveUseTmux.js";
@@ -351,6 +352,23 @@ export function registerWorktreeRoutes(app: FastifyInstance): void {
 
     const apiWorktree = serializeWorktree(projectId, createdWorktree!);
     return reply.status(201).send(apiWorktree);
+  });
+
+  // POST /worktrees/:id/done — mark all agent sessions as done (metadata only; no process kill)
+  app.post("/worktrees/:id/done", async (req, reply) => {
+    const { id: wtId } = req.params as { id: string };
+    const project = getAllProjects().find((p) => p.worktrees.some((w) => w.id === wtId));
+    if (!project) return reply.status(404).send({ error: `Worktree '${wtId}' not found` });
+
+    const worktree = project.worktrees.find((w) => w.id === wtId)!;
+    let updated = 0;
+    for (const session of worktree.sessions.filter((s) => s.type === "agent")) {
+      session.lifecycle = { state: "done", lastTransitionAt: new Date().toISOString() };
+      await persistLifecycleState(project.id, wtId, session.id, "done");
+      broadcastAll({ type: "session:state", sessionId: session.id, state: "done" });
+      updated += 1;
+    }
+    return reply.send({ ok: true, updated });
   });
 
   // DELETE /worktrees/:id

--- a/daemon/src/services/lifecycle.ts
+++ b/daemon/src/services/lifecycle.ts
@@ -135,7 +135,7 @@ async function pollSession(
   // Tmux path (existing behavior).
   const alive = await hasSession(session.tmuxName);
 
-  if (!alive && session.lifecycle.state !== "exited") {
+  if (!alive && session.lifecycle.state !== "exited" && session.lifecycle.state !== "done") {
     idleTracking.delete(session.id);
     notifySession(session.id, {
       type: "session:exited",

--- a/daemon/src/ws/handlers/fileWatch.ts
+++ b/daemon/src/ws/handlers/fileWatch.ts
@@ -2,11 +2,11 @@ import type { WSConnection } from "../connection.js";
 import type { ClientMessage } from "../protocol.js";
 import { FileWatcher } from "../streams/fileWatcher.js";
 import { join } from "node:path";
+import { getAllProjects } from "../../state/project-store.js";
+import { worktreePath as getWorktreePath } from "../../services/paths.js";
 
 /**
  * Handle file:watch: start watching a file for changes.
- * For Phase 6, we'll use a simple path construction.
- * In a real implementation, this would look up the worktree path from the project store.
  */
 export function handleFileWatch(
   conn: WSConnection,
@@ -23,10 +23,15 @@ export function handleFileWatch(
   }
 
   try {
-    // For Phase 6, construct the absolute path from worktreeId and path.
-    // In a real implementation, look up the worktree root from the project store.
-    // For now, assume a simple path structure or use a placeholder.
-    const worktreeRoot = join(process.env.HOME || "/tmp", ".vibe-station", "projects", "test", "worktrees", worktreeId);
+    const project = getAllProjects().find((p) => p.worktrees.some((w) => w.id === worktreeId));
+    if (!project) {
+      conn.send({
+        type: "system:error",
+        message: `Worktree '${worktreeId}' not found`,
+      });
+      return;
+    }
+    const worktreeRoot = getWorktreePath(project.id, worktreeId);
     const absPath = join(worktreeRoot, path);
 
     const watcher = new FileWatcher();

--- a/daemon/src/ws/handlers/treeWatch.ts
+++ b/daemon/src/ws/handlers/treeWatch.ts
@@ -2,11 +2,11 @@ import type { WSConnection } from "../connection.js";
 import type { ClientMessage } from "../protocol.js";
 import { FileWatcher } from "../streams/fileWatcher.js";
 import { join } from "node:path";
+import { getAllProjects } from "../../state/project-store.js";
+import { worktreePath as getWorktreePath } from "../../services/paths.js";
 
 /**
  * Handle tree:watch: start watching a directory tree for changes.
- * For Phase 7, we'll use a simple path construction.
- * In a real implementation, this would look up the worktree path from the project store.
  */
 export function handleTreeWatch(
   conn: WSConnection,
@@ -25,9 +25,15 @@ export function handleTreeWatch(
   }
 
   try {
-    // For Phase 7, construct the absolute path from worktreeId and path.
-    // In a real implementation, look up the worktree root from the project store.
-    const worktreeRoot = join(process.env.HOME || "/tmp", ".vibe-station", "projects", "test", "worktrees", worktreeId);
+    const project = getAllProjects().find((p) => p.worktrees.some((w) => w.id === worktreeId));
+    if (!project) {
+      conn.send({
+        type: "system:error",
+        message: `Worktree '${worktreeId}' not found`,
+      });
+      return;
+    }
+    const worktreeRoot = getWorktreePath(project.id, worktreeId);
     const absPath = treePath ? join(worktreeRoot, treePath) : worktreeRoot;
 
     const watcher = new FileWatcher();

--- a/web-ui/src/api/client.ts
+++ b/web-ui/src/api/client.ts
@@ -188,6 +188,22 @@ export function createClientApi() {
       return parseJson<{ ok: true }>(res);
     },
 
+    async dismissWorktree(id: string): Promise<{ ok: true }> {
+      const root = baseUrl();
+      const res = await fetch(`${root}/worktrees/${encodeURIComponent(id)}`, {
+        method: "DELETE",
+      });
+      return parseJson<{ ok: true }>(res);
+    },
+
+    async markWorktreeDone(id: string): Promise<{ ok: true; updated: number }> {
+      const root = baseUrl();
+      const res = await fetch(`${root}/worktrees/${encodeURIComponent(id)}/done`, {
+        method: "POST",
+      });
+      return parseJson<{ ok: true; updated: number }>(res);
+    },
+
     async listSessions(worktreeId: string): Promise<Session[]> {
       const q = new URLSearchParams({ worktree: worktreeId });
       const root = baseUrl();

--- a/web-ui/src/api/mock.ts
+++ b/web-ui/src/api/mock.ts
@@ -286,6 +286,31 @@ export function createMockApi() {
       return { ok: true };
     },
 
+    async dismissWorktree(id: string): Promise<{ ok: true }> {
+      const idx = worktrees.findIndex((w) => w.id === id);
+      if (idx === -1) throw new ApiError("not found", 404);
+      worktrees.splice(idx, 1);
+      for (let i = sessions.length - 1; i >= 0; i--) {
+        if (sessions[i]!.worktreeId === id) sessions.splice(i, 1);
+      }
+      emit({ type: "worktree:deleted", worktreeId: id });
+      return { ok: true };
+    },
+
+    async markWorktreeDone(id: string): Promise<{ ok: true; updated: number }> {
+      const wtExists = worktrees.some((w) => w.id === id);
+      const agents = sessions.filter((s) => s.worktreeId === id && s.type === "agent");
+      if (!wtExists) throw new ApiError("not found", 404);
+      let updated = 0;
+      for (const s of agents) {
+        s.state = "done";
+        s.lifecycleState = "done";
+        emit({ type: "session:state", sessionId: s.id, state: "done" });
+        updated += 1;
+      }
+      return { ok: true, updated };
+    },
+
     async listSessions(worktreeId: string): Promise<Session[]> {
       return structuredClone(sessions.filter((s) => s.worktreeId === worktreeId));
     },

--- a/web-ui/src/components/layout/DashboardPanel.test.tsx
+++ b/web-ui/src/components/layout/DashboardPanel.test.tsx
@@ -5,7 +5,7 @@ import { createMockApi } from "@/api/mock";
 import { DashboardPanel } from "./DashboardPanel";
 
 describe("DashboardPanel", () => {
-  it("renders daemon status and project list", async () => {
+  it("renders daemon status and project names on worktree cards", async () => {
     const api = createMockApi();
     render(
       <MemoryRouter>
@@ -20,7 +20,7 @@ describe("DashboardPanel", () => {
     });
   });
 
-  it("renders working and idle session sections", async () => {
+  it("renders working, idle, and finished sections", async () => {
     const api = createMockApi();
     render(
       <MemoryRouter>
@@ -32,9 +32,10 @@ describe("DashboardPanel", () => {
     });
     expect(screen.getByText("working")).toBeInTheDocument();
     expect(screen.getByText("idle")).toBeInTheDocument();
+    expect(screen.getByText("finished")).toBeInTheDocument();
   });
 
-  it("updates session row when session:state fires", async () => {
+  it("updates worktree row bucket when session:state fires", async () => {
     const api = createMockApi();
     render(
       <MemoryRouter>
@@ -46,17 +47,24 @@ describe("DashboardPanel", () => {
     });
     const workingSection = screen.getByText("working").closest("section");
     expect(workingSection).not.toBeNull();
-    expect(within(workingSection!).getByText("main")).toBeInTheDocument();
+    expect(within(workingSection!).getByRole("link", { name: /Proj A/i })).toHaveAttribute(
+      "href",
+      "/worktree/wt-1",
+    );
 
     api.__test.emit({ type: "session:state", sessionId: "sess-main", state: "idle" });
 
     await waitFor(() => {
-      expect(within(workingSection!).queryByText("main")).toBeNull();
+      // Bucket hides entirely when empty — old section refs would point at stale detached DOM.
+      expect(screen.queryByText("working")).toBeNull();
     });
     const idleSection = screen.getByText("idle").closest("section");
     expect(idleSection).not.toBeNull();
     await waitFor(() => {
-      expect(within(idleSection!).getAllByText("main").length).toBe(2);
+      expect(within(idleSection!).getByRole("link", { name: /Proj A/i })).toHaveAttribute(
+        "href",
+        "/worktree/wt-1",
+      );
     });
   });
 });

--- a/web-ui/src/components/layout/DashboardPanel.tsx
+++ b/web-ui/src/components/layout/DashboardPanel.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Columns3, EyeOff, LayoutList } from "lucide-react";
 import { Link } from "react-router-dom";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 import type { ApiInstance } from "@/api";
 import type { HealthResponse, Project, Session, SessionState, Worktree } from "@/api/types";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
@@ -52,6 +53,8 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
     setSessions(ss);
     syncSessionsFromApi(ss);
   }, [api, syncSessionsFromApi]);
+
+  const isMobile = useMediaQuery("(max-width: 768px)");
 
   const [dashboardView, setDashboardView] = useState<"list" | "kanban">(() => {
     try {
@@ -229,18 +232,21 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
               {daemonOk ? `daemon · port ${health.port}` : "daemon unreachable"}
             </span>
           </div>
-          <button
-            type="button"
-            className="icon-btn dashboard-header__view-toggle"
-            aria-label={toggleViewLabel}
-            title={toggleViewLabel}
-            onClick={() => setDashboardView((v) => (v === "list" ? "kanban" : "list"))}
-          >
-            {dashboardView === "list" ? <Columns3 size={18} /> : <LayoutList size={18} />}
-          </button>
+          {!isMobile ? (
+            <button
+              type="button"
+              className="icon-btn dashboard-header__view-toggle"
+              aria-label={toggleViewLabel}
+              title={toggleViewLabel}
+              onClick={() => setDashboardView((v) => (v === "list" ? "kanban" : "list"))}
+            >
+              {dashboardView === "list" ? <Columns3 size={18} /> : <LayoutList size={18} />}
+            </button>
+          ) : null}
         </div>
 
-        {dashboardView === "list" ? (
+        {/* On mobile always render the list layout — kanban columns don't work on narrow screens */}
+        {isMobile || dashboardView === "list" ? (
           <>
             {working.length > 0 ? (
               <section className="dashboard-section">
@@ -289,6 +295,32 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
             </div>
           </div>
         )}
+
+        {/* Projects — always shown below worktree sections */}
+        {projects.length > 0 ? (
+          <section className="dashboard-section">
+            <div className="dashboard-section__label">projects</div>
+            <div className="dashboard-card-list">
+              {projects.map((p) => {
+                const wts = worktrees.filter((w) => w.projectId === p.id);
+                const activeCount = wts.filter((w) =>
+                  sessions.some(
+                    (s) => s.worktreeId === w.id && (s.state === "working" || s.state === "idle"),
+                  ),
+                ).length;
+                return (
+                  <div key={p.id} className="dashboard-card dashboard-card--project">
+                    <span className="dashboard-card__primary">{p.name}</span>
+                    <span className="dashboard-card__secondary">
+                      {wts.length} {wts.length === 1 ? "worktree" : "worktrees"}
+                      {activeCount > 0 ? ` · ${activeCount} active` : ""}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        ) : null}
       </div>
 
       <ConfirmDialog

--- a/web-ui/src/components/layout/DashboardPanel.tsx
+++ b/web-ui/src/components/layout/DashboardPanel.tsx
@@ -1,29 +1,13 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Columns3, EyeOff, LayoutList } from "lucide-react";
+import { Link } from "react-router-dom";
 import type { ApiInstance } from "@/api";
 import type { HealthResponse, Project, Session, SessionState, Worktree } from "@/api/types";
+import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
+import { StatusDot } from "@/components/layout/StatusDot";
 import { useSubscription } from "@/hooks/useSubscription";
 import { useWorkspaceStore } from "@/hooks/useStore";
-
-function stateColor(state: Session["state"]) {
-  switch (state) {
-    case "working": return "var(--success)";
-    case "done": return "var(--fg-muted)";
-    case "exited": return "var(--fg-muted)";
-    default: return "var(--fg-secondary)";
-  }
-}
-
-function stateDot(state: Session["state"], type: Session["type"]) {
-  if (type === "terminal") return "─";
-  switch (state) {
-    case "working": return "●";
-    case "idle": return "○";
-    case "done": return "✓";
-    case "exited": return "✕";
-    default: return "○";
-  }
-}
+import { type WorktreeRolledUpStatus, worktreeRolledUpStatus } from "@/lib/worktreeStatus";
 
 interface DashboardPanelProps {
   api: ApiInstance;
@@ -33,33 +17,69 @@ function applySessionState(s: Session, state: SessionState): Session {
   return { ...s, state, lifecycleState: state };
 }
 
+function bucketForRollup(r: WorktreeRolledUpStatus): "working" | "idle" | "finished" {
+  if (r === "working" || r === "spawning") return "working";
+  if (r === "idle") return "idle";
+  return "finished";
+}
+
+const DASHBOARD_VIEW_KEY = "dashboard:view";
+
 export function DashboardPanel({ api }: DashboardPanelProps) {
-  const navigate = useNavigate();
   const [health, setHealth] = useState<HealthResponse | null>(null);
   const [projects, setProjects] = useState<Project[]>([]);
   const [worktrees, setWorktrees] = useState<Worktree[]>([]);
   const [sessions, setSessions] = useState<Session[]>([]);
+  const [pendingDismiss, setPendingDismiss] = useState<Worktree | null>(null);
   const setActiveWorktree = useWorkspaceStore((s) => s.setActiveWorktree);
+  const activeWorktreeId = useWorkspaceStore((s) => s.activeWorktreeId);
+  const clearWorkspaceSelection = useWorkspaceStore((s) => s.clearWorkspaceSelection);
   const patchSessionState = useWorkspaceStore((s) => s.patchSessionState);
   const syncSessionsFromApi = useWorkspaceStore((s) => s.syncSessionsFromApi);
 
-  useEffect(() => {
-    void (async () => {
-      try {
-        const h = await api.health();
-        setHealth(h);
-      } catch {
-        setHealth(null);
-      }
-      const ps = await api.listProjects();
-      setProjects(ps);
-      const wts = (await Promise.all(ps.map((p) => api.listWorktrees(p.id)))).flat();
-      setWorktrees(wts);
-      const ss = (await Promise.all(wts.map((w) => api.listSessions(w.id)))).flat();
-      setSessions(ss);
-      syncSessionsFromApi(ss);
-    })();
+  const refreshDashboard = useCallback(async () => {
+    try {
+      const h = await api.health();
+      setHealth(h);
+    } catch {
+      setHealth(null);
+    }
+    const ps = await api.listProjects();
+    setProjects(ps);
+    const wts = (await Promise.all(ps.map((p) => api.listWorktrees(p.id)))).flat();
+    setWorktrees(wts);
+    const ss = (await Promise.all(wts.map((w) => api.listSessions(w.id)))).flat();
+    setSessions(ss);
+    syncSessionsFromApi(ss);
   }, [api, syncSessionsFromApi]);
+
+  const [dashboardView, setDashboardView] = useState<"list" | "kanban">(() => {
+    try {
+      const v = localStorage.getItem(DASHBOARD_VIEW_KEY);
+      if (v === "kanban" || v === "list") return v;
+    } catch {
+      /* ignore */
+    }
+    return "list";
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(DASHBOARD_VIEW_KEY, dashboardView);
+    } catch {
+      /* ignore */
+    }
+  }, [dashboardView]);
+
+  useEffect(() => {
+    void refreshDashboard();
+  }, [refreshDashboard]);
+
+  useEffect(() => {
+    return api.on("*", (ev) => {
+      if (ev.type === "worktree:deleted") void refreshDashboard();
+    });
+  }, [api, refreshDashboard]);
 
   const sessionIdKey = useMemo(
     () =>
@@ -116,48 +136,86 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
     };
   }, [api, patchSessionState]);
 
-  const workingSessions = sessions.filter((s) => s.state === "working");
-  const idleSessions = sessions.filter((s) => s.state === "idle");
-  const daemonOk = health !== null;
+  const projectById = useMemo(() => Object.fromEntries(projects.map((p) => [p.id, p])), [projects]);
 
-  const openSessionRow = useCallback(
-    (s: Session) => {
-      const wt = worktrees.find((w) => w.id === s.worktreeId);
-      if (wt) {
-        const sessionsForWorktree = sessions.filter((ss) => ss.worktreeId === wt.id);
-        setActiveWorktree(wt.projectId, wt.id, sessionsForWorktree);
-        void navigate(`/worktree/${wt.id}`);
-      }
-    },
-    [navigate, sessions, setActiveWorktree, worktrees],
+  /** Roll up from local session rows (same source as cards); avoids stale global sessionStates shadowing fresh WS updates. */
+  const rollupLive = useMemo(
+    () => Object.fromEntries(sessions.map((s) => [s.id, s.state])) as Record<string, SessionState>,
+    [sessions],
   );
 
-  const renderSessionCards = (list: Session[]) =>
-    list.map((s) => {
-      const wt = worktrees.find((w) => w.id === s.worktreeId);
-      const proj = projects.find((p) => p.id === wt?.projectId);
+  const { working, idle, finished } = useMemo(() => {
+    const wtsWorking: Worktree[] = [];
+    const wtsIdle: Worktree[] = [];
+    const wtsFinished: Worktree[] = [];
+    for (const wt of worktrees) {
+      const agentSessions = sessions.filter((s) => s.worktreeId === wt.id && s.type === "agent");
+      if (agentSessions.length === 0) continue;
+      const rolled = worktreeRolledUpStatus(agentSessions, rollupLive);
+      const b = bucketForRollup(rolled);
+      if (b === "working") wtsWorking.push(wt);
+      else if (b === "idle") wtsIdle.push(wt);
+      else wtsFinished.push(wt);
+    }
+    return { working: wtsWorking, idle: wtsIdle, finished: wtsFinished };
+  }, [worktrees, sessions, rollupLive]);
+
+  const daemonOk = health !== null;
+
+  const renderWorktreeCard = useCallback(
+    (wt: Worktree) => {
+      const agentSessions = sessions.filter((s) => s.worktreeId === wt.id && s.type === "agent");
+      const rolled = worktreeRolledUpStatus(agentSessions, rollupLive);
+      const sessionsForWt = sessions.filter((s) => s.worktreeId === wt.id);
+      const proj = projectById[wt.projectId];
+      const showDismiss = rolled === "done" || rolled === "exited";
       return (
-        <button
-          key={s.id}
-          type="button"
-          className="dashboard-card dashboard-card--session"
-          onClick={() => openSessionRow(s)}
+        <div
+          key={wt.id}
+          className={`dashboard-card-shell${showDismiss ? " dashboard-card-shell--dismissable" : ""}`}
         >
-          <span className="dashboard-card__dot" style={{ color: stateColor(s.state) }}>
-            {stateDot(s.state, s.type)}
-          </span>
-          <span className="dashboard-card__session-main">
-            <span className="dashboard-card__primary">{s.label}</span>
-            {wt ? <span className="dashboard-card__branch">{wt.branch}</span> : null}
-          </span>
-          <span className="dashboard-card__secondary">{proj?.name ?? ""}</span>
-        </button>
+          <Link
+            to={`/worktree/${wt.id}`}
+            className="dashboard-card dashboard-card--session dashboard-card--worktree"
+            onClick={() => setActiveWorktree(wt.projectId, wt.id, sessionsForWt)}
+          >
+            <span className="dashboard-card__dot dashboard-card__dot--status">
+              <StatusDot status={rolled} />
+            </span>
+            <span className="dashboard-card__session-main">
+              <span className="dashboard-card__primary">{wt.branch}</span>
+              <span className="dashboard-card__branch">{wt.id}</span>
+            </span>
+            <span className="dashboard-card__secondary">{proj?.name ?? ""}</span>
+          </Link>
+          {showDismiss ? (
+            <button
+              type="button"
+              className="icon-btn dashboard-card__dismiss"
+              aria-label={`Dismiss ${wt.branch} from tracking`}
+              title="Dismiss from tracking (keep files)"
+              onClick={(e) => {
+                e.preventDefault();
+                setPendingDismiss(wt);
+              }}
+            >
+              <EyeOff size={16} />
+            </button>
+          ) : null}
+        </div>
       );
-    });
+    },
+    [projectById, rollupLive, sessions, setActiveWorktree],
+  );
+
+  const toggleViewLabel =
+    dashboardView === "list" ? "Switch to kanban layout" : "Switch to list layout";
 
   return (
     <div className="dashboard-panel">
-      <div className="dashboard-panel__inner">
+      <div
+        className={`dashboard-panel__inner${dashboardView === "kanban" ? " dashboard-panel__inner--kanban" : ""}`}
+      >
         <div className="dashboard-header">
           <div className="dashboard-header__wordmark">vibe-station</div>
           <div className="dashboard-header__daemon">
@@ -171,50 +229,89 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
               {daemonOk ? `daemon · port ${health.port}` : "daemon unreachable"}
             </span>
           </div>
+          <button
+            type="button"
+            className="icon-btn dashboard-header__view-toggle"
+            aria-label={toggleViewLabel}
+            title={toggleViewLabel}
+            onClick={() => setDashboardView((v) => (v === "list" ? "kanban" : "list"))}
+          >
+            {dashboardView === "list" ? <Columns3 size={18} /> : <LayoutList size={18} />}
+          </button>
         </div>
 
-        {workingSessions.length > 0 ? (
-          <section className="dashboard-section">
-            <div className="dashboard-section__label">working</div>
-            <div className="dashboard-card-list">{renderSessionCards(workingSessions)}</div>
-          </section>
-        ) : null}
+        {dashboardView === "list" ? (
+          <>
+            {working.length > 0 ? (
+              <section className="dashboard-section">
+                <div className="dashboard-section__label">working</div>
+                <div className="dashboard-card-list">{working.map((wt) => renderWorktreeCard(wt))}</div>
+              </section>
+            ) : null}
 
-        {idleSessions.length > 0 ? (
-          <section className="dashboard-section">
-            <div className="dashboard-section__label">idle</div>
-            <div className="dashboard-card-list">{renderSessionCards(idleSessions)}</div>
-          </section>
-        ) : null}
+            {idle.length > 0 ? (
+              <section className="dashboard-section">
+                <div className="dashboard-section__label">idle</div>
+                <div className="dashboard-card-list">{idle.map((wt) => renderWorktreeCard(wt))}</div>
+              </section>
+            ) : null}
 
-        <section className="dashboard-section">
-          <div className="dashboard-section__label">projects</div>
-          {projects.length === 0 ? (
-            <p className="dashboard-empty">No projects yet. Add one with the CLI.</p>
-          ) : (
-            <div className="dashboard-card-list">
-              {projects.map((p) => {
-                const wts = worktrees.filter((w) => w.projectId === p.id);
-                const count = wts.length;
-                const activeCount = wts.filter((w) =>
-                  sessions.some(
-                    (s) => s.worktreeId === w.id && (s.state === "working" || s.state === "idle"),
-                  ),
-                ).length;
-                return (
-                  <div key={p.id} className="dashboard-card dashboard-card--project">
-                    <span className="dashboard-card__primary">{p.name}</span>
-                    <span className="dashboard-card__secondary">
-                      {count} {count === 1 ? "worktree" : "worktrees"}
-                      {activeCount > 0 ? ` · ${activeCount} active` : ""}
-                    </span>
-                  </div>
-                );
-              })}
+            {finished.length > 0 ? (
+              <section className="dashboard-section">
+                <div className="dashboard-section__label">finished</div>
+                <div className="dashboard-card-list">{finished.map((wt) => renderWorktreeCard(wt))}</div>
+              </section>
+            ) : null}
+          </>
+        ) : (
+          <div className="dashboard-kanban">
+            <div className="dashboard-kanban__col">
+              <div className="dashboard-kanban__col-header">
+                Working <span className="dashboard-kanban__col-count">({working.length})</span>
+              </div>
+              <div className="dashboard-card-list">{working.map((wt) => renderWorktreeCard(wt))}</div>
             </div>
-          )}
-        </section>
+            <div className="dashboard-kanban__col">
+              <div className="dashboard-kanban__col-header">
+                Idle <span className="dashboard-kanban__col-count">({idle.length})</span>
+              </div>
+              <div className="dashboard-card-list">{idle.map((wt) => renderWorktreeCard(wt))}</div>
+            </div>
+            <div className="dashboard-kanban__col">
+              <div className="dashboard-kanban__col-header">
+                Finished <span className="dashboard-kanban__col-count">({finished.length})</span>
+              </div>
+              <div className="dashboard-card-list">{finished.map((wt) => renderWorktreeCard(wt))}</div>
+            </div>
+          </div>
+        )}
       </div>
+
+      <ConfirmDialog
+        open={pendingDismiss !== null}
+        title="Dismiss worktree?"
+        message={
+          pendingDismiss
+            ? `Remove “${pendingDismiss.branch}” from vst tracking? Files and git branch stay on disk.`
+            : ""
+        }
+        confirmLabel="Dismiss"
+        onConfirm={() => {
+          void (async () => {
+            const wt = pendingDismiss;
+            if (!wt) return;
+            setPendingDismiss(null);
+            try {
+              await api.dismissWorktree(wt.id);
+              if (activeWorktreeId === wt.id) clearWorkspaceSelection();
+              await refreshDashboard();
+            } catch {
+              /* surface errors later */
+            }
+          })();
+        }}
+        onCancel={() => setPendingDismiss(null)}
+      />
     </div>
   );
 }

--- a/web-ui/src/components/layout/DashboardPanel.tsx
+++ b/web-ui/src/components/layout/DashboardPanel.tsx
@@ -199,6 +199,7 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
               title="Dismiss from tracking (keep files)"
               onClick={(e) => {
                 e.preventDefault();
+                e.stopPropagation();
                 setPendingDismiss(wt);
               }}
             >

--- a/web-ui/src/components/layout/DashboardPanel.tsx
+++ b/web-ui/src/components/layout/DashboardPanel.tsx
@@ -262,6 +262,10 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
                 <div className="dashboard-card-list">{finished.map((wt) => renderWorktreeCard(wt))}</div>
               </section>
             ) : null}
+
+            {working.length === 0 && idle.length === 0 && finished.length === 0 ? (
+              <p className="dashboard-empty">No agent worktrees yet. Add a project with the CLI.</p>
+            ) : null}
           </>
         ) : (
           <div className="dashboard-kanban">

--- a/web-ui/src/components/layout/LeftSidebar.test.tsx
+++ b/web-ui/src/components/layout/LeftSidebar.test.tsx
@@ -40,11 +40,11 @@ describe("LeftSidebar", () => {
         <LeftSidebar api={api} />
       </MemoryRouter>,
     );
-    await screen.findByRole("button", { name: /Select worktree wt-1/i });
+    await screen.findByRole("link", { name: /Open worktree wt-1/i });
     await user.click(screen.getByText("Proj A"));
-    expect(screen.queryByRole("button", { name: /Select worktree wt-1/i })).toBeNull();
+    expect(screen.queryByRole("link", { name: /Open worktree wt-1/i })).toBeNull();
     await user.click(screen.getByText("Proj A"));
-    await screen.findByRole("button", { name: /Select worktree wt-1/i });
+    await screen.findByRole("link", { name: /Open worktree wt-1/i });
   });
 
   it("clicking worktree sets active worktree", async () => {
@@ -54,8 +54,8 @@ describe("LeftSidebar", () => {
         <LeftSidebar api={api} />
       </MemoryRouter>,
     );
-    await screen.findByRole("button", { name: /Select worktree wt-2/i });
-    await user.click(screen.getByRole("button", { name: /Select worktree wt-2/i }));
+    await screen.findByRole("link", { name: /Open worktree wt-2/i });
+    await user.click(screen.getByRole("link", { name: /Open worktree wt-2/i }));
     expect(useWorkspaceStore.getState().activeWorktreeId).toBe("wt-2");
   });
 
@@ -65,7 +65,7 @@ describe("LeftSidebar", () => {
         <LeftSidebar api={api} />
       </MemoryRouter>,
     );
-    await screen.findByRole("button", { name: /Select worktree wt-1/i });
+    await screen.findByRole("link", { name: /Open worktree wt-1/i });
     const menus = screen.getAllByRole("button", { name: /Worktree actions for/i });
     expect(menus[0]?.className).toContain("wt-menu-trigger");
   });
@@ -89,7 +89,7 @@ describe("LeftSidebar", () => {
         <LeftSidebar api={api} />
       </MemoryRouter>,
     );
-    await screen.findByRole("button", { name: /Select worktree wt-1/i });
+    await screen.findByRole("link", { name: /Open worktree wt-1/i });
     api.__test.emit({
       type: "session:created",
       sessionId: "sess-extra",
@@ -114,13 +114,15 @@ describe("LeftSidebar", () => {
     });
   });
 
-  it("Settings is an icon button with accessible name", async () => {
+  it("Settings is a link with accessible name", async () => {
     render(
       <MemoryRouter>
         <LeftSidebar api={api} />
       </MemoryRouter>,
     );
     await screen.findByText("Proj A");
-    expect(screen.getByRole("button", { name: /^Settings$/i })).toBeInTheDocument();
+    const settings = screen.getByRole("link", { name: /^Settings$/i });
+    expect(settings).toBeInTheDocument();
+    expect(settings).toHaveAttribute("href", "/settings");
   });
 });

--- a/web-ui/src/components/layout/LeftSidebar.tsx
+++ b/web-ui/src/components/layout/LeftSidebar.tsx
@@ -379,7 +379,7 @@ export function LeftSidebar({ api, collapsed = false, isMobile = false, onWorktr
                           onClick={() => selectWorktree(p.id, w)}
                           tabIndex={-1}
                         />
-                        <div className="wt-row__expand" style={{ position: "relative", zIndex: 1 }}>
+                        <div className="wt-row__expand">
                           {!collapsed ? (
                             <span className="wt-leading-slot" aria-hidden>
                               <StatusDot

--- a/web-ui/src/components/layout/LeftSidebar.tsx
+++ b/web-ui/src/components/layout/LeftSidebar.tsx
@@ -363,12 +363,21 @@ export function LeftSidebar({ api, collapsed = false, isMobile = false, onWorktr
                         data-active={activeWorktreeId === w.id}
                         style={{ position: "relative" }}
                         title={collapsed ? `${w.branch} — select worktree` : undefined}
+                        role="button"
+                        tabIndex={0}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            void selectWorktree(p.id, w);
+                          }
+                        }}
                       >
                         <Link
                           to={`/worktree/${w.id}`}
                           className="wt-row__stretch-link"
                           aria-label={`Open worktree ${w.branch}`}
                           onClick={() => selectWorktree(p.id, w)}
+                          tabIndex={-1}
                         />
                         <div className="wt-row__expand" style={{ position: "relative", zIndex: 1 }}>
                           {!collapsed ? (
@@ -482,7 +491,7 @@ export function LeftSidebar({ api, collapsed = false, isMobile = false, onWorktr
         title="Dismiss worktree?"
         message={
           pendingDismiss
-            ? `Remove “${pendingDismiss.branch}” from vst tracking? Files and git branch stay on disk.`
+            ? `Remove “${pendingDismiss.branch}” from vst tracking? Files and git branch stay on disk. Any running sessions will be stopped.`
             : ""
         }
         confirmLabel="Dismiss"

--- a/web-ui/src/components/layout/LeftSidebar.tsx
+++ b/web-ui/src/components/layout/LeftSidebar.tsx
@@ -285,7 +285,7 @@ export function LeftSidebar({ api, collapsed = false, isMobile = false, onWorktr
             setMobileSidebarOpen(false);
           }}
         >
-          vibe-station
+          Vibe Station
         </Link>
       ) : null}
       <div

--- a/web-ui/src/components/layout/LeftSidebar.tsx
+++ b/web-ui/src/components/layout/LeftSidebar.tsx
@@ -2,7 +2,7 @@ import { ChevronDown, ChevronRight, FolderTree, Moon, MoreHorizontal, Plus, Slid
 import { useTheme } from "@/hooks/useTheme";
 import { createPortal } from "react-dom";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import type { ApiInstance } from "@/api";
 import type { Project, Session, SessionState, Worktree } from "@/api/types";
 import { useWorkspaceStore } from "@/hooks/useStore";
@@ -49,11 +49,12 @@ interface LeftSidebarProps {
   api: ApiInstance;
   /** Narrow desktop rail: abbreviated labels + compact controls */
   collapsed?: boolean;
+  /** Mobile drawer: show pinned brand link at top */
+  isMobile?: boolean;
   onWorktreeSelected?: (wtId: string) => void;
 }
 
-export function LeftSidebar({ api, collapsed = false, onWorktreeSelected }: LeftSidebarProps) {
-  const navigate = useNavigate();
+export function LeftSidebar({ api, collapsed = false, isMobile = false, onWorktreeSelected }: LeftSidebarProps) {
   const location = useLocation();
   const { theme, toggleTheme, toggleFont } = useTheme();
   const [projects, setProjects] = useState<Project[]>([]);
@@ -69,6 +70,7 @@ export function LeftSidebar({ api, collapsed = false, onWorktreeSelected }: Left
 
   const { activeWorktreeId, activeProjectId, activeSessionId, setActiveWorktree } = useLayout();
   const clearWorkspaceSelection = useWorkspaceStore((s) => s.clearWorkspaceSelection);
+  const setMobileSidebarOpen = useWorkspaceStore((s) => s.setMobileSidebarOpen);
   const sessionStates = useWorkspaceStore((s) => s.sessionStates);
   const patchSessionState = useWorkspaceStore((s) => s.patchSessionState);
   const syncSessionsFromApi = useWorkspaceStore((s) => s.syncSessionsFromApi);
@@ -78,6 +80,7 @@ export function LeftSidebar({ api, collapsed = false, onWorktreeSelected }: Left
   const [newSessProject, setNewSessProject] = useState<Project | null>(null);
   const [wtMenu, setWtMenu] = useState<{ projectId: string; worktree: Worktree; rect: DOMRect } | null>(null);
   const [pendingDelete, setPendingDelete] = useState<Worktree | null>(null);
+  const [pendingDismiss, setPendingDismiss] = useState<Worktree | null>(null);
   const refreshProjects = useCallback(async () => {
     const ps = await api.listProjects();
     setProjects(ps);
@@ -215,6 +218,21 @@ export function LeftSidebar({ api, collapsed = false, onWorktreeSelected }: Left
     }
   }
 
+  async function confirmDismissWorktree() {
+    if (!pendingDismiss) return;
+    const worktree = pendingDismiss;
+    setPendingDismiss(null);
+    try {
+      await api.dismissWorktree(worktree.id);
+      if (activeWorktreeId === worktree.id) {
+        clearWorkspaceSelection();
+      }
+      await refreshProjects();
+    } catch {
+      /* surface errors later */
+    }
+  }
+
   useEffect(() => {
     try {
       localStorage.setItem("sidebar:openProj", JSON.stringify([...openProj]));
@@ -250,11 +268,26 @@ export function LeftSidebar({ api, collapsed = false, onWorktreeSelected }: Left
     onWorktreeSelected?.(w.id);
   }
 
+  const isSettings = location.pathname === "/settings";
+
   return (
     <div
       className={`left-sidebar ${collapsed ? "left-sidebar--collapsed" : ""}`}
       style={{ display: "flex", flexDirection: "column", height: "100%", minHeight: 0 }}
     >
+      {(isMobile || !collapsed) ? (
+        <Link
+          to="/"
+          className="left-sidebar__brand"
+          aria-label="Home"
+          onClick={() => {
+            clearWorkspaceSelection();
+            if (isMobile) setMobileSidebarOpen(false);
+          }}
+        >
+          vibe-station
+        </Link>
+      ) : null}
       <div
         className="left-sidebar__scroll"
         style={{ flex: 1, overflow: "auto", padding: collapsed ? "var(--space-1)" : "var(--space-2)" }}
@@ -328,19 +361,16 @@ export function LeftSidebar({ api, collapsed = false, onWorktreeSelected }: Left
                       <div
                         className="tree-row tree-row--worktree"
                         data-active={activeWorktreeId === w.id}
-                        onClick={() => void selectWorktree(p.id, w)}
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter" || e.key === " ") {
-                            e.preventDefault();
-                            void selectWorktree(p.id, w);
-                          }
-                        }}
-                        role="button"
-                        tabIndex={0}
-                        aria-label={`Select worktree ${w.branch}`}
+                        style={{ position: "relative" }}
                         title={collapsed ? `${w.branch} — select worktree` : undefined}
                       >
-                        <div className="wt-row__expand">
+                        <Link
+                          to={`/worktree/${w.id}`}
+                          className="wt-row__stretch-link"
+                          aria-label={`Open worktree ${w.branch}`}
+                          onClick={() => selectWorktree(p.id, w)}
+                        />
+                        <div className="wt-row__expand" style={{ position: "relative", zIndex: 1 }}>
                           {!collapsed ? (
                             <span className="wt-leading-slot" aria-hidden>
                               <StatusDot
@@ -353,7 +383,7 @@ export function LeftSidebar({ api, collapsed = false, onWorktreeSelected }: Left
                           </span>
                         </div>
                         {!collapsed ? (
-                          <div className="wt-row__trail">
+                          <div className="wt-row__trail" style={{ position: "relative", zIndex: 2 }}>
                             <span className="wt-row__id" title={w.id}>
                               {w.id}
                             </span>
@@ -388,33 +418,39 @@ export function LeftSidebar({ api, collapsed = false, onWorktreeSelected }: Left
         ))}
       </div>
       <div className="left-sidebar__footer">
-        <button
-          type="button"
-          className={location.pathname === "/settings" ? "icon-btn icon-btn--active" : "icon-btn"}
+        <Link
+          to="/settings"
+          className={`left-sidebar__nav-item${isSettings ? " left-sidebar__nav-item--active" : ""}`}
           title="Settings"
           aria-label="Settings"
-          onClick={() => navigate("/settings")}
+          aria-current={isSettings ? "page" : undefined}
+          onClick={() => {
+            if (isMobile) setMobileSidebarOpen(false);
+          }}
         >
-          <SlidersHorizontal size={16} />
-        </button>
-        <button
-          type="button"
-          className="icon-btn"
-          aria-label="Toggle font"
-          title="Font"
-          onClick={toggleFont}
-        >
-          <Type size={16} />
-        </button>
-        <button
-          type="button"
-          className="icon-btn"
-          aria-label="Toggle theme"
-          title={`Theme (${theme})`}
-          onClick={toggleTheme}
-        >
-          <Moon size={16} />
-        </button>
+          <SlidersHorizontal size={16} aria-hidden />
+          {!collapsed ? <span>Settings</span> : null}
+        </Link>
+        <div className="left-sidebar__icon-row">
+          <button
+            type="button"
+            className="icon-btn"
+            aria-label="Toggle font"
+            title="Font"
+            onClick={toggleFont}
+          >
+            <Type size={16} />
+          </button>
+          <button
+            type="button"
+            className="icon-btn"
+            aria-label="Toggle theme"
+            title={`Theme (${theme})`}
+            onClick={toggleTheme}
+          >
+            <Moon size={16} />
+          </button>
+        </div>
       </div>
 
       {newSessProject ? (
@@ -441,6 +477,19 @@ export function LeftSidebar({ api, collapsed = false, onWorktreeSelected }: Left
         onCancel={() => setPendingDelete(null)}
       />
 
+      <ConfirmDialog
+        open={pendingDismiss !== null}
+        title="Dismiss worktree?"
+        message={
+          pendingDismiss
+            ? `Remove “${pendingDismiss.branch}” from vst tracking? Files and git branch stay on disk.`
+            : ""
+        }
+        confirmLabel="Dismiss"
+        onConfirm={() => void confirmDismissWorktree()}
+        onCancel={() => setPendingDismiss(null)}
+      />
+
       {wtMenu
         ? createPortal(
             <div
@@ -462,6 +511,37 @@ export function LeftSidebar({ api, collapsed = false, onWorktreeSelected }: Left
                 zIndex: 4000,
               }}
             >
+              <button
+                type="button"
+                role="menuitem"
+                className="menu-pop__item"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void (async () => {
+                    try {
+                      await api.markWorktreeDone(wtMenu.worktree.id);
+                      await refreshProjects();
+                    } catch {
+                      /* surface errors later */
+                    }
+                    setWtMenu(null);
+                  })();
+                }}
+              >
+                Mark as done
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                className="menu-pop__item"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setPendingDismiss(wtMenu.worktree);
+                  setWtMenu(null);
+                }}
+              >
+                Dismiss (keep files)
+              </button>
               <button
                 type="button"
                 role="menuitem"

--- a/web-ui/src/components/layout/LeftSidebar.tsx
+++ b/web-ui/src/components/layout/LeftSidebar.tsx
@@ -275,14 +275,14 @@ export function LeftSidebar({ api, collapsed = false, isMobile = false, onWorktr
       className={`left-sidebar ${collapsed ? "left-sidebar--collapsed" : ""}`}
       style={{ display: "flex", flexDirection: "column", height: "100%", minHeight: 0 }}
     >
-      {(isMobile || !collapsed) ? (
+      {isMobile ? (
         <Link
           to="/"
           className="left-sidebar__brand"
           aria-label="Home"
           onClick={() => {
             clearWorkspaceSelection();
-            if (isMobile) setMobileSidebarOpen(false);
+            setMobileSidebarOpen(false);
           }}
         >
           vibe-station
@@ -360,7 +360,7 @@ export function LeftSidebar({ api, collapsed = false, isMobile = false, onWorktr
                     <div key={w.id} className="wt-row-wrap">
                       <div
                         className="tree-row tree-row--worktree"
-                        data-active={activeWorktreeId === w.id}
+                        data-active={activeWorktreeId === w.id && location.pathname.startsWith("/worktree/")}
                         style={{ position: "relative" }}
                         title={collapsed ? `${w.branch} — select worktree` : undefined}
                         role="button"

--- a/web-ui/src/components/layout/TerminalPane.test.tsx
+++ b/web-ui/src/components/layout/TerminalPane.test.tsx
@@ -17,6 +17,7 @@ vi.mock("@xterm/xterm", () => ({
     get rows() { return mockRows; }
     element = null;
     open() {}
+    focus() {}
     write = writeSpy;
     writeln() {}
     reset() {}

--- a/web-ui/src/components/layout/TopBar.tsx
+++ b/web-ui/src/components/layout/TopBar.tsx
@@ -30,7 +30,7 @@ function shortcutHints() {
 
 interface TopBarProps {
   /** Dashboard keeps projects sidebar; omits quick open, terminal layout, and pane toggles. */
-  layoutMode?: "workspace" | "dashboard";
+  layoutMode?: "workspace" | "dashboard" | "settings";
   projects: Project[];
   worktrees: Worktree[];
   sessions: Session[];
@@ -92,6 +92,8 @@ export function TopBar({
   const crumbParts: { label: string; highlight?: boolean }[] = [];
   if (layoutMode === "dashboard") {
     crumbParts.push({ label: "Dashboard" });
+  } else if (layoutMode === "settings") {
+    crumbParts.push({ label: "Settings" });
   } else {
     if (project) crumbParts.push({ label: project.name });
     if (wt) crumbParts.push({ label: wt.branch, highlight: true });
@@ -103,7 +105,9 @@ export function TopBar({
   const mobileTitle =
     layoutMode === "dashboard"
       ? "Dashboard"
-      : [project?.name, wt ? `${wt.id} ${wt.branch}` : null].filter(Boolean).join(" · ") || undefined;
+      : layoutMode === "settings"
+        ? "Settings"
+        : [project?.name, wt ? `${wt.id} ${wt.branch}` : null].filter(Boolean).join(" · ") || undefined;
 
   const crumbNode = crumbParts.length === 0 ? (
     <span className="top-bar__crumb-seg">—</span>
@@ -154,6 +158,8 @@ export function TopBar({
         <div className="top-bar__crumb top-bar__crumb--mobile-stack" title={mobileTitle}>
           {layoutMode === "dashboard" ? (
             <span className="top-bar__crumb-seg top-bar__mobile-line">Dashboard</span>
+          ) : layoutMode === "settings" ? (
+            <span className="top-bar__crumb-seg top-bar__mobile-line">Settings</span>
           ) : (
             <>
               <span className="top-bar__crumb-seg top-bar__mobile-line">{project?.name ?? "—"}</span>

--- a/web-ui/src/components/layout/TopBar.tsx
+++ b/web-ui/src/components/layout/TopBar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import {
   Columns2,
   PanelLeft,
@@ -54,7 +54,6 @@ export function TopBar({
   onOpenQuickOpen,
   leftColumnPx,
 }: TopBarProps) {
-  const navigate = useNavigate();
   const {
     activeProjectId,
     activeWorktreeId,
@@ -71,11 +70,6 @@ export function TopBar({
 
   const hints = shortcutHints();
 
-  function goHome() {
-    clearWorkspaceSelection();
-    navigate("/", { replace: true });
-  }
-
   const treeOn = !paneCollapsed[0];
   const previewOn = !paneCollapsed[1];
   const terminalOn = !paneCollapsed[2];
@@ -83,7 +77,7 @@ export function TopBar({
   const sidebarExpanded = isMobile ? mobileSidebarOpen : !leftSidebarCollapsed;
 
   // Measure the brand button so we can align the crumb to the sidebar's right edge.
-  const brandRef = useRef<HTMLButtonElement>(null);
+  const brandRef = useRef<HTMLAnchorElement>(null);
   const [brandWidth, setBrandWidth] = useState(0);
   useEffect(() => {
     if (brandRef.current) setBrandWidth(brandRef.current.offsetWidth);
@@ -138,9 +132,16 @@ export function TopBar({
       </button>
       {!isMobile ? (
         <>
-          <button ref={brandRef} type="button" className="top-bar__brand" aria-label="Home" onClick={goHome}>
+          <Link
+            ref={brandRef}
+            to="/"
+            replace
+            className="top-bar__brand"
+            aria-label="Home"
+            onClick={() => clearWorkspaceSelection()}
+          >
             vibe-station
-          </button>
+          </Link>
           <div
             className="top-bar__crumb"
             title={crumbTitle}

--- a/web-ui/src/components/layout/TopBar.tsx
+++ b/web-ui/src/components/layout/TopBar.tsx
@@ -144,7 +144,7 @@ export function TopBar({
             aria-label="Home"
             onClick={() => clearWorkspaceSelection()}
           >
-            vibe-station
+            Vibe Station
           </Link>
           <div
             className="top-bar__crumb"

--- a/web-ui/src/routes/Workspace.tsx
+++ b/web-ui/src/routes/Workspace.tsx
@@ -111,6 +111,7 @@ export function Workspace() {
           <LeftSidebar
             api={api}
             collapsed={!isMobile && leftSidebarCollapsed}
+            isMobile={isMobile}
             onWorktreeSelected={(wtId) => {
               if (isMobile) setMobileSidebarOpen(false);
               if (isDashboard || isSettings) navigate(`/worktree/${wtId}`);

--- a/web-ui/src/routes/Workspace.tsx
+++ b/web-ui/src/routes/Workspace.tsx
@@ -104,7 +104,7 @@ export function Workspace() {
       <Layout
         topBar={
           <TopBar
-            layoutMode={isFullWidthPane ? "dashboard" : "workspace"}
+            layoutMode={isSettings ? "settings" : isDashboard ? "dashboard" : "workspace"}
             projects={bundle.projects}
             worktrees={bundle.worktrees}
             sessions={bundle.sessions}

--- a/web-ui/src/routes/Workspace.tsx
+++ b/web-ui/src/routes/Workspace.tsx
@@ -45,6 +45,18 @@ export function Workspace() {
   useWorkspaceUrlSync(bundleLoaded, bundle.worktrees, bundle.sessions);
   useWorkspaceKeyboardShortcuts(setQuickOpen, !isFullWidthPane);
 
+  // Update browser tab title to reflect current context
+  useEffect(() => {
+    if (isSettings) {
+      document.title = "Settings — vibe-station";
+    } else if (isDashboard || !activeWorktreeId) {
+      document.title = "vibe-station";
+    } else {
+      const wt = bundle.worktrees.find((w) => w.id === activeWorktreeId);
+      document.title = wt ? `${wt.branch} — vibe-station` : "vibe-station";
+    }
+  }, [activeWorktreeId, bundle.worktrees, isDashboard, isSettings]);
+
   // Open the WS eagerly so the ConnectionStatus pill reflects daemon health
   // even before the first session subscription. The api client owns reconnects.
   useEffect(() => {

--- a/web-ui/src/routes/Workspace.tsx
+++ b/web-ui/src/routes/Workspace.tsx
@@ -48,12 +48,12 @@ export function Workspace() {
   // Update browser tab title to reflect current context
   useEffect(() => {
     if (isSettings) {
-      document.title = "Settings — vibe-station";
+      document.title = "Settings — Vibe Station";
     } else if (isDashboard || !activeWorktreeId) {
-      document.title = "vibe-station";
+      document.title = "Vibe Station";
     } else {
       const wt = bundle.worktrees.find((w) => w.id === activeWorktreeId);
-      document.title = wt ? `${wt.branch} — vibe-station` : "vibe-station";
+      document.title = wt ? `${wt.branch} — Vibe Station` : "Vibe Station";
     }
   }, [activeWorktreeId, bundle.worktrees, isDashboard, isSettings]);
 

--- a/web-ui/src/styles/workspace.css
+++ b/web-ui/src/styles/workspace.css
@@ -411,12 +411,14 @@
   gap: var(--space-1);
   margin-bottom: var(--space-2);
   min-height: 32px;
+  /* padding-left matches brand's padding-left (16px) minus scroll-area padding (8px)
+     so "Projects" text left-edge = brand "vibe-station" left-edge */
+  padding-left: var(--space-2);
 }
 
 .sidebar-projects-heading__gutter {
-  /* match tree-row left padding so "Projects" label aligns with the status dot column */
-  width: var(--space-2);
-  flex-shrink: 0;
+  /* hidden — alignment handled by padding-left on the heading itself */
+  display: none;
 }
 
 .sidebar-projects-heading__title {
@@ -518,6 +520,7 @@
   justify-content: center;
   margin-bottom: var(--space-1);
   min-height: 28px;
+  padding-left: 0;
 }
 
 .left-sidebar--collapsed .sidebar-projects-heading__gutter {

--- a/web-ui/src/styles/workspace.css
+++ b/web-ui/src/styles/workspace.css
@@ -414,7 +414,8 @@
 }
 
 .sidebar-projects-heading__gutter {
-  width: 28px;
+  /* match tree-row left padding so "Projects" label aligns with the status dot column */
+  width: var(--space-2);
   flex-shrink: 0;
 }
 
@@ -446,10 +447,11 @@
 
 .left-sidebar__brand {
   display: block;
-  padding: var(--space-3);
+  /* left padding matches scroll-area(8px) + tree-row(8px) so text sits
+     at the same x-position as the status dot column */
+  padding: var(--space-2) var(--space-4);
   font-weight: var(--font-weight-semibold);
   font-size: var(--font-size-base);
-  border-bottom: var(--border-width) solid var(--border-default);
   text-decoration: none;
   color: inherit;
   cursor: pointer;
@@ -489,7 +491,7 @@
 
 .left-sidebar__nav-item--active {
   background: var(--bg-active);
-  color: var(--accent, var(--fg-primary));
+  color: var(--fg-primary);
 }
 
 .left-sidebar--collapsed .left-sidebar__nav-item {

--- a/web-ui/src/styles/workspace.css
+++ b/web-ui/src/styles/workspace.css
@@ -2536,7 +2536,7 @@
 
 .dashboard-header {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: var(--space-4);
   padding-bottom: var(--space-6);
   border-bottom: var(--border-width) solid var(--border-default);

--- a/web-ui/src/styles/workspace.css
+++ b/web-ui/src/styles/workspace.css
@@ -729,7 +729,9 @@
 .wt-row__stretch-link {
   position: absolute;
   inset: 0;
-  z-index: 0;
+  /* z-index 1 puts the link above normal-flow content so mouse clicks land
+     here. wt-row__trail is z-index 2 so the ⋯ button stays above it. */
+  z-index: 1;
   text-decoration: none;
   color: transparent;
 }

--- a/web-ui/src/styles/workspace.css
+++ b/web-ui/src/styles/workspace.css
@@ -2530,7 +2530,8 @@
 }
 
 .dashboard-panel__inner--kanban {
-  max-width: none;
+  /* 3 columns × ~260px + 2 gaps × 12px + some breathing room */
+  max-width: 900px;
 }
 
 .dashboard-header {

--- a/web-ui/src/styles/workspace.css
+++ b/web-ui/src/styles/workspace.css
@@ -2547,10 +2547,10 @@
 }
 
 .dashboard-header__wordmark {
-  font-size: var(--font-size-xl);
-  font-weight: var(--font-weight-semibold);
-  color: var(--fg-primary);
-  letter-spacing: -0.02em;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--fg-muted);
+  letter-spacing: 0;
 }
 
 .dashboard-header__daemon {

--- a/web-ui/src/styles/workspace.css
+++ b/web-ui/src/styles/workspace.css
@@ -444,13 +444,64 @@
   color: var(--fg-muted);
 }
 
+.left-sidebar__brand {
+  display: block;
+  padding: var(--space-3);
+  font-weight: var(--font-weight-semibold);
+  font-size: var(--font-size-base);
+  border-bottom: var(--border-width) solid var(--border-default);
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.left-sidebar__brand:hover {
+  background: var(--bg-hover);
+}
+
 .left-sidebar__footer {
   display: flex;
-  justify-content: center;
-  align-items: center;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--space-1);
   padding: var(--space-2);
   border-top: var(--border-width) solid var(--border-default);
   flex-shrink: 0;
+}
+
+.left-sidebar__nav-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  text-decoration: none;
+  color: inherit;
+  width: 100%;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  box-sizing: border-box;
+}
+
+.left-sidebar__nav-item:hover {
+  background: var(--bg-hover);
+}
+
+.left-sidebar__nav-item--active {
+  background: var(--bg-active);
+  color: var(--accent, var(--fg-primary));
+}
+
+.left-sidebar--collapsed .left-sidebar__nav-item {
+  padding: var(--space-1);
+  justify-content: center;
+}
+
+.left-sidebar__icon-row {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: var(--space-1);
 }
 
 
@@ -668,6 +719,14 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
+}
+
+.wt-row__stretch-link {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  text-decoration: none;
+  color: transparent;
 }
 
 .wt-row__id {
@@ -2463,12 +2522,21 @@
   gap: var(--space-8);
 }
 
+.dashboard-panel__inner--kanban {
+  max-width: none;
+}
+
 .dashboard-header {
   display: flex;
   align-items: baseline;
   gap: var(--space-4);
   padding-bottom: var(--space-6);
   border-bottom: var(--border-width) solid var(--border-default);
+}
+
+.dashboard-header__view-toggle {
+  margin-left: auto;
+  flex-shrink: 0;
 }
 
 .dashboard-header__wordmark {
@@ -2511,6 +2579,23 @@
   gap: var(--space-1);
 }
 
+.dashboard-card-shell {
+  position: relative;
+}
+
+.dashboard-card-shell--dismissable:hover .dashboard-card__dismiss {
+  opacity: 1;
+}
+
+.dashboard-card__dismiss {
+  position: absolute;
+  top: var(--space-1);
+  right: var(--space-1);
+  z-index: 2;
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+}
+
 .dashboard-card {
   display: flex;
   align-items: center;
@@ -2531,6 +2616,11 @@
 .dashboard-card--session:hover {
   background: var(--bg-hover);
   border-color: var(--border-strong);
+}
+
+a.dashboard-card.dashboard-card--session {
+  text-decoration: none;
+  color: inherit;
 }
 
 .dashboard-card__dot {
@@ -2579,6 +2669,55 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.dashboard-card__dot--status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.dashboard-card__dot--status .status-dot {
+  font-size: var(--font-size-xs);
+}
+
+.dashboard-kanban {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-3);
+  align-items: start;
+  width: 100%;
+}
+
+.dashboard-kanban__col {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.dashboard-kanban__col-header {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding-bottom: var(--space-1);
+}
+
+.dashboard-kanban__col-count {
+  font-weight: var(--font-weight-normal);
+}
+
+.dashboard-kanban .dashboard-card {
+  min-width: 0;
+  word-break: break-word;
+}
+
+@media (max-width: 600px) {
+  .dashboard-kanban {
+    grid-template-columns: 1fr;
+  }
 }
 
 .dashboard-empty {


### PR DESCRIPTION
## Summary

A broad set of UI improvements across the sidebar, dashboard, and CLI, plus two daemon bug fixes.

### Sidebar
- **"Vibe Station" brand** in top bar and sidebar (mobile only — desktop already has it in the top bar); brand is a `<Link>` so Ctrl/Cmd+click opens home in a new tab
- **Settings as labeled nav row** above the Font/Theme icon pair, with active highlight; replaces the icon-only button
- **Worktree rows as stretch-links** — entire row is clickable via an absolute `<Link>` overlay (z-index 1), trail/⋯ button sits at z-index 2 above it; keyboard nav preserved via `onKeyDown` on outer div; Ctrl/Cmd+click opens worktree in a new tab
- **Active highlight cleared** when navigating to Settings or Dashboard (guarded by `location.pathname.startsWith("/worktree/")`)

### Dashboard
- **Worktree-centric layout** — shows worktrees (not sessions), branch name as primary label, `vs-N` chip as secondary; terminal-only worktrees excluded
- **Three status sections**: Working · Idle · Finished (done/exited merged), hidden when empty
- **Kanban view** — toggle (desktop only, remembered in localStorage) switches to 3-column grid; collapses to list layout on mobile (≤600px) and toggle is hidden; max-width 900px
- **Projects section** restored below worktree sections
- Empty-state message when no agent worktrees exist

### Worktree lifecycle
- New `POST /worktrees/:id/done` daemon endpoint — marks all agent sessions as `done`, broadcasts `session:state` per session, persists via `persistLifecycleState`
- New `vst worktree done <id>` CLI command
- **"Mark as done"** and **"Dismiss (keep files)"** actions in the sidebar ⋯ menu
- `dismissWorktree` API method — calls `DELETE /worktrees/:id` without `?purge` (files + branch stay on disk)

### CLI
- `vst worktree rm` — after the existing name-confirmation, prompts "Also delete files from disk? [y/N]"; Ctrl+C at the prompt cancels cleanly; `--purge` flag skips the new prompt

### Bug fixes
- **File watcher and tree watcher** — both handlers had a hardcoded `"test"` project path placeholder; replaced with `getAllProjects()` + `worktreePath()` lookups. This was why file preview and file tree weren't updating in real time when an agent edited files.
- **TopBar**: brand `<button>` → `<Link>` with correct `HTMLAnchorElement` ref type

### Polish
- `layoutMode="settings"` added to TopBar so breadcrumb shows "Settings" not "Dashboard"
- Browser tab title updates: `branch — Vibe Station` · `Settings — Vibe Station` · `Vibe Station`
- Dashboard header `align-items: baseline` → `center` (icon toggle was misaligned)
- Dashboard wordmark reduced to `font-size-sm / muted` (subtle label, not a heading)
- Kanban max-width 900px to match list view's proportional constraint

## Test plan

- [ ] Sidebar brand visible on mobile, hidden on desktop (top bar has it there)
- [ ] Ctrl+click worktree row opens in new tab; ⋯ menu still works
- [ ] Ctrl+click Settings nav item opens `/settings` in new tab
- [ ] Active highlight clears when navigating to Settings or Dashboard
- [ ] Dashboard list/kanban toggle hidden on mobile, remembered on desktop
- [ ] Kanban 3-col on desktop, single-col on mobile
- [ ] Dismiss (keep files) removes worktree from sidebar, files stay on disk
- [ ] Mark as done updates status dot to ✓ without page reload
- [ ] `vst worktree rm vs-N` prompts for purge; Ctrl+C cancels without deleting
- [ ] `vst worktree done vs-N` marks sessions done
- [ ] Open a file in preview; have an agent edit it — preview reloads automatically
- [ ] File tree refreshes when agent creates/deletes a file
- [ ] Browser tab shows correct title for each route

🤖 Generated with [Claude Code](https://claude.com/claude-code)