### PR TITLE
feat(projects): hide projects + snap sidebar to selected worktree

### DIFF
--- a/.feature-plans/done/hide-projects-and-scroll-to-selected.md
+++ b/.feature-plans/done/hide-projects-and-scroll-to-selected.md
@@ -1,0 +1,394 @@
+# Mini-Design: Hide projects + scroll-to-selected worktree
+
+> Project-level hide (server-side flag, Settings unhide) + sidebar reopen snaps to the selected worktree.
+
+**Issue:** hide-projects-and-scroll-to-selected
+**Branch:** `scrollfix-n-hiding`
+**Status:** Done
+**PRD:** `.feature-plans/pending/prd-hide-projects-and-scroll-to-selected.md`
+
+**Reference files:**
+- Data / schema: `daemon/src/types.ts:51` (`ProjectRecord`)
+- Project store: `daemon/src/state/project-store.ts:67` (`mutateProject`)
+- Project routes: `daemon/src/routes/projects.ts:41` (`registerProjectRoutes`)
+- WS protocol (zod): `daemon/src/ws/protocol.ts:239` (`ServerMessage` discriminatedUnion; `project:created` at `:191`)
+- Pin precedent: `daemon/src/routes/worktrees.ts:382` (PATCH `/worktrees/:id/pin`)
+- Client API: `web-ui/src/api/client.ts:192-204` (project methods)
+- Mock API: `web-ui/src/api/mock.ts:29` (`createMockApi`; `ApiInstance` is a `client | mock` union — both must implement new methods)
+- URL sync: `web-ui/src/hooks/useWorkspaceUrlSync.ts:41-66` (deep-link applies wtId with no hidden check)
+- Client types: `web-ui/src/api/types.ts:9` (`Project`), `:140` (WS events)
+- Server store: `web-ui/src/hooks/useServerStore.ts:32` (project reducers)
+- WS sync: `web-ui/src/hooks/useServerSync.ts:85` (project event wiring)
+- Sidebar: `web-ui/src/components/layout/LeftSidebar.tsx:400-431` (project row), `:281` (scroll container)
+- Dashboard: `web-ui/src/components/layout/DashboardPanel.tsx:45,93` (worktree lists)
+- Settings: `web-ui/src/components/settings/SettingsPanel.tsx:26` (sections)
+- Route shell: `web-ui/src/routes/Workspace.tsx:74-90` (stale-selection cleanup)
+
+---
+
+## Problem
+
+- Sidebar + dashboard list every project/worktree with no way to declutter.
+- No project-row kebab exists today (only chevron + "New session" `+` button at `LeftSidebar.tsx:422-430`).
+- Reopening the left sidebar resets scroll to top; selected worktree (`data-active="true"` at `LeftSidebar.tsx:443`) is lost if offscreen.
+
+## Out of Scope
+
+- Per-worktree hide (pin/dismiss already exist).
+- Project delete/archive (CLI-only).
+- Bulk hide/unhide, search, undo toast.
+- Smooth-animated sidebar scroll (instant snap only).
+
+## Concept
+
+- Add `hidden` flag to a project (server-side, persisted in manifest, broadcast via WS).
+- Project-row kebab menu (new) with **New worktree** + **Hide project**.
+- Hidden projects filtered out of sidebar + dashboard everywhere.
+- Settings gets a **Hidden projects** section to unhide.
+- On sidebar open transition, snap the active worktree row into view.
+
+## Requirements
+
+| # | Requirement |
+|---|-------------|
+| 1 | Project kebab menu with "New worktree" (reuse `NewSessionDialog`) + "Hide project" (no confirm) |
+| 2 | Hiding removes project + its worktrees from sidebar (expanded + collapsed) and dashboard, live across tabs |
+| 3 | Hidden state server-side on manifest; survives daemon restart; identical across clients |
+| 4 | Settings "Hidden projects" section lists hidden projects + per-row Unhide + empty state |
+| 5 | Hiding never touches sessions/worktrees/files |
+| 6 | Hiding the active project redirects to dashboard and clears active selection |
+| 7 | Sidebar open snaps selected worktree into view only if offscreen; no-op if visible or none selected |
+
+---
+
+## Research
+
+### Project data model — no visibility flag
+
+- **File:** `daemon/src/types.ts:51-58` — `ProjectRecord` has no `hidden`.
+- **File:** `daemon/src/routes/projects.ts:19-28` — `serializeProject` drops `worktrees`; must add `hidden`.
+- **Risk:** LOW — additive optional field.
+
+### No project PATCH endpoint
+
+- **File:** `daemon/src/routes/projects.ts:41-193` — only GET/POST/DELETE.
+- **Precedent:** `daemon/src/routes/worktrees.ts:382-469` (PATCH pin) — idempotent `mutateProject` + `broadcastAll`.
+- **Risk:** LOW — mirror the pin pattern.
+
+### WS `project:updated` event missing on BOTH sides (compile blocker)
+
+- **File:** `daemon/src/ws/protocol.ts:191-197,239` — `ServerMessage` is a zod `discriminatedUnion`; has `project:created`/`project:deleted`, **no** `project:updated`. `broadcastAll` (`broadcaster.ts:32`) is strictly typed to it → `broadcastAll({type:"project:updated"})` is a **TS error**.
+- **File:** `web-ui/src/api/types.ts:140-147` — client WS union also lacks `project:updated`.
+- **File:** `web-ui/src/hooks/useServerStore.ts:32-62` — has `applyProjectCreated`/`applyProjectDeleted`, **no** `applyProjectUpdated`.
+- **File:** `web-ui/src/hooks/useServerSync.ts:85-90,127-138` — wires `project:created`/`project:deleted` only.
+- **Risk:** MEDIUM — must add the event in 4 places (daemon zod + client union + reducer + sync); mirror `project:created`/`worktree:updated`.
+
+### Mock API must implement new methods (compile blocker)
+
+- **File:** `web-ui/src/api/mock.ts:29,257` — `createMockApi` has `deleteProject` (emits `project:deleted`) but no hide/unhide. `ApiInstance = client | mock` union (`api/index.ts:8`) → a method exists only if **both** declare it; all call sites take `api: ApiInstance`.
+- **Risk:** MEDIUM — without mock impl, every `api.hideProject` call + every vitest using the mock fails to compile. Mock impl must mutate in-memory project + `emit({type:"project:updated",project})` so reducer/integration tests exercise real flow.
+
+### Deep-link to hidden project's worktree (leak + effect fight)
+
+- **File:** `web-ui/src/hooks/useWorkspaceUrlSync.ts:41-66` — read effect resolves `params.wtId` from the **unfiltered** `worktrees` and sets it active with **no hidden check**; write effect (`:71-93`) mirrors it back to the path.
+- **File:** `web-ui/src/routes/Workspace.tsx:74-90` — stale-selection effect clears selection when worktree missing but does **not** `navigate()`; deps `[bundleLoaded, worktrees, sessions]` (no `projects`).
+- **Risk:** MEDIUM — hidden project's worktree stays openable by URL; redirect must cover the URL-sync path, add `projects` to deps, and be a **separate branch** from `!wtStillExists`.
+
+### Dashboard projects section + counts also list projects
+
+- **File:** `web-ui/src/components/layout/DashboardPanel.tsx:243-248` — a `projects.map` "projects" section (cards) below the worktree buckets; must also be filtered (R7), not just buckets at `:89-103`.
+- **Risk:** LOW.
+
+### Sidebar render sites
+
+- **File:** `LeftSidebar.tsx:72` — `projects` from `useServerStore`; mapped at `:400`.
+- **File:** `LeftSidebar.tsx:121` — `wtMenu` state + portal menu at `:585-680` is the kebab pattern to copy.
+- **File:** `LeftSidebar.tsx:281-283` — `.left-sidebar__scroll` is the scroll container (no ref today).
+- **File:** `LeftSidebar.tsx:222-230` — effect already auto-expands `activeProjectId` into `openProj` (so active row will exist in DOM).
+- **Risk:** MEDIUM — sidebar is dense; must filter in both expanded + collapsed paths and not break pinned section (pinned worktrees at `:97-104,285-359` must also drop hidden-project worktrees).
+
+### Dashboard render sites
+
+- **File:** `DashboardPanel.tsx:45-47` — `projects`/`worktrees`/`sessions` from store.
+- **File:** `DashboardPanel.tsx:89-103` — buckets iterate `worktrees`; filter by hidden-project here.
+- **File:** `DashboardPanel.tsx:82` — `projectById` available for lookup.
+- **Risk:** LOW.
+
+### Sidebar open transition
+
+- **File:** `Workspace.tsx:40-43,98` — `leftSidebarCollapsed` (desktop) / `mobileSidebarOpen` (mobile) control visibility; LeftSidebar gets `collapsed` + `isMobile` props (`:137-138`).
+- **File:** `useStore.ts:42-45,207-209` — both flags live in `useWorkspaceStore`.
+- **Risk:** MEDIUM — must detect false→true transition and scroll after layout settles (expand may add the row same frame).
+
+## Root Cause
+
+- **Hide:** feature never existed — no flag, no endpoint, no filter.
+- **Scroll:** sidebar has no scroll-restoration / scroll-to-active logic; native scroll resets when width/visibility changes.
+
+---
+
+## Architecture
+
+```
+[Project kebab "Hide"] → api.hideProject(id) → PATCH /projects/:id {hidden:true}
+                                                      ↓
+                                          mutateProject() → manifest.json
+                                                      ↓
+                                          broadcastAll(project:updated)
+                                                      ↓
+        useServerSync(project:updated) → useServerStore.applyProjectUpdated
+                                                      ↓
+              ┌──────────────────────────────────────┴───────────────────────┐
+        LeftSidebar (filter hidden)                              DashboardPanel (filter hidden)
+              │                                                                │
+        Workspace (active project hidden → clear + nav "/")        SettingsPanel → HiddenProjectsSetting → Unhide
+
+[Sidebar open transition] → useEffect(visible false→true) → scrollEl.querySelector('[data-active]').scrollIntoView({block:"nearest"})
+```
+
+---
+
+## Design Details
+
+### Critical User Journeys (CUJs)
+
+#### CUJ 1 — Hide a project
+
+```
+User opens project kebab (⋮) in sidebar
+  → Clicks "Hide project"
+  → api.hideProject(id) PATCH → manifest hidden:true → broadcast
+  → applyProjectUpdated sets project.hidden
+  → Sidebar + dashboard drop the project and its worktrees (all tabs)
+```
+
+- **Edge — active project hidden:** Workspace effect detects `activeProjectId` now hidden → clears selection + `navigate("/")`.
+- **Edge — concurrent delete:** `project:deleted` still cascades; `applyProjectUpdated` drops unknown ids (mirror `:80`).
+- **Error:** PATCH fails → swallow like sibling handlers (`LeftSidebar.tsx:197`); no state change, project stays visible.
+
+#### CUJ 2 — Unhide from Settings
+
+```
+User opens Settings → "Hidden projects"
+  → Sees hidden projects (or empty state)
+  → Clicks "Unhide"
+  → api.unhideProject(id) PATCH hidden:false → broadcast
+  → Project reappears in sidebar + dashboard; row leaves hidden list
+```
+
+- **Edge — none hidden:** empty state copy.
+
+#### CUJ 3 — Reopen sidebar with offscreen selection
+
+```
+User scrolled, selected worktree far down → collapses sidebar (or closes drawer)
+  → Reopens sidebar
+  → visible transitions false→true
+  → active project auto-expanded (existing effect :222)
+  → rAF: active row scrollIntoView({block:"nearest"})
+```
+
+- **Edge — already visible:** `block:"nearest"` no-ops.
+- **Edge — no selection / on dashboard:** no `[data-active="true"]` → no scroll.
+- **Edge — user scrolls during open:** one-shot per transition; not re-fired.
+
+### Data Model
+
+| Entity | Field | Type | Constraints | Notes |
+|--------|-------|------|-------------|-------|
+| `ProjectRecord` | `hidden` | `boolean?` | optional | Absent/undefined ≡ visible; drop field when false (clean manifest, mirror `pinnedAt` drop at `worktrees.ts:436`) |
+| `Project` (client) | `hidden` | `boolean` | always emit | Serialize `hidden: !!p.hidden` so client never special-cases |
+
+- **Migration:** N — additive optional field; existing manifests load as visible.
+
+### API Contracts
+
+```
+PATCH /projects/:id
+  Request:  { hidden: boolean }
+  Response: { ok: true, project: Project }
+  Errors:   400 VALIDATION_ERROR, 404 NOT_FOUND
+  Behavior: idempotent (no-op + no broadcast when already in requested state);
+            broadcasts project:updated only on actual change
+```
+
+```
+WS event (new): project:updated
+  Payload:  { type: "project:updated", project: Project }
+  Producer: PATCH /projects/:id  → Consumer: useServerSync → applyProjectUpdated
+```
+
+- Unchanged: GET/POST/DELETE `/projects` (only `serializeProject` gains `hidden`).
+
+### Key Decisions
+
+#### Decision 1: Server-side flag, not localStorage
+
+- **Decision:** store `hidden` on the project manifest; sync via WS.
+- **Rationale:** durable, cross-client, consistent with `pinnedAt`.
+- **Where:** `daemon/src/types.ts:51`, `daemon/src/routes/projects.ts` (new PATCH + serialize).
+
+#### Decision 2: Idempotent PATCH mirroring pin
+
+- **Decision:** reuse the pin handler's outcome-closure pattern (no-op vs updated; 404 on race).
+- **Rationale:** proven; avoids manifest churn + cross-tab bounce.
+- **Where:** `daemon/src/routes/projects.ts` (new handler modeled on `worktrees.ts:385-469`).
+
+#### Decision 3: Filter in render, single source of truth
+
+- **Decision:** keep full `projects`/`worktrees` in store; filter `hidden` at each render site (sidebar, dashboard) + derive `hiddenProjects` in Settings.
+- **Rationale:** store stays server-truth; Settings still needs the hidden ones.
+- **Where:** `LeftSidebar.tsx:400` (project map), `:97-104` (pinned), `DashboardPanel.tsx:89-103`, `SettingsPanel.tsx`.
+
+#### Decision 4: Hidden-aware projectId set helper
+
+- **Decision:** compute `hiddenProjectIds = new Set(projects.filter(p=>p.hidden).map(p=>p.id))` and exclude worktrees whose `projectId` is in it (pinned section + dashboard).
+- **Rationale:** worktrees carry only `projectId`; one set covers all worktree filters.
+- **Where:** `LeftSidebar.tsx` (memo near `:75`), `DashboardPanel.tsx` (memo near `:82`).
+
+#### Decision 5: Scroll trigger via visibility transition + double-rAF with null-retry
+
+- **Decision:** in LeftSidebar, `visible = isMobile ? mobileSidebarOpen : !collapsed`; `useEffect` on `visible` rising edge → **double `requestAnimationFrame`** → query `[data-active="true"]` inside scroll-container ref → `scrollIntoView({block:"nearest"})`. If `querySelector` returns null (active row not yet inserted by the auto-expand effect), retry once on the next frame.
+- **Rationale:** desktop expand changes width 52→220px + swaps abbrev→full labels + auto-expand inserts rows in the same commit; a single rAF runs before layout settles. Double-rAF runs after layout. `block:"nearest"` self-no-ops when already visible (R15).
+- **Caveat:** unit tests can only spy that `scrollIntoView` is *called* — jsdom has no layout/`scrollIntoView` geometry. Real correctness verified manually in Docker (5.T3).
+- **Where:** `LeftSidebar.tsx` (ref on `.left-sidebar__scroll` at `:282`, new effect + `prevVisible` ref near `:120`).
+
+#### Decision 6: Active-project-hidden redirect (covers store AND URL-sync deep-link paths)
+
+- **Decision:** in the `Workspace.tsx:74-90` effect, add a **separate branch**: if the active worktree exists but its project is `hidden`, clear selection AND `navigate("/")`. Add `projects` to the effect deps.
+- **Rationale:** url-sync (`useWorkspaceUrlSync.ts:41-66`) has no hidden check and would keep a hidden project's worktree open + mirror it to the URL; centralizing the gate in Workspace (same `bundleLoaded` timing) overrides it without touching url-sync's one-shot logic.
+- **Where:** `Workspace.tsx:74-90` (new branch separate from `!wtStillExists`; `projects` dep; `navigate("/")`).
+
+#### Decision 7: Add `project:updated` to daemon zod union + client union
+
+- **Decision:** add a `project:updated` schema to `daemon/src/ws/protocol.ts` `ServerMessage` (mirror `project:created` at `:191`, `project: z.record(z.string(), z.unknown())`) and to client `WSEvent` (`api/types.ts:159`). Cast payload `as unknown as Record<string,unknown>` like `projects.ts:148`.
+- **Rationale:** `broadcastAll` is strictly typed to the zod union — without the daemon schema the broadcast won't compile.
+- **Where:** `daemon/src/ws/protocol.ts:191,239`, `web-ui/src/api/types.ts:159`.
+
+---
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `daemon/src/types.ts` | Add `hidden?: boolean` to `ProjectRecord` |
+| `daemon/src/ws/protocol.ts` | Add `project:updated` schema to `ServerMessage` zod union (**compile blocker**) |
+| `daemon/src/routes/projects.ts` | Add `hidden` to `serializeProject`; add PATCH `/projects/:id` (idempotent, broadcast `project:updated`) |
+| `web-ui/src/api/types.ts` | Add `hidden: boolean` to `Project`; add `project:updated` to WS union |
+| `web-ui/src/api/client.ts` | Add `hideProject(id)`/`unhideProject(id)` (PATCH) |
+| `web-ui/src/api/mock.ts` | Implement `hideProject`/`unhideProject` (mutate + emit `project:updated`) (**compile blocker**) |
+| `web-ui/src/hooks/useServerStore.ts` | Add `applyProjectUpdated` reducer (replace by id; drop unknown) |
+| `web-ui/src/hooks/useServerSync.ts` | Wire `project:updated` → `applyProjectUpdated` |
+| `web-ui/src/components/layout/LeftSidebar.tsx` | Project kebab (New worktree + Hide); filter hidden in project map (`:400`) + pinned memo (`:97`); scroll-container ref + open-snap effect |
+| `web-ui/src/components/layout/DashboardPanel.tsx` | Exclude hidden-project worktrees from buckets (`:89`) AND projects section (`:243`) |
+| `web-ui/src/components/settings/SettingsPanel.tsx` | Register "Hidden projects" section |
+| `web-ui/src/components/settings/HiddenProjectsSetting.tsx` | **New** — list hidden projects + Unhide + empty state |
+| `web-ui/src/routes/Workspace.tsx` | Redirect/clear when active project hidden (covers deep-link) |
+
+## Risks / Open Questions
+
+| # | Question | Notes |
+|---|----------|-------|
+| 1 | Daemon broadcaster typed? | **YES** — `broadcastAll` is strictly typed to the zod `ServerMessage` union (`protocol.ts:239`); `project:updated` MUST be added there or it won't compile (Decision 7) |
+| 2 | Scroll timing on desktop expand | Same-component (no remount on collapse↔expand), but a single rAF runs before the width/label layout settles → use double-rAF + null-retry (Decision 5) |
+| 3 | Cross-branch remount resets `prevVisible` | LeftSidebar is rendered from 3 mutually-exclusive `Layout` branches (`Layout.tsx:133,317,341`); dashboard↔worktree nav or terminal-position toggle remounts it. A remount with an already-expanded sidebar fires one extra snap, which `block:"nearest"` no-ops if visible — acceptable; document that R18 "one-shot" holds within a mount, not across remounts |
+| 4 | Mobile drawer mount | LeftSidebar stays mounted when drawer closed (`Layout.tsx:102-119`), so effect fires on `mobileSidebarOpen` flip |
+| 5 | Collapsed rail kebab | Single `projects.map` at `:400` serves collapsed + expanded, so one `hiddenProjectIds` filter covers both; "Hide"/"New worktree" kebab shown expanded-only (no room on rail) — acceptable per PRD R5 |
+| 6 | Deep-link to hidden worktree | url-sync has no hidden check (`useWorkspaceUrlSync.ts:41`); gate centralized in Workspace effect (Decision 6) |
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Backend: hidden flag + PATCH + broadcast
+
+- [ ] **1.1** `daemon/src/types.ts:51` — add `hidden?: boolean` to `ProjectRecord`
+- [ ] **1.2** `daemon/src/ws/protocol.ts:191,239` — add `project:updated` schema (`{type:literal, project:z.record}`) to `ServerMessage` union
+- [ ] **1.3** `daemon/src/routes/projects.ts:19` — add `hidden: !!p.hidden` to `serializeProject`
+- [ ] **1.4** `daemon/src/routes/projects.ts` — add `app.patch("/projects/:id")`: zod `{hidden:boolean}`, `mutateProject` set/drop field, idempotent no-op (broadcast only on change), `broadcastAll({type:"project:updated",project: ... as unknown as Record<string,unknown>})`, 404 via caught `mutateProject` throw (simpler than pin's nested re-lookup — see Decision/N2)
+
+**Verify phase 1:**
+- [ ] **1.T1** Unit — projects route: PATCH `{hidden:true}` returns `{ok,project.hidden:true}`; PATCH unknown id → 404; invalid body → 400
+- [ ] **1.T2** Integration — manifest: PATCH persists `hidden` then reload (`readManifest`) returns it; PATCH `{hidden:false}` drops field
+- [ ] **1.T3** Regression — GET `/projects` still returns existing projects with `hidden:false`
+
+### Phase 2 — Client data layer
+
+- [ ] **2.1** `web-ui/src/api/types.ts:9` — `hidden: boolean` on `Project`; `:159` add `project:updated` event
+- [ ] **2.2** `web-ui/src/api/client.ts` — `hideProject(id)` / `unhideProject(id)` PATCH `/projects/:id`
+- [ ] **2.3** `web-ui/src/api/mock.ts:29` — implement `hideProject`/`unhideProject` (mutate in-memory project + `emit({type:"project:updated",project})`)
+- [ ] **2.4** `web-ui/src/hooks/useServerStore.ts` — `applyProjectUpdated` (replace by id, drop unknown — mirror `:75-84`)
+- [ ] **2.5** `web-ui/src/hooks/useServerSync.ts` — subscribe `project:updated` → `applyProjectUpdated` (+ cleanup)
+
+**Verify phase 2:**
+- [ ] **2.T1** Unit — `useServerStore`: `applyProjectUpdated` replaces matching project, ignores unknown id
+- [ ] **2.T2** Unit — mock api: `hideProject` issues PATCH with `{hidden:true}` to correct URL
+- [ ] **2.T3** Integration — sync: dispatched `project:updated` event updates store project's `hidden`
+
+### Phase 3 — UI: hide entry + filtering
+
+- [ ] **3.1** `LeftSidebar.tsx:75` — memo `hiddenProjectIds`; filter `projects.map` (`:400`) and `pinnedWorktrees` (`:97`) by hidden
+- [ ] **3.2** `LeftSidebar.tsx:120,422` — add `projMenu` state + project kebab button (expanded only) + portal menu (copy `:585-680`) with "New worktree" (`setNewSessProject(p)`) and "Hide project" (`api.hideProject(p.id)`)
+- [ ] **3.3** `DashboardPanel.tsx:82` — memo `hiddenProjectIds`; exclude worktrees whose `projectId` ∈ set in buckets (`:89-103`), `renderWorktreeCard`, AND the projects section `projects.map` (`:243-248`)
+- [ ] **3.4** `Workspace.tsx:74-90` — add branch: active worktree's project hidden → clear selection + `navigate("/")`; add `projects` to deps (covers url-sync deep-link)
+
+**Verify phase 3:**
+- [ ] **3.T1** Unit — `LeftSidebar`: hidden project not rendered; its worktrees absent from pinned section
+- [ ] **3.T2** Unit — `DashboardPanel`: hidden-project worktree cards AND its project card (`:243`) not rendered
+- [ ] **3.T3** Integration — hide active project → redirected to dashboard, selection cleared, TopBar crumb reads "Dashboard"
+- [ ] **3.T4** Integration — deep-link `/worktree/:id` of a hidden project → lands on dashboard (not the worktree)
+- [ ] **3.T5** Regression — non-hidden projects + "New session"/kebab worktree actions still work
+
+### Phase 4 — Settings unhide
+
+- [ ] **4.1** `web-ui/src/components/settings/HiddenProjectsSetting.tsx` — new component: `SectionHeader` + list of `projects.filter(hidden)` with Unhide button + empty state
+- [ ] **4.2** `SettingsPanel.tsx:21-39` — add ref + section entry "Hidden projects"
+
+**Verify phase 4:**
+- [ ] **4.T1** Unit — `HiddenProjectsSetting`: renders hidden projects; empty state when none; Unhide calls `api.unhideProject`
+- [ ] **4.T2** Integration — unhide → project reappears in sidebar list
+
+### Phase 5 — Scroll-to-selected on sidebar open
+
+- [ ] **5.1** `LeftSidebar.tsx:282` — `scrollRef` on `.left-sidebar__scroll`
+- [ ] **5.2** `LeftSidebar.tsx` — `visible = isMobile ? mobileSidebarOpen : !collapsed`; `prevVisible` ref; effect on rising edge → **double rAF** → `scrollRef.current?.querySelector('[data-active="true"]')?.scrollIntoView({block:"nearest"})`; if querySelector null, retry once next frame
+
+**Verify phase 5:**
+- [ ] **5.T1** Unit — `LeftSidebar`: on visible false→true with an active row offscreen, `scrollIntoView` called once (spy)
+- [ ] **5.T2** Unit — no active row → `scrollIntoView` not called
+- [ ] **5.T3** Integration — collapse→expand keeps selected worktree visible (manual/Docker)
+
+### Phase 6 — Verification (Docker)
+
+- [ ] **6.1** Build daemon + web-ui; run app in Docker (`docker-compose.dev.yml`)
+- [ ] **6.2** Manual: hide project from kebab → gone from sidebar + dashboard; unhide in Settings → returns
+- [ ] **6.3** Manual: scroll list, collapse + reopen → snaps to selected worktree; mobile drawer same
+
+**Verify phase 6:**
+- [ ] **6.T1** Integration — full lint + typecheck + `vitest` suite green
+- [ ] **6.T2** Integration — two browser tabs: hide in one reflects in the other (WS broadcast)
+
+---
+
+## Files Summary
+
+| File | Phase | Change |
+|------|-------|--------|
+| `daemon/src/types.ts` | 1.1 | `hidden?` on `ProjectRecord` |
+| `daemon/src/ws/protocol.ts` | 1.2 | `project:updated` zod schema in `ServerMessage` |
+| `daemon/src/routes/projects.ts` | 1.3,1.4 | serialize `hidden`; PATCH handler |
+| `web-ui/src/api/types.ts` | 2.1 | `Project.hidden`; `project:updated` event |
+| `web-ui/src/api/client.ts` | 2.2 | `hideProject`/`unhideProject` |
+| `web-ui/src/api/mock.ts` | 2.3 | mock `hideProject`/`unhideProject` + emit |
+| `web-ui/src/hooks/useServerStore.ts` | 2.4 | `applyProjectUpdated` |
+| `web-ui/src/hooks/useServerSync.ts` | 2.5 | wire `project:updated` |
+| `web-ui/src/components/layout/LeftSidebar.tsx` | 3.1,3.2,5.1,5.2 | filter + project kebab + scroll snap |
+| `web-ui/src/components/layout/DashboardPanel.tsx` | 3.3 | filter hidden worktrees |
+| `web-ui/src/routes/Workspace.tsx` | 3.4 | hidden active-project redirect |
+| `web-ui/src/components/settings/SettingsPanel.tsx` | 4.2 | register section |
+| `web-ui/src/components/settings/HiddenProjectsSetting.tsx` | 4.1 | new section component |
+| `daemon/src/routes/projects.test.ts` | 1.T1,1.T2 | PATCH unit/integration |
+| `web-ui/src/hooks/useServerStore.test.ts` | 2.T1 | reducer unit |
+| `web-ui/src/components/layout/LeftSidebar.test.tsx` | 3.T1,5.T1,5.T2 | filter + scroll unit |
+| `web-ui/src/components/layout/DashboardPanel.test.tsx` | 3.T2 | filter unit |
+| `web-ui/src/components/settings/HiddenProjectsSetting.test.tsx` | 4.T1 | settings unit |

--- a/.feature-plans/pending/prd-hide-projects-and-scroll-to-selected.md
+++ b/.feature-plans/pending/prd-hide-projects-and-scroll-to-selected.md
@@ -1,0 +1,210 @@
+# PRD: Hide projects + scroll-to-selected worktree
+
+> Let users hide whole projects (and all their worktrees) from the sidebar and dashboard with a Settings-based unhide flow, and fix the sidebar so reopening it snaps to the selected worktree instead of resetting to the top.
+
+**Status:** Approved (reviewed by Opus subagent)
+**Technical plan:** `.feature-plans/pending/hide-projects-and-scroll-to-selected.md`
+
+---
+
+## Problem
+
+- The left sidebar and the dashboard "Overview" list **every** registered project and all its worktrees, with no way to declutter. Users who have many projects (or finished/parked ones) are forced to scroll past noise to reach what they're working on.
+- There is no project-level row menu in the sidebar today — projects only have a chevron and a "New session" button — so there's no natural home for project-scoped actions.
+- When the left sidebar is reopened (expanded on desktop, or the drawer opened on mobile), the worktree list is **scrolled back to the top**. If the currently-selected worktree is far down the list, the user loses their place and has to hunt for it every time, even though the app already knows which worktree is active.
+
+Who is affected: any user with more than a handful of projects/worktrees — i.e. the power users the product is built for.
+
+Why now: both are low-risk quality-of-life fixes that directly address day-to-day friction, and the hiding feature has a clean precedent in the existing worktree-pinning implementation.
+
+## Goals
+
+- A user can hide a project from a menu on its sidebar row; the project and all its worktrees immediately disappear from the sidebar and the dashboard everywhere they normally appear.
+- Hidden projects remain fully intact (sessions keep running, files untouched) — hiding is purely a visibility filter, not a delete or archive.
+- A user can see all hidden projects in Settings and unhide any of them, restoring them to the sidebar and dashboard.
+- The hidden state is durable and consistent across browser tabs and reloads.
+- Reopening the left sidebar keeps the selected worktree visible: if it was scrolled out of view, the list snaps so the selected worktree row is on screen.
+
+## Non-goals
+
+- **Hiding individual worktrees.** This PRD hides at the *project* level only. (Per-worktree dismiss/pin already exists and is unchanged.)
+- **Bulk hide/unhide**, search, or sorting of the hidden-projects list in Settings. A simple list with per-row unhide is enough for v1.
+- **Deleting or archiving** projects. Delete remains a CLI-only destructive op.
+- **Animated/smooth scrolling** for the sidebar snap — an instant jump is acceptable and matches "quickly snapping to it."
+- **Persisting scroll position** of the sidebar between opens beyond what's needed to keep the selected worktree visible.
+- **Hiding the active project.** Allowed, but see R10 for what happens to the current view.
+
+---
+
+## Requirements
+
+### 1. Hiding a project from the sidebar
+
+Covers the entry point and immediate effect of hiding.
+
+| ID | Requirement |
+|----|-------------|
+| R1 | Each project row in the left sidebar has a "3 dots" (kebab) overflow menu, consistent in look and interaction with the existing worktree-row kebab menu (click to open, click-outside / Escape to close). |
+| R2 | The project kebab menu contains at least two actions: **"New worktree"** (opens the existing new-worktree/session dialog for that project, the same action the current "New session" button performs) and **"Hide project"**. |
+| R3 | Choosing "Hide project" immediately removes that project and all of its worktrees from the sidebar, with no confirmation dialog (the action is fully reversible from Settings). |
+| R4 | Hiding takes effect across all open browser tabs/clients without a manual refresh. |
+| R5 | The collapsed (icon-rail) sidebar must also respect the hidden filter — hidden projects do not appear in either the expanded or collapsed sidebar. |
+
+### 2. Hiding effect on the dashboard
+
+Covers the dashboard "Overview" surface.
+
+| ID | Requirement |
+|----|-------------|
+| R6 | The dashboard Overview must not show any worktree card belonging to a hidden project, in any of its groupings/views (e.g. working / idle / finished, list and kanban). |
+| R7 | Any other place that lists projects or worktrees for browsing (counts, overview headers) must exclude hidden projects, so a hidden project leaves no visible trace outside Settings. |
+
+### 3. Unhiding from Settings
+
+Covers discovery and restoration of hidden projects.
+
+| ID | Requirement |
+|----|-------------|
+| R8 | Settings has a section (e.g. "Hidden projects") that lists every currently-hidden project by name, with an "Unhide" control per row. |
+| R9 | Choosing "Unhide" immediately restores the project (and its worktrees) to the sidebar and dashboard across all clients, and removes it from the hidden list. |
+| R10 | When there are no hidden projects, the section shows a clear empty state rather than appearing broken or blank. |
+
+### 4. Edge cases & state
+
+| ID | Requirement |
+|----|-------------|
+| R11 | If the user hides the project whose worktree is currently open/active, the app must not break: it returns to a safe view (the dashboard Overview) and clears the now-hidden active selection. |
+| R12 | Hidden state is server-side and persisted, so it survives daemon restarts and is identical for every client. It is **not** stored only in one browser's local storage. |
+| R13 | Hiding/unhiding never alters worktrees, sessions, branches, or files — running agents continue running while a project is hidden. |
+
+### 5. Scroll-to-selected worktree on sidebar open
+
+Covers the sidebar reopen behavior.
+
+| ID | Requirement |
+|----|-------------|
+| R14 | When the left sidebar transitions from hidden to visible (desktop: collapsed → expanded; mobile: drawer closed → open), if a worktree is selected and its row is outside the visible scroll area, the list scrolls so that the selected worktree row is brought into view. |
+| R15 | If the selected worktree row is already visible when the sidebar opens, no scrolling occurs (no jarring jump). |
+| R16 | If no worktree is selected (e.g. user is on the dashboard), opening the sidebar does not force any scroll. |
+| R17 | The selected worktree's project must be expanded if needed so the row actually exists in the DOM to scroll to; a selected worktree inside a collapsed project group should be revealed. |
+| R18 | The snap is effectively instant ("quickly snapping"), and must not fight the user — once they start scrolling manually, the auto-snap does not re-trigger until the next open. |
+
+---
+
+## Options considered
+
+### Where to store the "hidden" state
+
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| A — Server-side flag on the project manifest (`hidden`), exposed via a new `PATCH /projects/:id` + `project:updated` WS broadcast | Durable across restarts; consistent across all clients/tabs; mirrors the existing worktree-pinning pattern exactly | Requires a small backend addition (new endpoint + WS event + store reducer) | ✅ chosen |
+| B — Client-only localStorage list of hidden project ids | No backend change | Per-browser only (hidden on laptop ≠ hidden on phone); easy to desync; inconsistent with how pinning works | ❌ rejected |
+
+**Decision:** Option A. The product already models per-worktree visibility (`pinnedAt`) server-side; project hiding should follow the same durable, broadcast-synced pattern so the experience is consistent across devices.
+
+### Hide entry point
+
+**Option A — Kebab menu on the project row (chosen)**
+Add a project-row kebab (which doesn't exist yet) and put "Hide project" + "New worktree" in it. Matches the worktree-row interaction users already know; gives project actions a permanent home.
+
+**Option B — A dedicated hide (eye) icon-button on hover**
+Faster to reach, but clutters the row, has no room on the collapsed rail, and doesn't scale as more project actions are added.
+
+**Decision:** Option A — the request explicitly asks for the 3-dots menu, and it's the extensible choice.
+
+### Scroll mechanism
+
+**Option A — `scrollIntoView({ block: "nearest" })` on the active row, triggered on the open transition (chosen)**
+Browser handles the math; only scrolls when needed; respects "nearest" so an already-visible row doesn't move.
+
+**Option B — Manually compute and set `scrollTop` on the scroll container**
+More code, more edge cases (row heights, padding), no benefit over the native API.
+
+**Decision:** Option A.
+
+---
+
+## Resolved design questions
+
+1. **Hide at project or worktree granularity?** — **Project.** The request says "hiding the projects … all the worktrees for that project should not be visible," so one flag per project hides the whole group.
+2. **Confirmation before hiding?** — **No.** Hiding is non-destructive and reversible from Settings; a confirmation would add friction for no safety benefit. (A toast/undo is a nice-to-have, see open questions.)
+3. **Where does unhide live?** — **Settings**, in a dedicated "Hidden projects" section, per the request.
+4. **Server-side vs client-side state?** — **Server-side** (`hidden` on the manifest), broadcast over WS, mirroring worktree pinning.
+5. **What happens to a running agent in a hidden project?** — **Nothing.** Hiding is visibility only; sessions keep running.
+6. **What if the active worktree's project is hidden?** — **Redirect to dashboard** and clear the active selection (R11).
+7. **Smooth vs instant scroll snap?** — **Instant** (`block: "nearest"`), matching "quickly snapping."
+8. **Does the new-worktree dialog change?** — **No.** "New worktree" in the kebab reuses the existing dialog the "New session" button already opens.
+9. **What if a user deep-links / reloads a URL pointing at a hidden project's worktree?** — **Redirect to the dashboard.** Hiding should leave no browseable trace; an explicit unhide in Settings is required to reach it again. (Found in review: the URL-sync path has no hidden check, so the gate is centralized in the workspace route.)
+
+---
+
+## Screen layouts
+
+### Project row kebab (left sidebar, expanded)
+
+```
+┌─────────────────────────────────────────────┐
+│  LEFT SIDEBAR                               │
+│                                             │
+│  ▸ vibe-station                  [ + ] [⋮]  │ ← project row: chevron, New, kebab(⋮)
+│      ● fix-auth-bug                          │
+│      ● scrollfix-n-hiding   (selected)       │
+│                                             │
+│            ┌──────────────────────────┐     │
+│            │  + New worktree          │     │ ← kebab menu (on ⋮ click)
+│            │  ⊘ Hide project          │     │
+│            └──────────────────────────┘     │
+│                                             │
+│  ▸ agent-orchestrator            [ + ] [⋮]  │
+│                                             │
+└─────────────────────────────────────────────┘
+```
+
+Notes:
+- "New worktree" → opens the existing new-worktree/session dialog scoped to that project.
+- "Hide project" → project and its worktrees vanish immediately from this list and the dashboard; menu closes.
+- The kebab visually matches the worktree-row kebab already in the sidebar.
+
+### Settings → Hidden projects section
+
+```
+┌──────────────────────────────────────────────────┐
+│  Settings                                         │
+│  ┌────────────┐  ┌──────────────────────────────┐ │
+│  │ Modes      │  │  Hidden projects             │ │ ← section header + description
+│  │ Appearance │  │  Projects you've hidden from │ │
+│  │ Hidden     │  │  the sidebar and dashboard.  │ │
+│  │  projects  │  │                              │ │
+│  └────────────┘  │  agent-orchestrator  [Unhide]│ │
+│                  │  old-prototype       [Unhide]│ │
+│                  │                              │ │
+│                  │  (empty state when none:     │ │
+│                  │   "No hidden projects.")     │ │
+│                  └──────────────────────────────┘ │
+└──────────────────────────────────────────────────┘
+```
+
+Notes:
+- "Unhide" restores the project across all clients and removes the row.
+- Empty state replaces the list when nothing is hidden (R10).
+
+---
+
+## Priority & sequencing
+
+| Order | Sub-feature | Depends on | Can ship independently? |
+|-------|-------------|------------|------------------------|
+| 1 | Backend: `hidden` flag + `PATCH /projects/:id` + `project:updated` broadcast + client store reducer | — | Yes (no visible change until UI uses it) |
+| 2 | Sidebar project kebab (New worktree + Hide) + hidden filtering in sidebar & dashboard | Sub-feature 1 | No |
+| 3 | Settings "Hidden projects" section (unhide) | Sub-feature 1 | No |
+| 4 | Scroll-to-selected-worktree on sidebar open | — | Yes (fully independent of the hide feature) |
+
+---
+
+## Open questions
+
+| # | Question | Proposed answer / owner |
+|---|----------|------------------------|
+| 1 | Should hiding show a toast with an "Undo" affordance? | Nice-to-have; defer. Settings unhide covers recovery for v1. |
+| 2 | Should the sidebar footer show a count/badge of hidden projects as a discovery hint for the Settings section? | Defer; not required for the core flow. |
+| 3 | On mobile, the sidebar is a 280px drawer — confirm scroll-to-selected works identically there (it should, same scroll container). | Verify during implementation/Docker test. |

--- a/daemon/src/__tests__/projects.test.ts
+++ b/daemon/src/__tests__/projects.test.ts
@@ -168,4 +168,72 @@ describe("GET /projects + POST /projects + DELETE /projects/:id", () => {
     const res = await app.inject({ method: "GET", url: "/projects/nonexistent/branches" });
     expect(res.statusCode).toBe(404);
   });
+
+  it("new projects serialize hidden:false by default", async () => {
+    const res = await app.inject({ method: "POST", url: "/projects", payload: { path: repoDir } });
+    expect(res.json<{ hidden: boolean }>().hidden).toBe(false);
+  });
+
+  it("PATCH /projects/:id { hidden:true } hides the project and persists across reload", async () => {
+    const created = await app.inject({ method: "POST", url: "/projects", payload: { path: repoDir } });
+    const project = created.json<ProjectRecord>();
+
+    const patch = await app.inject({
+      method: "PATCH",
+      url: `/projects/${project.id}`,
+      payload: { hidden: true },
+    });
+    expect(patch.statusCode).toBe(200);
+    expect(patch.json<{ ok: boolean; project: { hidden: boolean } }>().project.hidden).toBe(true);
+
+    // GET reflects it.
+    const list = await app.inject({ method: "GET", url: "/projects" });
+    expect(list.json<{ id: string; hidden: boolean }[]>().find((p) => p.id === project.id)?.hidden).toBe(true);
+
+    // Persisted on disk: reload manifest from a fresh store.
+    const { _clearStoreForTest, loadAll, getProject } = await import("../state/project-store.js");
+    _clearStoreForTest();
+    await loadAll();
+    expect(getProject(project.id)?.hidden).toBe(true);
+  });
+
+  it("PATCH /projects/:id { hidden:false } drops the field (clean manifest)", async () => {
+    const created = await app.inject({ method: "POST", url: "/projects", payload: { path: repoDir } });
+    const project = created.json<ProjectRecord>();
+
+    await app.inject({ method: "PATCH", url: `/projects/${project.id}`, payload: { hidden: true } });
+    const unhide = await app.inject({
+      method: "PATCH",
+      url: `/projects/${project.id}`,
+      payload: { hidden: false },
+    });
+    expect(unhide.statusCode).toBe(200);
+    expect(unhide.json<{ project: { hidden: boolean } }>().project.hidden).toBe(false);
+
+    const { _clearStoreForTest, loadAll, getProject } = await import("../state/project-store.js");
+    _clearStoreForTest();
+    await loadAll();
+    const reloaded = getProject(project.id);
+    expect(reloaded?.hidden).toBeUndefined();
+  });
+
+  it("PATCH /projects/:id 404 for unknown project", async () => {
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/projects/nonexistent",
+      payload: { hidden: true },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("PATCH /projects/:id 400 on invalid body", async () => {
+    const created = await app.inject({ method: "POST", url: "/projects", payload: { path: repoDir } });
+    const project = created.json<ProjectRecord>();
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/projects/${project.id}`,
+      payload: { hidden: "yes" },
+    });
+    expect(res.statusCode).toBe(400);
+  });
 });

--- a/daemon/src/routes/projects.ts
+++ b/daemon/src/routes/projects.ts
@@ -7,6 +7,7 @@ import {
   getProject,
   addProject,
   deleteProject,
+  mutateProject,
 } from "../state/project-store.js";
 import { isGitRepo, detectDefaultBranch, listBranches } from "../services/git.js";
 import { generateProjectPrefix } from "../services/prefix.js";
@@ -24,6 +25,8 @@ function serializeProject(p: ProjectRecord) {
     prefix: p.prefix,
     defaultBranch: p.defaultBranch,
     createdAt: p.createdAt,
+    // Always emit so the client never has to special-case undefined.
+    hidden: !!p.hidden,
   };
 }
 
@@ -148,6 +151,69 @@ export function registerProjectRoutes(app: FastifyInstance): void {
       project: apiProject as unknown as Record<string, unknown>,
     });
     return reply.status(201).send(apiProject);
+  });
+
+  // PATCH /projects/:id   { hidden: boolean }
+  // Toggles ProjectRecord.hidden — a visibility-only flag (sidebar + dashboard).
+  // Idempotent: no-op + no broadcast when already in the requested state, so
+  // cross-tab toggles don't churn the manifest. Drops the field when false to
+  // keep the manifest clean (mirrors worktree pinnedAt at worktrees.ts).
+  app.patch("/projects/:id", async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const bodySchema = z.object({ hidden: z.boolean() });
+    const parsed = bodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      return reply.status(400).send({ error: "Validation error", details: parsed.error.issues });
+    }
+    const { hidden } = parsed.data;
+
+    const current = getProject(id);
+    if (!current) {
+      return reply.status(404).send({ error: `Project '${id}' not found` });
+    }
+
+    // Idempotent fast-path: already in the requested state — return without
+    // touching disk (mutateProject always rewrites the manifest, even on a
+    // no-op fn) and without broadcasting. Avoids needless fsync churn from
+    // cross-tab toggles.
+    if (!!current.hidden === hidden) {
+      return reply.send({ ok: true, project: serializeProject(current) });
+    }
+
+    let changed = false;
+    let updated: ProjectRecord;
+    try {
+      updated = await mutateProject(id, (p) => {
+        const isHidden = !!p.hidden;
+        if (isHidden === hidden) {
+          // No state change — return unchanged (cheap idempotent rewrite).
+          return p;
+        }
+        changed = true;
+        if (hidden) {
+          return { ...p, hidden: true };
+        }
+        // Drop the field rather than setting false so the JSON stays clean.
+        const { hidden: _drop, ...rest } = p;
+        void _drop;
+        return rest as ProjectRecord;
+      });
+    } catch (err) {
+      // Project deleted between the check and the lock.
+      if (err instanceof Error && /not found/i.test(err.message)) {
+        return reply.status(404).send({ error: `Project '${id}' not found` });
+      }
+      throw err;
+    }
+
+    const apiProject = serializeProject(updated);
+    if (changed) {
+      broadcastAll({
+        type: "project:updated",
+        project: apiProject as unknown as Record<string, unknown>,
+      });
+    }
+    return reply.send({ ok: true, project: apiProject });
   });
 
   // DELETE /projects/:id

--- a/daemon/src/types.ts
+++ b/daemon/src/types.ts
@@ -54,5 +54,11 @@ export interface ProjectRecord {
   prefix: string;
   defaultBranch: string;
   createdAt: string; // ISO8601
+  /**
+   * When true, the project (and all its worktrees) is hidden from the sidebar
+   * and dashboard. Absent / undefined ≡ visible. Visibility-only — never
+   * affects sessions, worktrees, or files. Unhide via Settings.
+   */
+  hidden?: boolean;
   worktrees: WorktreeRecord[];
 }

--- a/daemon/src/ws/protocol.ts
+++ b/daemon/src/ws/protocol.ts
@@ -197,6 +197,11 @@ const ProjectDeletedEvent = z.object({
   projectId: z.string(),
 });
 
+const ProjectUpdatedEvent = z.object({
+  type: z.literal("project:updated"),
+  project: z.record(z.string(), z.unknown()),
+});
+
 const WorktreeCreatedEvent = z.object({
   type: z.literal("worktree:created"),
   worktree: z.record(z.string(), z.unknown()),
@@ -253,6 +258,7 @@ export const ServerMessage = z.discriminatedUnion("type", [
   // Broadcast events
   ProjectCreatedEvent,
   ProjectDeletedEvent,
+  ProjectUpdatedEvent,
   WorktreeCreatedEvent,
   WorktreeDeletedEvent,
   WorktreeUpdatedEvent,

--- a/web-ui/src/api/client.ts
+++ b/web-ui/src/api/client.ts
@@ -203,6 +203,26 @@ export function createClientApi() {
       return parseJson<{ ok: true }>(res);
     },
 
+    async hideProject(id: string): Promise<{ ok: true; project: Project }> {
+      const root = baseUrl();
+      const res = await apiFetch(`${root}/projects/${encodeURIComponent(id)}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ hidden: true }),
+      });
+      return parseJson<{ ok: true; project: Project }>(res);
+    },
+
+    async unhideProject(id: string): Promise<{ ok: true; project: Project }> {
+      const root = baseUrl();
+      const res = await apiFetch(`${root}/projects/${encodeURIComponent(id)}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ hidden: false }),
+      });
+      return parseJson<{ ok: true; project: Project }>(res);
+    },
+
     async listWorktrees(projectId?: string): Promise<Worktree[]> {
       const root = baseUrl();
       const url = projectId

--- a/web-ui/src/api/mock.ts
+++ b/web-ui/src/api/mock.ts
@@ -35,6 +35,7 @@ export function createMockApi() {
       prefix: "pa",
       defaultBranch: "main",
       createdAt: nowIso(),
+      hidden: false,
     },
     {
       id: "proj-b",
@@ -43,6 +44,7 @@ export function createMockApi() {
       prefix: "pb",
       defaultBranch: "develop",
       createdAt: nowIso(),
+      hidden: false,
     },
   ];
 
@@ -256,6 +258,26 @@ export function createMockApi() {
     async deleteProject(_id: string): Promise<{ ok: true }> {
       emit({ type: "project:deleted", projectId: _id });
       return { ok: true };
+    },
+
+    async hideProject(id: string): Promise<{ ok: true; project: Project }> {
+      const project = projects.find((p) => p.id === id);
+      if (!project) throw new ApiError("not found", 404);
+      if (!project.hidden) {
+        project.hidden = true;
+        emit({ type: "project:updated", project: structuredClone(project) });
+      }
+      return { ok: true, project: structuredClone(project) };
+    },
+
+    async unhideProject(id: string): Promise<{ ok: true; project: Project }> {
+      const project = projects.find((p) => p.id === id);
+      if (!project) throw new ApiError("not found", 404);
+      if (project.hidden) {
+        project.hidden = false;
+        emit({ type: "project:updated", project: structuredClone(project) });
+      }
+      return { ok: true, project: structuredClone(project) };
     },
 
     async listWorktrees(projectId?: string): Promise<Worktree[]> {

--- a/web-ui/src/api/types.ts
+++ b/web-ui/src/api/types.ts
@@ -13,6 +13,9 @@ export interface Project {
   prefix: string;
   defaultBranch: string;
   createdAt: string;
+  /** When true, the project and all its worktrees are hidden from the sidebar
+   *  and dashboard. Always emitted by the daemon (defaults to false). */
+  hidden: boolean;
 }
 
 export interface Worktree {
@@ -144,6 +147,10 @@ export type WSEvent =
   | {
       type: "project:deleted";
       projectId: string;
+    }
+  | {
+      type: "project:updated";
+      project: Project;
     }
   | {
       type: "worktree:created";

--- a/web-ui/src/components/layout/DashboardPanel.test.tsx
+++ b/web-ui/src/components/layout/DashboardPanel.test.tsx
@@ -88,4 +88,42 @@ describe("DashboardPanel", () => {
       );
     });
   });
+
+  it("excludes a hidden project's worktree cards and its project card", async () => {
+    const api = createMockApi();
+    render(
+      <MemoryRouter>
+        <Harness api={api}>
+          <DashboardPanel api={api} />
+        </Harness>
+      </MemoryRouter>,
+    );
+    // proj-a's worktree wt-1 has agent sessions → a worktree card linking to it.
+    await waitFor(() => {
+      expect(document.querySelector('a[href="/worktree/wt-1"]')).not.toBeNull();
+    });
+
+    api.__test.emit({
+      type: "project:updated",
+      project: {
+        id: "proj-a",
+        name: "Proj A",
+        path: "/home/dev/proj-a",
+        prefix: "pa",
+        defaultBranch: "main",
+        createdAt: new Date().toISOString(),
+        hidden: true,
+      },
+    });
+
+    // The hidden project's worktree cards disappear.
+    await waitFor(() => {
+      expect(document.querySelector('a[href="/worktree/wt-1"]')).toBeNull();
+    });
+    // No "Proj A" trace remains anywhere on the dashboard (worktree cards or
+    // the projects section).
+    expect(screen.queryByText("Proj A")).toBeNull();
+    // A visible project's worktree (proj-b / wt-3) is unaffected.
+    expect(document.querySelector('a[href="/worktree/wt-3"]')).not.toBeNull();
+  });
 });

--- a/web-ui/src/components/layout/DashboardPanel.tsx
+++ b/web-ui/src/components/layout/DashboardPanel.tsx
@@ -80,6 +80,13 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
   useSubscription(sessionIdKey ? sessionIdKey.split(",").filter(Boolean) : [], api);
 
   const projectById = useMemo(() => Object.fromEntries(projects.map((p) => [p.id, p])), [projects]);
+  /** Hidden projects (and all their worktrees) are excluded from every dashboard
+   *  list — visibility only; unhide from Settings. */
+  const hiddenProjectIds = useMemo(
+    () => new Set(projects.filter((p) => p.hidden).map((p) => p.id)),
+    [projects],
+  );
+  const visibleProjects = useMemo(() => projects.filter((p) => !p.hidden), [projects]);
 
   /** Live state map (persisted across page loads, refreshed on every ws:open
    *  by useServerSync). The rollup uses it as the primary signal and falls
@@ -91,6 +98,7 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
     const wtsIdle: Worktree[] = [];
     const wtsFinished: Worktree[] = [];
     for (const wt of worktrees) {
+      if (hiddenProjectIds.has(wt.projectId)) continue;
       const agentSessions = sessions.filter((s) => s.worktreeId === wt.id && s.type === "agent");
       if (agentSessions.length === 0) continue;
       const rolled = worktreeRolledUpStatus(agentSessions, sessionStates);
@@ -100,7 +108,7 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
       else wtsFinished.push(wt);
     }
     return { working: wtsWorking, idle: wtsIdle, finished: wtsFinished };
-  }, [worktrees, sessions, sessionStates]);
+  }, [worktrees, sessions, sessionStates, hiddenProjectIds]);
 
   const daemonOk = connState === "online";
 
@@ -240,12 +248,12 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
           </div>
         )}
 
-        {/* Projects — always shown below worktree sections */}
-        {projects.length > 0 ? (
+        {/* Projects — always shown below worktree sections (hidden projects excluded) */}
+        {visibleProjects.length > 0 ? (
           <section className="dashboard-section">
             <div className="dashboard-section__label">projects</div>
             <div className="dashboard-card-list">
-              {projects.map((p) => {
+              {visibleProjects.map((p) => {
                 const wts = worktrees.filter((w) => w.projectId === p.id);
                 const activeCount = wts.filter((w) =>
                   sessions.some(

--- a/web-ui/src/components/layout/LeftSidebar.test.tsx
+++ b/web-ui/src/components/layout/LeftSidebar.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { ReactNode } from "react";
 import type { ApiInstance } from "@/api";
 import { createMockApi } from "@/api/mock";
@@ -335,6 +335,134 @@ describe("LeftSidebar", () => {
       await waitFor(() => {
         expect(screen.getByRole("region", { name: /pinned worktrees/i })).toBeInTheDocument();
       });
+    });
+  });
+
+  // ─── Project hiding ──────────────────────────────────────────────────────
+  describe("project hiding", () => {
+    it("project row exposes a project actions (⋮) menu with Hide project + New worktree", async () => {
+      const user = userEvent.setup();
+      const localApi = createMockApi();
+      render(
+        <MemoryRouter>
+          <Harness api={localApi}>
+            <LeftSidebar api={localApi} />
+          </Harness>
+        </MemoryRouter>,
+      );
+      await screen.findByText("Proj A");
+      const trigger = screen.getAllByRole("button", { name: /Project actions for Proj A/i })[0]!;
+      await user.click(trigger);
+      expect(await screen.findByRole("menuitem", { name: /Hide project/i })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: /New worktree/i })).toBeInTheDocument();
+    });
+
+    it("clicking Hide project calls api.hideProject", async () => {
+      const user = userEvent.setup();
+      const localApi = createMockApi();
+      const spy = vi.spyOn(localApi, "hideProject");
+      render(
+        <MemoryRouter>
+          <Harness api={localApi}>
+            <LeftSidebar api={localApi} />
+          </Harness>
+        </MemoryRouter>,
+      );
+      await screen.findByText("Proj A");
+      await user.click(screen.getAllByRole("button", { name: /Project actions for Proj A/i })[0]!);
+      await user.click(await screen.findByRole("menuitem", { name: /Hide project/i }));
+      expect(spy).toHaveBeenCalledWith("proj-a");
+    });
+
+    it("a hidden project (and its worktrees) is filtered out of the sidebar", async () => {
+      const localApi = createMockApi();
+      render(
+        <MemoryRouter>
+          <Harness api={localApi}>
+            <LeftSidebar api={localApi} />
+          </Harness>
+        </MemoryRouter>,
+      );
+      await screen.findByText("Proj A");
+      // Another tab hides proj-a.
+      localApi.__test.emit({
+        type: "project:updated",
+        project: {
+          id: "proj-a",
+          name: "Proj A",
+          path: "/home/dev/proj-a",
+          prefix: "pa",
+          defaultBranch: "main",
+          createdAt: new Date().toISOString(),
+          hidden: true,
+        },
+      });
+      await waitFor(() => {
+        expect(screen.queryByText("Proj A")).toBeNull();
+      });
+      // Worktrees of the hidden project are gone too.
+      expect(screen.queryByRole("link", { name: /Open worktree wt-1/i })).toBeNull();
+      // A different (visible) project remains.
+      expect(screen.getByText("Proj B")).toBeInTheDocument();
+    });
+  });
+
+  // ─── Scroll-to-selected on reopen ────────────────────────────────────────
+  describe("scroll-to-selected worktree", () => {
+    beforeEach(() => {
+      // jsdom doesn't implement scrollIntoView — provide a spy so the guarded
+      // call runs and we can assert on it.
+      Element.prototype.scrollIntoView = vi.fn();
+    });
+
+    it("snaps the active worktree into view when the sidebar transitions hidden→visible", async () => {
+      const localApi = createMockApi();
+      const { rerender } = render(
+        <MemoryRouter initialEntries={["/worktree/wt-1"]}>
+          <Harness api={localApi}>
+            <LeftSidebar api={localApi} collapsed />
+          </Harness>
+        </MemoryRouter>,
+      );
+      await screen.findByText("Pra"); // collapsed (not visible) — abbreviated label
+      (Element.prototype.scrollIntoView as ReturnType<typeof vi.fn>).mockClear();
+
+      // Reopen: collapsed → expanded (rising edge).
+      rerender(
+        <MemoryRouter initialEntries={["/worktree/wt-1"]}>
+          <Harness api={localApi}>
+            <LeftSidebar api={localApi} />
+          </Harness>
+        </MemoryRouter>,
+      );
+      await waitFor(() => {
+        expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+      });
+    });
+
+    it("does not scroll when there is no active worktree", async () => {
+      useWorkspaceStore.setState({ activeWorktreeId: null, activeProjectId: null });
+      const localApi = createMockApi();
+      const { rerender } = render(
+        <MemoryRouter initialEntries={["/"]}>
+          <Harness api={localApi}>
+            <LeftSidebar api={localApi} collapsed />
+          </Harness>
+        </MemoryRouter>,
+      );
+      await screen.findByText("Pra");
+      (Element.prototype.scrollIntoView as ReturnType<typeof vi.fn>).mockClear();
+      rerender(
+        <MemoryRouter initialEntries={["/"]}>
+          <Harness api={localApi}>
+            <LeftSidebar api={localApi} />
+          </Harness>
+        </MemoryRouter>,
+      );
+      await screen.findByText("Proj A");
+      // Give the double-rAF a chance to (not) fire.
+      await new Promise((r) => setTimeout(r, 30));
+      expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
     });
   });
 

--- a/web-ui/src/components/layout/LeftSidebar.tsx
+++ b/web-ui/src/components/layout/LeftSidebar.tsx
@@ -1,7 +1,7 @@
-import { Check, ChevronDown, ChevronRight, Filter, FolderTree, Moon, MoreHorizontal, Pin, Plus, SlidersHorizontal, Type } from "lucide-react";
+import { Check, ChevronDown, ChevronRight, EyeOff, Filter, FolderTree, Moon, MoreHorizontal, Pin, Plus, SlidersHorizontal, Type } from "lucide-react";
 import { useTheme } from "@/hooks/useTheme";
 import { createPortal } from "react-dom";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import type { ApiInstance } from "@/api";
 import type { Project, Session, SessionState, Worktree } from "@/api/types";
@@ -88,19 +88,30 @@ export function LeftSidebar({
     for (const p of projects) m[p.id] = p;
     return m;
   }, [projects]);
+  /** Ids of hidden projects — their rows + all their worktrees are filtered out
+   *  of the sidebar everywhere (projects list AND pinned section). */
+  const hiddenProjectIds = useMemo(
+    () => new Set(projects.filter((p) => p.hidden).map((p) => p.id)),
+    [projects],
+  );
+  /** Visible (non-hidden) projects — the only ones rendered in the tree. */
+  const visibleProjects = useMemo(
+    () => projects.filter((p) => !p.hidden),
+    [projects],
+  );
   /**
    * Pinned worktrees in display order: ISO timestamp DESC (newest pinned first).
    * Filter out anything no longer present on the server (defense-in-depth — the
    * server-side delete naturally removes pinned worktrees, but a stale id from
-   * an in-flight event shouldn't crash render).
+   * an in-flight event shouldn't crash render) and any worktree of a hidden project.
    */
   const pinnedWorktrees = useMemo(
     () =>
       worktrees
-        .filter((w) => w.pinnedAt != null)
+        .filter((w) => w.pinnedAt != null && !hiddenProjectIds.has(w.projectId))
         .slice()
         .sort((a, b) => (b.pinnedAt ?? "").localeCompare(a.pinnedAt ?? "")),
-    [worktrees],
+    [worktrees, hiddenProjectIds],
   );
   const [openProj, setOpenProj] = useState<Set<string>>(() => {
     try {
@@ -113,12 +124,23 @@ export function LeftSidebar({
   const { activeWorktreeId, activeProjectId, activeSessionId, setActiveWorktree } = useLayout();
   const clearWorkspaceSelection = useWorkspaceStore((s) => s.clearWorkspaceSelection);
   const setMobileSidebarOpen = useWorkspaceStore((s) => s.setMobileSidebarOpen);
+  const mobileSidebarOpen = useWorkspaceStore((s) => s.mobileSidebarOpen);
   const sessionStates = useWorkspaceStore((s) => s.sessionStates);
   const hideInactiveWorktrees = useWorkspaceStore((s) => s.hideInactiveWorktrees);
   const toggleInactiveWorktreesFilter = useWorkspaceStore((s) => s.toggleInactiveWorktreesFilter);
 
   const [newSessProject, setNewSessProject] = useState<Project | null>(null);
   const [wtMenu, setWtMenu] = useState<{ projectId: string; worktree: Worktree; rect: DOMRect } | null>(null);
+  const [projMenu, setProjMenu] = useState<{ project: Project; rect: DOMRect } | null>(null);
+
+  /** Scroll container — used to snap the active worktree into view when the
+   *  sidebar is reopened (see effect below). */
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  /** Whether the sidebar was visible on the previous render, to detect the
+   *  hidden→visible (reopen) rising edge. Seeded to the current visibility so a
+   *  mount with an already-open sidebar still snaps once. */
+  const visible = isMobile ? mobileSidebarOpen : !collapsed;
+  const prevVisibleRef = useRef<boolean>(!visible);
   const [filterMenuRect, setFilterMenuRect] = useState<DOMRect | null>(null);
   const [pendingDelete, setPendingDelete] = useState<Worktree | null>(null);
   const [pendingDismiss, setPendingDismiss] = useState<Worktree | null>(null);
@@ -157,6 +179,31 @@ export function LeftSidebar({
       removeListeners?.();
     };
   }, [wtMenu]);
+
+  useEffect(() => {
+    if (!projMenu) return undefined;
+    let removeListeners: (() => void) | undefined;
+    const timer = window.setTimeout(() => {
+      function onDocClick(ev: MouseEvent) {
+        const t = ev.target as HTMLElement;
+        if (t.closest("[data-proj-menu-panel]") || t.closest("[data-proj-menu-trigger]")) return;
+        setProjMenu(null);
+      }
+      function onKey(ev: KeyboardEvent) {
+        if (ev.key === "Escape") setProjMenu(null);
+      }
+      document.addEventListener("click", onDocClick);
+      document.addEventListener("keydown", onKey);
+      removeListeners = () => {
+        document.removeEventListener("click", onDocClick);
+        document.removeEventListener("keydown", onKey);
+      };
+    }, 0);
+    return () => {
+      window.clearTimeout(timer);
+      removeListeners?.();
+    };
+  }, [projMenu]);
 
   useEffect(() => {
     if (!filterMenuRect) return undefined;
@@ -229,6 +276,43 @@ export function LeftSidebar({
     });
   }, [activeProjectId]);
 
+  // When the sidebar is reopened (desktop collapse→expand, mobile drawer open),
+  // snap the selected worktree into view if it scrolled out of sight. Only on
+  // the hidden→visible rising edge so we never fight the user mid-scroll.
+  // `block: "nearest"` self-no-ops when the row is already visible.
+  useEffect(() => {
+    const wasVisible = prevVisibleRef.current;
+    prevVisibleRef.current = visible;
+    if (!visible || wasVisible) return undefined;
+
+    let raf1 = 0;
+    let raf2 = 0;
+    let raf3 = 0;
+    function snap(): boolean {
+      const el = scrollRef.current?.querySelector<HTMLElement>('[data-active="true"]');
+      if (!el) return false;
+      // Guard: jsdom (test env) and very old browsers lack scrollIntoView.
+      if (typeof el.scrollIntoView === "function") {
+        el.scrollIntoView({ block: "nearest" });
+      }
+      return true;
+    }
+    // Double rAF: the expand changes width + swaps abbreviated→full labels +
+    // the active project auto-expands in the same commit; wait for layout to
+    // settle before measuring. Retry one more frame if the row isn't in the DOM
+    // yet (auto-expand may not have inserted it).
+    raf1 = window.requestAnimationFrame(() => {
+      raf2 = window.requestAnimationFrame(() => {
+        if (!snap()) raf3 = window.requestAnimationFrame(snap);
+      });
+    });
+    return () => {
+      window.cancelAnimationFrame(raf1);
+      window.cancelAnimationFrame(raf2);
+      window.cancelAnimationFrame(raf3);
+    };
+  }, [visible]);
+
   function toggleProj(id: string) {
     setOpenProj((prev) => {
       const n = new Set(prev);
@@ -279,6 +363,7 @@ export function LeftSidebar({
         </Link>
       ) : null}
       <div
+        ref={scrollRef}
         className="left-sidebar__scroll"
         style={{ flex: 1, overflow: "auto", padding: collapsed ? "var(--space-1)" : "var(--space-2)" }}
       >
@@ -388,7 +473,7 @@ export function LeftSidebar({
             </>
           )}
         </div>
-        {projects.length === 0 ? (
+        {visibleProjects.length === 0 ? (
           <div className={`empty-state ${collapsed ? "empty-state--collapsed-rail" : ""}`} style={{ padding: collapsed ? "var(--space-2)" : "var(--space-4)" }}>
             {collapsed ? (
               <span title="No projects yet — add one with the CLI">∅</span>
@@ -397,7 +482,7 @@ export function LeftSidebar({
             )}
           </div>
         ) : null}
-        {projects.map((p) => (
+        {visibleProjects.map((p) => (
           <div key={p.id}>
             <div className="tree-row tree-row--project">
               <button
@@ -416,7 +501,7 @@ export function LeftSidebar({
                   {openProj.has(p.id) ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
                 </span>
                 <span className="tree-row__label">
-                  {collapsed ? disambiguatedAbbrev(p.name, p.id, projects) : p.name}
+                  {collapsed ? disambiguatedAbbrev(p.name, p.id, visibleProjects) : p.name}
                 </span>
               </button>
               <button
@@ -428,6 +513,26 @@ export function LeftSidebar({
               >
                 <Plus size={16} />
               </button>
+              {!collapsed ? (
+                <button
+                  type="button"
+                  data-proj-menu-trigger
+                  className="icon-btn tree-row__action"
+                  aria-label={`Project actions for ${p.name}`}
+                  aria-expanded={projMenu?.project.id === p.id}
+                  aria-haspopup="menu"
+                  title="Project menu"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    const rect = e.currentTarget.getBoundingClientRect();
+                    setProjMenu((prev) =>
+                      prev?.project.id === p.id ? null : { project: p, rect },
+                    );
+                  }}
+                >
+                  <MoreHorizontal size={16} />
+                </button>
+              ) : null}
             </div>
             {openProj.has(p.id)
               ? (() => {
@@ -673,6 +778,66 @@ export function LeftSidebar({
                 }}
               >
                 Delete worktree…
+              </button>
+            </div>,
+            document.body,
+          )
+        : null}
+      {projMenu
+        ? createPortal(
+            <div
+              className="menu-pop wt-menu-pop--portal"
+              data-proj-menu-panel
+              role="menu"
+              aria-label="Project actions"
+              style={{
+                position: "fixed",
+                top: projMenu.rect.bottom + 6,
+                left: Math.max(
+                  8,
+                  Math.min(
+                    projMenu.rect.right - 176,
+                    typeof window !== "undefined" ? window.innerWidth - 184 : 8,
+                  ),
+                ),
+                minWidth: 160,
+                zIndex: 4000,
+              }}
+            >
+              <button
+                type="button"
+                role="menuitem"
+                className="menu-pop__item menu-pop__item--icon"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setNewSessProject(projMenu.project);
+                  setProjMenu(null);
+                }}
+              >
+                <Plus size={13} aria-hidden />
+                New worktree
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                className="menu-pop__item menu-pop__item--icon"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  const projectId = projMenu.project.id;
+                  setProjMenu(null);
+                  void (async () => {
+                    try {
+                      await api.hideProject(projectId);
+                      // Store stays current via the `project:updated` WS event;
+                      // the active-project redirect is handled in Workspace.
+                    } catch {
+                      /* surface errors later */
+                    }
+                  })();
+                }}
+              >
+                <EyeOff size={13} aria-hidden />
+                Hide project
               </button>
             </div>,
             document.body,

--- a/web-ui/src/components/settings/AppearanceSetting.tsx
+++ b/web-ui/src/components/settings/AppearanceSetting.tsx
@@ -96,7 +96,6 @@ export function AppearanceSetting() {
   return (
     <div>
       <SectionHeader
-        title="Appearance"
         description="Customize how vibe-station looks on your device."
       />
 

--- a/web-ui/src/components/settings/HiddenProjectsSetting.test.tsx
+++ b/web-ui/src/components/settings/HiddenProjectsSetting.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { Project } from "@/api/types";
+import { createMockApi } from "@/api/mock";
+import { HiddenProjectsSetting } from "./HiddenProjectsSetting";
+import { useServerStore } from "@/hooks/useServerStore";
+
+function proj(id: string, name: string, hidden: boolean): Project {
+  return {
+    id,
+    name,
+    path: `/home/dev/${id}`,
+    prefix: id.slice(0, 2),
+    defaultBranch: "main",
+    createdAt: "2024-01-01T00:00:00.000Z",
+    hidden,
+  };
+}
+
+describe("HiddenProjectsSetting", () => {
+  beforeEach(() => {
+    useServerStore.setState({ projects: [], worktrees: [], sessions: [], loaded: true });
+  });
+
+  it("shows an empty state when no projects are hidden", () => {
+    useServerStore.setState({ projects: [proj("a", "Alpha", false)] });
+    render(<HiddenProjectsSetting api={createMockApi()} />);
+    expect(screen.getByText(/no hidden projects/i)).toBeInTheDocument();
+  });
+
+  it("lists hidden projects and not visible ones", () => {
+    useServerStore.setState({
+      projects: [proj("a", "Alpha", false), proj("b", "Beta", true)],
+    });
+    render(<HiddenProjectsSetting api={createMockApi()} />);
+    expect(screen.getByText("Beta")).toBeInTheDocument();
+    expect(screen.queryByText("Alpha")).toBeNull();
+  });
+
+  it("clicking Unhide calls api.unhideProject", async () => {
+    const user = userEvent.setup();
+    useServerStore.setState({ projects: [proj("b", "Beta", true)] });
+    const api = createMockApi();
+    const spy = vi.spyOn(api, "unhideProject").mockResolvedValue({
+      ok: true,
+      project: proj("b", "Beta", false),
+    });
+    render(<HiddenProjectsSetting api={api} />);
+    await user.click(screen.getByRole("button", { name: /Unhide project Beta/i }));
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledWith("b");
+    });
+  });
+});

--- a/web-ui/src/components/settings/HiddenProjectsSetting.tsx
+++ b/web-ui/src/components/settings/HiddenProjectsSetting.tsx
@@ -1,0 +1,131 @@
+import { useMemo, useState } from "react";
+import { Eye } from "lucide-react";
+import type { ApiInstance } from "@/api";
+import { useServerStore } from "@/hooks/useServerStore";
+import { SectionHeader } from "./SectionHeader";
+
+interface HiddenProjectsSettingProps {
+  api: ApiInstance;
+}
+
+/**
+ * Lists projects the user has hidden from the sidebar + dashboard, with a
+ * per-row Unhide action. Hidden state is server-side (project manifest), so the
+ * list stays in sync via the `project:updated` WS event (no manual refetch).
+ */
+export function HiddenProjectsSetting({ api }: HiddenProjectsSettingProps) {
+  const projects = useServerStore((s) => s.projects);
+  const hidden = useMemo(() => projects.filter((p) => p.hidden), [projects]);
+  // Track in-flight unhide calls to disable the button + avoid double-fires.
+  const [busy, setBusy] = useState<Set<string>>(new Set());
+
+  function unhide(id: string) {
+    setBusy((prev) => new Set(prev).add(id));
+    void (async () => {
+      try {
+        await api.unhideProject(id);
+        // Store stays current via the `project:updated` WS event; the row drops
+        // out of `hidden` on the next render.
+      } catch {
+        /* surface errors later */
+      } finally {
+        setBusy((prev) => {
+          const next = new Set(prev);
+          next.delete(id);
+          return next;
+        });
+      }
+    })();
+  }
+
+  return (
+    <div>
+      <SectionHeader
+        description="Projects you've hidden from the sidebar and dashboard. Unhiding restores a project and all its worktrees."
+      />
+
+      {hidden.length === 0 ? (
+        <div
+          style={{
+            fontSize: "var(--font-size-sm)",
+            color: "var(--fg-muted)",
+            padding: "var(--space-3) 0",
+          }}
+        >
+          No hidden projects.
+        </div>
+      ) : (
+        <div>
+          {hidden.map((p) => (
+            <div
+              key={p.id}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: "var(--space-4)",
+                padding: "var(--space-3) 0",
+                borderBottom:
+                  "var(--border-width) solid var(--border-subtle, var(--border-default))",
+              }}
+            >
+              <div style={{ minWidth: 0 }}>
+                <div
+                  style={{
+                    fontSize: "var(--font-size-sm)",
+                    fontWeight: "var(--font-weight-medium)",
+                    color: "var(--fg-primary)",
+                    marginBottom: 2,
+                  }}
+                >
+                  {p.name}
+                </div>
+                <div
+                  style={{
+                    fontSize: "var(--font-size-xs)",
+                    color: "var(--fg-muted)",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                  title={p.path}
+                >
+                  {p.path}
+                </div>
+              </div>
+              <button
+                type="button"
+                disabled={busy.has(p.id)}
+                aria-label={`Unhide project ${p.name}`}
+                onClick={() => unhide(p.id)}
+                style={{
+                  flexShrink: 0,
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  gap: "var(--space-2)",
+                  height: "var(--space-7, 32px)",
+                  padding: "0 var(--space-3)",
+                  lineHeight: 1,
+                  whiteSpace: "nowrap",
+                  fontSize: "var(--font-size-sm)",
+                  fontWeight: "var(--font-weight-medium)",
+                  fontFamily: "inherit",
+                  border: "var(--border-width) solid var(--border-default)",
+                  borderRadius: "var(--radius-md)",
+                  background: "var(--bg-surface, var(--bg-card))",
+                  color: "var(--fg-primary)",
+                  cursor: busy.has(p.id) ? "default" : "pointer",
+                  opacity: busy.has(p.id) ? 0.6 : 1,
+                }}
+              >
+                <Eye size={14} aria-hidden style={{ flexShrink: 0 }} />
+                <span>Unhide</span>
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web-ui/src/components/settings/ModesSetting.tsx
+++ b/web-ui/src/components/settings/ModesSetting.tsx
@@ -68,7 +68,6 @@ export function ModesSetting({ api }: ModesSettingProps) {
   return (
     <div style={{ paddingBottom: "var(--space-8)" }}>
       <SectionHeader
-        title="Modes"
         description="Orchestrator modes define the CLI, system prompt, and model used when starting a new agent session."
       />
 

--- a/web-ui/src/components/settings/SectionHeader.tsx
+++ b/web-ui/src/components/settings/SectionHeader.tsx
@@ -2,19 +2,21 @@
  * Shared section header for settings panels.
  * Matches the design system's web-settings-section-title + web-settings-section-desc pattern.
  */
-export function SectionHeader({ title, description }: { title: string; description?: string }) {
+export function SectionHeader({ title, description }: { title?: string; description?: string }) {
   return (
     <div style={{ marginBottom: "var(--space-4)" }}>
-      <div
-        style={{
-          fontSize: "var(--font-size-base)",
-          fontWeight: "var(--font-weight-semibold)",
-          color: "var(--fg-primary)",
-          marginBottom: description ? "var(--space-1)" : 0,
-        }}
-      >
-        {title}
-      </div>
+      {title && (
+        <div
+          style={{
+            fontSize: "var(--font-size-base)",
+            fontWeight: "var(--font-weight-semibold)",
+            color: "var(--fg-primary)",
+            marginBottom: description ? "var(--space-1)" : 0,
+          }}
+        >
+          {title}
+        </div>
+      )}
       {description && (
         <div
           style={{

--- a/web-ui/src/components/settings/SettingsPanel.tsx
+++ b/web-ui/src/components/settings/SettingsPanel.tsx
@@ -4,6 +4,7 @@ import type { ApiInstance } from "@/api";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { ModesSetting } from "./ModesSetting";
 import { AppearanceSetting } from "./AppearanceSetting";
+import { HiddenProjectsSetting } from "./HiddenProjectsSetting";
 
 interface Section {
   id: string;
@@ -20,6 +21,7 @@ export function SettingsPanel({ api }: SettingsPanelProps) {
   const isMobile = useMediaQuery("(max-width: 768px)");
   const modesRef = useRef<HTMLElement | null>(null);
   const appearanceRef = useRef<HTMLElement | null>(null);
+  const hiddenProjectsRef = useRef<HTMLElement | null>(null);
   const [activeTab, setActiveTab] = useState("modes");
   const tabLayoutId = useId();
 
@@ -35,6 +37,12 @@ export function SettingsPanel({ api }: SettingsPanelProps) {
       label: "Appearance",
       ref: appearanceRef,
       content: <AppearanceSetting />,
+    },
+    {
+      id: "hidden-projects",
+      label: "Hidden projects",
+      ref: hiddenProjectsRef,
+      content: <HiddenProjectsSetting api={api} />,
     },
   ];
 
@@ -188,17 +196,36 @@ export function SettingsPanel({ api }: SettingsPanelProps) {
         style={{ overflow: "auto", minHeight: 0 }}
       >
         {sections.map((section, i) => (
-          <section
+          <div
             key={section.id}
-            id={`settings-${section.id}`}
-            ref={section.ref}
-            style={{
-              scrollMarginTop: "var(--space-3)",
-              marginBottom: i < sections.length - 1 ? "var(--space-7)" : 0,
-            }}
+            style={{ marginBottom: i < sections.length - 1 ? "var(--space-6)" : 0 }}
           >
-            {section.content}
-          </section>
+            <div
+              style={{
+                fontSize: "var(--font-size-xs)",
+                fontWeight: "var(--font-weight-medium)",
+                color: "var(--fg-muted)",
+                textTransform: "uppercase",
+                letterSpacing: "0.06em",
+                marginBottom: "var(--space-2)",
+              }}
+            >
+              {section.label}
+            </div>
+            <section
+              id={`settings-${section.id}`}
+              ref={section.ref}
+              style={{
+                scrollMarginTop: "var(--space-5)",
+                border: "var(--border-width) solid var(--border-default)",
+                borderRadius: "var(--radius-lg, var(--radius-md))",
+                background: "var(--bg-card)",
+                padding: "var(--space-4) var(--space-5)",
+              }}
+            >
+              {section.content}
+            </section>
+          </div>
         ))}
       </div>
     </div>

--- a/web-ui/src/hooks/useServerStore.test.ts
+++ b/web-ui/src/hooks/useServerStore.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useServerStore } from "./useServerStore";
+import type { Project } from "@/api/types";
+
+function proj(id: string, hidden = false): Project {
+  return {
+    id,
+    name: id,
+    path: `/tmp/${id}`,
+    prefix: id.slice(0, 2),
+    defaultBranch: "main",
+    createdAt: "2024-01-01T00:00:00.000Z",
+    hidden,
+  };
+}
+
+describe("useServerStore.applyProjectUpdated", () => {
+  beforeEach(() => {
+    useServerStore.setState({ projects: [], worktrees: [], sessions: [], loaded: false });
+  });
+
+  it("replaces the matching project (flips hidden)", () => {
+    useServerStore.getState().replaceAll({
+      projects: [proj("a"), proj("b")],
+      worktrees: [],
+      sessions: [],
+    });
+    useServerStore.getState().applyProjectUpdated(proj("a", true));
+    const { projects } = useServerStore.getState();
+    expect(projects.find((p) => p.id === "a")?.hidden).toBe(true);
+    expect(projects.find((p) => p.id === "b")?.hidden).toBe(false);
+  });
+
+  it("ignores an unknown project id (no surprise insert)", () => {
+    useServerStore.getState().replaceAll({
+      projects: [proj("a")],
+      worktrees: [],
+      sessions: [],
+    });
+    useServerStore.getState().applyProjectUpdated(proj("ghost", true));
+    expect(useServerStore.getState().projects.map((p) => p.id)).toEqual(["a"]);
+  });
+});

--- a/web-ui/src/hooks/useServerStore.ts
+++ b/web-ui/src/hooks/useServerStore.ts
@@ -31,6 +31,7 @@ interface ServerData {
   // for a single state transition.
   applyProjectCreated: (p: Project) => void;
   applyProjectDeleted: (projectId: string) => void;
+  applyProjectUpdated: (p: Project) => void;
   applyWorktreeCreated: (w: Worktree) => void;
   applyWorktreeDeleted: (worktreeId: string) => void;
   applyWorktreeUpdated: (w: Worktree) => void;
@@ -60,6 +61,17 @@ export const useServerStore = create<ServerData>((set) => ({
         (sess) => !s.worktrees.some((w) => w.projectId === projectId && w.id === sess.worktreeId),
       ),
     })),
+
+  applyProjectUpdated: (p) =>
+    set((s) => {
+      const idx = s.projects.findIndex((x) => x.id === p.id);
+      // Drop silently if we don't know this id — avoids surprise inserts from a
+      // server racing ahead of our initial list (mirrors applyWorktreeUpdated).
+      if (idx === -1) return s;
+      const next = s.projects.slice();
+      next[idx] = p;
+      return { projects: next };
+    }),
 
   applyWorktreeCreated: (w) =>
     set((s) =>

--- a/web-ui/src/hooks/useServerSync.ts
+++ b/web-ui/src/hooks/useServerSync.ts
@@ -36,6 +36,7 @@ export function useServerSync(api: ApiInstance): void {
   const replaceAll = useServerStore((s) => s.replaceAll);
   const applyProjectCreated = useServerStore((s) => s.applyProjectCreated);
   const applyProjectDeleted = useServerStore((s) => s.applyProjectDeleted);
+  const applyProjectUpdated = useServerStore((s) => s.applyProjectUpdated);
   const applyWorktreeCreated = useServerStore((s) => s.applyWorktreeCreated);
   const applyWorktreeDeleted = useServerStore((s) => s.applyWorktreeDeleted);
   const applyWorktreeUpdated = useServerStore((s) => s.applyWorktreeUpdated);
@@ -88,6 +89,9 @@ export function useServerSync(api: ApiInstance): void {
     const offProjDeleted = api.on("project:deleted", (ev) => {
       if (ev.type === "project:deleted") applyProjectDeleted(ev.projectId);
     });
+    const offProjUpdated = api.on("project:updated", (ev) => {
+      if (ev.type === "project:updated") applyProjectUpdated(ev.project);
+    });
     const offWtCreated = api.on("worktree:created", (ev) => {
       if (ev.type === "worktree:created") applyWorktreeCreated(ev.worktree);
     });
@@ -127,6 +131,7 @@ export function useServerSync(api: ApiInstance): void {
     return () => {
       offProjCreated();
       offProjDeleted();
+      offProjUpdated();
       offWtCreated();
       offWtDeleted();
       offWtUpdated();
@@ -140,6 +145,7 @@ export function useServerSync(api: ApiInstance): void {
     api,
     applyProjectCreated,
     applyProjectDeleted,
+    applyProjectUpdated,
     applyWorktreeCreated,
     applyWorktreeDeleted,
     applyWorktreeUpdated,

--- a/web-ui/src/routes/Workspace.tsx
+++ b/web-ui/src/routes/Workspace.tsx
@@ -74,20 +74,33 @@ export function Workspace() {
   useEffect(() => {
     if (!bundleLoaded) return;
     const s = useWorkspaceStore.getState();
-    const wtStillExists = s.activeWorktreeId && worktrees.some((w) => w.id === s.activeWorktreeId);
+    const activeWt = s.activeWorktreeId
+      ? worktrees.find((w) => w.id === s.activeWorktreeId)
+      : undefined;
+    const wtStillExists = !!activeWt;
+    // The active worktree's project may have been hidden (this tab, another tab,
+    // or via a deep-link to a hidden project's worktree — url-sync sets it active
+    // from the unfiltered list and has no hidden check, so the gate lives here).
+    const activeProjectHidden =
+      !!activeWt && projects.some((p) => p.id === activeWt.projectId && p.hidden);
     const sessStillExists =
       s.activeSessionId && sessions.some((ss) => ss.id === s.activeSessionId);
-    if (!wtStillExists) {
+    if (!wtStillExists || activeProjectHidden) {
       useWorkspaceStore.setState({
         activeProjectId: null,
         activeWorktreeId: null,
         activeSessionId: null,
         activeFilePath: null,
       });
+      // A hidden-project worktree is no longer browseable — leave the now-empty
+      // /worktree/:id route for the dashboard.
+      if (activeProjectHidden && location.pathname.startsWith("/worktree")) {
+        navigate("/", { replace: true });
+      }
     } else if (!sessStillExists) {
       useWorkspaceStore.setState({ activeSessionId: null });
     }
-  }, [bundleLoaded, worktrees, sessions]);
+  }, [bundleLoaded, worktrees, sessions, projects, location.pathname, navigate]);
 
   useEffect(() => {
     if (!isMobile && mobileSidebarOpen) {


### PR DESCRIPTION
## Summary
Two features for the sidebar/dashboard:

### 1. Hide projects
- Server-side `hidden` flag on the project manifest (`ProjectRecord`), serialized on the API, toggled via a new **idempotent `PATCH /projects/:id {hidden}`** that broadcasts a new `project:updated` WS event (added to the daemon zod union, client `WSEvent`, `useServerStore.applyProjectUpdated`, and `useServerSync`).
- New **project-row kebab menu** in the sidebar with **Hide project** + **New worktree**.
- Hidden projects (and all their worktrees) are filtered from the **sidebar** (project list + pinned section) and the **dashboard** (worktree buckets + projects section).
- Hiding the **active** project — or deep-linking `/worktree/:id` of a hidden one — redirects to the dashboard and clears selection.
- New **Settings → "Hidden projects"** section to unhide (with empty state).
- Visibility-only: never touches sessions, worktrees, branches, or files.

### 2. Scroll-to-selected worktree
- When the left sidebar reopens (desktop collapse→expand, mobile drawer open), it snaps the selected worktree row into view (rising-edge effect + double-rAF + `scrollIntoView({block:"nearest"})`), instead of resetting to the top. No-op if already visible or nothing selected.

### Settings UI polish
- Section titles moved **outside** bordered cards as small muted labels (100gb pattern); fixed the Unhide button sizing.

## Testing
- `web-ui`: 123/123 pass (new tests for store reducer, sidebar filter/kebab/scroll, dashboard filter, settings unhide).
- daemon `projects.test.ts`: 15/15 (new PATCH + manifest-persistence + 400/404 tests).
- typecheck clean; changed files lint-clean.
- Verified live in Docker: `hide → GET reflects → unhide`, plus 400/404 edge cases.

## Review
Reviewed by an Opus subagent (PRD + plan pre-implementation, and full diff pre-merge): no critical or blocking issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)