### PR TITLE
docs(agent-prompt): clarify worktree create already spawns main session

### DIFF
--- a/daemon/src/assets/agent-system-prompt.md
+++ b/daemon/src/assets/agent-system-prompt.md
@@ -67,17 +67,36 @@ vst session output <session-id> --lines=50
 vst session output <session-id> --follow
 ```
 
-### Spawn a sibling agent
+### Spawn more work
+
+There are two distinct operations. Pick the right one — they are not interchangeable.
+
+#### Case A — a NEW worktree (separate branch, isolated checkout)
 
 ```bash
-# Add an agent tab to your worktree
+# Creates the worktree AND its main agent session (slot `m`) in ONE command.
+vst worktree create $VST_PROJECT --mode=<modeId> --branch=<name> --prompt="the task"
+```
+
+**The main session is created automatically.** Do NOT follow this with
+`vst session create` — that would add a redundant second session. One
+`vst worktree create` call = one worktree + one ready-to-work agent.
+
+`$VST_PROJECT` is your own project id. To target a different project, list them
+with `vst project ls --json`.
+
+#### Case B — an extra session in the PROVIDED worktree (same branch/checkout)
+
+```bash
+# Adds a sibling agent tab to the given worktree (slots a1, a2, …).
 vst session create $VST_WORKTREE --type=agent --mode=<modeId> --prompt="your sub-task"
 
-# Add a plain terminal tab
+# Add a plain terminal tab (slots t1, t2, …).
 vst session create $VST_WORKTREE --type=terminal
 ```
 
-Sibling sessions share the same git checkout. Coordinate via files (e.g. write a spec file, let the sibling implement it).
+Use this only when the work should share an existing git checkout. Sibling
+sessions coordinate via files (e.g. write a spec file, let the sibling implement it).
 
 ### Send a message to a session
 
@@ -117,3 +136,4 @@ If you hit a blocker you cannot resolve (missing credentials, ambiguous requirem
 - Delete or modify another session's work without explicit coordination.
 - Run `vst worktree rm` or `vst session kill` on sessions you did not create.
 - Ignore test failures and commit anyway.
+- After `vst worktree create`, do NOT run `vst session create` for the same worktree — the main session already exists.


### PR DESCRIPTION
## Problem

When a user asks a vst-managed worker agent to "create a new worktree session", the agent runs `vst worktree create` (which already creates the worktree **+ its main session** atomically) and then *also* runs `vst session create` — producing a redundant extra session.

## Root cause

The worker system prompt (`daemon/src/assets/agent-system-prompt.md`) never documented `vst worktree create` at all. Its only spawn verb was `vst session create` (under a "Spawn a sibling agent" heading), so the agent had no model for "new worktree = main session included."

## Change (docs only)

- Restructure the spawn section into two explicit, non-interchangeable cases:
  - **Case A — new worktree**: `vst worktree create` creates the worktree + main session in one command; explicitly says do NOT follow with `vst session create`.
  - **Case B — sibling session in an existing worktree**: `vst session create`.
- Add a "must NOT do" guard: after `vst worktree create`, don't run `vst session create` for the same worktree.
- Use `$VST_PROJECT` for the project id instead of a `jq` round-trip.
- Fix sibling slot numbering (`a1/t1, …`, not `a2/t2`) to match the daemon (`reserveNextAgentSlot` starts at 1).

## Verification

Reviewed by a subagent against `vst worktree create --help`, `vst session create --help`, and the slot-assignment code/tests. Only substantive correction found (slot off-by-one) is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)