### PR TITLE
chore(terminal): gated input logging to capture the mobile double-text repro

### DIFF
--- a/daemon/src/debugLog.ts
+++ b/daemon/src/debugLog.ts
@@ -1,0 +1,45 @@
+/**
+ * Diagnostic input log (mobile double-text investigation).
+ *
+ * Append-only NDJSON sink for terminal input + client IME/composition events.
+ * Used to capture a live repro of the mobile "double text" bug on a real device
+ * — the phone's browser console is unreachable, so the client ships events over
+ * the WS (`debug:log`) and the daemon writes them here, interleaved with the
+ * raw bytes each `session:input` delivered.
+ *
+ * Privacy/footprint: nothing is written unless a client opts in by enabling
+ * input debugging (?debugInput=1), which is what triggers the `debug:log`
+ * messages in the first place. Default operation writes nothing. Override the
+ * directory with VST_DEBUG_LOG_DIR (defaults to <HOME>/.vibe-station).
+ */
+import { appendFile, mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+let cachedDir: string | null = null;
+let ensured = false;
+let chain: Promise<void> = Promise.resolve();
+
+function logDir(): string {
+  if (cachedDir) return cachedDir;
+  cachedDir = process.env.VST_DEBUG_LOG_DIR || join(homedir(), ".vibe-station");
+  return cachedDir;
+}
+
+/** Append one record. Best-effort and serialized so concurrent writers (the
+ *  batched client events + per-keystroke server log) don't interleave bytes. */
+export function appendDebug(obj: unknown): void {
+  const line = JSON.stringify(obj) + "\n";
+  chain = chain
+    .then(async () => {
+      const dir = logDir();
+      if (!ensured) {
+        await mkdir(dir, { recursive: true });
+        ensured = true;
+      }
+      await appendFile(join(dir, "input-debug.log"), line);
+    })
+    .catch(() => {
+      /* never let logging crash input handling */
+    });
+}

--- a/daemon/src/ws/connection.ts
+++ b/daemon/src/ws/connection.ts
@@ -25,6 +25,14 @@ export class WSConnection {
   fileWatches: Map<string, unknown> = new Map(); // key -> FSWatcher (public for handlers)
   treeWatches: Map<string, unknown> = new Map(); // key -> FSWatcher (public for handlers)
   readonly id: string; // Unique identifier for this connection
+  /**
+   * Diagnostic flag (mobile double-text investigation). Set once a client sends
+   * a `debug:log` message — the client only does so when input debugging is
+   * enabled (?debugInput=1). When true, this connection's `session:input` bytes
+   * are also written to the input-debug log so we have ground truth of what the
+   * daemon actually received vs. what the client thought it sent.
+   */
+  debugInput = false;
 
   constructor(private ws: WebSocket) {
     this.id = Math.random().toString(36).slice(2);

--- a/daemon/src/ws/handlers/debugLog.ts
+++ b/daemon/src/ws/handlers/debugLog.ts
@@ -1,0 +1,18 @@
+import type { WSConnection } from "../connection.js";
+import type { ClientMessage } from "../protocol.js";
+import { appendDebug } from "../../debugLog.js";
+
+/**
+ * Persist client-shipped input/composition events (mobile double-text
+ * investigation). Receiving any debug:log marks the connection debug-active so
+ * its session:input bytes are logged too (see sessionInput.ts).
+ */
+export function handleDebugLog(
+  conn: WSConnection,
+  msg: Extract<ClientMessage, { type: "debug:log" }>,
+): void {
+  conn.debugInput = true;
+  for (const entry of msg.entries) {
+    appendDebug({ src: "client", conn: conn.id, ...entry });
+  }
+}

--- a/daemon/src/ws/handlers/sessionInput.ts
+++ b/daemon/src/ws/handlers/sessionInput.ts
@@ -2,6 +2,7 @@ import { execSync } from "node:child_process";
 import type { WSConnection } from "../connection.js";
 import type { ClientMessage } from "../protocol.js";
 import { findSessionRecord } from "./sessionLookup.js";
+import { appendDebug } from "../../debugLog.js";
 
 /**
  * Forward client keystrokes to the session.
@@ -25,6 +26,23 @@ export function handleSessionInput(
 ): void {
   const { sessionId, data } = msg;
   if (!data || data.length === 0) return;
+
+  // Diagnostic ground truth (mobile double-text investigation): on a
+  // debug-active connection, record the exact bytes that reached the daemon per
+  // WS message. Buffer-replay shows up here as one message whose `text` is the
+  // whole prompt; a per-keystroke double shows up as two single-char messages.
+  if (conn.debugInput) {
+    appendDebug({
+      src: "server",
+      kind: "ws-recv",
+      conn: conn.id,
+      t: Date.now(),
+      sessionId,
+      dataLen: data.length,
+      text: data,
+      hex: Buffer.from(data, "utf8").toString("hex"),
+    });
+  }
 
   const result = findSessionRecord(sessionId);
   if (!result) {

--- a/daemon/src/ws/protocol.ts
+++ b/daemon/src/ws/protocol.ts
@@ -68,6 +68,15 @@ const PingMessage = z.object({
   type: z.literal("ping"),
 });
 
+// Diagnostic channel (mobile double-text investigation): the client ships
+// terminal input + IME/composition events here when ?debugInput=1 is enabled,
+// and the daemon writes them to input-debug.log. Gated entirely on the client;
+// when debugging is off, no debug:log messages are sent.
+const DebugLogMessage = z.object({
+  type: z.literal("debug:log"),
+  entries: z.array(z.record(z.string(), z.unknown())),
+});
+
 export const ClientMessage = z.discriminatedUnion("type", [
   SubscribeMessage,
   UnsubscribeMessage,
@@ -80,6 +89,7 @@ export const ClientMessage = z.discriminatedUnion("type", [
   TreeWatchMessage,
   TreeUnwatchMessage,
   PingMessage,
+  DebugLogMessage,
 ]);
 
 export type ClientMessage = z.infer<typeof ClientMessage>;

--- a/daemon/src/ws/server.ts
+++ b/daemon/src/ws/server.ts
@@ -13,6 +13,7 @@ import { handleFileWatch } from "./handlers/fileWatch.js";
 import { handleFileUnwatch } from "./handlers/fileUnwatch.js";
 import { handleTreeWatch } from "./handlers/treeWatch.js";
 import { handleTreeUnwatch } from "./handlers/treeUnwatch.js";
+import { handleDebugLog } from "./handlers/debugLog.js";
 import { registerConnection, unregisterConnection } from "../broadcaster.js";
 import { COOKIE_NAME, validateSessionCookie } from "../auth.js";
 
@@ -141,6 +142,10 @@ export async function registerWSEndpoint(app: FastifyInstance, daemonToken?: str
             break;
           case "tree:unwatch":
             await handleTreeUnwatch(conn, msg);
+            break;
+          // Diagnostic channel (mobile double-text investigation)
+          case "debug:log":
+            handleDebugLog(conn, msg);
             break;
         }
       } catch (err) {

--- a/web-ui/src/api/client.ts
+++ b/web-ui/src/api/client.ts
@@ -491,6 +491,17 @@ export function createClientApi() {
       await sendWs({ type: "session:input", sessionId, data });
     },
 
+    // Diagnostic channel (mobile double-text investigation): ship batched input/
+    // composition events to the daemon's input-debug log. Best-effort — never
+    // throw into the caller (the terminal hot path).
+    async sendDebug(entries: Record<string, unknown>[]): Promise<void> {
+      try {
+        await sendWs({ type: "debug:log", entries });
+      } catch {
+        /* ignore */
+      }
+    },
+
     async resizeSession(sessionId: string, cols: number, rows: number): Promise<void> {
       await sendWs({ type: "session:resize", sessionId, cols, rows });
     },

--- a/web-ui/src/api/mock.ts
+++ b/web-ui/src/api/mock.ts
@@ -449,6 +449,9 @@ export function createMockApi() {
 
     async resizeSession(_sessionId: string, _cols: number, _rows: number): Promise<void> {},
 
+    // Diagnostic channel (mobile double-text investigation) — no-op in the mock.
+    async sendDebug(): Promise<void> {},
+
     async getFile(worktreeId: string, filePath: string): Promise<string> {
       if (!worktrees.find((w) => w.id === worktreeId)) throw new ApiError("not found", 404);
       if (filePath === "HUGE.bin") {

--- a/web-ui/src/api/types.ts
+++ b/web-ui/src/api/types.ts
@@ -240,4 +240,8 @@ export interface TerminalApi {
   closeSession: (sessionId: string) => Promise<void>;
   sendKeystroke: (sessionId: string, data: string) => Promise<void>;
   resizeSession: (sessionId: string, cols: number, rows: number) => Promise<void>;
+  /** Diagnostic channel (mobile double-text investigation): ship batched input/
+   *  composition events to the daemon's input-debug log. Optional so the mock
+   *  can omit it. */
+  sendDebug?: (entries: Record<string, unknown>[]) => Promise<void>;
 }

--- a/web-ui/src/components/layout/TerminalPane.tsx
+++ b/web-ui/src/components/layout/TerminalPane.tsx
@@ -9,6 +9,7 @@ import { useWorkspaceStore } from "@/hooks/useStore";
 import { useSessionOutput } from "@/hooks/useSubscription";
 import { attachTouchScroll } from "@/lib/terminal-touch-scroll";
 import { attachMobileInputFix } from "@/lib/mobile-input-fix";
+import { createInputDebugger, isInputDebugEnabled, type InputDebugger } from "@/lib/input-debug";
 import { SpawningPlaceholder } from "./SpawningPlaceholder";
 
 interface TerminalPaneProps {
@@ -134,6 +135,16 @@ export function TerminalPane({ api, activeSession }: TerminalPaneProps) {
     // see mobile-input-fix.ts for the full root-cause writeup. Gated so it can
     // be disabled in a pinch with `localStorage.terminalInputFix = "0"`.
     const helperTextarea = host.querySelector<HTMLTextAreaElement>(".xterm-helper-textarea");
+
+    // Diagnostic logger (mobile double-text investigation). Enabled per-device
+    // with ?debugInput=1; records the full input pipeline to the daemon log so a
+    // live repro can be audited. No-op when disabled.
+    let inputDebug: InputDebugger | null = null;
+    if (isInputDebugEnabled()) {
+      inputDebug = createInputDebugger(api, activeSessionId);
+      inputDebug.attachTextarea(helperTextarea);
+    }
+
     const inputFixOn = (() => {
       try {
         return localStorage.getItem("terminalInputFix") !== "0";
@@ -141,10 +152,13 @@ export function TerminalPane({ api, activeSession }: TerminalPaneProps) {
         return true;
       }
     })();
+    inputDebug?.log({ kind: "fix-config", inputFixOn, hasTextarea: !!helperTextarea });
     let disposeInputFix: (() => void) | null = null;
     if (helperTextarea && inputFixOn) {
-      disposeInputFix = attachMobileInputFix(helperTextarea, (data) =>
-        void api.sendKeystroke(activeSessionId, data),
+      disposeInputFix = attachMobileInputFix(
+        helperTextarea,
+        (data) => void api.sendKeystroke(activeSessionId, data),
+        inputDebug ? (entry) => inputDebug!.log(entry) : undefined,
       );
     }
 
@@ -247,6 +261,9 @@ export function TerminalPane({ api, activeSession }: TerminalPaneProps) {
       // appearing as if typed). On a noisy connection this also turns into
       // a tight loop because the agent's redraw retriggers the query.
       if (isXtermAutoResponse(data)) return;
+      // Diagnostic: what xterm actually emitted. If a printable chunk shows up
+      // here while the fix also sent the char, that's the double-text smoking gun.
+      inputDebug?.log({ kind: "onData", chunk: data, chunkLen: data.length });
       void api.sendKeystroke(activeSessionId, data);
     });
     const r = term.onResize(({ cols, rows }) => {
@@ -256,6 +273,7 @@ export function TerminalPane({ api, activeSession }: TerminalPaneProps) {
     return () => {
       mounted = false;
       disposeInputFix?.();
+      inputDebug?.dispose();
       offOutput();
       d.dispose();
       r.dispose();

--- a/web-ui/src/lib/input-debug.ts
+++ b/web-ui/src/lib/input-debug.ts
@@ -1,0 +1,140 @@
+/**
+ * Diagnostic terminal-input logger (mobile double-text investigation).
+ *
+ * Captures the full keystroke pipeline on the device and ships it to the daemon
+ * over the WS (the phone's browser console is unreachable). For every key it
+ * records keydown / composition* / beforeinput / input (with inputType, data,
+ * isComposing, and the hidden textarea's value+selection), what
+ * attachMobileInputFix decided, and what xterm finally emitted via onData. The
+ * daemon writes these — interleaved with the bytes it actually received — to
+ * <data-dir>/input-debug.log so a maintainer can audit a live repro.
+ *
+ * OFF by default. Enable on mobile by opening the app with `?debugInput=1`
+ * (persisted to localStorage); disable with `?debugInput=0`. No console access
+ * needed. Remove this module once the bug is fixed.
+ */
+
+interface DebugSink {
+  sendDebug?: (entries: Record<string, unknown>[]) => void | Promise<void>;
+}
+
+const STORAGE_KEY = "debugTerminalInput";
+
+/** True if input debugging is enabled. Honours a `?debugInput=1|0` URL param
+ *  (persisting it) so it can be toggled on a phone without a console. */
+export function isInputDebugEnabled(): boolean {
+  try {
+    const q = new URLSearchParams(window.location.search).get("debugInput");
+    if (q === "1") localStorage.setItem(STORAGE_KEY, "1");
+    else if (q === "0") localStorage.setItem(STORAGE_KEY, "0");
+    return localStorage.getItem(STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export interface InputDebugger {
+  log: (entry: Record<string, unknown>) => void;
+  attachTextarea: (el: HTMLTextAreaElement | null) => void;
+  dispose: () => void;
+}
+
+export function createInputDebugger(api: DebugSink, sessionId: string): InputDebugger {
+  let buf: Record<string, unknown>[] = [];
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let seq = 0;
+  let textarea: HTMLTextAreaElement | null = null;
+  const listeners: Array<[string, EventListener]> = [];
+
+  const flush = () => {
+    if (buf.length === 0) return;
+    const entries = buf;
+    buf = [];
+    try {
+      void api.sendDebug?.(entries);
+    } catch {
+      /* best-effort */
+    }
+  };
+  const schedule = () => {
+    if (timer != null) return;
+    timer = setTimeout(() => {
+      timer = null;
+      flush();
+    }, 150);
+  };
+  const log = (entry: Record<string, unknown>) => {
+    buf.push({ seq: seq++, t: Date.now(), sessionId, ...entry });
+    if (buf.length >= 30) flush();
+    else schedule();
+  };
+
+  // One-time environment line — the keyboard/OS matters for this bug.
+  try {
+    log({
+      kind: "env",
+      ua: navigator.userAgent,
+      helperCount: document.querySelectorAll(".xterm-helper-textarea").length,
+    });
+  } catch {
+    /* ignore */
+  }
+
+  const attachTextarea = (el: HTMLTextAreaElement | null) => {
+    if (!el) {
+      log({ kind: "attach", hasTextarea: false });
+      return;
+    }
+    textarea = el;
+    log({ kind: "attach", hasTextarea: true });
+
+    // Capture phase so we observe the raw event before attachMobileInputFix's
+    // (bubble-phase) listener can preventDefault it.
+    const add = (type: string, fn: (e: Event) => void) => {
+      el.addEventListener(type, fn, true);
+      listeners.push([type, fn]);
+    };
+    const snap = () => ({
+      value: el.value,
+      valueLen: el.value.length,
+      selStart: el.selectionStart,
+      selEnd: el.selectionEnd,
+    });
+    add("keydown", (e) => {
+      const k = e as KeyboardEvent;
+      log({ kind: "keydown", key: k.key, code: k.code, keyCode: k.keyCode, isComposing: k.isComposing });
+    });
+    add("compositionstart", (e) =>
+      log({ kind: "compositionstart", data: (e as CompositionEvent).data, ...snap() }),
+    );
+    add("compositionupdate", (e) =>
+      log({ kind: "compositionupdate", data: (e as CompositionEvent).data, ...snap() }),
+    );
+    add("compositionend", (e) =>
+      log({ kind: "compositionend", data: (e as CompositionEvent).data, ...snap() }),
+    );
+    add("beforeinput", (e) => {
+      const i = e as InputEvent;
+      log({ kind: "beforeinput", inputType: i.inputType, data: i.data, isComposing: i.isComposing, ...snap() });
+    });
+    add("input", (e) => {
+      const i = e as InputEvent;
+      log({ kind: "input", inputType: i.inputType, data: i.data, isComposing: i.isComposing, ...snap() });
+    });
+  };
+
+  const dispose = () => {
+    flush();
+    if (timer != null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    if (textarea) {
+      for (const [type, fn] of listeners) textarea.removeEventListener(type, fn, true);
+    }
+    listeners.length = 0;
+    textarea = null;
+  };
+
+  return { log, attachTextarea, dispose };
+}

--- a/web-ui/src/lib/mobile-input-fix.ts
+++ b/web-ui/src/lib/mobile-input-fix.ts
@@ -36,6 +36,9 @@
 export function attachMobileInputFix(
   textarea: HTMLTextAreaElement,
   send: (data: string) => void,
+  // Optional diagnostic hook (mobile double-text investigation): records what
+  // the fix decided for each beforeinput. Off in normal operation.
+  log?: (entry: Record<string, unknown>) => void,
 ): () => void {
   let composing = false;
 
@@ -48,7 +51,10 @@ export function attachMobileInputFix(
 
   const onBeforeInput = (e: InputEvent) => {
     // Let the IME drive composition (CJK, emoji pickers, dead keys/accents).
-    if (composing || e.isComposing) return;
+    if (composing || e.isComposing) {
+      log?.({ kind: "fix", inputType: e.inputType, decision: "skip-composing", composing, isComposing: e.isComposing });
+      return;
+    }
 
     let handled = true;
     let out: string | null = null;
@@ -82,12 +88,16 @@ export function attachMobileInputFix(
         // leave to xterm rather than guessing.
         handled = false;
     }
-    if (!handled) return;
+    if (!handled) {
+      log?.({ kind: "fix", inputType: e.inputType, decision: "passthrough" });
+      return;
+    }
 
     // We own this event: cancel it so xterm's keyCode-229 textarea diff can
     // neither accumulate nor re-send. `out` may be null/"" (e.g. insertText with
     // no data) — still cancel to starve the textarea, and just send nothing.
     e.preventDefault();
+    log?.({ kind: "fix", inputType: e.inputType, decision: "send", out, outLen: out ? out.length : 0 });
     if (out) send(out);
   };
 


### PR DESCRIPTION
## Why

The `beforeinput` fix in #13 resolved the **container** repro, but the double-text still happens in **real mobile use** — so the captured path wasn't the whole story. This PR adds opt-in, on-device logging so we can capture a live repro and audit exactly which path produces the duplicate.

**This is diagnostics, not a fix.** Safe to merge: nothing is logged unless a device explicitly opts in.

## How to use

1. Merge + restart VST.
2. On the phone, open the app with **`?debugInput=1`** appended to the URL (e.g. `https://…/?debugInput=1`). This persists to localStorage — no browser console needed. (Disable later with `?debugInput=0`.)
3. Reproduce the double-text.
4. The maintainer reads `~/.vibe-station/input-debug.log` and audits.

## What it captures

Per keystroke, shipped over the WS and written to `~/.vibe-station/input-debug.log`:

- **Client** (`input-debug.ts`): `keydown` / `compositionstart|update|end` / `beforeinput` / `input` — with `inputType`, `data`, `isComposing`, and the hidden textarea's `value` + selection. Plus a one-time `env` line (userAgent, helper-textarea count).
- **Fix decision** (`mobile-input-fix.ts`): for each `beforeinput`, whether it skipped (composing), passed through, or sent — and what.
- **xterm output** (`onData`): what xterm actually emitted — so a printable `onData` chunk alongside a `fix` send is the double-send smoking gun.
- **Daemon ground truth** (`sessionInput.ts`): the exact bytes (`text` + `hex`) each `session:input` delivered, logged only for debug-active connections.

## Gating / safety

- Client: off unless `?debugInput=1` / `localStorage.debugTerminalInput="1"`.
- Daemon: a connection is marked debug-active only after it sends a `debug:log`; only then are its `session:input` bytes logged. Default operation writes nothing.
- New WS message `debug:log` (zod-validated). Log dir overridable via `VST_DEBUG_LOG_DIR`.

## Follow-up

Once a repro is captured and the bug is root-caused, this scaffolding gets reverted (tracked: it's all behind the `debug:log` channel + `input-debug.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)