### PR TITLE
feat(worktree): make worktree IDs monotonic (never reuse)

### DIFF
--- a/.feature-plans/worktree-id-monotonic.md
+++ b/.feature-plans/worktree-id-monotonic.md
@@ -1,0 +1,119 @@
+# Monotonic worktree IDs (never reuse)
+
+## Problem
+
+Worktree IDs are reused. `reserveNextWorktreeNum` (`daemon/src/services/sessionId.ts:17-34`)
+returns the smallest integer not in the manifest **and** whose directory doesn't exist on
+disk. So after a **purge** delete (UI always purges; CLI with `--purge`), a deleted worktree
+`vs-2` is recreated with the **same id** → same path, same session id `vs-2-m`, same tmux
+name `vr-vs-2-m`.
+
+Reuse produces three clashes:
+
+1. **tmux clash** — delete kills tmux best-effort (`daemon/src/routes/worktrees.ts:506-510`).
+   If the kill fails, the session survives. Spawn calls `newSession()`
+   (`daemon/src/services/tmux.ts:43-59`) with no `hasSession()` guard → `tmux new-session`
+   errors `session already exists` → spawn fails hard.
+2. **Claude/Cursor conversation bleed** — transcripts live at `~/.claude/projects/<slug>/<uuid>.jsonl`,
+   slug derived purely from the absolute worktree **path** (`daemon/src/agent-plugins/claudeRestore.ts:24-31`).
+   vibe-station never deletes this dir, even on purge. `getRestoreCommand` falls back to
+   `findLatestChatUuid(path)` when `session.agentChatId` is absent
+   (`daemon/src/agent-plugins/claude.ts:174-176`). A reused-path worktree can resume the
+   **deleted** worktree's conversation. Cursor has the same pattern (`cursorRestore.ts`).
+3. **session-data leftovers** (low severity) — `session-data/<wtId>/<sessionId>/` cleanup is
+   best-effort (`worktrees.ts:513`, `paths.ts:61-67`).
+
+## Decision
+
+Make worktree numbers **monotonic** — a removed `vs-2` is never recycled; next create is
+always `vs-3`. An id permanently means one piece of work. This dissolves all three clashes at
+the source (path / session id / tmux name are never reused), rather than patching each.
+
+## Plan
+
+### 1. Data model — add a high-water counter
+
+`daemon/src/types.ts`, `ProjectRecord`:
+
+```ts
+nextWorktreeNum?: number; // monotonic high-water mark; optional for back-compat
+```
+
+Persisted in `manifest.json` like the rest of the record.
+
+### 2. Reservation — monotonic + race-safe
+
+`daemon/src/services/sessionId.ts` — change `reserveNextWorktreeNum` from "smallest free" to
+"next from counter":
+
+```ts
+// seed for legacy manifests with no counter yet.
+// Number.isFinite filter is REQUIRED: any worktree id whose last segment isn't
+// numeric yields NaN, and Math.max(0, NaN) === NaN would produce id `vs-NaN` and
+// permanently poison the counter. (Today's smallest-free loop is immune because
+// NaN in a Set never matches — the monotonic rewrite is not.)
+const nums = project.worktrees.map(numOf).filter(Number.isFinite);
+const seed = Math.max(0, ...nums) + 1;
+let n = project.nextWorktreeNum ?? seed;
+// paranoia guard: never land on a stray on-disk dir (old non-purge orphans)
+while (existsSync(worktreePath(project.id, `${project.prefix}-${n}`))) n++;
+return n;
+```
+
+Keep the `existsSync` guard as a safety net (mostly moot now, but cheap). The guard runs
+*before* the counter is persisted (see below), so any orphan-dir skips are also recorded in
+`nextWorktreeNum`.
+
+`daemon/src/routes/worktrees.ts` create handler — bump-then-build:
+
+- Replace the bare `reserveNextWorktreeNum` call (line 269) with a `mutateProject` that
+  **reserves `n` (running the seed + existsSync guard) and writes back
+  `nextWorktreeNum = n + 1` atomically**, returning `n`. This both persists the counter and
+  closes the pre-lock race (`mutateProject` serializes via `withProjectLock`; the current
+  reserve runs before any lock).
+- Then `worktreeAdd(... n ...)`, then the existing `mutateProject` appends the record.
+- **Burn-on-failure is intentional:** if git add fails after the bump, the number is consumed
+  and never reused — exactly what "monotonic" means. No rollback of the counter.
+
+> **Locking footgun — do NOT wrap the create flow in an outer `withProjectLock`.**
+> `withProjectLock` (`daemon/src/services/mutex.ts:9-31`) is a plain boolean+queue and is
+> **not reentrant** — a nested acquire on the same project id deadlocks forever. The design
+> relies on **two sequential, non-nested** `mutateProject` calls (reserve, then append), each
+> acquiring and releasing independently. Never hoist an outer lock around them while still
+> calling `mutateProject` inside.
+
+Also fix two stale comments while here: the misleading `// ... under mutex` comment at
+`worktrees.ts:267`, and the `reserveNextWorktreeNum` JSDoc ("MUST be called under the project
+mutex") — it now genuinely runs inside a `mutateProject` callback.
+
+### 3. Back-compat / migration
+
+No explicit migration. Existing manifests have `nextWorktreeNum: undefined` → first create
+lazily seeds from `max(existing worktree nums) + 1`. Existing worktrees keep their ids. The
+`existsSync` guard absorbs any leftover orphan dirs from past non-purge deletes.
+
+### 4. Tests
+
+- `sessionId` test: delete-highest-then-create yields `N+1`, not the freed number.
+- Counter persists across a manifest reload.
+- Legacy manifest (no `nextWorktreeNum`) seeds correctly from existing worktrees.
+- Legacy manifest with a non-numeric-suffixed worktree id does **not** yield `NaN`
+  (regression guard for the `Number.isFinite` filter).
+- Two-phase window: a reserve/bump with **no** subsequent append (crash-simulated) still
+  advances the counter — the next create skips the burned number.
+
+## What this dissolves from earlier fix ideas
+
+- **Claude/Cursor chat cleanup: dropped** — path/slug is never reused, so no transcript to
+  bleed. Moot under monotonic.
+- **session-data leftovers (clash #3): moot** — `session-data/<wtId>/...` paths never recur.
+- **tmux idempotency (clash #1): optional** — tmux names (`vr-vs-N-m`) never recycle either,
+  so the clash can't arise from ID reuse. Out of scope for this change. A 1-line
+  defense-in-depth (`await killSession(opts.name)` atop `newSession`) is available if
+  belt-and-suspenders is ever wanted, but it's not needed here.
+
+## Scope / trade-offs
+
+- Small: one optional field, one rewritten function (~10 lines), one tightened call site, tests.
+- Cost: numbers grow over time and can look gappy (`vs-2`, `vs-3`, `vs-7`…). That's the
+  intended signal — gaps mean deleted work; ids never lie.

--- a/daemon/src/__tests__/sessionId.test.ts
+++ b/daemon/src/__tests__/sessionId.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ProjectRecord, WorktreeRecord } from "../types.js";
+
+let tempDir: string;
+
+vi.mock("../services/paths.js", async () => {
+  const { join: pathJoin } = await import("node:path");
+  return {
+    vstHome: () => tempDir,
+    projectDir: (id: string) => pathJoin(tempDir, "projects", id),
+    manifestPath: (id: string) => pathJoin(tempDir, "projects", id, "manifest.json"),
+    manifestTmpPath: (id: string) => pathJoin(tempDir, "projects", id, "manifest.json.tmp"),
+    worktreePath: (id: string, wtId: string) =>
+      pathJoin(tempDir, "projects", id, "worktrees", wtId),
+    configPath: () => pathJoin(tempDir, "config.json"),
+    modesPath: () => pathJoin(tempDir, "modes.json"),
+    daemonLogPath: () => pathJoin(tempDir, "logs", "daemon.log"),
+  };
+});
+
+const makeWorktree = (id: string): WorktreeRecord => ({
+  id,
+  branch: `branch-${id}`,
+  baseBranch: "main",
+  baseSha: "0".repeat(40),
+  createdAt: new Date().toISOString(),
+  sessions: [],
+});
+
+const makeProject = (overrides: Partial<ProjectRecord> = {}): ProjectRecord => ({
+  id: "proj-1",
+  absolutePath: "/fake/proj-1",
+  prefix: "vs",
+  defaultBranch: "main",
+  createdAt: new Date().toISOString(),
+  worktrees: [],
+  ...overrides,
+});
+
+describe("reserveNextWorktreeNum", () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "vst-sessionid-test-"));
+    await mkdir(join(tempDir, "projects", "proj-1", "worktrees"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("delete-highest-then-create yields N+1, not the freed number", async () => {
+    const { reserveNextWorktreeNum } = await import("../services/sessionId.js");
+
+    // vs-1, vs-2, vs-3 existed; vs-3 (the highest) was deleted (purged).
+    // The manifest already carries a persisted counter of 4 (set when vs-3 was reserved).
+    const project = makeProject({
+      worktrees: [makeWorktree("vs-1"), makeWorktree("vs-2")],
+      nextWorktreeNum: 4,
+    });
+
+    const n = reserveNextWorktreeNum(project);
+    expect(n).toBe(4); // NOT 3, the freed number
+  });
+
+  it("counter persists across a manifest reload", async () => {
+    const { writeManifest, readManifest } = await import("../services/manifest.js");
+    const { reserveNextWorktreeNum } = await import("../services/sessionId.js");
+
+    const project = makeProject({
+      worktrees: [makeWorktree("vs-1")],
+      nextWorktreeNum: 5,
+    });
+    await writeManifest(project);
+
+    const loaded = await readManifest("proj-1");
+    expect(loaded.nextWorktreeNum).toBe(5);
+    expect(reserveNextWorktreeNum(loaded)).toBe(5);
+  });
+
+  it("legacy manifest (no nextWorktreeNum) seeds from existing worktrees", async () => {
+    const { reserveNextWorktreeNum } = await import("../services/sessionId.js");
+
+    const project = makeProject({
+      worktrees: [makeWorktree("vs-1"), makeWorktree("vs-3"), makeWorktree("vs-2")],
+      // nextWorktreeNum intentionally omitted (legacy manifest)
+    });
+
+    expect(reserveNextWorktreeNum(project)).toBe(4); // max(1,3,2) + 1
+  });
+
+  it("legacy manifest with a non-numeric-suffixed worktree id does not yield NaN", async () => {
+    const { reserveNextWorktreeNum } = await import("../services/sessionId.js");
+
+    const project = makeProject({
+      worktrees: [makeWorktree("vs-1"), makeWorktree("vs-feature")],
+    });
+
+    const n = reserveNextWorktreeNum(project);
+    expect(n).not.toBeNaN();
+    expect(n).toBe(2); // max(1, NaN filtered out) + 1
+  });
+
+  it("empty legacy manifest seeds at 1", async () => {
+    const { reserveNextWorktreeNum } = await import("../services/sessionId.js");
+    const project = makeProject({ worktrees: [] });
+    expect(reserveNextWorktreeNum(project)).toBe(1);
+  });
+
+  it("skips a stray on-disk directory left by a non-purge delete", async () => {
+    const { reserveNextWorktreeNum } = await import("../services/sessionId.js");
+
+    // vs-4 has no manifest entry (removed without --purge) but the directory is still there.
+    await mkdir(join(tempDir, "projects", "proj-1", "worktrees", "vs-4"), { recursive: true });
+
+    const project = makeProject({
+      worktrees: [makeWorktree("vs-1")],
+      nextWorktreeNum: 4,
+    });
+
+    expect(reserveNextWorktreeNum(project)).toBe(5); // skips the orphaned vs-4 dir
+  });
+
+  it("two-phase window: a reserve/bump with no append still advances the counter", async () => {
+    const { mutateProject, addProject, getProject, _clearStoreForTest } = await import(
+      "../state/project-store.js"
+    );
+    const { reserveNextWorktreeNum } = await import("../services/sessionId.js");
+
+    _clearStoreForTest();
+    const project = makeProject({ worktrees: [] });
+    await addProject(project);
+
+    // Simulate the route's reserve-and-bump mutateProject call, WITHOUT the
+    // subsequent append (as if worktree creation crashed right after the bump).
+    let reserved!: number;
+    await mutateProject("proj-1", (p) => {
+      reserved = reserveNextWorktreeNum(p);
+      return { ...p, nextWorktreeNum: reserved + 1 };
+    });
+    expect(reserved).toBe(1);
+
+    // No worktree was ever appended for number 1 — it's burned.
+    const afterCrash = getProject("proj-1")!;
+    expect(afterCrash.worktrees).toEqual([]);
+    expect(afterCrash.nextWorktreeNum).toBe(2);
+
+    // The next create must skip the burned number 1.
+    expect(reserveNextWorktreeNum(afterCrash)).toBe(2);
+  });
+});

--- a/daemon/src/routes/worktrees.ts
+++ b/daemon/src/routes/worktrees.ts
@@ -264,9 +264,15 @@ export function registerWorktreeRoutes(app: FastifyInstance): void {
     let worktreeAdded = false;
 
     try {
-      // 3. Reserve worktree id under mutex (read project fresh from store)
-      const freshProject = getProject(projectId)!;
-      const wtNum = reserveNextWorktreeNum(freshProject);
+      // 3. Reserve worktree id: reserve + bump `nextWorktreeNum` atomically inside
+      // a single mutateProject call, so the reservation is race-safe and the
+      // counter is persisted even if worktree creation fails below (burn-on-failure
+      // is intentional — a burned number is never reused).
+      let wtNum!: number;
+      const freshProject = await mutateProject(projectId, (p) => {
+        wtNum = reserveNextWorktreeNum(p);
+        return { ...p, nextWorktreeNum: wtNum + 1 };
+      });
       const wtId = `${freshProject.prefix}-${wtNum}`;
       const wtPath = getWorktreePath(projectId, wtId);
 

--- a/daemon/src/services/sessionId.ts
+++ b/daemon/src/services/sessionId.ts
@@ -6,31 +6,38 @@ import { existsSync } from "node:fs";
 import type { ProjectRecord, SessionSlot, WorktreeRecord } from "../types.js";
 import { worktreePath } from "./paths.js";
 
+/** Extract the trailing "-<num>" from a worktree id (e.g. "vs-3" -> 3). May be NaN. */
+function numOf(wt: WorktreeRecord): number {
+  const parts = wt.id.split("-");
+  const last = parts[parts.length - 1];
+  return parseInt(last ?? "", 10);
+}
+
 /**
- * Reserve the next free worktree number for a project.
- * Returns the smallest positive integer not already used by any worktree in the project,
- * AND whose worktree directory does not already exist on disk. The disk check guards
- * against orphans left by `vst worktree rm` (without --purge), which intentionally
- * removes from the manifest but keeps files and git registration.
- * MUST be called under the project mutex.
+ * Reserve the next worktree number for a project — monotonic, never reused.
+ *
+ * Uses the persisted high-water counter `project.nextWorktreeNum`. For legacy
+ * manifests written before that field existed, it's lazily seeded from
+ * `max(existing worktree nums) + 1` (the `Number.isFinite` filter is required:
+ * a worktree id whose trailing segment isn't numeric parses to NaN, and
+ * `Math.max(0, NaN)` is NaN, which would poison the counter permanently).
+ *
+ * The `existsSync` check is a paranoia guard against stray on-disk directories
+ * left by non-purge deletes (`vst worktree rm` without `--purge`) — mostly moot
+ * once the counter is persisted, but cheap to keep.
+ *
+ * This function is pure (it doesn't mutate or persist anything) — callers MUST
+ * run it inside a `mutateProject` callback and write the returned value + 1 back
+ * to `nextWorktreeNum` as part of that same atomic update, so the reservation
+ * and the counter bump land together.
  */
 export function reserveNextWorktreeNum(project: ProjectRecord): number {
-  const usedNums = new Set(
-    project.worktrees.map((wt) => {
-      // wt.id is "<prefix>-<num>"
-      const parts = wt.id.split("-");
-      const last = parts[parts.length - 1];
-      return parseInt(last ?? "0", 10);
-    }),
-  );
-
-  for (let n = 1; n < 100_000; n++) {
-    if (usedNums.has(n)) continue;
-    const candidatePath = worktreePath(project.id, `${project.prefix}-${n}`);
-    if (existsSync(candidatePath)) continue;
-    return n;
-  }
-  throw new Error(`Could not reserve worktree number for project ${project.id}`);
+  const nums = project.worktrees.map(numOf).filter(Number.isFinite);
+  const seed = Math.max(0, ...nums) + 1;
+  let n = project.nextWorktreeNum ?? seed;
+  // paranoia guard: never land on a stray on-disk dir (old non-purge orphans)
+  while (existsSync(worktreePath(project.id, `${project.prefix}-${n}`))) n++;
+  return n;
 }
 
 /**

--- a/daemon/src/types.ts
+++ b/daemon/src/types.ts
@@ -55,4 +55,11 @@ export interface ProjectRecord {
   defaultBranch: string;
   createdAt: string; // ISO8601
   worktrees: WorktreeRecord[];
+  /**
+   * Monotonic high-water mark for worktree numbers. Never decreases, never reused,
+   * even after a worktree is deleted. Optional for back-compat with manifests
+   * written before this field existed — `reserveNextWorktreeNum` lazily seeds it
+   * from the existing worktrees the first time it's needed.
+   */
+  nextWorktreeNum?: number;
 }


### PR DESCRIPTION
## Problem

Worktree numbers were allocated as the **smallest** integer not in the manifest and not present on disk (`reserveNextWorktreeNum`). After a purge-delete (the UI always purges; CLI `worktree rm --purge`), a removed worktree like `vs-2` was recreated with the **same id** — and therefore the same path, session id (`vs-2-m`), and tmux name (`vr-vs-2-m`).

That reuse caused two real clashes:

- **tmux**: delete kills the tmux session best-effort. If that kill fails, the stale `vr-vs-2-m` session survives, and the next `tmux new-session` for the reused id fails with `session already exists` → spawn fails.
- **Claude/Cursor conversation bleed**: chat transcripts live at `~/.claude/projects/<slug>/…` (and the Cursor equivalent), keyed purely by the absolute worktree **path**, and are never deleted on purge. `getRestoreCommand` falls back to a path lookup when no `agentChatId` is set — so a reused path could resume the **deleted** worktree's conversation.

## Fix

Allocate from a **persisted high-water counter** (`ProjectRecord.nextWorktreeNum`) so numbers only ever increase. A removed `vs-2` now yields `vs-3`; paths / session-ids / tmux-names are never recycled, dissolving both clashes at the source.

- **types**: add optional `nextWorktreeNum` (back-compat; lazily seeded).
- **sessionId**: `reserveNextWorktreeNum` reads the counter and seeds legacy manifests from `max(existing) + 1`, filtered with `Number.isFinite` so a non-numeric id suffix can't produce a `NaN`-poisoned counter. Keeps the on-disk orphan guard as a cheap safety net.
- **worktrees route**: reserve **and** bump the counter atomically inside one `mutateProject` (closes the pre-lock race). Burn-on-failure is intentional — a number consumed by a failed create is never reused. The two `mutateProject` calls (reserve, then append) stay sequential and non-nested; the project lock is **not** reentrant.

## Trade-off

Numbers can look gappy (`vs-2`, `vs-3`, `vs-7`…) — that's the intended signal: a gap means deleted work, and an id always maps to exactly one piece of work.

## Out of scope (intentional)

The per-CLI transcript cleanup and best-effort session-data cleanup are moot under monotonic ids (paths never recur), so they're not included.

## Tests

New `daemon/src/__tests__/sessionId.test.ts` (7 tests): monotonic-after-delete-highest, counter persistence across a manifest reload, legacy-manifest seeding, empty-manifest seed at 1, on-disk orphan skip, non-numeric-suffix NaN guard, and the reserve-without-append burn window.

## Verification

- `pnpm -w run typecheck` — passes.
- Full suite: **203 passed**; new sessionId tests **7/7**.
- The 4 remaining failures (`lifecycle.test.ts` ×3, `modes.test.ts` gemini `defaultModel`) are **pre-existing** — confirmed identical on the clean baseline (`git stash`), unrelated to this change.

Plan + review: drafted, reviewed by a Fable subagent (*ship-with-changes* — NaN filter, non-reentrant-lock note, stale-comment fixes folded in), implemented by Sonnet, verified on Opus. See `.feature-plans/worktree-id-monotonic.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)