### PR TITLE
fix(terminal): re-apply withSessionLock to eliminate tmux client leak

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,3 +89,37 @@ else if (mode.cli === "opencode") { ... }
 - **New CLI support:** if a fourth CLI is ever added, implement *all* required methods and the optional ones that make sense. The TypeScript interface will enforce required methods at compile time.
 - **`resolvePlugin` in routes vs. services:** `resolvePlugin` is in `daemon/src/agent-plugins/registry.ts`. Routes are allowed to import it. Services (`daemon/src/services/spawn.ts`) receive the already-resolved plugin as an argument — they never import `resolvePlugin` themselves.
 - **`CliId` type:** defined in `daemon/src/types.ts`. Adding a new CLI means adding it to `CliId`, adding a plugin file, registering it in `registry.ts`, and updating Zod schemas in `modes.ts`.
+
+---
+
+## WebSocket — serialize session:open / session:close per (connection, sessionId)
+
+**Files:** `daemon/src/ws/connection.ts` · `daemon/src/ws/handlers/sessionOpen.ts` · `daemon/src/ws/handlers/sessionClose.ts`
+
+### The invariant
+
+`session:open` and `session:close` for the **same `(connection, sessionId)` pair** MUST be serialized. The `socket.on("message", async …)` dispatcher does NOT serialize concurrent handlers — it awaits each handler independently, so a close immediately followed by an open run interleaved.
+
+A terminal remount fires `session:close` then `session:open` back-to-back. Without serialization both handlers park at their respective `await stream.detach` / `await stream.attach` calls concurrently. Both `open` calls can get past the stale-stream check before either registers its new stream, so both spawn a `tmux attach-session` client. Only the last is registered in `openStreams`; the orphaned client keeps forwarding tmux pane output to `conn.send` → browser receives duplicate ("double") echo.
+
+### The mechanism: `WSConnection.withSessionLock`
+
+`connection.ts` holds a per-session promise-chain lock (`sessionLocks: Map<string, Promise<void>>`). Wrap every `session:open` and `session:close` handler body with it:
+
+```ts
+export function handleSessionOpen(conn, msg): Promise<void> {
+  return conn.withSessionLock(msg.sessionId, () => openSessionLocked(conn, msg));
+}
+// same shape for handleSessionClose
+```
+
+Keep the **entire** handler body — including the `await stream.attach` park point — inside the `fn` passed to `withSessionLock`. Moving the attach outside defeats the purpose.
+
+The lock is scoped to one `WSConnection`. Two browser tabs legitimately hold two tmux clients (one per connection), so never serialize across connections.
+
+### What to watch for
+
+- **New open/close-like handlers:** any handler that calls `stream.attach()` or `stream.detach()` must be wrapped with `conn.withSessionLock`.
+- **Don't move attach outside the lock:** the race occurs precisely because `attach` is an async park point. Splitting into "register then attach" outside the lock recreates the bug.
+- **Symptom if violated:** `tmux list-clients -t <session>` shows >1 client for a single browser → duplicated ("double") echo that a page refresh temporarily clears.
+- **Invariant:** for any `(conn, sessionId)`, at most one `TmuxOutputStream` should be live (i.e., have a non-killed PTY) at any moment. The stale-stream teardown in `sessionOpen.ts` reinforces this but only works reliably once the lock prevents interleaving across the attach await.

--- a/daemon/src/ws/connection.ts
+++ b/daemon/src/ws/connection.ts
@@ -25,6 +25,7 @@ export class WSConnection {
   fileWatches: Map<string, unknown> = new Map(); // key -> FSWatcher (public for handlers)
   treeWatches: Map<string, unknown> = new Map(); // key -> FSWatcher (public for handlers)
   readonly id: string; // Unique identifier for this connection
+  private sessionLocks: Map<string, Promise<void>> = new Map(); // sessionId -> tail of promise chain
   /**
    * Diagnostic flag (mobile double-text investigation). Set once a client sends
    * a `debug:log` message — the client only does so when input debugging is
@@ -83,6 +84,43 @@ export class WSConnection {
    */
   isSubscribedTo(sessionId: string): boolean {
     return this.subscriptions.has(sessionId);
+  }
+
+  /**
+   * Run `fn` under this connection's per-session lock, serializing it against
+   * any other open/close for the same sessionId on THIS connection. The
+   * critical section spans the entire `fn`, so callers MUST keep the
+   * `await stream.attach` park point inside `fn`.
+   *
+   * Scoped to this connection only — two browser tabs are two WSConnections and
+   * legitimately hold two tmux clients, so we never serialize across
+   * connections or across tmux names.
+   *
+   * A terminal remount fires close-then-open back-to-back. Without this lock
+   * both handlers await their `stream.attach` concurrently, each spawns a
+   * `tmux attach-session` client, but only the last is registered in
+   * `openStreams`. The orphaned client keeps emitting chunks → duplicate echo.
+   */
+  withSessionLock<T>(sessionId: string, fn: () => Promise<T>): Promise<T> {
+    const prev = this.sessionLocks.get(sessionId) ?? Promise.resolve();
+    // Chain fn after the previous operation, regardless of whether it
+    // succeeded or failed.
+    const run = prev.then(fn, fn);
+    // The tail swallows the result so a failure cannot poison the chain for
+    // subsequent callers.
+    const tail = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.sessionLocks.set(sessionId, tail);
+    void tail.finally(() => {
+      // Clean up the map entry once the chain is idle so it doesn't grow
+      // unboundedly for sessions that are only ever opened once.
+      if (this.sessionLocks.get(sessionId) === tail) {
+        this.sessionLocks.delete(sessionId);
+      }
+    });
+    return run;
   }
 
   /**

--- a/daemon/src/ws/handlers/sessionClose.ts
+++ b/daemon/src/ws/handlers/sessionClose.ts
@@ -5,13 +5,24 @@ import type { ClientMessage } from "../protocol.js";
  * Handle session:close: detach from a stream and stop streaming.
  * Works for both tmux and direct-pty modes.
  *
+ * Runs under WSConnection.withSessionLock so that a rapid close+open sequence
+ * (e.g. a terminal pane remount) cannot interleave: the open waits for the
+ * close to finish before attaching, preventing multiple live tmux clients.
+ *
  * Race-safe: only unregisters the entry if it's still the same one we
  * captured. Under StrictMode dev (or back-to-back close+open from a
  * pane-fullscreen toggle), an open#2 can interleave during the await and
  * register a fresh entry; an unconditional unregister here would clobber it
  * and silently drop subsequent input/resize that look up by sessionId.
  */
-export async function handleSessionClose(
+export function handleSessionClose(
+  conn: WSConnection,
+  msg: Extract<ClientMessage, { type: "session:close" }>,
+): Promise<void> {
+  return conn.withSessionLock(msg.sessionId, () => closeSessionLocked(conn, msg));
+}
+
+async function closeSessionLocked(
   conn: WSConnection,
   msg: Extract<ClientMessage, { type: "session:close" }>,
 ): Promise<void> {

--- a/daemon/src/ws/handlers/sessionOpen.ts
+++ b/daemon/src/ws/handlers/sessionOpen.ts
@@ -6,7 +6,14 @@ import { findSessionRecord } from "./sessionLookup.js";
 import { directPtyRegistry } from "../../state/directPtyRegistry.js";
 import type { SessionStream } from "../streams/sessionStream.js";
 
-export async function handleSessionOpen(
+export function handleSessionOpen(
+  conn: WSConnection,
+  msg: Extract<ClientMessage, { type: "session:open" }>,
+): Promise<void> {
+  return conn.withSessionLock(msg.sessionId, () => openSessionLocked(conn, msg));
+}
+
+async function openSessionLocked(
   conn: WSConnection,
   msg: Extract<ClientMessage, { type: "session:open" }>,
 ): Promise<void> {


### PR DESCRIPTION
## Root cause

Each terminal pane remount fires `session:close` then `session:open` back-to-back. The `socket.on("message", async …)` dispatcher does NOT serialize concurrent handlers, so both race across their `await stream.detach` / `await stream.attach` park points — each spawning a `tmux attach-session` client. Only the last is registered in `openStreams`; the orphaned earlier client keeps forwarding pane output to the browser, producing duplicated ("double") echo that climbs by ~1 client per toggle.

## Files changed

| File | Change |
|------|--------|
| `daemon/src/ws/connection.ts` | Added `withSessionLock<T>(sessionId, fn)` — a per-session promise-chain that serializes open/close for the same `(conn, sessionId)` pair. Private `sessionLocks: Map<string, Promise<void>>` field added. |
| `daemon/src/ws/handlers/sessionOpen.ts` | Split into thin wrapper (`handleSessionOpen` → `conn.withSessionLock(...)`) + locked body (`openSessionLocked`). The entire existing body including `await stream.attach` stays inside the critical section. |
| `daemon/src/ws/handlers/sessionClose.ts` | Same pattern: `handleSessionClose` → `conn.withSessionLock(...)` → `closeSessionLocked`. |
| `AGENTS.md` | Added "WebSocket — serialize session:open / session:close per (connection, sessionId)" section documenting the invariant, mechanism, and symptoms so it cannot be silently reintroduced. |

## Before / after `tmux list-clients`

**Before fix:**
```
/dev/pts/3:  vr-unl-37-m  [141x82]  (attached)
/dev/pts/12: vr-unl-37-m  [141x55]  (attached)
/dev/pts/36: vr-unl-37-m  [141x55]  (attached)
/dev/pts/41: vr-unl-37-m  [141x82]  (attached)
```
→ **4 clients** on `vr-unl-37-m` for a single browser tab (also 2 on `vr-vs-13-m`).

**After fix:** daemon restart clears accumulated leak; with the lock in place a rapid open/close/open sequence cannot accumulate more than 1 live client per `(conn, session)`. Each browser tab's active session now shows exactly **1 client**.

## Spec reference

`.feature-plans/pending/fix-tmux-client-leak-regression.md`

This re-applies the PR #17 (`fix/terminal-remount-tmux-fixes`) pattern to the current refactored file layout. PR #17 is stale — this is a clean re-implementation from the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)