### PR TITLE
fix(terminal): stop tmux history squish on toggle + serialize session open/close

### DIFF
--- a/daemon/src/ws/connection.ts
+++ b/daemon/src/ws/connection.ts
@@ -22,6 +22,18 @@ export type OpenStreamEntry = {
 export class WSConnection {
   private subscriptions: Set<string> = new Set();
   openStreams: Map<string, OpenStreamEntry> = new Map(); // sessionId -> OpenStreamEntry (public for handlers)
+  /**
+   * Per-(conn, sessionId) async lock (a promise chain). Serializes
+   * session:open / session:close for the SAME session on THIS connection so an
+   * open#2 can't run while open#1 is parked on `await stream.attach` and
+   * overwrite the single-slot openStreams entry — which orphans open#1's tmux
+   * PTY but leaves it live (the N-client echo leak).
+   *
+   * Scoped to this connection only: two browsers are two WSConnections and
+   * legitimately hold two tmux clients, so this lock must never serialize
+   * across connections or across tmux names.
+   */
+  private sessionLocks: Map<string, Promise<void>> = new Map(); // sessionId -> tail of chain
   fileWatches: Map<string, unknown> = new Map(); // key -> FSWatcher (public for handlers)
   treeWatches: Map<string, unknown> = new Map(); // key -> FSWatcher (public for handlers)
   readonly id: string; // Unique identifier for this connection
@@ -83,6 +95,32 @@ export class WSConnection {
    */
   isSubscribedTo(sessionId: string): boolean {
     return this.subscriptions.has(sessionId);
+  }
+
+  /**
+   * Run `fn` under this connection's per-session lock, serializing it against
+   * any other open/close for the same sessionId on this connection. The
+   * critical section spans the entire `fn` — callers must keep the
+   * `await stream.attach(...)` park-point inside `fn` so a concurrent open can't
+   * interleave during the attach.
+   */
+  withSessionLock<T>(sessionId: string, fn: () => Promise<T>): Promise<T> {
+    const prev = this.sessionLocks.get(sessionId) ?? Promise.resolve();
+    // Run fn only after the prior op for this session settles (success or not).
+    const run = prev.then(fn, fn);
+    // Advance the chain tail; swallow rejections so a failed op doesn't poison
+    // the chain for the next waiter. Clean up the map entry when we're the tail.
+    const tail = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.sessionLocks.set(sessionId, tail);
+    void tail.finally(() => {
+      if (this.sessionLocks.get(sessionId) === tail) {
+        this.sessionLocks.delete(sessionId);
+      }
+    });
+    return run;
   }
 
   /**

--- a/daemon/src/ws/handlers/sessionClose.ts
+++ b/daemon/src/ws/handlers/sessionClose.ts
@@ -1,9 +1,14 @@
 import type { WSConnection } from "../connection.js";
 import type { ClientMessage } from "../protocol.js";
+import { getLiveTmuxStreamCount } from "../streams/tmuxOutput.js";
+import { appendDebug } from "../../debugLog.js";
 
 /**
  * Handle session:close: detach from a stream and stop streaming.
  * Works for both tmux and direct-pty modes.
+ *
+ * Serialized under the connection's per-session lock so close can't interleave
+ * with an open for the same session (which is what orphaned a live PTY).
  *
  * Race-safe: only unregisters the entry if it's still the same one we
  * captured. Under StrictMode dev (or back-to-back close+open from a
@@ -11,7 +16,14 @@ import type { ClientMessage } from "../protocol.js";
  * register a fresh entry; an unconditional unregister here would clobber it
  * and silently drop subsequent input/resize that look up by sessionId.
  */
-export async function handleSessionClose(
+export function handleSessionClose(
+  conn: WSConnection,
+  msg: Extract<ClientMessage, { type: "session:close" }>,
+): Promise<void> {
+  return conn.withSessionLock(msg.sessionId, () => closeSessionLocked(conn, msg));
+}
+
+async function closeSessionLocked(
   conn: WSConnection,
   msg: Extract<ClientMessage, { type: "session:close" }>,
 ): Promise<void> {
@@ -25,6 +37,15 @@ export async function handleSessionClose(
     await entry.stream.detach(entry.subscriberId);
     if (conn.openStreams.get(sessionId) === entry) {
       conn.unregisterOpenStream(sessionId);
+    }
+    if (conn.debugInput) {
+      appendDebug({
+        src: "daemon",
+        conn: conn.id,
+        kind: "stream:detach",
+        sessionId,
+        liveTmuxStreams: getLiveTmuxStreamCount(),
+      });
     }
   } catch (err) {
     console.error(`[WS] Error closing session ${sessionId}:`, err);

--- a/daemon/src/ws/handlers/sessionOpen.ts
+++ b/daemon/src/ws/handlers/sessionOpen.ts
@@ -1,20 +1,34 @@
 import type { WSConnection } from "../connection.js";
 import type { OpenStreamEntry } from "../connection.js";
 import type { ClientMessage } from "../protocol.js";
-import { TmuxOutputStream } from "../streams/tmuxOutput.js";
+import { TmuxOutputStream, getLiveTmuxStreamCount } from "../streams/tmuxOutput.js";
 import { findSessionRecord } from "./sessionLookup.js";
 import { directPtyRegistry } from "../../state/directPtyRegistry.js";
 import type { SessionStream } from "../streams/sessionStream.js";
+import { appendDebug } from "../../debugLog.js";
 
-export async function handleSessionOpen(
+export function handleSessionOpen(
+  conn: WSConnection,
+  msg: Extract<ClientMessage, { type: "session:open" }>,
+): Promise<void> {
+  // Serialize the ENTIRE open (incl. the `await stream.attach` park-point) under
+  // this connection's per-session lock so a concurrent open#2 can't run while
+  // open#1 is parked on attach and overwrite the single-slot openStreams entry
+  // (which would orphan open#1's PTY but leave it live — the N-client leak).
+  return conn.withSessionLock(msg.sessionId, () => openSessionLocked(conn, msg));
+}
+
+async function openSessionLocked(
   conn: WSConnection,
   msg: Extract<ClientMessage, { type: "session:open" }>,
 ): Promise<void> {
   const { sessionId, cols, rows } = msg;
 
-  // If a stale stream is still registered (e.g. user clicked Resume after the
-  // tmux pane died — the FIFO close didn't unregister), tear it down so this
-  // open can attach to the freshly-spawned pane.
+  // Structural invariant: never create a 2nd attach while one is registered for
+  // this (conn, session). Detach any prior stream UNCONDITIONALLY before the new
+  // attach — this survives future async reordering and complements the lock.
+  // (Also covers the legitimate stale case: user clicked Resume after the tmux
+  // pane died and the FIFO close didn't unregister.)
   const stale = conn.openStreams.get(sessionId);
   if (stale) {
     try {
@@ -45,6 +59,18 @@ export async function handleSessionOpen(
     if (session.useTmux) {
       // Tmux mode: one PTY per connection
       stream = new TmuxOutputStream(session.tmuxName);
+      if (conn.debugInput) {
+        appendDebug({
+          src: "daemon",
+          conn: conn.id,
+          kind: "stream:create",
+          sessionId,
+          tmuxName: session.tmuxName,
+          cols,
+          rows,
+          liveTmuxStreams: getLiveTmuxStreamCount(),
+        });
+      }
     } else {
       // Direct-pty mode: shared stream from registry
       const existing = directPtyRegistry.get(sessionId);
@@ -107,8 +133,21 @@ export async function handleSessionOpen(
       }
     });
 
-    // Start attachment
+    // Start attachment. The lock is held across this await, so the attach
+    // park-point is inside the critical section.
     await stream.attach(cols, rows, subscriberId);
+
+    if (conn.debugInput) {
+      appendDebug({
+        src: "daemon",
+        conn: conn.id,
+        kind: "stream:attached",
+        sessionId,
+        cols,
+        rows,
+        liveTmuxStreams: getLiveTmuxStreamCount(),
+      });
+    }
   } catch (err) {
     conn.send({
       type: "session:error",

--- a/daemon/src/ws/handlers/sessionResize.ts
+++ b/daemon/src/ws/handlers/sessionResize.ts
@@ -2,6 +2,7 @@ import { execSync } from "node:child_process";
 import type { WSConnection } from "../connection.js";
 import type { ClientMessage } from "../protocol.js";
 import { findSessionRecord } from "./sessionLookup.js";
+import { MIN_TMUX_COLS } from "../streams/tmuxOutput.js";
 
 /**
  * Resize the session's PTY to match the client viewport.
@@ -34,6 +35,14 @@ export function handleSessionResize(
   const entry = conn.openStreams.get(sessionId);
 
   if (session.useTmux) {
+    // Authoritative squished-history guard. tmux's scrollback reflow is lossy:
+    // an implausibly narrow width permanently mangles the pane's history and
+    // widening can't restore it (only a fresh attach can). A usable terminal is
+    // never this narrow, so any such value is a transient layout artifact (e.g.
+    // a remounting pane's host collapsing to ~0). Drop it here — the single
+    // chokepoint for BOTH the stream-resize and the no-stream resize-window
+    // paths below — so no client code path can ever bake the history.
+    if (cols < MIN_TMUX_COLS) return;
     if (entry) {
       try {
         entry.stream.resize(cols, rows, entry.subscriberId);

--- a/daemon/src/ws/streams/tmuxOutput.ts
+++ b/daemon/src/ws/streams/tmuxOutput.ts
@@ -37,14 +37,49 @@ import type { SessionStream } from "./sessionStream.js";
  * The subscriberId parameter is ignored because each TmuxOutputStream is owned by
  * one WSConnection, not shared across subscribers.
  */
+/**
+ * Module-level count of TmuxOutputStream instances with a LIVE attach PTY.
+ * Incremented when the attach PTY spawns, decremented when it is killed
+ * (detach / exit). This is the only reliable way to observe orphaned streams:
+ * the per-connection openStreams map is single-slot and can't see a stream that
+ * a re-open race overwrote, so a map-size count would read "1" while N PTYs
+ * leak. Diagnostic only (read behind the debug gate).
+ */
+let liveTmuxStreamCount = 0;
+
+/** Current number of TmuxOutputStream instances with a live attach PTY. */
+export function getLiveTmuxStreamCount(): number {
+  return liveTmuxStreamCount;
+}
+
+/**
+ * Minimum tmux window width we will ever apply. tmux scrollback reflow is lossy
+ * (a narrow width permanently mangles history; widening can't restore it), so a
+ * transient sub-this width from a layout remount must never reach the pane.
+ * Usable terminals are always wider than this — any narrower value is an
+ * artifact, not a real client size.
+ */
+export const MIN_TMUX_COLS = 20;
+
 export class TmuxOutputStream extends EventEmitter implements SessionStream {
   private tmuxName: string;
   private pty: IPty | null = null;
   private closed = false;
+  /** True while this instance is counted in liveTmuxStreamCount. Guards against
+   *  double-decrement when both onExit and detach() run for the same PTY. */
+  private counted = false;
 
   constructor(tmuxName: string) {
     super();
     this.tmuxName = tmuxName;
+  }
+
+  /** Decrement the live counter at most once for this instance. */
+  private uncount(): void {
+    if (this.counted) {
+      this.counted = false;
+      liveTmuxStreamCount--;
+    }
   }
 
   /**
@@ -57,6 +92,10 @@ export class TmuxOutputStream extends EventEmitter implements SessionStream {
    * subscriberId: ignored (single-subscriber per instance)
    */
   async attach(cols: number, rows: number, subscriberId: string): Promise<void> {
+    // Never size the pane below a usable minimum on attach either (see
+    // resize()) — an implausibly narrow initial width would bake the replayed
+    // history narrow with no way back short of a restart.
+    cols = Math.max(cols, MIN_TMUX_COLS);
     try {
       // Pre-flight: confirm the tmux session exists. Without this check, a
       // missing/dead session causes `tmux attach-session` to print
@@ -111,6 +150,8 @@ export class TmuxOutputStream extends EventEmitter implements SessionStream {
       });
 
       this.pty = pty;
+      this.counted = true;
+      liveTmuxStreamCount++;
 
       pty.onData((data: string) => {
         if (this.closed) return;
@@ -118,6 +159,7 @@ export class TmuxOutputStream extends EventEmitter implements SessionStream {
       });
 
       pty.onExit(({ exitCode }) => {
+        this.uncount();
         if (this.closed) return;
         this.closed = true;
         // Exit code 0 from `tmux attach-session` is a clean detach (the
@@ -146,6 +188,13 @@ export class TmuxOutputStream extends EventEmitter implements SessionStream {
 
   /** Resize the PTY (and through it, tmux's pane) to match the client. subscriberId ignored (single subscriber). */
   resize(cols: number, rows: number, _subscriberId?: string): void {
+    // Squished-history guard: tmux's scrollback reflow is LOSSY — once the
+    // window is shrunk to an implausibly narrow width it permanently wraps the
+    // pane's history, and widening back cannot restore it (only a fresh attach
+    // can). A usable terminal is never this narrow, so such a value is always a
+    // transient layout artifact from a remount/relayout — ignore it and keep
+    // the current (wider) size; the next real resize corrects it.
+    if (cols < MIN_TMUX_COLS) return;
     if (this.pty && !this.closed) {
       try {
         this.pty.resize(cols, rows);
@@ -179,6 +228,8 @@ export class TmuxOutputStream extends EventEmitter implements SessionStream {
   async detach(subscriberId: string): Promise<void> {
     if (this.closed) return;
     this.closed = true;
+
+    this.uncount();
 
     if (this.pty) {
       try {

--- a/web-ui/src/components/layout/TerminalPane.tsx
+++ b/web-ui/src/components/layout/TerminalPane.tsx
@@ -196,10 +196,30 @@ export function TerminalPane({ api, activeSession }: TerminalPaneProps) {
       }
     });
 
-    // Open session synchronously after fit. Daemon won't emit chunks
-    // until openSession lands.
-    markSessionAttachPending(activeSessionId);
-    void api.openSession(activeSessionId, term.cols, term.rows);
+    // Gated diagnostic logger for terminal sizing (squished-width
+    // investigation). Behind the existing input-debug gate so it never logs
+    // unless ?debugInput is enabled.
+    const logSize = (kind: "openSession" | "resize", cols: number, rows: number) => {
+      inputDebug?.log({ kind, cols, rows });
+    };
+
+    // Bug #4 (squished width): the FIRST openSession must NOT fire synchronously
+    // here. react-resizable-panels restores the saved per-worktree panel size
+    // AFTER mount, so a synchronous fit()+open sends the transient 33.4%-default
+    // (narrow) cols and the daemon bakes tmux/Claude history at the wrong width.
+    // Instead, the ResizeObserver below performs the initial open on its FIRST
+    // fire — which is the post-restore resize, the deterministic "layout
+    // settled" signal. The session:output subscription above is already wired
+    // synchronously, so the first replay chunk is still captured.
+    let initialOpenDone = false;
+    const doInitialOpen = () => {
+      if (initialOpenDone) return;
+      initialOpenDone = true;
+      // (fit() has already run in applySettledSize before this is called.)
+      markSessionAttachPending(activeSessionId);
+      logSize("openSession", term.cols, term.rows);
+      void api.openSession(activeSessionId, term.cols, term.rows);
+    };
 
     // Mobile vertical-swipe scrolling. In normal buffer it scrolls xterm's
     // scrollback; in alternate buffer (vim/htop/tmux copy-mode) it sends
@@ -218,43 +238,46 @@ export function TerminalPane({ api, activeSession }: TerminalPaneProps) {
       setAtBottom(b.viewportY >= b.length - term.rows);
     });
 
-    let roPendingRaf: number | null = null;
-    const ro = new ResizeObserver(() => {
-      if (roPendingRaf !== null) cancelAnimationFrame(roPendingRaf);
-      roPendingRaf = requestAnimationFrame(() => {
-        roPendingRaf = null;
-        if (!mounted) return;
-        try {
-          fit.fit();
-          void api.resizeSession(activeSessionId, term.cols, term.rows);
-          // Bug #2 (resize doubling): switching the workspace layout (e.g. to a
-          // vertical split) remounts the terminal — see Layout.tsx, the
-          // terminalPosition left/bottom branches are different React subtrees —
-          // and the remount's scrollback replay reflowed at an unstable width
-          // leaves duplicated rows on the canvas. Forcing a full redraw from the
-          // buffer after the fit settles clears those stale rows (the same thing
-          // a workspace-switch remount does, which is why it "self-heals").
-          // NOTE for reviewer: this is a render-level mitigation. The root fix is
-          // to stop the terminal remounting on a layout-position change (keep it
-          // in a stable React position). Evaluate whether that larger Layout
-          // change is worth doing instead of / in addition to this.
-          if (term.rows > 0) term.refresh(0, term.rows - 1);
-        } catch {
-          /* ignore */
-        }
-      });
-    });
-    ro.observe(host);
-
-    const handleWindowResize = () => {
+    // Bug #4 (squished width), part 2 — the ONGOING resize. Switching to a
+    // worktree whose layout differs (e.g. one that shows the file preview) makes
+    // the terminal's host width transiently COLLAPSE (~80px) while the panels
+    // re-lay-out. Firing fit()+resizeSession per frame ships that transient
+    // narrow width to the daemon → tmux/Claude reflow history to ~10 cols and
+    // bake it. So we settle-debounce: only act once the size has been STABLE
+    // for a beat, and never send an implausibly small width (the panel's
+    // minSize means a real terminal is never ~10 cols — small == transition
+    // artifact). The local terminal also only fits on settle, so it can't flash
+    // narrow either.
+    const MIN_COLS = 20;
+    let settleTimer: ReturnType<typeof setTimeout> | null = null;
+    const applySettledSize = () => {
+      settleTimer = null;
       if (!mounted) return;
       try {
         fit.fit();
-        void api.resizeSession(activeSessionId, term.cols, term.rows);
       } catch {
-        /* ignore */
+        return;
       }
+      if (term.cols < MIN_COLS) return; // transient narrow — don't tell the daemon
+      if (!initialOpenDone) {
+        doInitialOpen(); // first open, now at the settled width
+        return;
+      }
+      logSize("resize", term.cols, term.rows);
+      void api.resizeSession(activeSessionId, term.cols, term.rows);
+      // Bug #2 mitigation: force a full redraw to clear any reflow-duplicated
+      // rows left by a remount's replay.
+      if (term.rows > 0) term.refresh(0, term.rows - 1);
     };
+    const scheduleSettle = () => {
+      if (settleTimer !== null) clearTimeout(settleTimer);
+      settleTimer = setTimeout(applySettledSize, 150);
+    };
+
+    const ro = new ResizeObserver(() => scheduleSettle());
+    ro.observe(host);
+
+    const handleWindowResize = () => scheduleSettle();
     window.addEventListener("resize", handleWindowResize);
 
     const d = term.onData((data) => {
@@ -272,6 +295,10 @@ export function TerminalPane({ api, activeSession }: TerminalPaneProps) {
       void api.sendKeystroke(activeSessionId, data);
     });
     const r = term.onResize(({ cols, rows }) => {
+      // Guard (squished-history): xterm fits can momentarily report a collapsed
+      // width during a remount; never forward a sub-20 width to the daemon —
+      // tmux's lossy scrollback reflow would bake history at that transient.
+      if (cols < MIN_COLS) return;
       void api.resizeSession(activeSessionId, cols, rows);
     });
 
@@ -286,7 +313,7 @@ export function TerminalPane({ api, activeSession }: TerminalPaneProps) {
       ro.disconnect();
       window.removeEventListener("resize", handleWindowResize);
       cleanupTouchScroll();
-      if (roPendingRaf !== null) cancelAnimationFrame(roPendingRaf);
+      if (settleTimer !== null) clearTimeout(settleTimer);
       void api.closeSession(activeSessionId);
       term.dispose();
       termRef.current = null;
@@ -306,7 +333,10 @@ export function TerminalPane({ api, activeSession }: TerminalPaneProps) {
     term.options.fontSize = Math.round(14 * terminalFontScale);
     term.clearTextureAtlas?.();
     fitRef.current?.fit();
-    if (activeSessionId) {
+    // Guard (squished-history): never ship a sub-20 width — on an activeSessionId
+    // toggle this effect runs while the host is mid-collapse, and tmux's lossy
+    // reflow bakes history at that transient. A real terminal is never this narrow.
+    if (activeSessionId && term.cols >= 20) {
       void api.resizeSession(activeSessionId, term.cols, term.rows);
     }
   }, [terminalFontScale, activeSessionId, api, mountTerminal]);
@@ -332,6 +362,9 @@ export function TerminalPane({ api, activeSession }: TerminalPaneProps) {
       ) {
         termRef.current.reset();
         markSessionAttachPending(activeSessionId);
+        // No width deferral needed here: this reconnect open reuses the
+        // already-fitted termRef.current.cols and runs after layout has settled
+        // (only the initial mount open races the panel-size restore — Bug #4).
         void api.openSession(activeSessionId, termRef.current.cols, termRef.current.rows);
       }
       if (s === "online") everOnline = true;
@@ -353,6 +386,8 @@ export function TerminalPane({ api, activeSession }: TerminalPaneProps) {
       if (term) {
         term.reset();
         markSessionAttachPending(activeSessionId);
+        // Reuses the already-fitted term.cols and runs after layout settled, so
+        // no width deferral is needed (unlike the initial mount open — Bug #4).
         void api.openSession(activeSessionId, term.cols, term.rows);
       }
     } finally {

--- a/web-ui/src/lib/input-debug.ts
+++ b/web-ui/src/lib/input-debug.ts
@@ -27,6 +27,9 @@ export function isInputDebugEnabled(): boolean {
     const q = new URLSearchParams(window.location.search).get("debugInput");
     if (q === "1") localStorage.setItem(STORAGE_KEY, "1");
     else if (q === "0") localStorage.setItem(STORAGE_KEY, "0");
+    // Default OFF (opt-in). Enable per-browser with ?debugInput=1 to capture a
+    // recurrence; this gates both the input logging and the daemon-side terminal
+    // diagnostics (sizes, stream create/detach, live tmux-attach count).
     return localStorage.getItem(STORAGE_KEY) === "1";
   } catch {
     return false;


### PR DESCRIPTION
## What

Fixes the **squished Claude history on worktree/layout toggle**, plus the related **tmux-client leak** (f → ff → fff), both rooted in the terminal tearing down + re-attaching on a layout change.

### Squished history
On a toggle the remounting terminal's host briefly collapses to ~0px. The client shipped that transient width to the daemon, which ran `tmux resize-window -x 2`. tmux's scrollback reflow is **lossy**, so a single narrow value permanently mangled the history — only a daemon restart "fixed" it. Guarded at every layer:

- **Client** (`TerminalPane.tsx`): skip sub-`MIN_COLS` widths in the `onResize` and font-scale effects; defer the initial `openSession` behind a settle-debounce so only the settled layout width reaches the daemon.
- **Daemon** (`sessionResize.ts`, `tmuxOutput.ts`): drop any tmux resize/attach below `MIN_TMUX_COLS` (20) at one authoritative chokepoint — no client path can ever bake the history again.

### tmux-client leak
Concurrent `session:open`/`close` on one connection interleaved across `await stream.attach`, overwriting the single-slot `openStreams` entry and orphaning a live PTY. Now serialized per-(conn, session) via `WSConnection.withSessionLock`, with an unconditional stale-stream teardown before each new attach.

## Verification
Driven end-to-end with a headless browser performing the toggle while tracing the tmux window width — it previously dropped to `2x37` on every toggle and now never falls below the real layout width.

## Notes
- Gated diagnostics (off unless `?debugInput=1`) retained for fast future triage.
- The `window-size manual` experiment was measured to address a non-issue and was dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
