### PR TITLE
feat(new-session-dialog): real branch selector + fix dialog focus steal

### DIFF
--- a/.feature-plans/done/new-session-dialog-branch-selector-n-focus-fixes.md
+++ b/.feature-plans/done/new-session-dialog-branch-selector-n-focus-fixes.md
@@ -1,0 +1,249 @@
+# New Session Dialog — real branch selector + mobile focus-steal fix
+
+- **Status:** done
+- **Branch:** `new-session-dialog-branch-selector-n-focus-fixes`
+- **PRD:** n/a (small feature + bug fix)
+- **Author:** Claude
+
+## Verification results
+
+- `pnpm -r typecheck` — clean (web-ui + cli).
+- `pnpm lint` — 8 problems, **identical to clean base** (all pre-existing: TerminalPane
+  control-regex errors + unused-var warnings); zero new issues.
+- web-ui tests — 111/111 pass (new Dialog focus tests + branch-selector tests included).
+- daemon tests — 196 pass (added 2 branch-endpoint tests); the 4 failures (`lifecycle.test.ts`
+  timing, `modes.test.ts` gemini model) are pre-existing on the base, unrelated to this work.
+- **Docker (dev.Dockerfile):** image builds; daemon boots; `GET /projects/:id/branches` against a
+  real multi-branch repo returns `{"branches":["develop","feature-x","main","release/2.0"],"defaultBranch":"main"}`
+  (confirms shell-quoted `--format` handles `release/2.0`), and unknown project → 404.
+
+---
+
+## Problem
+
+Two independent issues in the "New session" dialog (`web-ui/src/components/dialogs/NewSessionDialog.tsx`):
+
+1. **Hardcoded base branch.** The "Base branch" field defaults to the literal string `"main"`
+  (`NewSessionDialog.tsx:32`) and is a free-text `<Input>` (`:155-160`). Projects that use
+  `master`, or any other branch, get a wrong default and no list of what actually exists. Typos
+  only fail server-side after submit.
+
+2. **Mobile keyboard hides itself / Close button looks focused.** When typing in the dialog on a
+  mobile on-screen keyboard — especially while a background agent chat in the open worktree is
+  streaming output — focus jumps to the Close (`×`) button (visible focus border) and the keyboard
+  collapses.
+
+---
+
+## Root cause — issue 2 (focus steal) — CONFIRMED on desktop
+
+- `Dialog` auto-focuses the first focusable element on open via a `setTimeout` inside a
+  `useEffect` whose deps are `[open, handleKeyDown]` (`Dialog.tsx:56-69`).
+- `handleKeyDown` is `useCallback`-memoized on `[onClose]` (`Dialog.tsx:29-54`).
+- The caller passes a **new inline `onClose` each render**:
+  `onClose={() => setNewSessProject(null)}` (`LeftSidebar.tsx:539`).
+- `LeftSidebar` re-renders whenever the server-data store changes. A background agent chat
+  streaming output triggers `session:*` WS events → store updates → `LeftSidebar` re-renders.
+- Each re-render → new `onClose` → new `handleKeyDown` → effect cleanup + **re-run** → `setTimeout`
+  fires → `first?.focus()` focuses the **Close button** (first focusable in the card) → steals
+  focus from the `<input>`/`<textarea>` the user is typing in.
+
+This is a **pure focus-management bug, not a keyboard/IME bug**. Confirmed reproducing on desktop
+(focus jumps to the Close button mid-typing while a background agent streams); the mobile keyboard
+collapse is just a downstream symptom of the same focus jump. Two distinct defects to fix:
+
+1. **When** auto-focus runs — it re-runs on every background re-render instead of once per open.
+2. **What** it focuses — the first focusable element is the **Close (`×`) button**, which is the
+   wrong target (a stray Enter/Space closes the dialog). Initial focus should land on the **branch
+   name field** (the first meaningful input), per product decision.
+
+---
+
+## Goals
+
+- Base branch field becomes a **dropdown of real branches** for the project, defaulting to the
+  detected default branch (`master`/`main`/origin-HEAD fallback chain already implemented in
+  `detectDefaultBranch`).
+- All error/loading/empty states handled (offline daemon, empty repo, fetch failure).
+- Auto-focus runs **once per open**, never re-steals focus on background re-renders.
+- No regression to Escape handling, Tab focus-trap, or overlay-click-to-close.
+
+## Non-goals
+
+- Changing how worktrees are actually created server-side (branch creation logic stays).
+- Letting users pick an arbitrary branch for "existing worktree" flow (that flow has no base
+  branch field).
+- Caching branch lists across dialog opens.
+
+---
+
+## Design
+
+### Backend: new `GET /projects/:projectId/branches` endpoint
+
+- Add a `listBranches(repoPath)` helper to `daemon/src/services/git.ts` that returns local branch
+  names via `git branch --list --format=%(refname:short)` (clean, no `*`/whitespace parsing).
+- Add endpoint in `daemon/src/routes/projects.ts` returning
+  `{ branches: string[]; defaultBranch: string }`:
+  - `getProject(projectId)` → 404 if missing.
+  - `isGitRepo(project.absolutePath)` → 400 if not a repo.
+  - `branches = await listBranches(...)`.
+  - `defaultBranch = (await detectDefaultBranch(...)) ?? project.defaultBranch`.
+  - Return both so the client doesn't re-implement the fallback chain.
+- Endpoint already registered via `registerProjectRoutes` in `server.ts:115` — no new register call.
+
+### Frontend: API client + types
+
+- Add `listProjectBranches(projectId): Promise<{ branches: string[]; defaultBranch: string }>` to
+  `web-ui/src/api/client.ts` (mirror `listWorktrees` pattern, `encodeURIComponent`).
+- Add response type to `web-ui/src/api/types.ts`.
+
+### Frontend: NewSessionDialog branch selector
+
+- Replace `baseBranch` free-text `<Input>` (`:155-160`) with a `<Select>` of fetched branches.
+- New state: `branches: string[]`, `branchesError: string | null`, `branchesLoading: boolean`.
+- Extend the on-open `useEffect` (`:41-53`) to also call `api.listProjectBranches(projectId)`:
+  - On success: `setBranches(res.branches)`; set `baseBranch` to `res.defaultBranch` if present in
+    list, else first branch.
+  - On failure (offline/non-repo): `setBranchesError(...)`; **fall back to a free-text Input** so
+    the user can still type a branch and submit (graceful degradation — keeps current behavior
+    working when the endpoint is unavailable).
+- Empty list (new/empty repo): show the free-text Input fallback + a hint.
+- Default `baseBranch` initial state changes from `"main"` to `""` (populated after fetch).
+- Keep sending `baseBranch.trim() || undefined` in `createWorktree` (`:74`) — server still applies
+  its own fallback to `project.defaultBranch`.
+
+### Frontend: Dialog focus fix (the core bug)
+
+Fix both defects — *when* focus runs and *what* it focuses.
+
+- **Stable keydown handler via ref.** Add `onCloseRef = useRef(onClose)` updated every render
+  (`onCloseRef.current = onClose`). Define `handleKeyDown` with `useCallback(..., [])` (empty deps)
+  and have it call `onCloseRef.current()` for Escape. The handler identity is now permanently
+  stable, so nothing it touches forces an effect re-run, while Escape still calls the *latest*
+  `onClose` (no stale-closure bug). Tab focus-trap logic is unchanged.
+- **Split the single effect** (`Dialog.tsx:56-69`) into two:
+  1. **Keydown listener effect** — keyed on `[open, handleKeyDown]` (handleKeyDown is now stable,
+     so effectively just `[open]`): add/remove the `keydown` listener once per open.
+  2. **Auto-focus effect** — keyed on `[open]` **only**. Runs once when the dialog opens; never
+     re-runs on background re-renders.
+- **Correct initial focus target.** The auto-focus effect focuses, in priority order:
+  1. An element marked `[data-autofocus]` inside the card (the New Session dialog tags its branch
+     name input with `data-autofocus`), else
+  2. the first `input, select, textarea` that is **not** a button and not `[disabled]`, else
+  3. the dialog card itself (give `cardRef` `tabIndex={-1}` so it can receive focus as a neutral
+     fallback when there is no field).
+  The Close button is **never** a default focus target.
+- `Input`/`Select` already spread `{...props}` onto the native element (`ui/Input.tsx:5`,
+  `ui/Select.tsx:5`), so `data-autofocus` passes straight through — no ref-forwarding needed.
+- Net effect: focus lands on the branch field exactly once when the dialog opens; background
+  re-renders never move focus; Escape/Tab/overlay-click behavior preserved. Fix lives entirely in
+  `Dialog.tsx` + one attribute in `NewSessionDialog.tsx`, robust regardless of caller `onClose`
+  hygiene.
+
+---
+
+## Review corrections (Opus review — incorporated below)
+
+- **(B1)** `ApiInstance` is a **union** of `createMockApi` | `createClientApi` (`api/index.ts:8`).
+  `listProjectBranches` MUST be added to **both** `client.ts` AND `mock.ts`, or typecheck and every
+  dialog test (which use `createMockApi`) break.
+- **(B2)** `NewSessionDialog.test.tsx:33` hard-asserts `baseBranch: "main"`. Mock must return a
+  deterministic default (`proj-a` → `main`) so the assertion still holds after the field becomes a
+  fetched dropdown; update the test if the asserted value changes.
+- **(M3)** `git branch --list --format='%(refname:short)'` — the format string **must be
+  single-quoted**; `git.ts` interpolates into a `/bin/sh` string (`git.ts:12-14`) and `()` are
+  shell metacharacters that otherwise break.
+- **(H1)** Fetch branches in a **separate try/catch**, NOT folded into the existing
+  `Promise.all([listWorktrees, listModes])` (`NewSessionDialog.tsx:43-52`) — else a branch-fetch
+  reject breaks worktree/mode loading and defeats graceful degradation.
+- **(H2)** `LeftSidebar.tsx:534` conditionally renders the dialog → it **unmounts on close**, so
+  `useState` resets naturally. No "reset-on-open" logic needed for the app; relevant only if a test
+  toggles `open` on a persistent mount.
+- **(M5)** Always coerce `baseBranch` to a value that exists in the rendered `<option>`s (default
+  if present in list, else first branch) to avoid a controlled-`<select>` value/option mismatch.
+- **(B3)** `Dialog.test.tsx` already exists (3 tests). New focus chain must keep them green; with a
+  buttons-only dialog, focus now lands on the card (`tabIndex={-1}`) — `dlg.contains(activeElement)`
+  still true since `contains` includes self. Audit `ConfirmDialog`/`NewModeDialog` etc.: their
+  initial focus shifts from "first button" to "the card" (Enter no longer auto-confirms) — acceptable
+  and arguably safer, but noted.
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `daemon/src/services/git.ts` | Add `listBranches(repoPath)` helper (~`:91`, after `branchExists`); single-quote `--format` |
+| `daemon/src/routes/projects.ts` | Add `GET /projects/:projectId/branches` handler in `registerProjectRoutes` |
+| `web-ui/src/api/types.ts` | Add `ProjectBranchesResponse` interface |
+| `web-ui/src/api/client.ts` | Add `listProjectBranches()` (~`:204`, near `listWorktrees`) |
+| `web-ui/src/api/mock.ts` | **(B1)** Add `listProjectBranches()` returning per-project branches + default |
+| `web-ui/src/components/dialogs/NewSessionDialog.tsx` | Branch `<Select>` + separate-catch fetch + error/empty fallback; default state `""`; `data-autofocus` on branch input |
+| `web-ui/src/components/dialogs/Dialog.tsx` | Split effect; stable keydown via ref; focus-once on open; `[data-autofocus]`-first focus target; card `tabIndex={-1}` |
+| `web-ui/src/components/dialogs/NewSessionDialog.test.tsx` | Update payload assertion; add branch selector + error fallback tests |
+| `web-ui/src/components/dialogs/Dialog.test.tsx` | **Exists** — add focus-once + autofocus-target tests; keep existing 3 green |
+
+## Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| `git branch --list` slow on huge repos | Local-only, fast; runs once on dialog open; show loading state |
+| Endpoint fails (offline daemon / non-repo) | Graceful fallback to free-text Input; surface error inline |
+| Focus refactor breaks Tab focus-trap or Escape | Keep `handleKeyDown` logic identical; only change *when* effects run; covered by tests |
+| Default branch not in branch list (detached/edge) | Fall back to first branch, else free-text |
+| `replace_all`/state reset between opens | Reset branch state on `open` transition so a second open re-fetches |
+
+---
+
+## Implementation phases
+
+### Phase 1 — Backend branch endpoint
+- [ ] 1.1 Add `listBranches(repoPath): Promise<string[]>` to `git.ts` using
+      `git branch --list --format=%(refname:short)`, splitting/filtering empty lines.
+- [ ] 1.2 Add `GET /projects/:projectId/branches` to `projects.ts`: 404 (no project), 400 (not a
+      repo), else `{ branches, defaultBranch }` with `detectDefaultBranch ?? project.defaultBranch`.
+- **1.T1** `curl localhost:<port>/projects/<id>/branches` returns real branches + correct default.
+- **1.T2** `curl` a bad project id → 404; a non-repo project → 400 with clear `error`.
+
+### Phase 2 — Frontend API client
+- [ ] 2.1 Add `ProjectBranchesResponse` to `types.ts`.
+- [ ] 2.2 Add `listProjectBranches(projectId)` to `client.ts`.
+- **2.T1** `npm run typecheck` (web-ui) passes.
+
+### Phase 3 — Branch selector in dialog
+- [ ] 3.1 Change `baseBranch` initial state to `""`; add `branches`, `branchesError` state.
+- [ ] 3.2 In on-open effect, fetch branches; set default; handle reject → `branchesError`.
+- [ ] 3.3 Render `<Select>` of branches when loaded & non-empty; free-text `<Input>` fallback
+      when error or empty; reset state when `open` toggles.
+- [ ] 3.4 Keep submit payload unchanged (`baseBranch.trim() || undefined`).
+- **3.T1** Dialog shows a dropdown listing the project's branches; default = detected default.
+- **3.T2** With daemon offline / non-repo, dialog falls back to free-text input and still submits;
+      error message shown inline.
+- **3.T3** Existing-worktree flow unaffected (no base branch field shown).
+
+### Phase 4 — Dialog focus-steal fix
+- [ ] 4.1 Add `onCloseRef`, update each render; make `handleKeyDown` stable via `useCallback([])`
+      reading `onCloseRef.current`.
+- [ ] 4.2 Split into keydown-listener effect and auto-focus effect (`[open]` only).
+- [ ] 4.3 Auto-focus priority: `[data-autofocus]` → first non-button `input/select/textarea` →
+      card (`tabIndex={-1}`). Never the Close button.
+- [ ] 4.4 Tag the branch name `<Input>` in `NewSessionDialog.tsx` with `data-autofocus`.
+- **4.T1** New `Dialog.test.tsx`: open Dialog, focus a child input, then re-render with a NEW
+      `onClose` identity repeatedly → focus stays on that input (does NOT jump to Close button).
+- **4.T2** `Dialog.test.tsx`: on open, `[data-autofocus]` element receives focus; Escape calls the
+      *current* `onClose` (not a stale one); Tab from last focusable wraps to first.
+- **4.T3** Manual: open dialog with a background agent streaming; type in branch field — focus
+      stays put, Close button never gains focus; on mobile the keyboard stays up.
+
+### Phase 5 — Full verification
+- [ ] 5.1 `npm run typecheck` + `npm run lint` + `npm test` in `web-ui`.
+- [ ] 5.2 Daemon typecheck/test.
+- **5.T1** All suites green; manual smoke of new-worktree creation with a non-`main` default.
+
+---
+
+## Open questions
+
+- Should the branch list also include remote-only branches (e.g. `origin/feature-x`)? Plan scopes
+  to **local branches** only, matching what `worktreeAdd` can branch from without an explicit
+  fetch. Server already fetches-on-miss for typed branches, so the free-text fallback still covers
+  remote branches. Flag if remote branches should be selectable up front.

--- a/daemon/src/__tests__/projects.test.ts
+++ b/daemon/src/__tests__/projects.test.ts
@@ -139,4 +139,33 @@ describe("GET /projects + POST /projects + DELETE /projects/:id", () => {
     const res = await app.inject({ method: "GET", url: "/projects" });
     expect(res.json<ProjectRecord[]>()).toHaveLength(1);
   });
+
+  it("GET /projects/:id/branches returns local branches and the default branch", async () => {
+    // Add a couple of extra branches to the repo.
+    execSync(
+      `git -C "${repoDir}" branch feature-a && git -C "${repoDir}" branch feature-b`,
+      { stdio: "ignore" },
+    );
+    const created = await app.inject({
+      method: "POST",
+      url: "/projects",
+      payload: { path: repoDir },
+    });
+    const project = created.json<ProjectRecord>();
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/projects/${project.id}/branches`,
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ branches: string[]; defaultBranch: string }>();
+    expect(body.branches).toEqual(expect.arrayContaining(["feature-a", "feature-b"]));
+    expect(body.branches).toContain(body.defaultBranch);
+    expect(body.defaultBranch).toBeTruthy();
+  });
+
+  it("GET /projects/:id/branches 404 for unknown project", async () => {
+    const res = await app.inject({ method: "GET", url: "/projects/nonexistent/branches" });
+    expect(res.statusCode).toBe(404);
+  });
 });

--- a/daemon/src/routes/projects.ts
+++ b/daemon/src/routes/projects.ts
@@ -8,7 +8,7 @@ import {
   addProject,
   deleteProject,
 } from "../state/project-store.js";
-import { isGitRepo, detectDefaultBranch } from "../services/git.js";
+import { isGitRepo, detectDefaultBranch, listBranches } from "../services/git.js";
 import { generateProjectPrefix } from "../services/prefix.js";
 import { slugify } from "../services/slugify.js";
 import { projectDir } from "../services/paths.js";
@@ -52,6 +52,30 @@ export function registerProjectRoutes(app: FastifyInstance): void {
     });
     return reply.send(sorted.map(serializeProject));
   });
+
+  // GET /projects/:projectId/branches
+  // Lists local git branches for the project's repo plus the detected default
+  // branch, so the New Session dialog can offer a real branch picker instead of
+  // a hardcoded "main".
+  app.get<{ Params: { projectId: string } }>(
+    "/projects/:projectId/branches",
+    async (req, reply) => {
+      const { projectId } = req.params;
+      const project = getProject(projectId);
+      if (!project) {
+        return reply.status(404).send({ error: `Project '${projectId}' not found` });
+      }
+      if (!(await isGitRepo(project.absolutePath))) {
+        return reply
+          .status(400)
+          .send({ error: `'${project.absolutePath}' is not a git repository` });
+      }
+      const branches = await listBranches(project.absolutePath);
+      const detected = await detectDefaultBranch(project.absolutePath);
+      const defaultBranch = detected ?? project.defaultBranch;
+      return reply.send({ branches, defaultBranch });
+    },
+  );
 
   // POST /projects
   app.post("/projects", async (req, reply) => {

--- a/daemon/src/services/git.ts
+++ b/daemon/src/services/git.ts
@@ -90,6 +90,21 @@ export async function branchExists(repoPath: string, branch: string): Promise<bo
   }
 }
 
+/**
+ * List local branch names in the repo, sorted by most-recent commit first.
+ * The `--format` string is single-quoted because `()` are shell metacharacters
+ * (commands here are interpolated into a /bin/sh string — see `run`).
+ */
+export async function listBranches(repoPath: string): Promise<string[]> {
+  const out = await run(
+    `git -C "${repoPath}" branch --list --sort=-committerdate --format='%(refname:short)'`,
+  );
+  return out
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+}
+
 /** Returns the full SHA of `ref` in the repo. */
 export async function revParse(repoPath: string, ref: string): Promise<string> {
   return run(`git -C "${repoPath}" rev-parse "${ref}"`);

--- a/web-ui/src/api/client.ts
+++ b/web-ui/src/api/client.ts
@@ -7,6 +7,7 @@ import type {
   HealthResponse,
   Mode,
   Project,
+  ProjectBranchesResponse,
   SendInputBody,
   Session,
   SupportedCli,
@@ -209,6 +210,14 @@ export function createClientApi() {
         : `${root}/worktrees`;
       const res = await apiFetch(url);
       return parseJson<Worktree[]>(res);
+    },
+
+    async listProjectBranches(projectId: string): Promise<ProjectBranchesResponse> {
+      const root = baseUrl();
+      const res = await apiFetch(
+        `${root}/projects/${encodeURIComponent(projectId)}/branches`,
+      );
+      return parseJson<ProjectBranchesResponse>(res);
     },
 
     async createWorktree(body: CreateWorktreeBody): Promise<Worktree> {

--- a/web-ui/src/api/mock.ts
+++ b/web-ui/src/api/mock.ts
@@ -7,6 +7,7 @@ import type {
   HealthResponse,
   Mode,
   Project,
+  ProjectBranchesResponse,
   SendInputBody,
   Session,
   SupportedCli,
@@ -259,6 +260,19 @@ export function createMockApi() {
 
     async listWorktrees(projectId?: string): Promise<Worktree[]> {
       return structuredClone(projectId ? worktrees.filter((w) => w.projectId === projectId) : worktrees);
+    },
+
+    async listProjectBranches(projectId: string): Promise<ProjectBranchesResponse> {
+      const project = projects.find((p) => p.id === projectId);
+      if (!project) throw new ApiError("not found", 404);
+      // Derive a stable branch set: the project default plus any branches its
+      // worktrees were based on, deduped with the default listed first.
+      const defaultBranch = project.defaultBranch;
+      const others = worktrees
+        .filter((w) => w.projectId === projectId)
+        .map((w) => w.baseBranch);
+      const branches = [...new Set([defaultBranch, ...others, "feature/example"])];
+      return { branches, defaultBranch };
     },
 
     async createWorktree(body: CreateWorktreeBody): Promise<Worktree> {

--- a/web-ui/src/api/types.ts
+++ b/web-ui/src/api/types.ts
@@ -193,6 +193,11 @@ export interface ChangedPathEntry {
   status: GitStatusChar;
 }
 
+export interface ProjectBranchesResponse {
+  branches: string[];
+  defaultBranch: string;
+}
+
 export interface CreateWorktreeBody {
   projectId: string;
   branch: string;

--- a/web-ui/src/components/dialogs/Dialog.test.tsx
+++ b/web-ui/src/components/dialogs/Dialog.test.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
@@ -41,5 +42,72 @@ describe("Dialog", () => {
       const dlg = screen.getByRole("dialog");
       expect(dlg.contains(document.activeElement)).toBe(true);
     });
+  });
+
+  it("auto-focuses the [data-autofocus] field on open, not the Close button", async () => {
+    render(
+      <Dialog open title="T" onClose={() => {}}>
+        <input data-autofocus aria-label="Focus me" />
+      </Dialog>,
+    );
+    await waitFor(() => {
+      expect(document.activeElement).toBe(screen.getByLabelText("Focus me"));
+    });
+    expect(document.activeElement).not.toBe(
+      screen.getByRole("button", { name: /Close dialog/i }),
+    );
+  });
+
+  it("does NOT re-steal focus when the parent re-renders with a new onClose identity", async () => {
+    const user = userEvent.setup();
+    function Harness() {
+      const [, force] = useState(0);
+      // New inline onClose each render — mirrors the real LeftSidebar caller.
+      return (
+        <>
+          <button type="button" onClick={() => force((n) => n + 1)}>
+            rerender
+          </button>
+          <Dialog open title="T" onClose={() => {}}>
+            <input data-autofocus aria-label="Field" />
+          </Dialog>
+        </>
+      );
+    }
+    render(<Harness />);
+    const field = await screen.findByLabelText("Field");
+    await waitFor(() => expect(document.activeElement).toBe(field));
+
+    // Move focus elsewhere inside the dialog, then force several re-renders.
+    field.blur();
+    const rerender = screen.getByRole("button", { name: "rerender" });
+    for (let i = 0; i < 3; i++) await user.click(rerender);
+
+    // Focus must NOT have jumped back to the autofocus field or the Close button.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(document.activeElement).not.toBe(
+      screen.getByRole("button", { name: /Close dialog/i }),
+    );
+  });
+
+  it("Escape calls the latest onClose after re-renders (no stale closure)", async () => {
+    const user = userEvent.setup();
+    function Harness() {
+      const [n, setN] = useState(0);
+      return (
+        <>
+          <button type="button" onClick={() => setN((x) => x + 1)}>
+            bump
+          </button>
+          <Dialog open title="T" onClose={() => setN((x) => x + 100)}>
+            <span>count {n}</span>
+          </Dialog>
+        </>
+      );
+    }
+    render(<Harness />);
+    await user.click(screen.getByRole("button", { name: "bump" })); // n = 1
+    await user.keyboard("{Escape}"); // latest onClose → n += 100
+    await waitFor(() => expect(screen.getByText(/count 101/)).toBeInTheDocument());
   });
 });

--- a/web-ui/src/components/dialogs/Dialog.tsx
+++ b/web-ui/src/components/dialogs/Dialog.tsx
@@ -26,47 +26,62 @@ export function Dialog({
   const overlayRef = useRef<HTMLDivElement>(null);
   const cardRef = useRef<HTMLDivElement>(null);
 
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.stopPropagation();
-        onClose();
-      }
-      if (e.key === "Tab" && cardRef.current) {
-        const focusables = cardRef.current.querySelectorAll<HTMLElement>(
-          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
-        );
-        const list = [...focusables].filter((el) => !el.hasAttribute("disabled"));
-        if (list.length === 0) return;
-        const first = list[0];
-        const last = list[list.length - 1];
-        if (!first || !last) return;
-        if (e.shiftKey && document.activeElement === first) {
-          e.preventDefault();
-          last.focus();
-        } else if (!e.shiftKey && document.activeElement === last) {
-          e.preventDefault();
-          first.focus();
-        }
-      }
-    },
-    [onClose],
-  );
+  // Keep the latest `onClose` in a ref so the keydown handler can stay
+  // permanently stable. Callers commonly pass a new inline `onClose` on every
+  // render; if the handler's identity tracked `onClose`, the focus effect below
+  // would re-run on every background re-render (e.g. an agent chat streaming
+  // output) and yank focus back to the first focusable element mid-typing.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
 
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      e.stopPropagation();
+      onCloseRef.current();
+    }
+    if (e.key === "Tab" && cardRef.current) {
+      const focusables = cardRef.current.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      );
+      const list = [...focusables].filter((el) => !el.hasAttribute("disabled"));
+      if (list.length === 0) return;
+      const first = list[0];
+      const last = list[list.length - 1];
+      if (!first || !last) return;
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }, []);
+
+  // Keydown listener — attached once per open. `handleKeyDown` is stable.
   useEffect(() => {
     if (!open) return undefined;
     document.addEventListener("keydown", handleKeyDown);
-    const t = window.setTimeout(() => {
-      const first = cardRef.current?.querySelector<HTMLElement>(
-        'button, [href], input, select, textarea',
-      );
-      first?.focus();
-    }, 0);
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-      window.clearTimeout(t);
-    };
+    return () => document.removeEventListener("keydown", handleKeyDown);
   }, [open, handleKeyDown]);
+
+  // Auto-focus on open — keyed on `open` ONLY so background re-renders never
+  // re-steal focus. Target priority: an explicit [data-autofocus] field, else
+  // the first non-button form control, else the dialog card itself (a neutral
+  // fallback via tabIndex=-1). The Close button is never an auto-focus target.
+  useEffect(() => {
+    if (!open) return undefined;
+    const t = window.setTimeout(() => {
+      const card = cardRef.current;
+      if (!card) return;
+      const target =
+        card.querySelector<HTMLElement>("[data-autofocus]") ??
+        card.querySelector<HTMLElement>("input, select, textarea") ??
+        card;
+      target.focus();
+    }, 0);
+    return () => window.clearTimeout(t);
+  }, [open]);
 
   if (!open) return null;
 
@@ -85,6 +100,7 @@ export function Dialog({
         role="dialog"
         aria-modal="true"
         aria-labelledby={ariaLabelledBy}
+        tabIndex={-1}
         onMouseDown={(e) => e.stopPropagation()}
       >
         <div className="dialog-card__header">

--- a/web-ui/src/components/dialogs/NewSessionDialog.test.tsx
+++ b/web-ui/src/components/dialogs/NewSessionDialog.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import { createMockApi } from "@/api/mock";
@@ -30,11 +30,67 @@ describe("NewSessionDialog", () => {
         expect.objectContaining({
           projectId: "proj-a",
           branch: "wt-new",
+          // Base branch defaults to the project's detected default (mock proj-a → "main").
           baseBranch: "main",
         }),
       );
     });
     // New worktree: POST /worktrees spawns the main session — no separate createSession.
     expect(cs).not.toHaveBeenCalled();
+  });
+
+  it("populates the base-branch dropdown from listProjectBranches and submits the selection", async () => {
+    const user = userEvent.setup();
+    const api = createMockApi();
+    const cw = vi.spyOn(api, "createWorktree");
+    render(
+      <NewSessionDialog
+        open
+        api={api}
+        projectId="proj-a"
+        projectName="Proj A"
+        onClose={() => {}}
+      />,
+    );
+    // Base branch is rendered as a <select> populated with real branches.
+    const select = await screen.findByRole("combobox", { name: /Base branch/i });
+    await waitFor(() => {
+      expect(within(select).getByRole("option", { name: "feature/example" })).toBeInTheDocument();
+    });
+    await user.type(screen.getByRole("textbox", { name: /New worktree branch/i }), "wt-x");
+    await user.selectOptions(select, "feature/example");
+    await user.click(screen.getByRole("button", { name: /Create/i }));
+    await waitFor(() => {
+      expect(cw).toHaveBeenCalledWith(
+        expect.objectContaining({ branch: "wt-x", baseBranch: "feature/example" }),
+      );
+    });
+  });
+
+  it("falls back to a free-text base-branch input when branch loading fails", async () => {
+    const user = userEvent.setup();
+    const api = createMockApi();
+    vi.spyOn(api, "listProjectBranches").mockRejectedValue(new Error("offline"));
+    const cw = vi.spyOn(api, "createWorktree");
+    render(
+      <NewSessionDialog
+        open
+        api={api}
+        projectId="proj-a"
+        projectName="Proj A"
+        onClose={() => {}}
+      />,
+    );
+    // No dropdown — a free-text Base branch input plus an error hint.
+    const input = await screen.findByRole("textbox", { name: /Base branch/i });
+    expect(screen.getByText(/Couldn’t load branches/i)).toBeInTheDocument();
+    await user.type(screen.getByRole("textbox", { name: /New worktree branch/i }), "wt-y");
+    await user.type(input, "release-1");
+    await user.click(screen.getByRole("button", { name: /Create/i }));
+    await waitFor(() => {
+      expect(cw).toHaveBeenCalledWith(
+        expect.objectContaining({ branch: "wt-y", baseBranch: "release-1" }),
+      );
+    });
   });
 });

--- a/web-ui/src/components/dialogs/NewSessionDialog.tsx
+++ b/web-ui/src/components/dialogs/NewSessionDialog.tsx
@@ -29,7 +29,9 @@ export function NewSessionDialog({
   const [worktrees, setWorktrees] = useState<Worktree[]>([]);
   const [existingWtId, setExistingWtId] = useState("");
   const [newWtBranch, setNewWtBranch] = useState("");
-  const [baseBranch, setBaseBranch] = useState("main");
+  const [baseBranch, setBaseBranch] = useState("");
+  const [branches, setBranches] = useState<string[]>([]);
+  const [branchesError, setBranchesError] = useState<string | null>(null);
   const [modes, setModes] = useState<Mode[]>([]);
   const [modeId, setModeId] = useState("");
   const [initialPrompt, setInitialPrompt] = useState("");
@@ -49,6 +51,30 @@ export function NewSessionDialog({
       setModes(ms);
       if (wts[0]) setExistingWtId(wts[0].id);
       if (ms[0]) setModeId(ms[0].id);
+    })();
+    // Fetch branches independently — a failure here must NOT break worktree/mode
+    // loading. On error we fall back to a free-text branch input.
+    void (async () => {
+      setBranchesError(null);
+      try {
+        const res = await api.listProjectBranches(projectId);
+        setBranches(res.branches);
+        // Coerce baseBranch to a value present in the rendered options so the
+        // controlled <select> never points at a missing <option>.
+        const def = res.branches.includes(res.defaultBranch)
+          ? res.defaultBranch
+          : (res.branches[0] ?? res.defaultBranch);
+        setBaseBranch(def);
+      } catch (err) {
+        setBranches([]);
+        setBranchesError(
+          err instanceof ApiError
+            ? err.message || `Could not load branches (HTTP ${err.status})`
+            : err instanceof Error
+              ? err.message
+              : String(err),
+        );
+      }
     })();
   }, [open, api, projectId]);
 
@@ -148,16 +174,43 @@ export function NewSessionDialog({
         <>
           <div className="field-label">Branch</div>
           <Input
+            data-autofocus
             aria-label="New worktree branch"
             value={newWtBranch}
             onChange={(e) => setNewWtBranch(e.target.value)}
           />
           <div className="field-label">Base branch</div>
-          <Input
-            aria-label="Base branch"
-            value={baseBranch}
-            onChange={(e) => setBaseBranch(e.target.value)}
-          />
+          {branches.length > 0 ? (
+            <Select
+              aria-label="Base branch"
+              value={baseBranch}
+              onChange={(e) => setBaseBranch(e.target.value)}
+            >
+              {branches.map((b) => (
+                <option key={b} value={b}>
+                  {b}
+                </option>
+              ))}
+            </Select>
+          ) : (
+            <>
+              <Input
+                aria-label="Base branch"
+                placeholder="main"
+                value={baseBranch}
+                onChange={(e) => setBaseBranch(e.target.value)}
+              />
+              {branchesError ? (
+                <div className="field-error">
+                  Couldn’t load branches ({branchesError}). Type a base branch name.
+                </div>
+              ) : (
+                <div className="field-label" style={{ fontWeight: "normal", color: "var(--fg-muted)" }}>
+                  No branches found — type a base branch name.
+                </div>
+              )}
+            </>
+          )}
         </>
       ) : null}
       <div className="field-label">Mode</div>


### PR DESCRIPTION
## Summary

Two fixes to the **New Session** dialog.

### 1. Real branch selector (replaces hardcoded `main`)
- New daemon endpoint `GET /projects/:id/branches`, backed by a `git.listBranches()` helper (committerdate-sorted; `--format` is single-quoted so branch names with `()`/`/` don't break the shell).
- The dialog now fetches and lists **real branches** in a dropdown, defaulting to the detected default branch (`master`/`main`/origin-HEAD chain) instead of a hardcoded `main` text field.
- Branch fetch runs in its own try/catch (independent of the worktree/mode load) and **gracefully degrades** to a free-text input with an inline hint when the daemon is offline or the repo has no branches.
- `listProjectBranches` added to both the client and mock APIs (`ApiInstance` is a union — both members need it).

### 2. Dialog focus-steal fix
Root cause: the auto-focus effect re-ran on **every background re-render** because `handleKeyDown`'s identity tracked a fresh inline `onClose`, stealing focus to the Close button mid-typing. Confirmed on desktop; surfaced on mobile as the on-screen keyboard collapsing.

- `onClose` kept in a ref → `handleKeyDown` is permanently stable (no stale Escape closure).
- Split into a keydown-listener effect and an auto-focus effect keyed on `[open]` only, so background re-renders never re-steal focus.
- Auto-focus now targets `[data-autofocus]` (the branch name field) → first non-button field → the dialog card (`tabIndex=-1`), **never** the Close button.

## Testing
- `pnpm -r typecheck` — clean.
- `pnpm lint` — 8 problems, **identical to base** (all pre-existing); zero new.
- web-ui tests 111/111; daemon tests 196 pass (+2 new endpoint tests). The 4 daemon failures (lifecycle timing, gemini model) are pre-existing on `main` and unrelated.
- **Docker (dev.Dockerfile):** image builds, daemon boots, `GET /projects/:id/branches` against a real multi-branch repo returns `{"branches":["develop","feature-x","main","release/2.0"],"defaultBranch":"main"}`, unknown project → 404.

Plan: `.feature-plans/done/new-session-dialog-branch-selector-n-focus-fixes.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)