### PR TITLE
feat(models): add Claude fable model to curated list

### DIFF
--- a/daemon/src/__tests__/plugins.test.ts
+++ b/daemon/src/__tests__/plugins.test.ts
@@ -91,6 +91,13 @@ describe("Agent plugins", () => {
       expect(cmd[0]).toBe("claude");
     });
 
+    it("listModels() includes the fable alias and full name", async () => {
+      const { resolvePlugin } = await import("../agent-plugins/registry.js");
+      const { models } = await resolvePlugin("claude").listModels();
+      expect(models).toContain("fable");
+      expect(models).toContain("claude-fable-5");
+    });
+
     it("T10.6 — composeLaunchPrompt with both system + task: useShell=true, shellLine contains --dangerously-skip-permissions, $(cat ...), task; postLaunchInput is undefined", async () => {
       const { resolvePlugin } = await import("../agent-plugins/registry.js");
       const plugin = resolvePlugin("claude");

--- a/daemon/src/agent-plugins/claude.ts
+++ b/daemon/src/agent-plugins/claude.ts
@@ -33,9 +33,11 @@ const CLAUDE_MODELS = [
   "sonnet",
   "opus",
   "haiku",
+  "fable",
   "claude-opus-4-5",
   "claude-sonnet-4-5",
   "claude-haiku-4-5",
+  "claude-fable-5",
 ] as const;
 
 export function createClaudePlugin(): AgentPlugin {


### PR DESCRIPTION
## What

Adds the newly released Claude **`fable`** model to the picker.

- `fable` (alias) and `claude-fable-5` (full name) added to `CLAUDE_MODELS` in `daemon/src/agent-plugins/claude.ts`, mirroring the existing alias + full-name convention.
- Test in `plugins.test.ts` asserting `listModels()` includes both.

## Why this is the whole change

The Claude model list is a **hand-curated static array** in the Claude agent plugin — the `claude` CLI has no list-models command to query (verified: subcommands are agents/auth/auto-mode/doctor/gateway/install/mcp/plugin/project/setup-token/ultrareview/update; no `--list-models` flag). So maintaining this array by hand is the intended path.

The array only populates the `ModelPicker` dropdown; the mode `model` field is free-form (`z.string()`, not an enum) and passed straight to `claude --model`, so no schema/validation changes are needed.

`fable` is confirmed as an official alias by `claude --model` help (v2.1.198): *"Provide an alias for the latest model (e.g. 'fable', 'opus', or 'sonnet') or a model's full name (e.g. 'claude-fable-5')."*

## Testing

- `plugins.test.ts` — 44/44 pass (incl. new fable assertions)
- typecheck + lint clean
- 4 unrelated tests fail identically on the clean base branch (3 flaky lifecycle timers + 1 pre-existing gemini defaultModel mismatch) — not touched by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)