### PR TITLE
feat(terminal): auto-create first shell and dock close button

### DIFF
--- a/.feature-plans/done/terminal-dock-auto-create-and-close.md
+++ b/.feature-plans/done/terminal-dock-auto-create-and-close.md
@@ -4,7 +4,7 @@
 
 **Issue:** terminal-panel-close
 **Branch:** `terminal-panel-close`
-**Status:** Pending
+**Status:** Done
 **PRD:** _(none — small UI fix)_
 **Parent design:** _(none)_
 

--- a/.feature-plans/pending/terminal-dock-auto-create-and-close.md
+++ b/.feature-plans/pending/terminal-dock-auto-create-and-close.md
@@ -1,0 +1,265 @@
+# Mini-Design: Terminal dock auto-create + panel close
+
+> Auto-create first terminal when the dock opens empty; add an in-panel close button (TopBar toggle unchanged).
+
+**Issue:** terminal-panel-close
+**Branch:** `terminal-panel-close`
+**Status:** Pending
+**PRD:** _(none — small UI fix)_
+**Parent design:** _(none)_
+
+**Reference files:**
+- Tab strip / empty state: `web-ui/src/components/layout/TabsStrip.tsx`
+- Create terminal API: `web-ui/src/components/dialogs/NewTerminalDialog.tsx`
+- Dock visibility: `web-ui/src/hooks/useStore.ts` (`toggleTerminalDock`)
+- Close-button precedent: `web-ui/src/components/layout/ToolPanel.tsx`
+- Dock mount gate: `web-ui/src/components/layout/Layout.tsx`
+- Wiring: `web-ui/src/routes/Workspace.tsx`
+
+---
+
+## Problem
+
+- Opening the terminal dock with zero terminals shows empty hint ("No terminals — open one with +") instead of a ready shell
+- Dock can only be closed via TopBar toggle — no close control on the panel itself
+
+## Out of Scope
+
+- Changing TopBar terminal toggle UI, shortcut, or behavior
+- Keeping `TerminalPane` mounted while dock is hidden (existing hide/unmount stays)
+- Auto-creating when the last terminal tab is closed while the dock stays open
+- Renaming / dialog UX for the auto-created terminal
+- Agent-tab strip changes
+
+## Concept
+
+- First open of terminal dock for a worktree or direct-session project with **no** terminal sessions → create one immediately (defaults, no dialog)
+- X button on the right of the terminal tab strip closes the dock (same action as TopBar toggle)
+- TopBar toggle left as-is
+
+## Requirements
+
+| # | Requirement |
+|---|-------------|
+| 1 | Worktree + direct (project-scope) docks both auto-create when opened with zero terminals |
+| 2 | Auto-create uses existing create APIs + default name / `useTmux: true` — no dialog |
+| 3 | Guard against double-create (StrictMode remount / concurrent effect) |
+| 4 | Close button on right of terminal `TabsStrip` tools calls `toggleTerminalDock` |
+| 5 | TopBar toggle unchanged |
+| 6 | Do not remount `TerminalPane` for reasons other than existing dock show/hide |
+
+---
+
+## Research
+
+### Dock mounts `TabsStrip` only when visible
+
+- **File:** `web-ui/src/components/layout/Layout.tsx:188-204`
+- **Trigger:** `showTerminalDock` false → dock branch not rendered → `TabsStrip` unmounts
+- **Risk:** LOW — remount on open is a natural place for “opened empty → create”
+
+### Empty terminal state today
+
+- **File:** `web-ui/src/components/layout/TabsStrip.tsx:169-171`
+- **Trigger:** `kind === "terminal"` and `sessions.length === 0`
+- **Risk:** LOW — replace with auto-create; keep empty hint as fallback while create in flight / on error
+
+### Create paths
+
+- **File:** `web-ui/src/components/dialogs/NewTerminalDialog.tsx:63-79`
+- **Trigger:** worktree → `api.createSession({ type: "terminal", … })`; project → `api.createDirectSession({ type: "terminal", … })`
+- **Risk:** LOW — reuse same calls without dialog
+
+### Active tab selection after create
+
+- **File:** `web-ui/src/components/layout/TabsStrip.tsx:110-122` (`session:created` → `setActiveSession`)
+- **Trigger:** create emits `session:created`
+- **Risk:** LOW — existing handler selects new tab
+
+### Tool panel close precedent
+
+- **File:** `web-ui/src/components/layout/ToolPanel.tsx:54-64`
+- **Trigger:** X in `__tabs-actions` → `toggleToolPanel()`
+- **Risk:** LOW — mirror in `tabs-strip__tools` for terminal kind only
+
+### AGENTS.md terminal remount
+
+- **File:** `AGENTS.md` (TerminalPane invariant)
+- **Trigger:** React tree-position change remounts PTY stream
+- **Risk:** MEDIUM — do not move close/create UI in a way that relocates `TerminalPane`; dock hide already unmounts (accepted, unchanged)
+
+## Root Cause
+
+- Empty dock is passive (hint only) — no first-open create
+- Terminal strip has zoom/fullscreen tools but no panel close control
+
+---
+
+## Architecture
+
+```
+[TopBar toggle] ──→ [useStore.toggleTerminalDock] ──→ [Layout showTerminalDock]
+                                                              ↓
+                         [Workspace terminalDock] → [TabsStrip kind=terminal]
+                                                              ↓
+                         empty + mounted → [api.createSession / createDirectSession]
+                                                              ↓
+                         [session:created] → setActiveTerminalSession → [TerminalPane]
+
+[TabsStrip close X] ──→ [toggleTerminalDock] ──→ (same hide path as TopBar)
+```
+
+---
+
+## Design Details
+
+### Critical User Journeys (CUJs)
+
+#### CUJ 1 — First open, no terminals
+
+```
+User opens worktree / direct session
+  → Clicks TopBar terminal toggle (dock was hidden, 0 terminals)
+  → Layout mounts TabsStrip (terminal)
+  → TabsStrip sees sessions.length === 0
+  → Calls createSession / createDirectSession (defaults)
+  → session:created → new tab active → TerminalPane attached
+```
+
+- **Error path:** create fails → show empty hint + keep + control; no retry loop
+- **Edge case:** user already has terminals → no auto-create
+
+#### CUJ 2 — Close dock from panel
+
+```
+User has terminal dock open
+  → Clicks X on right of tabs-strip tools
+  → toggleTerminalDock() (same as TopBar)
+  → Dock unmounts; fullscreen terminal cleared if needed (existing store logic)
+```
+
+- **Error path:** n/a (local UI state)
+- **Edge case:** TopBar toggle still works identically
+
+#### CUJ 3 — Reopen after deleting all terminals
+
+```
+User deletes last terminal tab while dock open → empty hint, no auto-create
+  → User closes dock, opens again with still 0 terminals
+  → Auto-create runs again (condition is “opened + empty”, not a one-shot flag)
+```
+
+### Data Model
+
+| Entity | Field | Type | Constraints | Notes |
+|--------|-------|------|-------------|-------|
+| _(none)_ | — | — | — | No store/schema fields added |
+| Session | `type` | `"terminal"` | existing | Created via existing APIs |
+
+- **Relationships:** unchanged
+- **Indexes:** n/a
+- **Migration:** N
+
+### API Contracts
+
+```
+# Unchanged — reuse existing:
+
+POST createSession
+  Request:  { worktreeId, modeId: null, type: "terminal", name?: string, useTmux: true }
+  Response: Session
+  Errors:   existing daemon errors (surface via empty hint / no toast required)
+
+POST createDirectSession
+  Request:  { target: "direct", projectId, type: "terminal", name?: string, useTmux: true }
+  Response: Session
+  Errors:   existing
+```
+
+### Key Decisions
+
+#### Decision 1: Auto-create lives in `TabsStrip` (terminal only)
+
+- **Decision:** Effect after load when `kind === "terminal"` && `sessions.length === 0` && context id present
+- **Rationale:** Strip only mounts when dock visible — natural “opened” signal for worktree + project scope
+- **Where:** `web-ui/src/components/layout/TabsStrip.tsx` (~after session load effects ~L72–152)
+
+#### Decision 2: No dialog; defaults match NewTerminalDialog happy path
+
+- **Decision:** `useTmux: true`; name via `nextTerminalName` when worktree, omit/undefined for project
+- **Rationale:** Zero friction on first open; + button still opens dialog for named shells
+- **Where:** `TabsStrip.tsx` (new helper / inline); mirror `NewTerminalDialog.tsx:63-79`
+
+#### Decision 3: In-flight / StrictMode guard
+
+- **Decision:** Module-or-ref key (`scope:contextId`) so one create attempt per mount cycle; reset when sessions appear or context changes
+- **Rationale:** Avoid duplicate terminals from double effect fire
+- **Where:** `TabsStrip.tsx`
+
+#### Decision 4: Close button = `toggleTerminalDock`, terminal kind only
+
+- **Decision:** X after fullscreen in `tabs-strip__tools`; agent strip unchanged
+- **Rationale:** Match `ToolPanel` close; leave TopBar alone
+- **Where:** `TabsStrip.tsx:227-252`; style via existing `tab tab--icon` (+ minor CSS if needed)
+
+#### Decision 5: Do not fix dock hide remount in this change
+
+- **Decision:** Accept existing Layout unmount of dock when hidden
+- **Rationale:** Out of scope; AGENTS.md fullscreen rule still respected (no secondary render site)
+- **Where:** `Layout.tsx:188-204` — no change
+
+---
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `web-ui/src/components/layout/TabsStrip.tsx` | Auto-create effect; close button on terminal tools |
+| `web-ui/src/components/layout/TabsStrip.test.tsx` | Tests for auto-create + close |
+| `web-ui/src/styles/workspace.css` | Optional spacing for close control in `__tools` |
+
+## Risks / Open Questions
+
+| # | Question | Notes |
+|---|----------|-------|
+| 1 | **Re-auto-create every empty open?** | Yes — “opened + empty”, not a persisted once flag (CUJ 3) |
+| 2 | **Create while listing still empty race?** | Guard + rely on `session:created` / list refresh |
+| 3 | **Should open-failure toast?** | Prefer silent empty hint; toast optional if project already toasts API errors |
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Panel close button
+
+- [ ] **1.1** Add X button to terminal `tabs-strip__tools` calling `toggleTerminalDock` from `useLayout` / store
+- [ ] **1.2** Only render for `kind === "terminal"`; leave agent strip alone
+- [ ] **1.3** Aria: `Close terminal dock`; mirror ToolPanel sizing (`X` size 13)
+
+**Verify phase 1:**
+- [ ] **1.T1** Unit — `TabsStrip.test`: terminal strip exposes “Close terminal dock”; click calls toggle (dock visible → false)
+- [ ] **1.T2** Regression — `TabsStrip.test`: agent strip still has no dock-close control; TopBar tests untouched
+
+---
+
+### Phase 2 — Auto-create on empty open
+
+- [ ] **2.1** After sessions resolved empty for terminal strip + `worktreeId`, call create API (worktree vs project scope)
+- [ ] **2.2** In-flight / once-per-mount-cycle guard
+- [ ] **2.3** On failure, leave empty hint; do not spin forever
+- [ ] **2.4** Rely on existing `session:created` to activate tab
+
+**Verify phase 2:**
+- [ ] **2.T1** Unit — `TabsStrip.test`: mounting terminal strip with 0 sessions invokes `createSession` / `createDirectSession` once
+- [ ] **2.T2** Unit — `TabsStrip.test`: mounting with existing terminals does not create
+- [ ] **2.T3** Regression — manual / existing: TopBar toggle still shows/hides dock; + still opens `NewTerminalDialog`
+
+---
+
+## Files Summary
+
+| File | Phase | Change |
+|------|--------|--------|
+| `web-ui/src/components/layout/TabsStrip.tsx` | 1.1–1.3, 2.1–2.4 | Close X + auto-create |
+| `web-ui/src/components/layout/TabsStrip.test.tsx` | 1.T1–1.T2, 2.T1–2.T2 | Coverage |
+| `web-ui/src/styles/workspace.css` | 1.1 | Optional tools spacing |

--- a/web-ui/src/components/layout/TabsStrip.test.tsx
+++ b/web-ui/src/components/layout/TabsStrip.test.tsx
@@ -1,10 +1,10 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { createMockApi } from "@/api/mock";
 import { TabsStrip } from "./TabsStrip";
-import { useWorkspaceStore } from "@/hooks/useStore";
+import { DEFAULT_WORKTREE_LAYOUT, useWorkspaceStore } from "@/hooks/useStore";
 
 describe("TabsStrip", () => {
   const api = createMockApi();
@@ -13,7 +13,12 @@ describe("TabsStrip", () => {
     useWorkspaceStore.setState({
       activeWorktreeId: "wt-1",
       activeSessionId: "sess-main",
+      activeTerminalSessionId: null,
       sessionStates: {},
+      layoutByWorktree: {
+        "wt-1": { ...DEFAULT_WORKTREE_LAYOUT, terminalDockVisible: true },
+        "wt-2": { ...DEFAULT_WORKTREE_LAYOUT, terminalDockVisible: true },
+      },
     });
   });
 
@@ -62,5 +67,69 @@ describe("TabsStrip", () => {
     );
     await user.click(screen.getByRole("button", { name: /New agent/i }));
     expect(screen.getByRole("dialog", { name: /New agent/i })).toBeInTheDocument();
+  });
+
+  it("agent strip has no dock-close control", async () => {
+    render(
+      <MemoryRouter>
+        <TabsStrip api={api} worktreeId="wt-1" kind="agent" />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /^main$/i })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("button", { name: /Close terminal dock/i })).toBeNull();
+  });
+
+  it("terminal strip close button hides the dock", async () => {
+    const user = userEvent.setup();
+    useWorkspaceStore.setState({ activeWorktreeId: "wt-1" });
+    render(
+      <MemoryRouter>
+        <TabsStrip api={api} worktreeId="wt-1" kind="terminal" />
+      </MemoryRouter>,
+    );
+    const closeBtn = await screen.findByRole("button", { name: /Close terminal dock/i });
+    await user.click(closeBtn);
+    expect(useWorkspaceStore.getState().layoutByWorktree["wt-1"]?.terminalDockVisible).toBe(false);
+  });
+
+  it("auto-creates a terminal when dock opens empty", async () => {
+    const createSpy = vi.spyOn(api, "createSession");
+    useWorkspaceStore.setState({
+      activeWorktreeId: "wt-2",
+      activeTerminalSessionId: null,
+    });
+    render(
+      <MemoryRouter>
+        <TabsStrip api={api} worktreeId="wt-2" kind="terminal" />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(createSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(createSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        worktreeId: "wt-2",
+        type: "terminal",
+        useTmux: true,
+      }),
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /Terminal/i })).toBeInTheDocument();
+    });
+  });
+
+  it("does not auto-create when terminals already exist", async () => {
+    const createSpy = vi.spyOn(api, "createSession");
+    render(
+      <MemoryRouter>
+        <TabsStrip api={api} worktreeId="wt-1" kind="terminal" />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /term-1/i })).toBeInTheDocument();
+    });
+    expect(createSpy).not.toHaveBeenCalled();
   });
 });

--- a/web-ui/src/components/layout/TabsStrip.test.tsx
+++ b/web-ui/src/components/layout/TabsStrip.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, beforeEach, vi } from "vitest";
@@ -122,6 +122,7 @@ describe("TabsStrip", () => {
 
   it("does not auto-create when terminals already exist", async () => {
     const createSpy = vi.spyOn(api, "createSession");
+    createSpy.mockClear();
     render(
       <MemoryRouter>
         <TabsStrip api={api} worktreeId="wt-1" kind="terminal" />
@@ -131,5 +132,85 @@ describe("TabsStrip", () => {
       expect(screen.getByRole("tab", { name: /term-1/i })).toBeInTheDocument();
     });
     expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it("auto-creates again for a second empty worktree after switching", async () => {
+    const createSpy = vi.spyOn(api, "createSession");
+    createSpy.mockClear();
+    const { rerender } = render(
+      <MemoryRouter>
+        <TabsStrip api={api} worktreeId="wt-empty-a" kind="terminal" />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(createSpy).toHaveBeenCalledTimes(1);
+    });
+    // Switching worktrees keeps the same TabsStrip instance mounted (no key),
+    // so the once-per-mount guard must be scoped to the context, not the mount.
+    rerender(
+      <MemoryRouter>
+        <TabsStrip api={api} worktreeId="wt-empty-b" kind="terminal" />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(createSpy).toHaveBeenCalledTimes(2);
+    });
+    expect(createSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ worktreeId: "wt-empty-b", type: "terminal", useTmux: true }),
+    );
+  });
+
+  it("does not re-create when the last terminal is closed while the dock stays open", async () => {
+    const user = userEvent.setup();
+    const createSpy = vi.spyOn(api, "createSession");
+    createSpy.mockClear();
+    render(
+      <MemoryRouter>
+        <TabsStrip api={api} worktreeId="wt-empty-close" kind="terminal" />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(createSpy).toHaveBeenCalledTimes(1);
+    });
+    const tab = await screen.findByRole("tab", { name: /Terminal 1/i });
+
+    // Closing the last tab must leave the dock empty — auto-create is a
+    // dock-open behaviour, not an "always keep one terminal alive" rule.
+    await user.click(screen.getByRole("button", { name: /Close Terminal 1/i }));
+    await user.click(
+      within(screen.getByRole("dialog")).getByRole("button", { name: /^Close$/i }),
+    );
+    await waitFor(() => {
+      expect(tab).not.toBeInTheDocument();
+    });
+    expect(screen.getByText(/No terminals/i)).toBeInTheDocument();
+    expect(createSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries auto-create on a later dock open when the previous create left no session", async () => {
+    const createSpy = vi
+      .spyOn(api, "createSession")
+      .mockResolvedValue({ id: "sess-ghost" } as never);
+    createSpy.mockClear();
+    const { unmount } = render(
+      <MemoryRouter>
+        <TabsStrip api={api} worktreeId="wt-empty-ghost" kind="terminal" />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(createSpy).toHaveBeenCalledTimes(1);
+    });
+    // Dock closed before the created session ever showed up. Re-opening it on a
+    // still-empty worktree must not be permanently wedged by a stale in-flight key.
+    unmount();
+    render(
+      <MemoryRouter>
+        <TabsStrip api={api} worktreeId="wt-empty-ghost" kind="terminal" />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(createSpy).toHaveBeenCalledTimes(2);
+    });
+    createSpy.mockRestore();
   });
 });

--- a/web-ui/src/components/layout/TabsStrip.tsx
+++ b/web-ui/src/components/layout/TabsStrip.tsx
@@ -22,7 +22,11 @@ interface TabsStripProps {
   scope?: "worktree" | "project";
 }
 
-/** In-flight auto-create keys — dedupes StrictMode double-effect and parallel races. */
+/** Contexts with an auto-create request in flight. Guards the window between
+ *  "decided to create" and "server knows about it", where a fresh strip would
+ *  still read zero terminals and create a second one. Held only for that
+ *  window — see the release comment below. Module-scoped so it survives a
+ *  remount (StrictMode's double-effect is covered by the per-instance ref). */
 const autoCreateInFlight = new Set<string>();
 
 export function TabsStrip({ api, worktreeId, kind, scope = "worktree" }: TabsStripProps) {
@@ -41,8 +45,12 @@ export function TabsStrip({ api, worktreeId, kind, scope = "worktree" }: TabsStr
   const setWorkspacePaneFullscreen = useWorkspaceStore((s) => s.setWorkspacePaneFullscreen);
   const toggleTerminalDock = useWorkspaceStore((s) => s.toggleTerminalDock);
   const scrollRef = useRef<HTMLDivElement>(null);
-  /** One auto-create attempt per mount of an empty terminal strip (not on last-tab close). */
-  const didAttemptAutoCreate = useRef(false);
+  /** Context key ("scope:id") this instance already tried to auto-create for.
+   *  Keyed by context, not just "did it run": the strip is NOT remounted when
+   *  the user switches worktrees (same tree position, new props), so a plain
+   *  boolean would let the first empty worktree suppress every later one.
+   *  Closing the last tab keeps the key, so it does not re-trigger. */
+  const autoCreateAttemptedFor = useRef<string | null>(null);
 
   useEffect(() => {
     const el = scrollRef.current;
@@ -163,26 +171,24 @@ export function TabsStrip({ api, worktreeId, kind, scope = "worktree" }: TabsStr
   }, [api, worktreeId, kind, isAgent, isProject, setActiveSession]);
 
   // Opening an empty terminal dock creates one shell immediately (no dialog).
-  // Runs once per mount — closing the last tab while the dock stays open does not re-trigger.
+  // Fires at most once per context (worktree/project): the dock is unmounted
+  // while hidden, so "mounted empty" == "opened empty". Closing the last tab
+  // while the dock stays open keeps the attempted-key set, so it does not
+  // re-trigger; switching to another empty worktree does.
   useEffect(() => {
-    if (isAgent || !worktreeId || !sessionsLoaded) return;
-    if (sessions.length > 0) {
-      autoCreateInFlight.delete(`${scope}:${worktreeId}`);
-      return;
-    }
-    if (didAttemptAutoCreate.current) return;
+    if (isAgent || !worktreeId || !sessionsLoaded || sessions.length > 0) return;
 
     const lockKey = `${scope}:${worktreeId}`;
+    if (autoCreateAttemptedFor.current === lockKey) return;
     if (autoCreateInFlight.has(lockKey)) {
-      didAttemptAutoCreate.current = true;
+      autoCreateAttemptedFor.current = lockKey;
       return;
     }
-    didAttemptAutoCreate.current = true;
+    autoCreateAttemptedFor.current = lockKey;
     autoCreateInFlight.add(lockKey);
 
     let cancelled = false;
     void (async () => {
-      let created = false;
       try {
         if (isProject) {
           const existing = useServerStore
@@ -197,7 +203,6 @@ export function TabsStrip({ api, worktreeId, kind, scope = "worktree" }: TabsStr
             type: "terminal",
             useTmux: true,
           });
-          created = true;
         } else {
           const all = await api.listSessions(worktreeId);
           if (cancelled || all.some((s) => s.type === "terminal")) return;
@@ -215,13 +220,17 @@ export function TabsStrip({ api, worktreeId, kind, scope = "worktree" }: TabsStr
             name,
             useTmux: true,
           });
-          created = true;
         }
       } catch {
-        // Leave empty hint; allow a later remount to retry.
-        didAttemptAutoCreate.current = false;
+        // Leave the empty hint; allow a later dock open to retry.
+        autoCreateAttemptedFor.current = null;
       } finally {
-        if (!created) autoCreateInFlight.delete(lockKey);
+        // Always release: the key guards only the in-flight window, where a
+        // racing strip would not yet see the new session. Once the create has
+        // resolved, a racing strip re-reads the server / store and bails on its
+        // own. Holding the key past that point would strand it forever if this
+        // strip unmounts before the session lands.
+        autoCreateInFlight.delete(lockKey);
       }
     })();
 

--- a/web-ui/src/components/layout/TabsStrip.tsx
+++ b/web-ui/src/components/layout/TabsStrip.tsx
@@ -1,4 +1,4 @@
-import { Maximize2, Minimize2, Minus, Plus } from "lucide-react";
+import { Maximize2, Minimize2, Minus, Plus, X } from "lucide-react";
 import { motion } from "framer-motion";
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { ApiInstance } from "@/api";
@@ -22,6 +22,9 @@ interface TabsStripProps {
   scope?: "worktree" | "project";
 }
 
+/** In-flight auto-create keys — dedupes StrictMode double-effect and parallel races. */
+const autoCreateInFlight = new Set<string>();
+
 export function TabsStrip({ api, worktreeId, kind, scope = "worktree" }: TabsStripProps) {
   const isAgent = kind === "agent";
   const isProject = scope === "project";
@@ -36,7 +39,10 @@ export function TabsStrip({ api, worktreeId, kind, scope = "worktree" }: TabsStr
   const bumpTerminalFont = useWorkspaceStore((s) => s.bumpTerminalFont);
   const workspacePaneFullscreen = useWorkspaceStore((s) => s.workspacePaneFullscreen);
   const setWorkspacePaneFullscreen = useWorkspaceStore((s) => s.setWorkspacePaneFullscreen);
+  const toggleTerminalDock = useWorkspaceStore((s) => s.toggleTerminalDock);
   const scrollRef = useRef<HTMLDivElement>(null);
+  /** One auto-create attempt per mount of an empty terminal strip (not on last-tab close). */
+  const didAttemptAutoCreate = useRef(false);
 
   useEffect(() => {
     const el = scrollRef.current;
@@ -50,6 +56,8 @@ export function TabsStrip({ api, worktreeId, kind, scope = "worktree" }: TabsStr
     return () => el.removeEventListener("wheel", onWheel);
   }, []);
   const [localSessions, setSessions] = useState<Session[]>([]);
+  /** Worktree list finished (project scope is always ready from the server store). */
+  const [sessionsLoaded, setSessionsLoaded] = useState(isProject);
   const [newOpen, setNewOpen] = useState(false);
   const [closeTarget, setCloseTarget] = useState<Session | null>(null);
 
@@ -82,13 +90,16 @@ export function TabsStrip({ api, worktreeId, kind, scope = "worktree" }: TabsStr
     if (isProject) return; // project scope derives from the server store above
     if (!worktreeId) {
       setSessions([]);
+      setSessionsLoaded(true);
       return;
     }
+    setSessionsLoaded(false);
     const matches = (s: Session) => s.type === kind;
     void (async () => {
       const all = await api.listSessions(worktreeId);
       const ss = all.filter(matches);
       setSessions(ss);
+      setSessionsLoaded(true);
       const store = useWorkspaceStore.getState();
       store.syncSessionsFromApi(all);
       const cur = isAgent ? store.activeSessionId : store.activeTerminalSessionId;
@@ -150,6 +161,74 @@ export function TabsStrip({ api, worktreeId, kind, scope = "worktree" }: TabsStr
       offDeleted();
     };
   }, [api, worktreeId, kind, isAgent, isProject, setActiveSession]);
+
+  // Opening an empty terminal dock creates one shell immediately (no dialog).
+  // Runs once per mount — closing the last tab while the dock stays open does not re-trigger.
+  useEffect(() => {
+    if (isAgent || !worktreeId || !sessionsLoaded) return;
+    if (sessions.length > 0) {
+      autoCreateInFlight.delete(`${scope}:${worktreeId}`);
+      return;
+    }
+    if (didAttemptAutoCreate.current) return;
+
+    const lockKey = `${scope}:${worktreeId}`;
+    if (autoCreateInFlight.has(lockKey)) {
+      didAttemptAutoCreate.current = true;
+      return;
+    }
+    didAttemptAutoCreate.current = true;
+    autoCreateInFlight.add(lockKey);
+
+    let cancelled = false;
+    void (async () => {
+      let created = false;
+      try {
+        if (isProject) {
+          const existing = useServerStore
+            .getState()
+            .sessions.some(
+              (s) => s.projectId === worktreeId && s.worktreeId === null && s.type === "terminal",
+            );
+          if (existing || cancelled) return;
+          await api.createDirectSession({
+            target: "direct",
+            projectId: worktreeId,
+            type: "terminal",
+            useTmux: true,
+          });
+          created = true;
+        } else {
+          const all = await api.listSessions(worktreeId);
+          if (cancelled || all.some((s) => s.type === "terminal")) return;
+          let name: string | undefined;
+          try {
+            name = await api.nextTerminalName(worktreeId);
+          } catch {
+            name = undefined;
+          }
+          if (cancelled) return;
+          await api.createSession({
+            worktreeId,
+            modeId: null,
+            type: "terminal",
+            name,
+            useTmux: true,
+          });
+          created = true;
+        }
+      } catch {
+        // Leave empty hint; allow a later remount to retry.
+        didAttemptAutoCreate.current = false;
+      } finally {
+        if (!created) autoCreateInFlight.delete(lockKey);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [api, isAgent, isProject, scope, sessions.length, sessionsLoaded, worktreeId]);
 
   async function refreshTabs() {
     // Project scope derives from the server store (WS session:deleted updates
@@ -250,6 +329,17 @@ export function TabsStrip({ api, worktreeId, kind, scope = "worktree" }: TabsStr
             )}
           </button>
         </div>
+        {!isAgent ? (
+          <button
+            type="button"
+            className="tab tab--icon tool-bar-btn"
+            aria-label="Close terminal dock"
+            title="Close terminal dock"
+            onClick={() => toggleTerminalDock()}
+          >
+            <X size={13} aria-hidden />
+          </button>
+        ) : null}
       </div>
 
       {isAgent ? (


### PR DESCRIPTION
## Summary
- When the terminal dock opens empty (worktree or direct/project), automatically create one terminal with defaults — no dialog
- Add an in-panel close (X) on the terminal tab strip, matching the tool panel; TopBar toggle unchanged
- Plan: `.feature-plans/done/terminal-dock-auto-create-and-close.md`

## Test plan
- [ ] Open a worktree with no terminals → toggle terminal dock → a terminal tab appears without using +
- [ ] Click the X on the right of the terminal strip → dock closes
- [ ] TopBar terminal toggle still opens/closes the dock
- [ ] Worktree that already has terminals → opening dock does not create an extra one
- [ ] Direct-session / project-scoped terminal dock: same auto-create + close behavior
- [ ] Unit: `pnpm --filter @vibestation/web exec vitest run src/components/layout/TabsStrip.test.tsx`