### PR TITLE
fix(sidebar): don't navigate current tab on ctrl/cmd-click of worktree

### DIFF
--- a/web-ui/src/components/layout/LeftSidebar.test.tsx
+++ b/web-ui/src/components/layout/LeftSidebar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, beforeEach } from "vitest";
@@ -78,6 +78,30 @@ describe("LeftSidebar", () => {
     await screen.findByRole("link", { name: /Open worktree wt-2/i });
     await user.click(screen.getByRole("link", { name: /Open worktree wt-2/i }));
     expect(useWorkspaceStore.getState().activeWorktreeId).toBe("wt-2");
+  });
+
+  it("ctrl/meta/middle-clicking a worktree does NOT change the active worktree (new-tab open)", async () => {
+    render(
+      <MemoryRouter>
+        <Harness api={api}>
+          <LeftSidebar api={api} />
+        </Harness>
+      </MemoryRouter>,
+    );
+    const link = await screen.findByRole("link", { name: /Open worktree wt-2/i });
+    // Active worktree starts at wt-1 (set in beforeEach).
+    expect(useWorkspaceStore.getState().activeWorktreeId).toBe("wt-1");
+
+    // Each modified click should let the browser open a new tab without
+    // mutating the current tab's active worktree.
+    fireEvent.click(link, { ctrlKey: true });
+    expect(useWorkspaceStore.getState().activeWorktreeId).toBe("wt-1");
+
+    fireEvent.click(link, { metaKey: true });
+    expect(useWorkspaceStore.getState().activeWorktreeId).toBe("wt-1");
+
+    fireEvent.click(link, { button: 1 });
+    expect(useWorkspaceStore.getState().activeWorktreeId).toBe("wt-1");
   });
 
   it("worktree row exposes overflow menu control", async () => {

--- a/web-ui/src/components/layout/LeftSidebar.tsx
+++ b/web-ui/src/components/layout/LeftSidebar.tsx
@@ -248,6 +248,14 @@ export function LeftSidebar({
     onWorktreeSelected?.(w.id);
   }
 
+  // A modified click (ctrl/cmd/shift/alt or non-primary button) lets React
+  // Router's <Link> fall through to the browser's default "open in new tab"
+  // behavior without in-app navigation. We must NOT call selectWorktree() in
+  // that case, otherwise the current tab would also navigate to the worktree.
+  function isModifiedClick(e: React.MouseEvent) {
+    return e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0;
+  }
+
   const isSettings = location.pathname === "/settings";
 
   return (
@@ -302,7 +310,10 @@ export function LeftSidebar({
                       to={`/worktree/${w.id}`}
                       className="wt-row__stretch-link"
                       aria-label={`Open pinned worktree ${w.branch}`}
-                      onClick={() => selectWorktree(w.projectId, w)}
+                      onClick={(e) => {
+                        if (isModifiedClick(e)) return;
+                        selectWorktree(w.projectId, w);
+                      }}
                       tabIndex={-1}
                     />
                     <span className="wt-leading-slot pinned-row__leading" aria-hidden>
@@ -445,7 +456,10 @@ export function LeftSidebar({
                           to={`/worktree/${w.id}`}
                           className="wt-row__stretch-link"
                           aria-label={`Open worktree ${w.branch}`}
-                          onClick={() => selectWorktree(p.id, w)}
+                          onClick={(e) => {
+                            if (isModifiedClick(e)) return;
+                            selectWorktree(p.id, w);
+                          }}
                           tabIndex={-1}
                         />
                         <div className="wt-row__expand">


### PR DESCRIPTION
## Problem
Ctrl/Cmd-clicking (or middle-clicking) a worktree row in the sidebar correctly opens that worktree in a **new browser tab**, but it **also** navigates the **current tab** to that worktree. The current tab should stay where it is.

## Root cause
In `web-ui/src/components/layout/LeftSidebar.tsx`, each worktree row renders a stretched React Router `<Link>` whose `onClick` called `selectWorktree(...)` **unconditionally** (both the pinned and non-pinned rows).

React Router's `<Link>` defers modified clicks (ctrl/cmd/shift/alt or a non-primary button) to the browser's native "open in new tab" behavior and does **not** perform in-app navigation. But our `onClick` still fired and called `setActiveWorktree(...)`, mutating the persisted `activeWorktreeId` in the current tab — re-rendering it onto the clicked worktree.

## Fix
Add an `isModifiedClick(e)` helper that mirrors React Router's own `shouldProcessLinkClick`/`isModifiedEvent` logic (`metaKey || ctrlKey || shiftKey || altKey || button !== 0`), and guard both worktree-row `onClick` handlers so `selectWorktree()` runs **only** for an unmodified primary click — exactly the case where React Router navigates the current tab.

Normal-click and keyboard (Enter/Space) activation are unchanged.

## Testing
- ✅ `pnpm typecheck` clean
- ✅ `pnpm test` — 106 tests pass, including a new regression test in `LeftSidebar.test.tsx` asserting ctrl/meta/middle-click does **not** change `activeWorktreeId`
- ✅ Subagent code review (correctness + completeness audit of all sidebar nav handlers)
- ✅ Manual E2E in an isolated Docker container (screenshot sandbox w/ 9 demo worktrees, Playwright real ctrl-click):
  - Normal click → current tab navigates ✅
  - Ctrl-click → new tab opens at worktree, **current tab unchanged** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)