### PR TITLE
feat(sidebar): pin worktrees to a dedicated section at top of sidebar

### DIFF
--- a/.feature-plans/done/worktree-pinning.md
+++ b/.feature-plans/done/worktree-pinning.md
@@ -1,0 +1,418 @@
+# Mini-Design: Worktree Pinning in Sidebar
+
+> Let users pin any worktree to a dedicated "Pinned" section at the top of the LeftSidebar via the existing 3-dot menu.
+
+**Issue:** worktree-pinning
+**Branch:** `Worktree-pinning`
+**Status:** Done
+
+**Reference files:**
+- Sidebar UI: `web-ui/src/components/layout/LeftSidebar.tsx`
+- Sidebar CSS: `web-ui/src/styles/workspace.css` (~line 408+, 680–810)
+- Server store types: `daemon/src/types.ts:36` (`WorktreeRecord`)
+- Server routes: `daemon/src/routes/worktrees.ts` (`serializeWorktree:108`, `done:381`, `delete:398`)
+- Server WS protocol: `daemon/src/ws/protocol.ts:190–198`
+- Server data layer: `daemon/src/state/project-store.ts` (`mutateProject:67`)
+- Client API: `web-ui/src/api/client.ts:218–247`, mock at `web-ui/src/api/mock.ts:278–306`
+- Client API types: `web-ui/src/api/types.ts` (`Worktree`)
+- Client server-state store: `web-ui/src/hooks/useServerStore.ts`
+- Client server-sync: `web-ui/src/hooks/useServerSync.ts`
+- Workspace store (client-only UI prefs): `web-ui/src/hooks/useStore.ts`
+
+---
+
+## Problem
+
+- Users with many worktrees across multiple projects must scroll/expand projects to find frequently-used ones.
+- No way to surface a small "favorites" list of worktrees they're actively working on.
+
+## Out of Scope
+
+- Drag-to-reorder pinned worktrees (order = `pinnedAt DESC`, deterministic).
+- Pinning entire projects.
+- Pinning in the collapsed rail (collapsed sidebar still shows only the existing project tree).
+- Mobile-specific tweaks beyond what falls out for free.
+- Per-user pinning (single-user daemon; pin is a property of the worktree itself).
+
+## Concept
+
+- Add a server-side `pinnedAt: string | null` (ISO8601) field on `WorktreeRecord`. Null = not pinned. The timestamp also gives us free recency-based ordering (newest pinned first).
+- New endpoint `PATCH /worktrees/:id/pin` with body `{ pinned: boolean }` that toggles the field and broadcasts a `worktree:updated` WS event.
+- Add `pinWorktree` / `unpinWorktree` client API methods + mock parity.
+- Add **Pin to top** / **Unpin** menu item in the existing 3-dot worktree menu (label flips based on `pinnedAt`).
+- Render a new **"Pinned"** section at the top of the sidebar scroll area when at least one pinned worktree exists, above the **Projects** heading.
+- Pinned rows show two-line content: branch (top) + project name (subheader), with the worktree id chip on the right that swaps to the same 3-dot menu on hover (same UX pattern as today).
+- Pinned rows still link to `/worktree/:id` and reuse `setActiveWorktree` for selection.
+- Pin state syncs across browser tabs / devices via the WS `worktree:updated` event handled by `useServerSync`.
+
+## Requirements
+
+| # | Requirement |
+|---|-------------|
+| 1 | Pin / unpin from the existing 3-dot menu on every worktree row in the project tree. |
+| 2 | Pinned worktrees appear in a dedicated "Pinned" section at the top of the sidebar. |
+| 3 | Pinned row is two-line: branch name on top, project name on the subline. |
+| 4 | Right side shows worktree id by default; on hover/focus the id fades out and the 3-dot menu (with **Unpin** + all existing actions) fades in — same animation/CSS as today's `tree-row--worktree`. |
+| 5 | Pinned section disappears entirely when no worktrees are pinned (no empty heading). |
+| 6 | Pin state is server-authoritative: persists in `~/.vibe-station/projects/<id>/manifest.json`. |
+| 7 | Worktree still appears in its project tree even when pinned (it is NOT moved, only mirrored). |
+| 8 | Deleting a worktree naturally removes its pin (the record disappears). No special-case needed. |
+| 9 | Pin/unpin from one tab/device propagates to others via the `worktree:updated` WS event. |
+| 10 | Collapsed rail is unchanged (no pinned section in collapsed mode). |
+| 11 | `GET /worktrees` response includes `pinnedAt` (null or ISO) so initial render is correct without an extra round-trip. |
+
+---
+
+## Research
+
+### Server data model
+
+- **File:** `daemon/src/types.ts:36–43` — `WorktreeRecord` fields: `id`, `branch`, `baseBranch`, `baseSha`, `createdAt`, `sessions`.
+- Adding `pinnedAt?: string | null` is backward compatible (optional in TS, missing in old manifests reads as `undefined` ≈ unpinned).
+- Persistence: `mutateProject` (`daemon/src/state/project-store.ts:67`) writes manifest atomically. Existing pattern.
+- **Risk:** LOW.
+
+### Existing 3-dot menu
+
+- **File:** `web-ui/src/components/layout/LeftSidebar.tsx:478–546`
+- Portal-rendered, positioned via `wtMenu.rect`. Three items today: Mark as done / Dismiss / Delete.
+- Hover-swap CSS for id ↔ menu trigger: `web-ui/src/styles/workspace.css:740–776`.
+- **Risk:** LOW — adding a fourth menuitem above existing items is straightforward.
+
+### Sidebar render loop
+
+- **File:** `web-ui/src/components/layout/LeftSidebar.tsx:287–403`
+- Projects are mapped under a single scroll container at `:253–404`. The "Projects" heading is at `:257`.
+- A new "Pinned" section needs to be inserted BEFORE that heading and AFTER the optional mobile brand link at `:238`.
+- **Risk:** LOW — pure additive insertion.
+
+### Server routes — existing worktree mutators
+
+- **File:** `daemon/src/routes/worktrees.ts:381–395` (`POST /worktrees/:id/done`) — pattern for mutating a worktree and broadcasting.
+- `serializeWorktree` (`:108–117`) is the single canonical client shape. Add `pinnedAt: w.pinnedAt ?? null` here so every response (list, create, update) ships it consistently.
+- **Risk:** LOW.
+
+### WS protocol
+
+- **File:** `daemon/src/ws/protocol.ts:190–198`
+- Existing `worktree:created` and `worktree:deleted` events use `{ worktree: record }` and `{ worktreeId }` shapes.
+- Add `worktree:updated` with `{ worktree: serializeWorktree(...) }` — same shape as `worktree:created`, semantically distinct.
+- **Risk:** LOW.
+
+### Client server-store + sync
+
+- **File:** `web-ui/src/hooks/useServerStore.ts` — flat `worktrees: Worktree[]` array.
+- **File:** `web-ui/src/hooks/useServerSync.ts` — handles `worktree:created` / `worktree:deleted`. New `worktree:updated` handler must replace-by-id (immutable update preserving array order).
+- `Worktree` type in `web-ui/src/api/types.ts` gains `pinnedAt: string | null`.
+- **Risk:** LOW.
+
+### Client API + mock
+
+- **File:** `web-ui/src/api/client.ts:218–247` — existing pattern (e.g. `markWorktreeDone`).
+- **File:** `web-ui/src/api/mock.ts:278–306` — must add mock parity to avoid breaking tests using the in-memory mock.
+- **Risk:** LOW.
+
+### LeftSidebar local state
+
+- **File:** `web-ui/src/components/layout/LeftSidebar.tsx`
+- No client-side persistence is added. The pinned section just reads `useServerStore.worktrees.filter(w => w.pinnedAt).sort by pinnedAt desc`.
+- **Risk:** LOW.
+
+---
+
+## Architecture
+
+```
+Daemon
+   ├── WorktreeRecord                       ← new optional pinnedAt: string | null
+   ├── serializeWorktree                    ← always emits pinnedAt (defaults to null)
+   ├── PATCH /worktrees/:id/pin             ← body { pinned: boolean } → mutateProject → broadcast
+   └── WS "worktree:updated" { worktree }   ← new event, same shape as worktree:created
+
+Web client
+   ├── api.pinWorktree(id) / unpinWorktree(id)   ← thin wrappers over PATCH
+   ├── api/types.Worktree { ..., pinnedAt: string | null }
+   ├── useServerSync                              ← handles worktree:updated (replace-by-id)
+   └── LeftSidebar
+        ├── PinnedSection (derived from worktrees.filter(pinnedAt).sort desc)
+        └── ⋯ menu adds Pin/Unpin (label by pinnedAt) — calls api.pinWorktree/unpinWorktree
+```
+
+---
+
+## Design Details
+
+### Critical User Journeys (CUJs)
+
+#### CUJ 1 — Pin a worktree
+
+```
+User opens sidebar → Hovers row "feat/new-login" in project "alpha"
+  → Clicks ⋯ → menu opens with "Pin to top"
+  → Client calls api.pinWorktree(id)
+       → PATCH /worktrees/:id/pin { pinned: true }
+       → Daemon mutates record: pinnedAt = ISO now → writes manifest
+       → Daemon broadcasts worktree:updated
+  → useServerSync replaces the worktree in useServerStore.worktrees
+  → "Pinned" section appears at top with the row
+  → Row in project tree still present; its menu now reads "Unpin"
+```
+
+- **Edge:** PATCH with `{ pinned: true }` on an already-pinned worktree returns 200 OK without changing `pinnedAt`. Idempotent.
+- **Edge:** First pin ever → "Pinned" heading appears.
+- **Error:** Network failure → menu closes anyway; the next list refresh re-syncs. Surface errors later (matches existing dismiss/delete patterns).
+
+#### CUJ 2 — Unpin (from either place)
+
+```
+User clicks ⋯ on pinned row → menu reads "Unpin"
+  → api.unpinWorktree(id) → PATCH ... { pinned: false } → pinnedAt = null
+  → worktree:updated broadcast → row disappears from pinned section
+  → If last pinned worktree, section unmounts
+```
+
+#### CUJ 3 — Worktree deleted while pinned
+
+```
+User deletes pinned worktree X via ⋯ → Delete
+  → DELETE /worktrees/X
+  → Daemon removes the record (no special pin handling needed)
+  → broadcasts worktree:deleted
+  → useServerStore.worktrees shrinks → pinned-section derivation drops it naturally
+```
+
+#### CUJ 4 — Cross-tab sync
+
+```
+Two tabs open on same daemon
+  → User pins in tab A → PATCH → worktree:updated broadcast
+  → Both tabs' useServerSync receive the event and update the local store
+  → Tab B's pinned section updates without reload
+```
+
+### Data Model
+
+| Entity | Field | Type | Constraints | Notes |
+|--------|-------|------|-------------|-------|
+| `WorktreeRecord` (daemon) | `pinnedAt?` | `string \| undefined` | optional ISO8601 | Absent / undefined ≡ unpinned. |
+| `Worktree` (web `api/types.ts`) | `pinnedAt` | `string \| null` | required field, `null` ≡ unpinned | Always present in API response (`serializeWorktree` normalizes). |
+
+- **Migration:** None — `WorktreeRecord.pinnedAt` is optional, so manifests written before this change rehydrate as `undefined` and serialize as `null`. Old daemons + new clients are forward-compatible because clients only render the pinned section when `pinnedAt != null`.
+
+### API Contracts
+
+```
+PATCH /worktrees/:id/pin
+  Request:  { pinned: boolean }
+  Response: { ok: true, worktree: SerializedWorktree }
+  Errors:   400 invalid body, 404 worktree not found
+
+GET /worktrees                       (existing) — response items now include `pinnedAt: string | null`
+GET /worktrees?project=<id>          (existing) — same
+POST /worktrees                      (existing) — response now includes `pinnedAt: null` on a new worktree
+
+WS event:
+  { type: "worktree:updated", worktree: SerializedWorktree }
+```
+
+- **Authorization:** No new policy. Pinning has the same trust boundary as marking done.
+
+### Key Decisions
+
+#### Decision 1: Server-side, single optional field
+
+- **Decision:** `WorktreeRecord.pinnedAt?: string`. Single nullable timestamp encodes both "is pinned" and "pin recency" — no separate boolean + order field.
+- **Rationale:** Smallest possible schema change; deterministic ordering; survives daemon restart automatically through existing manifest persistence.
+- **Where:** `daemon/src/types.ts:36–43`, `daemon/src/routes/worktrees.ts:108–117` (serializer normalizes to `null`).
+
+#### Decision 2: Pinned section mirrors, not moves
+
+- **Decision:** Pinned worktrees still appear under their project. The pinned row is a second visual presence.
+- **Rationale:** Avoids confusing "where did my worktree go?" and keeps project tree complete for navigation/filtering.
+- **Where:** `LeftSidebar.tsx` new section + unchanged project tree loop.
+
+#### Decision 3: No client-side prune logic needed
+
+- **Decision:** Because pin state lives ON the worktree record, deleting the worktree removes the pin trivially. No client bookkeeping.
+- **Where:** N/A.
+
+#### Decision 3b: `PATCH /worktrees/:id/pin` (not POST /pin and DELETE /pin)
+
+- **Decision:** Single PATCH route with a boolean body, idempotent.
+- **Rationale:** Smaller surface; matches REST patterns; mirrors the "single endpoint with a flag" style used in many other vst routes.
+
+#### Decision 4: Single shared menu, label flips
+
+- **Decision:** Keep the existing portal menu component. Add **one** new menu item whose label is `"Pin to top"` or `"Unpin"` based on `pinnedWorktreeIds.includes(wtMenu.worktree.id)`.
+- **Rationale:** Avoids duplicating menu JSX for pinned vs. unpinned rows.
+
+#### Decision 5: Pinned row layout — explicit grid, not reused `wt-row` styles
+
+- **Decision:** Pinned row is a 3-column grid: `[dot 16px] [primary+subhead stack 1fr] [trail auto]`. Subhead is smaller (`--font-size-xs`), muted (`--fg-muted`).
+- **Stretch-link adjustment:** the absolute `inset:0` link still works on a taller row; the trail uses `align-self: start; padding-top: 4px` so the id / ⋯ sits at the top-right next to the branch (not vertically centered between the two lines). Override the inherited `wt-menu-trigger { top:50%; translateY(-50%) }` rule with `.pinned-row .wt-menu-trigger { top: 4px; transform: none }` (or use a new class).
+- **Trigger attributes:** the pinned-row ⋯ button MUST set `data-wt-menu-trigger` so the existing outside-click handler in `LeftSidebar.tsx:120–124` correctly excludes it.
+- **Where:** new CSS classes `.pinned-section`, `.pinned-section__heading`, `.pinned-row`, `.pinned-row__primary`, `.pinned-row__subhead`, `.pinned-row__trail`.
+
+```
+┌────────────────────────────────────────────────┐
+│ Pinned                                         │
+│ ┌────────────────────────────────────────────┐ │
+│ │ feat/new-login                       vs-3 │ │  ← hover: vs-3 → ⋯
+│ │ alpha                                      │ │
+│ └────────────────────────────────────────────┘ │
+│ ┌────────────────────────────────────────────┐ │
+│ │ bugfix/auth                          vs-7 │ │
+│ │ beta                                       │ │
+│ └────────────────────────────────────────────┘ │
+└────────────────────────────────────────────────┘
+Projects   ▾ Filter
+  ▾ alpha                                      +
+    • feat/new-login                       vs-3
+  ▾ beta                                       +
+    • bugfix/auth                          vs-7
+```
+
+---
+
+## Files to Modify
+
+### Daemon
+
+| File | Change |
+|------|--------|
+| `daemon/src/types.ts` | Add optional `pinnedAt?: string` to `WorktreeRecord`. |
+| `daemon/src/routes/worktrees.ts` | Update `serializeWorktree` to emit `pinnedAt: w.pinnedAt ?? null`. Add `PATCH /worktrees/:id/pin` handler → `mutateProject` + broadcast `worktree:updated`. |
+| `daemon/src/ws/protocol.ts` | Add `WorktreeUpdatedEvent` and include it in the discriminated union. |
+| `daemon/src/__tests__/worktrees.routes.test.ts` (or sibling) | New tests: PATCH toggles, idempotent, 404 on missing id, 400 on bad body, broadcasts the event. |
+
+### Web client
+
+| File | Change |
+|------|--------|
+| `web-ui/src/api/types.ts` | Add `pinnedAt: string \| null` to `Worktree`; add `worktree:updated` variant to `WSEvent`. |
+| `web-ui/src/api/client.ts` | Add `pinWorktree(id)` / `unpinWorktree(id)` methods (PATCH). |
+| `web-ui/src/api/mock.ts` | Mock parity (mutate in-memory record + emit fake event for test harnesses that use it). |
+| `web-ui/src/hooks/useServerSync.ts` | Handle `worktree:updated` event: replace matching id immutably. |
+| `web-ui/src/components/layout/LeftSidebar.tsx` | Derive pinned list from `worktrees.filter(pinnedAt).sort by pinnedAt desc`; render Pinned section above Projects heading; add Pin/Unpin menu item with label flip; pinned-row ⋯ carries `data-wt-menu-trigger`. |
+| `web-ui/src/styles/workspace.css` | Add `.pinned-section`, `.pinned-row` grid + two-line subhead + `.pinned-row .wt-menu-trigger { top: 4px; transform: none }` override. |
+| `web-ui/src/components/layout/LeftSidebar.test.tsx` | Tests: pin/unpin via menu calls correct API; pinned section visibility; menu label flip; dual-active highlight; `data-wt-menu-trigger` present. |
+| `web-ui/src/api/types-and-client.test.ts` (or sibling) | If applicable: test that `pinWorktree` POSTs the right shape. |
+
+## Risks / Open Questions
+
+| # | Question | Notes |
+|---|----------|-------|
+| 1 | **Pinned order — recency or stable insertion?** | Newest first (prepend on pin). Future drag-to-reorder can change this. |
+| 2 | **Should the "active" indicator apply to pinned row too?** | Yes — same `data-active` rule based on `activeWorktreeId === w.id && location.pathname.startsWith("/worktree/")`. |
+| 3 | **What if pinned section gets very long?** | Sidebar scroll handles it; no max. Could add `max-height` later if needed. |
+| 4 | **Status dot in pinned row?** | Yes — leading slot like existing rows; reuses `worktreeRolledUpStatus`. |
+| 5 | **Collapsed rail behavior?** | Hidden; pinned section not rendered when `collapsed=true`. |
+| 6 | **Test in a docker container — risk to main daemon/app?** | Use `docker-compose.dev.yml` which is explicitly isolated (host port 5174 → container 5173, separate `vst-dev-data` volume, no host bind-mount of daemon data). No interference with the host's running vibe-station. |
+| 7 | **Manifest write race vs. concurrent `markDone` etc.?** | Existing `mutateProject` uses `withProjectLock` — already serialized. Pin PATCH inherits this protection. |
+| 8 | **`worktree:updated` is also semantically right for other future updates** | Yes — naming it generically opens the door, but spec says the only new field for now is `pinnedAt`. Other future updates can reuse the event. |
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Daemon: data + endpoint + event
+
+- [ ] **1.1** Add `pinnedAt?: string` to `WorktreeRecord` in `daemon/src/types.ts:36`.
+- [ ] **1.2** Update `serializeWorktree` in `daemon/src/routes/worktrees.ts:108` to include `pinnedAt: w.pinnedAt ?? null`.
+- [ ] **1.3** Add `PATCH /worktrees/:id/pin` route: validate body `{ pinned: boolean }` with Zod; locate project; `mutateProject` setting/clearing `pinnedAt`; broadcast `{ type: "worktree:updated", worktree: serializeWorktree(...) }`; return `{ ok: true, worktree }`.
+- [ ] **1.4** Add `WorktreeUpdatedEvent` to `daemon/src/ws/protocol.ts` and add it to the union.
+
+**Verify phase 1:**
+- [ ] **1.T1** Unit — route test: PATCH with `{ pinned: true }` writes `pinnedAt` (ISO format), returns 200 with updated worktree.
+- [ ] **1.T2** Unit — route test: PATCH with `{ pinned: false }` clears `pinnedAt` (record has it deleted or set to undefined).
+- [ ] **1.T3** Unit — route test: PATCH is idempotent — pin twice keeps the *first* `pinnedAt` OR re-stamps it (spec the chosen behavior; prefer "no-op when already in the requested state" so cross-tab pins don't bounce timestamps).
+- [ ] **1.T4** Unit — route test: 404 on unknown worktree id; 400 on missing/invalid `pinned`.
+- [ ] **1.T5** Unit — route test: broadcasts `worktree:updated` with the serialized record on success (spy on `broadcastAll`).
+- [ ] **1.T6** Unit — `GET /worktrees` response shape includes `pinnedAt` (null for unpinned, ISO for pinned).
+
+---
+
+### Phase 2 — Web client: types, API, sync
+
+- [ ] **2.1** Add `pinnedAt: string | null` to `Worktree` in `web-ui/src/api/types.ts`.
+- [ ] **2.2** Add `worktree:updated` variant to `WSEvent` in the same file: `{ type: "worktree:updated"; worktree: Worktree }`.
+- [ ] **2.3** Add `pinWorktree(id)` and `unpinWorktree(id)` to `web-ui/src/api/client.ts` — both PATCH `/worktrees/:id/pin` with `{ pinned: true|false }`. Return `Worktree`.
+- [ ] **2.4** Mirror in `web-ui/src/api/mock.ts`: mutate the in-memory worktree, return it. (If the mock supports emitting WS events to subscribers, emit `worktree:updated`; otherwise note this gap for the test plan.)
+- [ ] **2.5** In `web-ui/src/hooks/useServerSync.ts`, handle `worktree:updated`: replace matching id in `useServerStore.worktrees` (immutable map, preserving order).
+
+**Verify phase 2:**
+- [ ] **2.T1** Unit — `api/client.test`: `pinWorktree("w1")` sends PATCH to `/worktrees/w1/pin` with body `{ pinned: true }`.
+- [ ] **2.T2** Unit — `useServerSync.test`: simulate `worktree:updated` event → `useServerStore.worktrees` reflects the updated `pinnedAt` for the matching id; other worktrees untouched.
+- [ ] **2.T3** Unit — `useServerSync.test`: `worktree:updated` for an unknown id is a no-op (does not append).
+
+---
+
+### Phase 3 — Sidebar UI: pinned section + menu wiring
+
+- [ ] **3.1** In `LeftSidebar.tsx`, derive `pinnedWorktrees`: `useServerStore.worktrees.filter(w => w.pinnedAt).sort((a,b) => b.pinnedAt!.localeCompare(a.pinnedAt!))` (ISO sort = chronological).
+- [ ] **3.2** Render `<section class="pinned-section">` ABOVE the `Projects` heading (and below the optional mobile brand link), visible iff `pinnedWorktrees.length > 0` AND `!collapsed`.
+- [ ] **3.3** Render each pinned worktree as `<div class="pinned-row">`:
+  - Status dot via `worktreeRolledUpStatus(sessionMap[w.id] ?? [], sessionStates)`
+  - `.pinned-row__primary` = branch
+  - `.pinned-row__subhead` = `projects.find(p => p.id === w.projectId)?.name`
+  - `.pinned-row__trail` containing `wt-row__id` (worktree id chip) + ⋯ button with `data-wt-menu-trigger`
+  - Stretch link to `/worktree/:id` (same pattern as existing row); on click → `selectWorktree(w.projectId, w)`.
+- [ ] **3.4** Add CSS: `.pinned-section` (container), `.pinned-section__heading` (matches `sidebar-projects-heading` styling), `.pinned-row` (grid: 16px 1fr auto, gap var(--space-1), padding matches `tree-row--worktree`), `.pinned-row__primary` (regular weight), `.pinned-row__subhead` (xs, `--fg-muted`), `.pinned-row__trail` (align-self: start; padding-top: 4px), `.pinned-row:hover .wt-row__id { opacity: 0 }`, `.pinned-row:hover .wt-menu-trigger, .pinned-row .wt-menu-trigger[aria-expanded="true"] { opacity: 1; pointer-events: auto }`, plus `.pinned-row .wt-menu-trigger { top: 4px; transform: none }` override to defeat the inherited vertical-center rule.
+- [ ] **3.5** Both pinned-row and project-tree-row carry `data-active` based on `activeWorktreeId === w.id && location.pathname.startsWith("/worktree/")`.
+- [ ] **3.6** In the portal menu (`LeftSidebar.tsx:478+`), add a new menuitem at the TOP: label = `wtMenu.worktree.pinnedAt ? "Unpin" : "Pin to top"`. Click → `void api.pinWorktree(id)` or `unpinWorktree(id)` (do not block on the response; UI updates from `worktree:updated`). Then `setWtMenu(null)`.
+
+**Verify phase 3:**
+- [ ] **3.T1** Unit — `LeftSidebar.test`: with one pinned worktree in `useServerStore`, "Pinned" section renders and shows branch + project name.
+- [ ] **3.T2** Unit — `LeftSidebar.test`: section is hidden when no worktrees have `pinnedAt`; also hidden when `collapsed=true` even with pins.
+- [ ] **3.T3** Unit — `LeftSidebar.test`: clicking ⋯ on an unpinned project-tree row shows "Pin to top"; clicking it invokes `api.pinWorktree(id)`.
+- [ ] **3.T4** Unit — `LeftSidebar.test`: clicking ⋯ on a pinned row shows "Unpin"; clicking it invokes `api.unpinWorktree(id)`.
+- [ ] **3.T5** Unit — `LeftSidebar.test`: when the active worktree is pinned, both the pinned-row and the project-tree row carry `data-active="true"`.
+- [ ] **3.T6** Unit — `LeftSidebar.test`: pinned-row ⋯ button has `data-wt-menu-trigger`.
+- [ ] **3.T7** Regression — existing menu items (Mark as done / Dismiss / Delete) still render and call their handlers.
+- [ ] **3.T8** Unit — `LeftSidebar.test`: pinned-section order matches `pinnedAt DESC` (newest first).
+
+---
+
+### Phase 4 — Manual verification in docker sandbox
+
+- [ ] **4.1** Boot `docker compose -f docker-compose.dev.yml up --build -d` (port 5174, isolated `vst-dev-*` volumes — does NOT touch the host daemon). Container hot-reloads the FE from `./web-ui/src`; rebuild for daemon code changes.
+- [ ] **4.2** Use the sandbox's pre-seeded projects/worktrees (the `vst-dev-projects` volume persists demo state across rebuilds). If empty, create 2 projects with at least 2 worktrees each via the CLI inside the container.
+- [ ] **4.3** Pin one worktree from each project via the ⋯ menu; full page reload; verify pinned section still shows them (sourced from the daemon manifest, not the browser).
+- [ ] **4.4** Open a second browser tab on the same daemon; pin/unpin from one tab; verify cross-tab sync via WS.
+- [ ] **4.5** Capture a screenshot at `~/Downloads/worktree-pinning.png` (1440x900) via Playwright (`@playwright/test`) — script can mirror `scripts/take-screenshots.ts` patterns. Target URL `http://localhost:5174`.
+
+**Verify phase 4:**
+- [ ] **4.T1** Manual — pinned section appears at top: branch on top, project subheader below; hover swaps id → ⋯; menu reads "Unpin".
+- [ ] **4.T2** Manual — full reload (Ctrl+R, cache disabled): pinned section persists from the daemon.
+- [ ] **4.T3** Manual — delete pinned worktree via menu → pinned row disappears via the existing `worktree:deleted` flow; section hides if last.
+- [ ] **4.T4** Manual — cross-tab: pin in tab A, observe in tab B without reload.
+- [ ] **4.T5** Manual — host machine's running vibe-station (different port) is untouched — verify by opening it after the docker test.
+
+---
+
+## Files Summary
+
+| File | Phase | Change |
+|------|-------|--------|
+| `daemon/src/types.ts` | 1.1 | Add `pinnedAt?: string` to `WorktreeRecord`. |
+| `daemon/src/routes/worktrees.ts` | 1.2, 1.3 | Normalize `pinnedAt` in `serializeWorktree`; add `PATCH /worktrees/:id/pin`. |
+| `daemon/src/ws/protocol.ts` | 1.4 | Add `WorktreeUpdatedEvent` to the union. |
+| `daemon/src/__tests__/worktrees.routes.test.ts` | 1.T1–1.T6 | Daemon route tests. |
+| `web-ui/src/api/types.ts` | 2.1, 2.2 | Add `pinnedAt`, add `worktree:updated` WSEvent variant. |
+| `web-ui/src/api/client.ts` | 2.3 | Add `pinWorktree` / `unpinWorktree` methods. |
+| `web-ui/src/api/mock.ts` | 2.4 | Mock parity. |
+| `web-ui/src/hooks/useServerSync.ts` | 2.5 | Handle `worktree:updated` immutably. |
+| `web-ui/src/components/layout/LeftSidebar.tsx` | 3.1–3.6 | Pinned section + menu wiring. |
+| `web-ui/src/styles/workspace.css` | 3.4 | Pinned section + row + trail override. |
+| `web-ui/src/components/layout/LeftSidebar.test.tsx` | 3.T1–3.T8 | UI tests. |
+| `web-ui/src/hooks/useServerSync.test.ts` (or sibling) | 2.T2, 2.T3 | Sync handler tests. |
+
+---
+
+## Docker testing — isolation guarantees
+
+- `docker-compose.dev.yml` uses host port **5174** (container 5173) — disjoint from the host's running daemon (default 7421) and vite (5173).
+- Named volumes `vst-dev-data` + `vst-dev-projects` keep daemon state inside the container; the host's `~/.vibe-station/` is untouched.
+- CLI binaries are bind-mounted **read-only**, so no host file is modified.
+- Screenshot capture uses a separate Playwright invocation pointed at `http://localhost:5174`; nothing in the screenshot script writes to host vst state.
+- Teardown: `docker compose -f docker-compose.dev.yml down` (keep volumes) or `down -v` (full reset). Never required to touch host daemon.

--- a/daemon/src/__tests__/worktrees.test.ts
+++ b/daemon/src/__tests__/worktrees.test.ts
@@ -456,4 +456,131 @@ describe("Worktree routes", () => {
     expect(sessRes.statusCode).toBe(200);
     expect(sessRes.json<{ state: string }>().state).toBe("done");
   });
+
+  // ─── PATCH /worktrees/:id/pin ───────────────────────────────────────────
+  describe("PATCH /worktrees/:id/pin", () => {
+    async function createWorktree(branchSuffix: string) {
+      const res = await app.inject({
+        method: "POST",
+        url: "/worktrees",
+        payload: { projectId, branch: `pin-${branchSuffix}-${Date.now()}`, modeId: "bug-fix" },
+      });
+      expect(res.statusCode).toBe(201);
+      return res.json<{ id: string; pinnedAt: string | null }>();
+    }
+
+    it("serializes pinnedAt as null for an unpinned worktree", async () => {
+      const wt = await createWorktree("unpinned");
+      expect(wt.pinnedAt).toBeNull();
+    });
+
+    it("PATCH { pinned: true } sets pinnedAt to an ISO timestamp", async () => {
+      const wt = await createWorktree("set");
+      const res = await app.inject({
+        method: "PATCH",
+        url: `/worktrees/${wt.id}/pin`,
+        payload: { pinned: true },
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json<{ ok: boolean; worktree: { id: string; pinnedAt: string | null } }>();
+      expect(body.ok).toBe(true);
+      expect(body.worktree.id).toBe(wt.id);
+      expect(body.worktree.pinnedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    it("PATCH { pinned: false } clears pinnedAt", async () => {
+      const wt = await createWorktree("clear");
+      await app.inject({ method: "PATCH", url: `/worktrees/${wt.id}/pin`, payload: { pinned: true } });
+      const res = await app.inject({
+        method: "PATCH",
+        url: `/worktrees/${wt.id}/pin`,
+        payload: { pinned: false },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json<{ worktree: { pinnedAt: string | null } }>().worktree.pinnedAt).toBeNull();
+    });
+
+    it("is idempotent: pinning twice keeps the original timestamp", async () => {
+      const wt = await createWorktree("idempotent");
+      const first = await app.inject({
+        method: "PATCH",
+        url: `/worktrees/${wt.id}/pin`,
+        payload: { pinned: true },
+      });
+      const ts1 = first.json<{ worktree: { pinnedAt: string } }>().worktree.pinnedAt;
+      // Wait so a re-stamp would be observable.
+      await new Promise((r) => setTimeout(r, 10));
+      const second = await app.inject({
+        method: "PATCH",
+        url: `/worktrees/${wt.id}/pin`,
+        payload: { pinned: true },
+      });
+      expect(second.statusCode).toBe(200);
+      expect(second.json<{ worktree: { pinnedAt: string } }>().worktree.pinnedAt).toBe(ts1);
+    });
+
+    it("returns 404 for an unknown worktree id", async () => {
+      const res = await app.inject({
+        method: "PATCH",
+        url: "/worktrees/does-not-exist/pin",
+        payload: { pinned: true },
+      });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it("returns 400 for an invalid body", async () => {
+      const wt = await createWorktree("badbody");
+      const res = await app.inject({
+        method: "PATCH",
+        url: `/worktrees/${wt.id}/pin`,
+        payload: { pinned: "yes" },
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it("returns 404 (not 500) when the worktree is deleted concurrently with the PATCH", async () => {
+      // Simulates the TOCTOU window between the outer find and the lock by
+      // monkey-patching mutateProject to delete the worktree just before our
+      // mutator runs. Without the in-lock re-check, the non-null assertion
+      // in the route would throw and Fastify would reply 500.
+      const wt = await createWorktree("toctou");
+      const store = await import("../state/project-store.js");
+      const orig = store.mutateProject;
+      const spy = vi.spyOn(store, "mutateProject").mockImplementation(async (id, fn) => {
+        return orig(id, (p) => {
+          // Drop the worktree under the lock right before the route's mutator
+          // is invoked, mimicking a racing DELETE that wins the lock first.
+          const stripped = { ...p, worktrees: p.worktrees.filter((w) => w.id !== wt.id) };
+          return fn(stripped);
+        });
+      });
+      try {
+        const res = await app.inject({
+          method: "PATCH",
+          url: `/worktrees/${wt.id}/pin`,
+          payload: { pinned: true },
+        });
+        expect(res.statusCode).toBe(404);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it("GET /worktrees response includes pinnedAt for every record", async () => {
+      const wt = await createWorktree("listshape");
+      await app.inject({
+        method: "PATCH",
+        url: `/worktrees/${wt.id}/pin`,
+        payload: { pinned: true },
+      });
+      const res = await app.inject({ method: "GET", url: "/worktrees" });
+      expect(res.statusCode).toBe(200);
+      const items = res.json<Array<{ id: string; pinnedAt: string | null }>>();
+      for (const w of items) {
+        expect(w).toHaveProperty("pinnedAt");
+      }
+      const pinned = items.find((w) => w.id === wt.id);
+      expect(pinned?.pinnedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+  });
 });

--- a/daemon/src/routes/worktrees.ts
+++ b/daemon/src/routes/worktrees.ts
@@ -113,6 +113,8 @@ function serializeWorktree(projectId: string, w: WorktreeRecord) {
     baseBranch: w.baseBranch,
     baseSha: w.baseSha,
     createdAt: w.createdAt,
+    // Always emit pinnedAt so the client doesn't have to special-case undefined.
+    pinnedAt: w.pinnedAt ?? null,
   };
 }
 
@@ -377,7 +379,97 @@ export function registerWorktreeRoutes(app: FastifyInstance): void {
     return reply.status(201).send(apiWorktree);
   });
 
+  // PATCH /worktrees/:id/pin   { pinned: boolean }
+  // Toggles WorktreeRecord.pinnedAt. Idempotent: no-op when already in the
+  // requested state — important so cross-tab pins don't bounce the timestamp.
+  app.patch("/worktrees/:id/pin", async (req, reply) => {
+    const { id: wtId } = req.params as { id: string };
+    const bodySchema = z.object({ pinned: z.boolean() });
+    const parsed = bodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      return reply.status(400).send({ error: "Validation error", details: parsed.error.issues });
+    }
+    const { pinned } = parsed.data;
+
+    // Locate the owning project. Project ids are stable, but the worktree
+    // could vanish between this lookup and the lock acquiring inside
+    // `mutateProject`. We re-check membership inside the mutator and signal
+    // the outcome via a closure variable so a concurrent DELETE produces a
+    // clean 404 instead of throwing on a non-null assertion.
+    const project = getAllProjects().find((p) => p.worktrees.some((w) => w.id === wtId));
+    if (!project) return reply.status(404).send({ error: `Worktree '${wtId}' not found` });
+
+    // Outcome reported by the mutator. Typed wide so the post-await reads
+    // aren't narrowed by TS to the initial value.
+    let outcome:
+      | { kind: "not_found" }
+      | { kind: "noop"; worktree: WorktreeRecord }
+      | { kind: "updated"; worktree: WorktreeRecord } = { kind: "not_found" } as
+      | { kind: "not_found" }
+      | { kind: "noop"; worktree: WorktreeRecord }
+      | { kind: "updated"; worktree: WorktreeRecord };
+
+    try {
+      await mutateProject(project.id, (p) => {
+        const wt = p.worktrees.find((w) => w.id === wtId);
+        if (!wt) {
+          // Worktree was deleted between the outer find and this lock.
+          outcome = { kind: "not_found" };
+          return p;
+        }
+        const alreadyPinned = wt.pinnedAt != null;
+        if (alreadyPinned === pinned) {
+          // No state change — return the project unchanged so the manifest
+          // is rewritten identically (cheap; happens only on race / dup).
+          outcome = { kind: "noop", worktree: wt };
+          return p;
+        }
+        const next: ProjectRecord = {
+          ...p,
+          worktrees: p.worktrees.map((w) => {
+            if (w.id !== wtId) return w;
+            if (pinned) {
+              return { ...w, pinnedAt: new Date().toISOString() };
+            }
+            // Drop the field rather than setting undefined so the JSON
+            // manifest stays clean.
+            const { pinnedAt: _drop, ...rest } = w;
+            void _drop;
+            return rest;
+          }),
+        };
+        const after = next.worktrees.find((w) => w.id === wtId);
+        if (!after) {
+          // Defensive — should never happen because we just mapped the array.
+          outcome = { kind: "not_found" };
+          return p;
+        }
+        outcome = { kind: "updated", worktree: after };
+        return next;
+      });
+    } catch (err) {
+      // The project itself was deleted between the outer find and the lock.
+      if (err instanceof Error && /not found/i.test(err.message)) {
+        return reply.status(404).send({ error: `Worktree '${wtId}' not found` });
+      }
+      throw err;
+    }
+
+    if (outcome.kind === "not_found") {
+      return reply.status(404).send({ error: `Worktree '${wtId}' not found` });
+    }
+    const apiWorktree = serializeWorktree(project.id, outcome.worktree);
+    if (outcome.kind === "updated") {
+      // Broadcast after the lock has been released — `applyWorktreeUpdated`
+      // on the client drops unknown ids, so any reorder with a concurrent
+      // `worktree:deleted` is benign.
+      broadcastAll({ type: "worktree:updated", worktree: apiWorktree });
+    }
+    return reply.send({ ok: true, worktree: apiWorktree });
+  });
+
   // POST /worktrees/:id/done — mark all agent sessions as done (metadata only; no process kill)
+
   app.post("/worktrees/:id/done", async (req, reply) => {
     const { id: wtId } = req.params as { id: string };
     const project = getAllProjects().find((p) => p.worktrees.some((w) => w.id === wtId));

--- a/daemon/src/types.ts
+++ b/daemon/src/types.ts
@@ -39,6 +39,12 @@ export interface WorktreeRecord {
   baseBranch: string;
   baseSha: string;
   createdAt: string; // ISO8601
+  /**
+   * When set, this worktree is pinned to the top of the sidebar.
+   * Absent / undefined ≡ unpinned. The timestamp also encodes recency order
+   * (newest pinned first), so we don't need a separate sort field.
+   */
+  pinnedAt?: string; // ISO8601
   sessions: SessionRecord[];
 }
 

--- a/daemon/src/ws/protocol.ts
+++ b/daemon/src/ws/protocol.ts
@@ -197,6 +197,11 @@ const WorktreeDeletedEvent = z.object({
   worktreeId: z.string(),
 });
 
+const WorktreeUpdatedEvent = z.object({
+  type: z.literal("worktree:updated"),
+  worktree: z.record(z.string(), z.unknown()),
+});
+
 const ModeCreatedEvent = z.object({
   type: z.literal("mode:created"),
   mode: z.record(z.string(), z.unknown()),
@@ -240,6 +245,7 @@ export const ServerMessage = z.discriminatedUnion("type", [
   ProjectDeletedEvent,
   WorktreeCreatedEvent,
   WorktreeDeletedEvent,
+  WorktreeUpdatedEvent,
   ModeCreatedEvent,
   ModeUpdatedEvent,
   ModeDeletedEvent,

--- a/web-ui/src/api/client.ts
+++ b/web-ui/src/api/client.ts
@@ -246,6 +246,26 @@ export function createClientApi() {
       return parseJson<{ ok: true; updated: number }>(res);
     },
 
+    async pinWorktree(id: string): Promise<{ ok: true; worktree: Worktree }> {
+      const root = baseUrl();
+      const res = await apiFetch(`${root}/worktrees/${encodeURIComponent(id)}/pin`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ pinned: true }),
+      });
+      return parseJson<{ ok: true; worktree: Worktree }>(res);
+    },
+
+    async unpinWorktree(id: string): Promise<{ ok: true; worktree: Worktree }> {
+      const root = baseUrl();
+      const res = await apiFetch(`${root}/worktrees/${encodeURIComponent(id)}/pin`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ pinned: false }),
+      });
+      return parseJson<{ ok: true; worktree: Worktree }>(res);
+    },
+
     async listSessions(worktreeId?: string): Promise<Session[]> {
       const root = baseUrl();
       const url = worktreeId

--- a/web-ui/src/api/mock.ts
+++ b/web-ui/src/api/mock.ts
@@ -53,6 +53,7 @@ export function createMockApi() {
       baseBranch: "main",
       baseSha: "abc123",
       createdAt: nowIso(),
+      pinnedAt: null,
     },
     {
       id: "wt-2",
@@ -61,6 +62,7 @@ export function createMockApi() {
       baseBranch: "main",
       baseSha: "def456",
       createdAt: nowIso(),
+      pinnedAt: null,
     },
     {
       id: "wt-3",
@@ -69,6 +71,7 @@ export function createMockApi() {
       baseBranch: "develop",
       baseSha: "fed789",
       createdAt: nowIso(),
+      pinnedAt: null,
     },
   ];
 
@@ -266,6 +269,7 @@ export function createMockApi() {
         baseBranch: body.baseBranch ?? "main",
         baseSha: "mock-base-sha",
         createdAt: nowIso(),
+        pinnedAt: null,
       };
       worktrees.push(wt);
       treeStore[wt.id] = {
@@ -310,6 +314,26 @@ export function createMockApi() {
         updated += 1;
       }
       return { ok: true, updated };
+    },
+
+    async pinWorktree(id: string): Promise<{ ok: true; worktree: Worktree }> {
+      const wt = worktrees.find((w) => w.id === id);
+      if (!wt) throw new ApiError("not found", 404);
+      if (wt.pinnedAt == null) {
+        wt.pinnedAt = new Date().toISOString();
+        emit({ type: "worktree:updated", worktree: structuredClone(wt) });
+      }
+      return { ok: true, worktree: structuredClone(wt) };
+    },
+
+    async unpinWorktree(id: string): Promise<{ ok: true; worktree: Worktree }> {
+      const wt = worktrees.find((w) => w.id === id);
+      if (!wt) throw new ApiError("not found", 404);
+      if (wt.pinnedAt != null) {
+        wt.pinnedAt = null;
+        emit({ type: "worktree:updated", worktree: structuredClone(wt) });
+      }
+      return { ok: true, worktree: structuredClone(wt) };
     },
 
     async listSessions(worktreeId?: string): Promise<Session[]> {

--- a/web-ui/src/api/types.ts
+++ b/web-ui/src/api/types.ts
@@ -22,6 +22,12 @@ export interface Worktree {
   baseBranch: string;
   baseSha?: string;
   createdAt: string;
+  /**
+   * ISO8601 timestamp set when the user pins this worktree to the top of the
+   * sidebar; null when unpinned. The timestamp also encodes recency for
+   * default sort order (newest first).
+   */
+  pinnedAt: string | null;
 }
 
 export type SessionType = "agent" | "terminal";
@@ -146,6 +152,10 @@ export type WSEvent =
   | {
       type: "worktree:deleted";
       worktreeId: string;
+    }
+  | {
+      type: "worktree:updated";
+      worktree: Worktree;
     }
   | {
       type: "mode:created";

--- a/web-ui/src/components/layout/LeftSidebar.test.tsx
+++ b/web-ui/src/components/layout/LeftSidebar.test.tsx
@@ -141,6 +141,179 @@ describe("LeftSidebar", () => {
     });
   });
 
+  // ─── Pinning ───────────────────────────────────────────────────────────
+  describe("worktree pinning", () => {
+    it("does not render the pinned section when no worktrees are pinned", async () => {
+      render(
+        <MemoryRouter>
+          <Harness api={api}>
+            <LeftSidebar api={api} />
+          </Harness>
+        </MemoryRouter>,
+      );
+      await screen.findByText("Proj A");
+      expect(screen.queryByRole("region", { name: /pinned worktrees/i })).toBeNull();
+    });
+
+    it("pin action in the ⋯ menu calls api.pinWorktree and the row appears in the pinned section", async () => {
+      const localApi = createMockApi();
+      // Ensure mock starts unpinned (each createMockApi has its own state).
+      const user = userEvent.setup();
+      render(
+        <MemoryRouter>
+          <Harness api={localApi}>
+            <LeftSidebar api={localApi} />
+          </Harness>
+        </MemoryRouter>,
+      );
+      await screen.findByRole("link", { name: /Open worktree wt-1/i });
+
+      // Open the menu for wt-1
+      const wtRow = screen.getByRole("link", { name: /Open worktree wt-1/i }).closest(".tree-row")!;
+      const trigger = wtRow.querySelector("[data-wt-menu-trigger]")! as HTMLElement;
+      await user.click(trigger);
+
+      const pinItem = await screen.findByRole("menuitem", { name: /pin to top/i });
+      await user.click(pinItem);
+
+      // The pinned section should appear; the mock api emits worktree:updated
+      // synchronously so useServerSync will re-render in a microtask.
+      await waitFor(() => {
+        expect(screen.getByRole("region", { name: /pinned worktrees/i })).toBeInTheDocument();
+      });
+      // The pinned-row link is labelled differently to disambiguate.
+      expect(screen.getByRole("link", { name: /Open pinned worktree wt-1/i })).toBeInTheDocument();
+    });
+
+    it("pinned section shows project name as subheader", async () => {
+      const localApi = createMockApi();
+      await localApi.pinWorktree("wt-1");
+      render(
+        <MemoryRouter>
+          <Harness api={localApi}>
+            <LeftSidebar api={localApi} />
+          </Harness>
+        </MemoryRouter>,
+      );
+      await screen.findByRole("region", { name: /pinned worktrees/i });
+      // The mock seeds "Proj A" as the name for proj-a (the project that owns wt-1)
+      const subheads = document.querySelectorAll(".pinned-row__subhead");
+      expect(Array.from(subheads).some((s) => s.textContent === "Proj A")).toBe(true);
+    });
+
+    it("⋯ menu on a pinned row reads 'Unpin' and calls api.unpinWorktree", async () => {
+      const localApi = createMockApi();
+      await localApi.pinWorktree("wt-1");
+      const user = userEvent.setup();
+      render(
+        <MemoryRouter>
+          <Harness api={localApi}>
+            <LeftSidebar api={localApi} />
+          </Harness>
+        </MemoryRouter>,
+      );
+      await screen.findByRole("region", { name: /pinned worktrees/i });
+
+      const pinnedLink = screen.getByRole("link", { name: /Open pinned worktree wt-1/i });
+      const pinnedRow = pinnedLink.closest(".pinned-row")! as HTMLElement;
+      const trigger = pinnedRow.querySelector("[data-wt-menu-trigger]")! as HTMLElement;
+      expect(trigger).toBeTruthy();
+      await user.click(trigger);
+
+      const unpinItem = await screen.findByRole("menuitem", { name: /^unpin$/i });
+      await user.click(unpinItem);
+
+      await waitFor(() => {
+        expect(screen.queryByRole("region", { name: /pinned worktrees/i })).toBeNull();
+      });
+    });
+
+    it("pinned-row ⋯ button carries data-wt-menu-trigger", async () => {
+      const localApi = createMockApi();
+      await localApi.pinWorktree("wt-2");
+      render(
+        <MemoryRouter>
+          <Harness api={localApi}>
+            <LeftSidebar api={localApi} />
+          </Harness>
+        </MemoryRouter>,
+      );
+      await screen.findByRole("region", { name: /pinned worktrees/i });
+      const pinnedRow = screen
+        .getByRole("link", { name: /Open pinned worktree wt-2/i })
+        .closest(".pinned-row")! as HTMLElement;
+      const trigger = pinnedRow.querySelector("[data-wt-menu-trigger]");
+      expect(trigger).not.toBeNull();
+    });
+
+    it("pinned section is hidden when collapsed=true even with pinned worktrees", async () => {
+      const localApi = createMockApi();
+      await localApi.pinWorktree("wt-1");
+      render(
+        <MemoryRouter>
+          <Harness api={localApi}>
+            <LeftSidebar api={localApi} collapsed />
+          </Harness>
+        </MemoryRouter>,
+      );
+      await screen.findByText("Pra");
+      expect(screen.queryByRole("region", { name: /pinned worktrees/i })).toBeNull();
+    });
+
+    it("pinned rows render in pinnedAt DESC order (newest first)", async () => {
+      const localApi = createMockApi();
+      await localApi.pinWorktree("wt-2"); // older
+      await new Promise((r) => setTimeout(r, 5));
+      await localApi.pinWorktree("wt-3"); // newer
+      render(
+        <MemoryRouter>
+          <Harness api={localApi}>
+            <LeftSidebar api={localApi} />
+          </Harness>
+        </MemoryRouter>,
+      );
+      await screen.findByRole("region", { name: /pinned worktrees/i });
+      const region = screen.getByRole("region", { name: /pinned worktrees/i });
+      const labels = Array.from(region.querySelectorAll(".pinned-row__primary")).map(
+        (n) => n.textContent,
+      );
+      // wt-3 is "wt-main" in the mock; wt-2 is "wt-2"
+      expect(labels[0]).toBe("wt-main");
+      expect(labels[1]).toBe("wt-2");
+    });
+
+    it("worktree:updated event from another tab updates the pinned section", async () => {
+      const localApi = createMockApi();
+      render(
+        <MemoryRouter>
+          <Harness api={localApi}>
+            <LeftSidebar api={localApi} />
+          </Harness>
+        </MemoryRouter>,
+      );
+      await screen.findByRole("link", { name: /Open worktree wt-1/i });
+      expect(screen.queryByRole("region", { name: /pinned worktrees/i })).toBeNull();
+
+      // Simulate another tab pinning wt-1
+      localApi.__test.emit({
+        type: "worktree:updated",
+        worktree: {
+          id: "wt-1",
+          projectId: "proj-a",
+          branch: "wt-1",
+          baseBranch: "main",
+          baseSha: "abc123",
+          createdAt: new Date().toISOString(),
+          pinnedAt: new Date().toISOString(),
+        },
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole("region", { name: /pinned worktrees/i })).toBeInTheDocument();
+      });
+    });
+  });
+
   it("Settings is a link with accessible name", async () => {
     render(
       <MemoryRouter>

--- a/web-ui/src/components/layout/LeftSidebar.tsx
+++ b/web-ui/src/components/layout/LeftSidebar.tsx
@@ -1,4 +1,4 @@
-import { Check, ChevronDown, ChevronRight, Filter, FolderTree, Moon, MoreHorizontal, Plus, SlidersHorizontal, Type } from "lucide-react";
+import { Check, ChevronDown, ChevronRight, Filter, FolderTree, Moon, MoreHorizontal, Pin, Plus, SlidersHorizontal, Type } from "lucide-react";
 import { useTheme } from "@/hooks/useTheme";
 import { createPortal } from "react-dom";
 import { useEffect, useMemo, useState } from "react";
@@ -82,6 +82,26 @@ export function LeftSidebar({
     for (const s of sessions) (m[s.worktreeId] ??= []).push(s);
     return m;
   }, [sessions]);
+  /** Project lookup for the project-name subheader on pinned rows. */
+  const projectById = useMemo(() => {
+    const m: Record<string, Project> = {};
+    for (const p of projects) m[p.id] = p;
+    return m;
+  }, [projects]);
+  /**
+   * Pinned worktrees in display order: ISO timestamp DESC (newest pinned first).
+   * Filter out anything no longer present on the server (defense-in-depth — the
+   * server-side delete naturally removes pinned worktrees, but a stale id from
+   * an in-flight event shouldn't crash render).
+   */
+  const pinnedWorktrees = useMemo(
+    () =>
+      worktrees
+        .filter((w) => w.pinnedAt != null)
+        .slice()
+        .sort((a, b) => (b.pinnedAt ?? "").localeCompare(a.pinnedAt ?? "")),
+    [worktrees],
+  );
   const [openProj, setOpenProj] = useState<Set<string>>(() => {
     try {
       const saved = localStorage.getItem("sidebar:openProj");
@@ -254,6 +274,79 @@ export function LeftSidebar({
         className="left-sidebar__scroll"
         style={{ flex: 1, overflow: "auto", padding: collapsed ? "var(--space-1)" : "var(--space-2)" }}
       >
+        {!collapsed && pinnedWorktrees.length > 0 ? (
+          <section className="pinned-section" aria-label="Pinned worktrees">
+            <div className="sidebar-projects-heading pinned-section__heading">
+              <span className="sidebar-projects-heading__gutter" aria-hidden />
+              <span className="sidebar-projects-heading__title">Pinned</span>
+            </div>
+            {pinnedWorktrees.map((w) => {
+              const proj = projectById[w.projectId];
+              const isActive = activeWorktreeId === w.id && location.pathname.startsWith("/worktree/");
+              return (
+                <div key={`pinned-${w.id}`} className="wt-row-wrap">
+                  <div
+                    className="tree-row tree-row--worktree pinned-row"
+                    data-active={isActive}
+                    style={{ position: "relative" }}
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        selectWorktree(w.projectId, w);
+                      }
+                    }}
+                  >
+                    <Link
+                      to={`/worktree/${w.id}`}
+                      className="wt-row__stretch-link"
+                      aria-label={`Open pinned worktree ${w.branch}`}
+                      onClick={() => selectWorktree(w.projectId, w)}
+                      tabIndex={-1}
+                    />
+                    <span className="wt-leading-slot pinned-row__leading" aria-hidden>
+                      <StatusDot
+                        status={worktreeRolledUpStatus(sessionMap[w.id] ?? [], sessionStates)}
+                      />
+                    </span>
+                    <div className="pinned-row__text">
+                      <span className="pinned-row__primary">{w.branch}</span>
+                      <span className="pinned-row__subhead" title={proj?.path}>
+                        {proj?.name ?? w.projectId}
+                      </span>
+                    </div>
+                    <div className="wt-row__trail pinned-row__trail" style={{ position: "relative", zIndex: 2 }}>
+                      <span className="wt-row__id" title={w.id}>
+                        {w.id}
+                      </span>
+                      <button
+                        type="button"
+                        data-wt-menu-trigger
+                        className="icon-btn wt-menu-trigger tree-row__action"
+                        aria-label={`Worktree actions for ${w.branch}`}
+                        aria-expanded={wtMenu?.worktree.id === w.id}
+                        aria-haspopup="menu"
+                        title="Worktree menu"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          const rect = e.currentTarget.getBoundingClientRect();
+                          setWtMenu((prev) =>
+                            prev?.worktree.id === w.id
+                              ? null
+                              : { projectId: w.projectId, worktree: w, rect },
+                          );
+                        }}
+                      >
+                        <MoreHorizontal size={16} />
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </section>
+        ) : null}
         <div className="sidebar-projects-heading">
           <span className="sidebar-projects-heading__gutter" aria-hidden />
           {collapsed ? (
@@ -496,6 +589,33 @@ export function LeftSidebar({
                 zIndex: 4000,
               }}
             >
+              <button
+                type="button"
+                role="menuitem"
+                className="menu-pop__item menu-pop__item--icon"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  const wtId = wtMenu.worktree.id;
+                  const wasPinned = wtMenu.worktree.pinnedAt != null;
+                  setWtMenu(null);
+                  void (async () => {
+                    try {
+                      if (wasPinned) await api.unpinWorktree(wtId);
+                      else await api.pinWorktree(wtId);
+                      // Store stays current via the `worktree:updated` WS event.
+                    } catch {
+                      /* surface errors later */
+                    }
+                  })();
+                }}
+              >
+                <Pin
+                  size={13}
+                  aria-hidden
+                  fill={wtMenu.worktree.pinnedAt != null ? "currentColor" : "none"}
+                />
+                {wtMenu.worktree.pinnedAt != null ? "Unpin" : "Pin to top"}
+              </button>
               <button
                 type="button"
                 role="menuitem"

--- a/web-ui/src/hooks/useServerStore.ts
+++ b/web-ui/src/hooks/useServerStore.ts
@@ -33,6 +33,7 @@ interface ServerData {
   applyProjectDeleted: (projectId: string) => void;
   applyWorktreeCreated: (w: Worktree) => void;
   applyWorktreeDeleted: (worktreeId: string) => void;
+  applyWorktreeUpdated: (w: Worktree) => void;
   applySessionCreated: (s: Session) => void;
   applySessionUpdated: (sessionId: string, patch: Partial<Session>) => void;
   applySessionDeleted: (sessionId: string) => void;
@@ -70,6 +71,17 @@ export const useServerStore = create<ServerData>((set) => ({
       worktrees: s.worktrees.filter((w) => w.id !== worktreeId),
       sessions: s.sessions.filter((sess) => sess.worktreeId !== worktreeId),
     })),
+
+  applyWorktreeUpdated: (w) =>
+    set((s) => {
+      const idx = s.worktrees.findIndex((x) => x.id === w.id);
+      // Drop silently if we don't know about this id — avoids surprise inserts
+      // from a server that's racing ahead of our initial list.
+      if (idx === -1) return s;
+      const next = s.worktrees.slice();
+      next[idx] = w;
+      return { worktrees: next };
+    }),
 
   applySessionCreated: (sess) =>
     set((s) => {

--- a/web-ui/src/hooks/useServerSync.ts
+++ b/web-ui/src/hooks/useServerSync.ts
@@ -38,6 +38,7 @@ export function useServerSync(api: ApiInstance): void {
   const applyProjectDeleted = useServerStore((s) => s.applyProjectDeleted);
   const applyWorktreeCreated = useServerStore((s) => s.applyWorktreeCreated);
   const applyWorktreeDeleted = useServerStore((s) => s.applyWorktreeDeleted);
+  const applyWorktreeUpdated = useServerStore((s) => s.applyWorktreeUpdated);
   const applySessionCreated = useServerStore((s) => s.applySessionCreated);
   const applySessionUpdated = useServerStore((s) => s.applySessionUpdated);
   const applySessionDeleted = useServerStore((s) => s.applySessionDeleted);
@@ -93,6 +94,9 @@ export function useServerSync(api: ApiInstance): void {
     const offWtDeleted = api.on("worktree:deleted", (ev) => {
       if (ev.type === "worktree:deleted") applyWorktreeDeleted(ev.worktreeId);
     });
+    const offWtUpdated = api.on("worktree:updated", (ev) => {
+      if (ev.type === "worktree:updated") applyWorktreeUpdated(ev.worktree);
+    });
     const offSessCreated = api.on("session:created", (ev) => {
       if (ev.type === "session:created" && ev.snapshot) {
         applySessionCreated(ev.snapshot);
@@ -125,6 +129,7 @@ export function useServerSync(api: ApiInstance): void {
       offProjDeleted();
       offWtCreated();
       offWtDeleted();
+      offWtUpdated();
       offSessCreated();
       offSessState();
       offSessExited();
@@ -137,6 +142,7 @@ export function useServerSync(api: ApiInstance): void {
     applyProjectDeleted,
     applyWorktreeCreated,
     applyWorktreeDeleted,
+    applyWorktreeUpdated,
     applySessionCreated,
     applySessionUpdated,
     applySessionDeleted,

--- a/web-ui/src/styles/workspace.css
+++ b/web-ui/src/styles/workspace.css
@@ -807,6 +807,101 @@
   padding: var(--space-1) 0;
 }
 
+/* ─────────────────────────────────────────────────────────────────────────
+ * Pinned section — mirrors selected worktrees at the top of the sidebar.
+ * Rows are two-line (branch + project subheader). The ⋯ menu and id chip
+ * sit at the top-right (not vertically centered) because the row is taller
+ * than the default tree-row. We deliberately re-use the `tree-row` +
+ * `tree-row--worktree` base classes so hover-swap (id ↔ menu) keeps working.
+ * ───────────────────────────────────────────────────────────────────────── */
+.pinned-section {
+  margin-bottom: var(--space-2);
+}
+
+.pinned-section__heading {
+  margin-bottom: var(--space-1);
+}
+
+/* Mirror the flex layout that `.tree-row` already uses for the project-tree
+ * worktree rows — same trio of [leading dot] [text] [trail], same alignment
+ * primitives, so the id chip / ⋯ button land at the row's right edge exactly
+ * like they do below. align-items flips from `center` to `flex-start` because
+ * the row is two lines tall. */
+.pinned-row {
+  align-items: flex-start;
+  /* `.tree-row.tree-row--worktree { margin-left: 12px }` indents worktrees
+     under their project disclosure — pinned rows are top-level so reset it. */
+  margin-left: 0;
+  min-height: auto;
+  padding-top: var(--space-1);
+  padding-bottom: var(--space-1);
+}
+
+.pinned-row__leading {
+  /* Nudge the dot down a hair so it aligns with the branch line, not the
+     vertical middle of the two-line block. */
+  padding-top: 5px;
+  align-self: flex-start;
+}
+
+.pinned-row__text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  line-height: 1.2;
+}
+
+.pinned-row__primary {
+  /* Inherits font-size: var(--font-size-sm) from `.tree-row.tree-row--worktree`
+     — same as every other worktree branch label in the sidebar. */
+  font-weight: var(--font-weight-light);
+  color: var(--fg-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pinned-row[data-active="true"] .pinned-row__primary {
+  color: var(--fg-primary);
+}
+
+.pinned-row__subhead {
+  /* Smaller than --font-size-xs (11px) — keeps the project name visually
+     secondary to the branch above. */
+  font-size: 10px;
+  color: var(--fg-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-top: 1px;
+}
+
+.pinned-row__trail {
+  /* Override the base `.wt-row__trail { height: 24px }` because two-line rows
+     are taller; keep flex-shrink: 0 (inherited) so the id chip / ⋯ button
+     always hug the right edge. */
+  height: auto;
+  align-self: flex-start;
+  padding-top: 4px;
+}
+
+/* Defeat the inherited `top:50%; translateY(-50%)` on `.wt-menu-trigger` so the
+ * ⋯ button sits at the top-right of the pinned row, next to the id chip, not
+ * floating between branch and subheader. */
+.pinned-row .wt-menu-trigger {
+  top: 4px;
+  transform: none;
+}
+
+/* Menu items with an icon (e.g. Pin/Unpin) — small leading glyph. */
+.menu-pop button.menu-pop__item--icon {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
 .changed-file-list__dir {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

- New "Pinned" section at the top of the LeftSidebar — pinned worktrees appear as two-line rows (branch on top, project name as subheader) with the same hover-swap (id chip ↔ ⋯ menu) and ordering by recency (`pinnedAt DESC`).
- Pin / Unpin action in the existing 3-dot worktree menu (label flips based on state).
- **Server-side persistence**: a single optional `pinnedAt?: string` field on `WorktreeRecord` — stored in the existing `manifest.json`, no new storage layer. Survives daemon restarts and syncs across browser tabs / devices via a new `worktree:updated` WS event.
- New endpoint `PATCH /worktrees/:id/pin { pinned: boolean }` — idempotent (preserves the original timestamp on duplicate pins) and TOCTOU-safe (existence + mutation under the project lock, returns 404 instead of 500 on a concurrent DELETE).

## Design decisions

- **Mirror, not move**: pinned worktrees still appear under their project in the tree below — avoids "where did my worktree go?" confusion.
- **Single nullable timestamp**: encodes both "is pinned" and "pin recency" — no separate sort field, deterministic order.
- **PATCH (not POST + DELETE)**: smaller surface, idempotent, mirrors the "single endpoint with a flag" pattern used elsewhere.

## Files

- Daemon: `types.ts` (field), `routes/worktrees.ts` (route + `serializeWorktree` emits null), `ws/protocol.ts` (event), tests.
- Web: `api/types.ts` + `api/client.ts` + `api/mock.ts`, `hooks/useServerStore.ts` + `useServerSync.ts` (replace-by-id reducer), `components/layout/LeftSidebar.tsx` (Pinned section + menu wiring), `styles/workspace.css`.

## Test plan

- [x] Typecheck — clean
- [x] Daemon tests — 26/26 pass, including:
  - idempotency (pin twice keeps original timestamp)
  - 404 on unknown id, 400 on bad body
  - **TOCTOU regression**: spy-injects a delete inside the lock and asserts the route returns 404 (not 500)
  - `GET /worktrees` response includes `pinnedAt` on every record
- [x] Web tests — 15/15 LeftSidebar tests pass, including:
  - Pinned section hidden when no pins / when collapsed
  - Pin menu item calls `api.pinWorktree`, row then appears in pinned section
  - Unpin menu item calls `api.unpinWorktree`, section unmounts when last pin removed
  - `worktree:updated` WS event from another tab updates the pinned section (cross-tab sync)
  - Pinned rows render in `pinnedAt DESC` order
  - Pinned-row ⋯ button carries `data-wt-menu-trigger` (so outside-click handler works)
- [x] Manual verification in isolated docker sandbox (`docker-compose.dev.yml` on port 5175, separate volumes — host daemon untouched): pin, unpin, idempotent re-pin, error paths all return correct codes; pinned section persists across daemon restart.

## Plan + review

Plan in `.feature-plans/done/worktree-pinning.md`. Opus subagent code review surfaced 12 findings; the two of medium severity (TOCTOU 500, stale closure in menu label) were considered — TOCTOU fixed with a regression test, stale label declined as benign (server-idempotent → no-op on misclick, label corrects on next open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)