### PR TITLE
fix(terminal): stop mobile soft-keyboard replaying the whole prompt

### DIFF
--- a/.feature-plans/done/mobile-soft-keyboard-double-text-fix.md
+++ b/.feature-plans/done/mobile-soft-keyboard-double-text-fix.md
@@ -1,0 +1,46 @@
+# Mini-Design: Mobile soft-keyboard "prompt-buffer replay" fix
+
+> One keypress on a mobile soft-keyboard randomly re-sent the **entire prompt typed so far** to the agent (e.g. `hello wor` + tap `l` → `hello worhello worl`). Desktop unaffected.
+
+**Issue:** double-text-fix-2
+**Branch:** `double-text-fix-2`
+**Status:** Done — root-caused from on-device logs, fix confirmed on the reporter's phone.
+
+**Key files:**
+- Fix: `web-ui/src/lib/mobile-input-fix.ts` (new)
+- Wiring: `web-ui/src/components/layout/TerminalPane.tsx`
+
+---
+
+## Problem
+
+- Mobile only: a single keypress occasionally replayed the whole accumulated buffer to the agent. Random, recurrent.
+- A prior attempt (reconnect double-attach guard) was unrelated and did not fix it.
+
+## Root cause (confirmed)
+
+- Captured the reporter's keystrokes via a temporary on-device logger + read xterm@6.0.0 source.
+- On Android/Gboard, every plain keypress arrives as `keydown keyCode 229` ("Unidentified") with **no composition events**.
+- xterm routes 229 keys through `CompositionHelper._handleAnyTextareaChanges`, which:
+  - never clears its hidden helper textarea on this path → the textarea **accumulates** the typed buffer, and
+  - recovers the new char via `newValue.replace(oldValue, "")` — a **substring** replace that assumes `oldValue` is a clean prefix.
+- Once the textarea accumulates and the caret drifts so a char lands non-contiguously, `.replace` finds no match and returns the **entire** value → xterm re-sends the whole buffer on one keypress.
+- Why mobile-only: desktop physical keys produce real keydown events that xterm handles directly (textarea path never entered).
+- The 229 path is **not** dead code — it is also what makes IME composition (CJK), dictation, and predictive text work, so it must not be removed.
+
+## Fix
+
+- `attachMobileInputFix` intercepts `beforeinput` on the helper textarea:
+  - For non-composing `insertText` / line-break / delete: `preventDefault()` (so the textarea can't accumulate and xterm's broken diff sends nothing) and forward the reliable single `event.data` ourselves.
+  - Composition (`isComposing` / `insertCompositionText`) and paste fall through to xterm untouched.
+- Desktop unaffected: xterm cancels printable keys in keydown, so `beforeinput` never fires for them and the interceptor stays dormant.
+- Gated: disable with `localStorage.terminalInputFix = "0"`.
+
+## Verification
+
+- On-device log after the fix: every `beforeinput` shows `value:""` (textarea no longer accumulates); each keypress forwards exactly one char; daemon `session:input` `dataLen` is 1. No replay.
+- Typecheck (`tsc -b --noEmit`) passes.
+
+## Notes
+
+- Diagnosis used a temporary harness (server-side input log + client→WS event shipping + dev-container Claude mount). All of it was reverted; only the fix and a `dev.Dockerfile` build-tools addition (python3/make/g++, needed to compile node-pty) remain.

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -12,6 +12,7 @@ FROM node:24-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     tmux git procps curl ripgrep \
+    python3 make g++ \
   && rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g pnpm@9.0.0 @google/gemini-cli

--- a/web-ui/src/components/layout/TerminalPane.tsx
+++ b/web-ui/src/components/layout/TerminalPane.tsx
@@ -8,6 +8,7 @@ import type { Session } from "@/api/types";
 import { useWorkspaceStore } from "@/hooks/useStore";
 import { useSessionOutput } from "@/hooks/useSubscription";
 import { attachTouchScroll } from "@/lib/terminal-touch-scroll";
+import { attachMobileInputFix } from "@/lib/mobile-input-fix";
 import { SpawningPlaceholder } from "./SpawningPlaceholder";
 
 interface TerminalPaneProps {
@@ -125,6 +126,28 @@ export function TerminalPane({ api, activeSession }: TerminalPaneProps) {
     term.loadAddon(new WebLinksAddon((_, url) => window.open(url, "_blank", "noopener,noreferrer")));
 
     term.open(host);
+
+    // xterm creates a hidden helper textarea inside open(). On mobile soft
+    // keyboards (Android/Gboard etc.) xterm's keyCode-229 textarea-diff path
+    // re-sends the whole accumulated buffer on a single keypress. The fix
+    // intercepts beforeinput and forwards the reliable single char instead —
+    // see mobile-input-fix.ts for the full root-cause writeup. Gated so it can
+    // be disabled in a pinch with `localStorage.terminalInputFix = "0"`.
+    const helperTextarea = host.querySelector<HTMLTextAreaElement>(".xterm-helper-textarea");
+    const inputFixOn = (() => {
+      try {
+        return localStorage.getItem("terminalInputFix") !== "0";
+      } catch {
+        return true;
+      }
+    })();
+    let disposeInputFix: (() => void) | null = null;
+    if (helperTextarea && inputFixOn) {
+      disposeInputFix = attachMobileInputFix(helperTextarea, (data) =>
+        void api.sendKeystroke(activeSessionId, data),
+      );
+    }
+
     // Take keyboard focus so the user can start typing immediately when a tab
     // or worktree is opened. The effect re-runs on activeSessionId change, so
     // tab switches refocus the new tab's terminal too.
@@ -232,6 +255,7 @@ export function TerminalPane({ api, activeSession }: TerminalPaneProps) {
 
     return () => {
       mounted = false;
+      disposeInputFix?.();
       offOutput();
       d.dispose();
       r.dispose();

--- a/web-ui/src/lib/mobile-input-fix.ts
+++ b/web-ui/src/lib/mobile-input-fix.ts
@@ -1,0 +1,103 @@
+/**
+ * Mobile soft-keyboard input fix (double-text-fix-2).
+ *
+ * ── Why xterm has the code we're working around (do NOT "simplify" it away) ──
+ * Browsers fire keydown with `keyCode === 229` whenever a keystroke is being
+ * produced by an input method rather than a directly-identifiable physical key.
+ * xterm can't know the character at keydown time in that case, so it falls back
+ * to `CompositionHelper._handleAnyTextareaChanges`: let the input method type
+ * into the hidden helper textarea, then diff the textarea's before/after value
+ * to recover what was entered. That 229 path is NOT dead code and is NOT
+ * mobile-only plumbing you can delete — it is what makes IME composition (CJK),
+ * dictation/voice input, and predictive text work. It just happens to be buggy
+ * for the plain-typing sub-case that mobile soft keyboards exercise.
+ *
+ * ── The bug (confirmed from on-device logs + xterm@6.0.0 source) ──
+ * On Android/Gboard, every plain keypress arrives as keyCode 229 with NO
+ * composition events. xterm never clears the textarea on this path and extracts
+ * the new char via `newValue.replace(oldValue, "")` — a *substring* replace
+ * that assumes oldValue is a clean prefix of newValue. The textarea accumulates,
+ * the caret drifts so chars land non-contiguously, the replace finds no match
+ * and returns the ENTIRE value, and xterm re-sends the whole accumulated buffer
+ * on a single keypress (the "prompt replay" bug).
+ *
+ * ── The fix ──
+ * Intercept `beforeinput` on the helper textarea. For non-composing
+ * insert/delete we preventDefault (so the textarea can't accumulate and xterm's
+ * broken diff sends nothing) and forward the reliable single `event.data`
+ * ourselves. Composition (CJK/IME) and paste are left to fall through to xterm
+ * untouched — that is why we bail on `isComposing` and `insertCompositionText`
+ * rather than patching or removing xterm's 229 handler.
+ *
+ * Desktop is unaffected: xterm cancels printable keys in keydown, so beforeinput
+ * never fires for them there and this interceptor stays dormant.
+ */
+
+export function attachMobileInputFix(
+  textarea: HTMLTextAreaElement,
+  send: (data: string) => void,
+): () => void {
+  let composing = false;
+
+  const onCompositionStart = () => {
+    composing = true;
+  };
+  const onCompositionEnd = () => {
+    composing = false;
+  };
+
+  const onBeforeInput = (e: InputEvent) => {
+    // Let the IME drive composition (CJK, emoji pickers, dead keys/accents).
+    if (composing || e.isComposing) return;
+
+    let handled = true;
+    let out: string | null = null;
+    // "insertText" is a normal key. "insertReplacementText" is a glide-typed
+    // word or an autocorrect/suggestion swap — we can only forward the new word
+    // (e.data) since the hidden textarea is kept empty so there's no range to
+    // diff, but that still beats xterm replaying the whole buffer.
+    switch (e.inputType) {
+      case "insertText":
+      case "insertReplacementText":
+        out = e.data;
+        break;
+      case "insertLineBreak":
+      case "insertParagraph":
+        out = "\r";
+        break;
+      case "deleteContentBackward":
+        out = "\x7f"; // DEL / backspace
+        break;
+      case "deleteContentForward":
+        out = "\x1b[3~"; // forward-delete
+        break;
+      case "deleteWordBackward":
+        out = "\x17"; // Ctrl-W
+        break;
+      case "deleteWordForward":
+        out = "\x1bd"; // Meta-d
+        break;
+      default:
+        // insertFromPaste (xterm's paste handler covers it), undo/redo, etc. —
+        // leave to xterm rather than guessing.
+        handled = false;
+    }
+    if (!handled) return;
+
+    // We own this event: cancel it so xterm's keyCode-229 textarea diff can
+    // neither accumulate nor re-send. `out` may be null/"" (e.g. insertText with
+    // no data) — still cancel to starve the textarea, and just send nothing.
+    e.preventDefault();
+    if (out) send(out);
+  };
+
+  textarea.addEventListener("compositionstart", onCompositionStart);
+  textarea.addEventListener("compositionend", onCompositionEnd);
+  textarea.addEventListener("beforeinput", onBeforeInput as EventListener);
+
+  return () => {
+    textarea.removeEventListener("compositionstart", onCompositionStart);
+    textarea.removeEventListener("compositionend", onCompositionEnd);
+    textarea.removeEventListener("beforeinput", onBeforeInput as EventListener);
+  };
+}


### PR DESCRIPTION
## Problem

On mobile soft keyboards (Android/Gboard), a single keypress could re-send the **entire prompt typed so far** to the agent — e.g. typing `l` after `hello wor` produced `hello worhello worl`. Random, recurrent, mobile-only. A prior attempt (reconnect double-attach guard) was unrelated and did not fix it.

## Root cause (confirmed on-device + from xterm@6.0.0 source)

- Android keys arrive as `keydown keyCode 229` ("Unidentified") with **no composition events**.
- xterm routes 229 keys through `CompositionHelper._handleAnyTextareaChanges`, which never clears its hidden helper textarea and recovers the new char via `newValue.replace(oldValue, "")` — a **substring** replace that assumes `oldValue` is a clean prefix.
- The textarea accumulates; once the caret drifts and a char lands non-contiguously, `.replace` finds no match and returns the **entire** value → xterm re-sends the whole buffer on one keypress.
- Desktop is unaffected: physical keys are handled (and cancelled) in xterm's keydown, so they never reach the textarea-diff path.
- The 229 path is **not** dead code — it also drives IME composition (CJK), dictation, and predictive text, so it must not be removed.

## Fix

`web-ui/src/lib/mobile-input-fix.ts` intercepts `beforeinput` on the helper textarea:

- For non-composing insert/delete, forward the reliable single `event.data` and `preventDefault()` so xterm's broken diff can neither accumulate nor re-send.
- Composition (`isComposing` / `insertCompositionText`) and paste fall through to xterm untouched.
- Gated via `localStorage.terminalInputFix` (default on).

## Verification

- **Reproduced and root-caused on the reporter's actual phone** using a temporary input-logging harness (since the device console is unreachable). Post-fix logs show every keypress forwarding exactly one character and `session:input` `dataLen: 1` — no replay. Harness fully reverted; only the fix ships.
- `tsc -b --noEmit` and eslint pass on the changed files.

## Reviewed

Adversarially reviewed against the xterm source by a second pass: confirmed no double-send on the Android path (`preventDefault` on `beforeinput` cancels the mutation, so xterm's `input` handler never fires and its 229 `setTimeout` reads an unchanged textarea → no-op). Review fixes applied: handle `deleteWordForward` and `insertReplacementText` (Gboard autocorrect/glide words), cancel even when `event.data` is null to starve the textarea.

## Keystroke mappings

backspace → `DEL`, Enter → `\r`, deleteWordBackward → `Ctrl-W`, deleteWordForward → `Meta-d`, forward-delete → `\e[3~`.

## Follow-ups (not blocking)

- On-device validation of CJK commit and iOS Safari soft keyboard (composition-heavy paths; fix bails to xterm there, expected net-neutral).

## Other

- `dev.Dockerfile`: add `python3 make g++` so `node-pty` compiles in the dev container.
- `.feature-plans/done/`: post-mortem record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)