### PR TITLE
fix(direct-sessions): make direct sessions work over WebSocket

### DIFF
--- a/.feature-plans/done/direct-sessions-broken-over-websocket.md
+++ b/.feature-plans/done/direct-sessions-broken-over-websocket.md
@@ -1,0 +1,184 @@
+# Direct sessions are broken over WebSocket
+
+**Status: DONE** — all fixes implemented and verified in the Docker sandbox. See "Outcome" at the bottom.
+
+Investigation of the `trade-cheetah` report: *"2 items in the sidebar (one is a terminal), and Direct 1 says session exited and can't be resumed."*
+
+**Verdict:** two independent bugs. Neither is a real crash — `trade-cheetah-d1` was **alive and healthy** throughout.
+
+---
+
+## Ground truth (measured, not inferred)
+
+| Evidence | Result |
+|---|---|
+| `tmux ls` | `vr-tc-d1` **and** `vr-tc-d2` both alive |
+| `pstree` of d1 pane | `sh(3316808)───claude(3316825)` — Claude running |
+| `capture-pane -t vr-tc-d1` | Live conversation, input box populated, awaiting input |
+| `manifest.json` → d1 | `lifecycle.state = "idle"` — **`exited` was never persisted** |
+| WS `session:open trade-cheetah-d1` | ❌ `Session 'trade-cheetah-d1' not found` |
+| WS `session:open trade-cheetah-d2` | ❌ `Session 'trade-cheetah-d2' not found` |
+| WS `session:open vs-20-m` (worktree, control) | ✅ `session:opened` |
+
+The daemon never thought the session died. The banner is a **client-side false positive**.
+
+---
+
+## Root cause: two lookup functions, only one knows about direct sessions
+
+The direct-sessions feature (`5e719f1`) taught the **REST** layer about `project.directSessions` but never the **WS lookup**. (It did touch `ws/protocol.ts` — the gap is specifically the lookup helper.)
+
+| | `findSessionContext` | `findSessionRecord` |
+|---|---|---|
+| File | `daemon/src/routes/sessions.ts:59` | `daemon/src/ws/handlers/sessionLookup.ts:5` |
+| Used by | REST routes (`vst send`, prompt box) | **WS**: `session:open`, `session:input`, `session:resize` |
+| Scans `worktrees` | ✅ | ✅ |
+| Scans `directSessions` | ✅ (`kind: "direct"`) | ❌ **never** |
+
+The WS version's return type is the tell — `worktree: WorktreeRecord` is **non-optional**, so a direct session is *structurally unrepresentable*:
+
+```ts
+// ws/handlers/sessionLookup.ts — worktree-only, by type
+): { project: ProjectRecord; worktree: WorktreeRecord; session: SessionRecord } | null {
+  for (const project of getAllProjects())
+    for (const worktree of project.worktrees) { /* directSessions never scanned */ }
+  return null;
+}
+```
+
+This is why the agent still *works* (REST input reaches it) but the terminal never *attaches*.
+
+### How "not found" becomes "Session exited."
+
+```mermaid
+flowchart TD
+  A["UI opens direct session"] --> B["WS session:open"]
+  B --> C["findSessionRecord — worktree-only"]
+  C -->|no match| D["session:error<br/>'Session ... not found'"]
+  D --> E["useSubscription.ts:62<br/>/not found|exited|not running|cant find pane/i"]
+  E --> F["setSessionState('exited')"]
+  F --> G["TerminalPane.tsx:372<br/>'Session exited.' banner"]
+  H["tmux vr-tc-d1<br/>claude ALIVE, state=idle"] -.->|"never consulted"| G
+  style D fill:#f8d7da
+  style G fill:#f8d7da
+  style H fill:#d4edda
+```
+
+- The UI infers lifecycle by **regex-matching an error string**, and latches it locally.
+- Nothing re-derives state from the daemon — only `session:resumed`/`session:state` clears it.
+
+### Why Resume can't clear it either — a *separate* bug
+
+- `routes/sessions.ts:683` — `restoreArgv = isWorktreeSession ? plugin.getRestoreCommand(...) : null` → `// Direct sessions don't support restore yet`
+- So Resume skips the resume branch and falls through to **fresh spawn** → `spawnDirectSession` → `newSession({ name: "vr-tc-d1" })`
+- But `vr-tc-d1` **still exists** → tmux: `duplicate session: vr-tc-d1` (verified) → caught at `:764` → **500 Failed to resume session**
+- Net: banner is unclearable, and even on success it would start a *new* conversation, losing history.
+
+---
+
+## Bug 2: the phantom "Terminal" row
+
+The New Project dialog is **innocent** — all three paths hardcode `type: "agent"` and never create a terminal.
+
+```mermaid
+flowchart LR
+  A["Navigate to /session/trade-cheetah-d1"] --> B["TabsStrip scope='project'"]
+  B --> C["auto-create effect<br/>TabsStrip.tsx:178"]
+  C --> D["createDirectSession<br/>type: 'terminal'"]
+  D --> E["project.directSessions += d2"]
+  E --> F["LeftSidebar directSessionMap<br/>worktreeId === null — NO type filter"]
+  F --> G["'Terminal 1' row appears"]
+  style G fill:#fff3cd
+```
+
+The `type === "agent"` filter exists **only on the worktree path**, so the direct path has nothing to bypass:
+
+| Path | Rows come from | Filters terminals? |
+|---|---|---|
+| Worktree | `worktreeIsInactive` (`LeftSidebar.tsx:52`), `worktreeStatus.ts:31` | ✅ |
+| **Direct** | `directSessionMap` (`LeftSidebar.tsx:109`) | ❌ **none** |
+
+- Also: the direct row's status dot renders a *terminal's* lifecycle state (`LeftSidebar.tsx:759`) — exactly what `worktreeStatus.ts:23-25` calls not user-meaningful.
+- `manifest.json` confirms: `d1 type:"agent"`, `d2 type:"terminal" name:"Terminal 1"`.
+
+---
+
+## Fixes
+
+| # | Fix | File | Priority |
+|---|---|---|---|
+| 1 | Scan `project.directSessions` in the WS lookup. **~3 lines** — see below. | `ws/handlers/sessionLookup.ts` | **P0 — unblocks all direct sessions** |
+| 2 | Filter `type === "agent"` in `directSessionMap` (and `pinnedDirectSessions`) | `LeftSidebar.tsx:106-113`, `:161-167` | P2 — cosmetic |
+| 3 | Replace error-string regex inference with a structured signal (below) | `useSubscription.ts:58-68` | P1 — hardening |
+| 4 | Direct-session restore — **3 changes, not 1** (below) | `routes/sessions.ts:683` + plugin API | P2 — real feature |
+| 5 | Guard `newSession` with `hasSession()` — in **all three** spawners, not just the direct one | `spawn.ts:472`, `:296`, `:157` | P1 |
+
+**Fix #1 alone** makes the agent usable again. Everything else is hardening or scope.
+
+### #1 — smaller and safer than it looks
+
+All three callers destructure **only `{ session }`** — `sessionOpen.ts:46`, `sessionInput.ts:57`, `sessionResize.ts:33`. **Nothing in `ws/handlers/` ever reads `worktree` or `project`.** So dropping `worktree` from the return type (or making it nullable) breaks zero callers. Just add the `directSessions` scan.
+
+⚠️ **Do not** `import { findSessionContext } from "../../routes/sessions.js"` — that drags the whole Fastify route graph (spawn, plugins, zod) into the WS layer. No cycle today, but wrong layering. If you want one shared helper, **extract it to `state/` or a service module** and have both layers import that.
+
+### #3 — the regex exists for a reason
+
+The daemon does broadcast an authoritative `session:exited` (`lifecycle.ts:240`; it polls direct sessions too, `:261-265`), so inference *can* go. But the regex also covers a genuinely-dead pane between poller ticks, and the `not_started` suppression at `:66-67` shows this code has already been burned by races. Deleting it needs a replacement — e.g. daemon sends a structured `reason` on `session:error` — not just removal.
+
+### #4 — the "synthetic worktree" shortcut does not work
+
+`spawn.ts:377` fabricates a worktree (`branch: "direct"`) for *spawn*, but restore needs more:
+- `claude.ts:157` & `:178` both call `getWorktreePath(project.id, worktree.id)` → a synthetic id resolves to a **nonexistent directory**, so chat-id lookup silently finds nothing. Restore needs `cwd = project.absolutePath` → **plugin API change**.
+- `spawnDirectSession` **never calls `captureChatId`** at all (compare `spawnSession` step 7.5, `spawn.ts:280-283`) → direct sessions have **no `agentChatId` to restore from**, even with the path fixed.
+- Plus #5's duplicate-name guard.
+
+### Note for whoever fixes this
+
+- One root cause (#1) explains the exited banner, the dead terminal, **and** dead keyboard input for *every* direct session — not just `trade-cheetah`.
+- The running daemon is built from `/home/gb/code/fastestdevalive/vibe-station/cli/dist` — **not** this worktree. Verified: the deployed `dist` has the identical worktree-only lookup. Rebuild + restart or the fix won't be observed.
+- `~/.vibe-station/logs/daemon.log` is useless here: 481 MB, last written 12:14, project created 22:25. Rotation appears broken and it's spamming `[WS] Write buffer exceeded 1MB`.
+
+### Same blind spot elsewhere — other worktree-only scans
+
+| Site | Scans direct? | Impact |
+|---|---|---|
+| `routes/modes.ts:136-144` `isModeInUse` | ❌ | **Live.** Wired to the DELETE guard (`:256`) — a mode used *only* by a direct session can be deleted while in use. |
+| `main.ts:94-107` `sweepDirectPtySessionsOnBoot` | ❌ | Latent — bites `useTmux: false` direct sessions on boot. |
+| `services/doctor.ts:56` `checkOrphanSessions` | ❌ | **Dead code** — would report live `vr-tc-*` as orphans and advise `tmux kill-session`, but nothing imports `runDoctor`; `vst doctor` is a separate PATH-only check (`cli/src/commands/doctor.ts`). Harmless today, a footgun if ever wired up. |
+
+Worth a grep for `p.worktrees.flatMap` / `for (const worktree of` before calling this class of bug closed.
+
+### Latent, unrelated (found in passing)
+
+- `TabsStrip.tsx:194-199` reads the store synchronously *before* the await. `autoCreateInFlight` + `autoCreateAttemptedFor` (`:182-186`) guard one instance; **neither covers two browser tabs racing** — the server has no dedupe.
+
+---
+
+## Outcome
+
+All five fixes plus the three blind spots landed. Verified in the Docker sandbox (`docker-compose.dev.yml`) against a real direct agent session.
+
+| Fix | What shipped |
+|---|---|
+| 1 | `findSessionRecord` scans `directSessions`; `worktree` **dropped** from the return type (no caller used it) with a comment forbidding its return |
+| 2 | `directSessionMap` + `pinnedDirectSessions` filter `type === "agent"` |
+| 3 | New `reason: "gone" \| "transient"` on `session:error`; client branches on it instead of regex-matching the message |
+| 4 | Plugin API takes `cwd` instead of `worktree` (all 4 plugins); `spawnDirectSession` now calls `captureChatId`; resume no longer hardcodes `null` for direct |
+| 5 | `killStaleTmuxSession` guards **all three** spawners |
+| — | `isModeInUse`, `sweepDirectPtySessionsOnBoot`, `doctor.ts` orphan check now scan `directSessions` |
+
+**Docker A/B — same container, same session, only the lookup differing:**
+
+| Lookup | `session:open direct-test-d1` |
+|---|---|
+| Old (worktree-only) | ❌ `Session 'direct-test-d1' not found` |
+| New (direct-aware) | ✅ `session:opened` |
+
+Also verified: `session:input` reached the pane (marker echoed); resume on a live pane returned **200** (was 500) with `[spawn] … killing stale pane` logged; UI showed **no** "Session exited." banner and **no** "Terminal 1" sidebar row while the daemon really did hold a `type: "terminal"` direct session.
+
+Tests: +9 regression tests (`sessionLookup.test.ts`, `useSubscription.test.ts`, `LeftSidebar.test.tsx`); each confirmed to fail against the pre-fix code. Suite went 2-failing → **367 passing**.
+
+### Deliberately not done
+
+- **`getLaunchCommand` still derives paths from the synthetic worktree** (`cursor.ts:51`, `opencode.ts:59`, `gemini.ts:51`) — same nonexistent-path class as fix #4, but on the *launch* path rather than restore. Means cursor/opencode direct sessions likely get a bogus `--workspace` / config path. Not triggered by this report (claude doesn't use it); wants its own change. `syntheticDirectWorktree`'s doc comment warns about exactly this.
+- **Terminal resume swallows errors** — `routes/sessions.ts` terminal branch has a bare `catch {}`, so resuming a live terminal silently no-ops instead of 500ing. Pre-existing; left alone.

--- a/daemon/src/__tests__/modes.test.ts
+++ b/daemon/src/__tests__/modes.test.ts
@@ -58,7 +58,8 @@ describe("Mode routes", () => {
     expect(res.statusCode).toBe(200);
     const body = res.json<Array<{ id: string; defaultModel: string }>>();
     const gemini = body.find((c) => c.id === "gemini");
-    expect(gemini).toEqual({ id: "gemini", defaultModel: "gemini-2.5-pro" });
+    // 9c53fd0 moved gemini's defaultModel to "auto"; this expectation was left stale.
+    expect(gemini).toEqual({ id: "gemini", defaultModel: "auto" });
     expect(body.map((c) => c.id).sort()).toEqual(["claude", "cursor", "gemini", "opencode"]);
   });
 

--- a/daemon/src/__tests__/plugins.test.ts
+++ b/daemon/src/__tests__/plugins.test.ts
@@ -163,7 +163,7 @@ describe("Agent plugins", () => {
       const result = await plugin.getRestoreCommand?.({
         session: {},
         project: { id: "test-proj" },
-        worktree: { id: "wt-1" },
+        cwd: "/tmp/vst-test-cwd",
       });
 
       // When no uuid exists, should return null
@@ -243,7 +243,7 @@ describe("Agent plugins", () => {
       const result = await plugin.getRestoreCommand?.({
         session: { agentChatId: "abc" },
         project: {},
-        worktree: {},
+        cwd: "/tmp/vst-test-cwd",
       });
       expect(result).toEqual(["opencode", "--session", "abc"]);
     });
@@ -254,7 +254,7 @@ describe("Agent plugins", () => {
       const result = await plugin.getRestoreCommand?.({
         session: {},
         project: {},
-        worktree: {},
+        cwd: "/tmp/vst-test-cwd",
       });
       expect(result).toBeNull();
     });
@@ -359,7 +359,7 @@ describe("Agent plugins", () => {
       const id = await plugin.provideChatId?.({
         session: { id: "s1" } as never,
         project: { id: "p1" } as never,
-        worktree: { id: "w1" } as never,
+        cwd: "/tmp/vst-test-cwd" as never,
       });
       expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
     });
@@ -370,7 +370,7 @@ describe("Agent plugins", () => {
       const result = await plugin.getRestoreCommand?.({
         session: { agentChatId: "abc-uuid" } as never,
         project: { id: "p1" } as never,
-        worktree: { id: "w1" } as never,
+        cwd: "/tmp/vst-test-cwd" as never,
         model: "gemini-3.1-pro-preview",
       });
       expect(result).toEqual(["gemini", "--yolo", "--skip-trust", "--resume", "abc-uuid", "-m", "gemini-3.1-pro-preview"]);
@@ -382,7 +382,7 @@ describe("Agent plugins", () => {
       const result = await plugin.getRestoreCommand?.({
         session: { agentChatId: "abc-uuid" } as never,
         project: { id: "p1" } as never,
-        worktree: { id: "w1" } as never,
+        cwd: "/tmp/vst-test-cwd" as never,
         model: "auto",
       });
       expect(result).toEqual(["gemini", "--yolo", "--skip-trust", "--resume", "abc-uuid"]);
@@ -394,7 +394,7 @@ describe("Agent plugins", () => {
       const result = await plugin.getRestoreCommand?.({
         session: {} as never,
         project: { id: "p1" } as never,
-        worktree: { id: "w1" } as never,
+        cwd: "/tmp/vst-test-cwd" as never,
       });
       expect(result).toBeNull();
     });
@@ -536,7 +536,7 @@ describe("Agent plugins", () => {
         const result = await plugin.getRestoreCommand?.({
           session: {},
           project: { id: name },
-          worktree: { id: name },
+          cwd: "/tmp/vst-test-cwd",
         });
         expect(result === null || Array.isArray(result)).toBe(true);
       }
@@ -629,9 +629,15 @@ describe("Claude plugin — chat-id capture", () => {
     const result = await plugin.getRestoreCommand!({
       session: { agentChatId: "known-uuid" } as any,
       project: { id: "p1" } as any,
-      worktree: { id: "w1" } as any,
+      cwd: "/tmp/vst-test-cwd",
     });
-    expect(result).toEqual(["claude", "--resume", "known-uuid", "--dangerously-skip-permissions"]);
+    expect(result).toEqual([
+      "claude",
+      "--resume",
+      "known-uuid",
+      "--dangerously-skip-permissions",
+      "--chrome",
+    ]);
   });
 });
 
@@ -678,7 +684,7 @@ describe("Cursor plugin — chat-id capture", () => {
     const result = await plugin.getRestoreCommand!({
       session: {},
       project: { id: "p1" },
-      worktree: { id: "w1" },
+      cwd: "/tmp/vst-test-cwd-no-chats",
     });
     expect(result).toBeNull();
   });

--- a/daemon/src/__tests__/sessionLookup.test.ts
+++ b/daemon/src/__tests__/sessionLookup.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { ProjectRecord, SessionRecord } from "../types.js";
+
+const h = vi.hoisted(() => ({ projects: [] as unknown[] }));
+
+vi.mock("../state/project-store.js", () => ({
+  getAllProjects: () => h.projects,
+}));
+
+function session(id: string, over: Partial<SessionRecord> = {}): SessionRecord {
+  return {
+    id,
+    slot: "m",
+    type: "agent",
+    tmuxName: `vr-${id}`,
+    useTmux: true,
+    lifecycle: { state: "idle", lastTransitionAt: "2026-01-01T00:00:00.000Z" },
+    ...over,
+  } as SessionRecord;
+}
+
+/**
+ * Regression coverage for the WS session lookup.
+ *
+ * This function used to scan only project.worktrees, so every direct session
+ * was invisible to session:open / session:input / session:resize: the daemon
+ * answered "Session not found" while the agent was alive and healthy, and the
+ * UI turned that error into a phantom "Session exited." banner.
+ */
+describe("findSessionRecord", () => {
+  const wtSession = session("proj-1-w1-m");
+  const directAgent = session("proj-1-d1", { slot: "d1" });
+  const directTerminal = session("proj-1-d2", { slot: "d2", type: "terminal" });
+
+  beforeEach(() => {
+    h.projects = [
+      {
+        id: "proj-1",
+        absolutePath: "/tmp/proj-1",
+        prefix: "p1",
+        isGit: true,
+        defaultBranch: "main",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        worktrees: [
+          {
+            id: "proj-1-w1",
+            branch: "feat",
+            baseBranch: "main",
+            baseSha: "",
+            createdAt: "2026-01-01T00:00:00.000Z",
+            sessions: [wtSession],
+          },
+        ],
+        directSessions: [directAgent, directTerminal],
+      } as unknown as ProjectRecord,
+    ];
+  });
+
+  it("resolves a worktree session", async () => {
+    const { findSessionRecord } = await import("../ws/handlers/sessionLookup.js");
+    const result = findSessionRecord("proj-1-w1-m");
+    expect(result?.session).toBe(wtSession);
+    expect(result?.project.id).toBe("proj-1");
+  });
+
+  it("resolves a direct agent session (regression: used to return null)", async () => {
+    const { findSessionRecord } = await import("../ws/handlers/sessionLookup.js");
+    const result = findSessionRecord("proj-1-d1");
+    expect(result).not.toBeNull();
+    expect(result?.session).toBe(directAgent);
+    expect(result?.project.id).toBe("proj-1");
+  });
+
+  it("resolves a direct terminal session (the terminal dock's auto-created shell)", async () => {
+    const { findSessionRecord } = await import("../ws/handlers/sessionLookup.js");
+    expect(findSessionRecord("proj-1-d2")?.session).toBe(directTerminal);
+  });
+
+  it("returns null for an unknown session id", async () => {
+    const { findSessionRecord } = await import("../ws/handlers/sessionLookup.js");
+    expect(findSessionRecord("nope")).toBeNull();
+  });
+
+  it("finds direct sessions across projects", async () => {
+    const otherDirect = session("proj-2-d1", { slot: "d1" });
+    (h.projects as ProjectRecord[]).push({
+      id: "proj-2",
+      worktrees: [],
+      directSessions: [otherDirect],
+    } as unknown as ProjectRecord);
+
+    const { findSessionRecord } = await import("../ws/handlers/sessionLookup.js");
+    expect(findSessionRecord("proj-2-d1")?.session).toBe(otherDirect);
+  });
+});

--- a/daemon/src/__tests__/spawn.test.ts
+++ b/daemon/src/__tests__/spawn.test.ts
@@ -23,8 +23,10 @@ vi.mock("node:fs", async (importOriginal) => {
 vi.mock("../services/tmux.js", () => ({
   newSession: vi.fn().mockResolvedValue(undefined),
   hasSession: vi.fn().mockResolvedValue(true),
+  killSession: vi.fn().mockResolvedValue(undefined),
   capturePane: vi.fn(),
   pasteBuffer: vi.fn().mockResolvedValue(undefined),
+  sendKeys: vi.fn().mockResolvedValue(undefined),
 }));
 
 describe("spawnSession prompt verification", () => {

--- a/daemon/src/agent-plugins/claude.ts
+++ b/daemon/src/agent-plugins/claude.ts
@@ -9,10 +9,9 @@
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
 import type { AgentPlugin, LaunchConfig } from "../services/spawn.js";
-import { worktreePath as getWorktreePath } from "../services/paths.js";
 import { sq } from "../services/shell.js";
 import { findLatestChatUuid } from "./claudeRestore.js";
-import type { SessionRecord, ProjectRecord, WorktreeRecord } from "../types.js";
+import type { SessionRecord, ProjectRecord } from "../types.js";
 
 async function ensureGitignoreEntry(gitignorePath: string, entry: string): Promise<void> {
   let content = "";
@@ -152,10 +151,9 @@ export function createClaudePlugin(): AgentPlugin {
     async captureChatId(args: {
       session: SessionRecord;
       project: ProjectRecord;
-      worktree: WorktreeRecord;
+      cwd: string;
     }): Promise<string | null> {
-      const wtPath = getWorktreePath(args.project.id, args.worktree.id);
-      const tokenFile = join(wtPath, ".vibe-station", "agent-chat-ids", args.session.id);
+      const tokenFile = join(args.cwd, ".vibe-station", "agent-chat-ids", args.session.id);
       try {
         const uuid = (await fs.readFile(tokenFile, "utf8")).trim();
         await fs.unlink(tokenFile).catch(() => {});
@@ -169,13 +167,11 @@ export function createClaudePlugin(): AgentPlugin {
     async getRestoreCommand(args: {
       session: SessionRecord;
       project: ProjectRecord;
-      worktree: WorktreeRecord;
+      cwd: string;
       model?: string;
     }): Promise<string[] | null> {
-      const { project, worktree, session, model } = args;
-      const uuid =
-        session.agentChatId ??
-        (await findLatestChatUuid(getWorktreePath(project.id, worktree.id)));
+      const { cwd, session, model } = args;
+      const uuid = session.agentChatId ?? (await findLatestChatUuid(cwd));
       if (uuid) {
         const argv = ["claude", "--resume", uuid, "--dangerously-skip-permissions", "--chrome"];
         if (model) argv.push("--model", model);

--- a/daemon/src/agent-plugins/cursor.ts
+++ b/daemon/src/agent-plugins/cursor.ts
@@ -126,7 +126,7 @@ export function createCursorPlugin(): AgentPlugin {
     async getRestoreCommand(args: {
       session: { agentChatId?: string };
       project: { id: string };
-      worktree: { id: string };
+      cwd: string;
       model?: string;
     }): Promise<string[] | null> {
       // cursor-agent --resume <chatId> reloads the prior conversation from cursor's
@@ -135,15 +135,14 @@ export function createCursorPlugin(): AgentPlugin {
       // shell-line, no system-prompt re-injection. Tradeoff: a resumed session will
       // NOT pick up edits to AGENTS.md / .vibe-station/rules.md made between runs;
       // those only land on a fresh spawn.
-      const { project, worktree, session, model } = args;
-      const wtPath = getWorktreePath(project.id, worktree.id);
-      const chatId = session.agentChatId ?? (await findLatestCursorChatId(wtPath));
+      const { cwd, session, model } = args;
+      const chatId = session.agentChatId ?? (await findLatestCursorChatId(cwd));
       if (!chatId) return null;
       // Mirror the fresh-launch flags so the restored session has the same
       // workspace/sandbox/MCP behaviour. --resume picks an existing chat.
       const argv = ["cursor-agent", "--resume", chatId];
       if (model) argv.push("--model", model);
-      argv.push("--workspace", wtPath, "--force", "--sandbox", "disabled", "--approve-mcps");
+      argv.push("--workspace", cwd, "--force", "--sandbox", "disabled", "--approve-mcps");
       return argv;
     },
   };

--- a/daemon/src/agent-plugins/gemini.ts
+++ b/daemon/src/agent-plugins/gemini.ts
@@ -80,7 +80,7 @@ export function createGeminiPlugin(): AgentPlugin {
     async getRestoreCommand(args: {
       session: SessionRecord;
       project: ProjectRecord;
-      worktree: WorktreeRecord;
+      cwd: string;
       model?: string;
     }): Promise<string[] | null> {
       const { session, model } = args;

--- a/daemon/src/agent-plugins/opencode.ts
+++ b/daemon/src/agent-plugins/opencode.ts
@@ -136,16 +136,11 @@ export function createOpencodePlugin(): AgentPlugin {
     async captureChatId(args: {
       session: SessionRecord;
       project: ProjectRecord;
-      worktree: WorktreeRecord;
+      cwd: string;
     }): Promise<string | null> {
       // session.created fires when the user's first chat is created, which for the TUI
       // may be after the ready sentinel. Poll for up to 30s; timeout → null → mtime fallback.
-      const tokenFile = join(
-        getWorktreePath(args.project.id, args.worktree.id),
-        ".vibe-station",
-        "agent-chat-ids",
-        args.session.id,
-      );
+      const tokenFile = join(args.cwd, ".vibe-station", "agent-chat-ids", args.session.id);
       const deadline = Date.now() + 30_000;
       while (Date.now() < deadline) {
         try {
@@ -163,7 +158,7 @@ export function createOpencodePlugin(): AgentPlugin {
     async getRestoreCommand(args: {
       session: { agentChatId?: string };
       project: { id: string };
-      worktree: { id: string };
+      cwd: string;
       model?: string;
     }): Promise<string[] | null> {
       if (args.session.agentChatId) {

--- a/daemon/src/main.ts
+++ b/daemon/src/main.ts
@@ -104,6 +104,13 @@ async function sweepDirectPtySessionsOnBoot(): Promise<void> {
         }
       }
     }
+    // Direct sessions (no worktree) — their PTYs are daemon children too.
+    for (const session of project.directSessions) {
+      if (!session.useTmux && session.lifecycle.state !== "exited") {
+        console.log(`[sweep] ${session.id}: direct-pty died with daemon → mark exited`);
+        await persistLifecycleState(project.id, undefined, session.id, "exited");
+      }
+    }
   }
 }
 

--- a/daemon/src/routes/modes.ts
+++ b/daemon/src/routes/modes.ts
@@ -132,13 +132,20 @@ export async function resolveCliModels(cli: CliId): Promise<{ models: string[]; 
   return fetchPromise;
 }
 
-/** Check if any running session references this modeId. */
+/**
+ * Check if any session references this modeId — worktree sessions AND direct
+ * sessions. Missing directSessions here let a mode used only by a direct
+ * session be deleted while in use.
+ */
 function isModeInUse(modeId: string): boolean {
   for (const project of getAllProjects()) {
     for (const wt of project.worktrees) {
       for (const session of wt.sessions) {
         if (session.modeId === modeId) return true;
       }
+    }
+    for (const session of project.directSessions) {
+      if (session.modeId === modeId) return true;
     }
   }
   return false;

--- a/daemon/src/routes/sessions.ts
+++ b/daemon/src/routes/sessions.ts
@@ -10,7 +10,12 @@ import {
 } from "../services/sessionId.js";
 import { killSession, newSession, pasteBuffer, capturePane } from "../services/tmux.js";
 import { directPtyRegistry } from "../state/directPtyRegistry.js";
-import { spawnSession, spawnSessionFromArgv, spawnDirectSession } from "../services/spawn.js";
+import {
+  spawnSession,
+  spawnSessionFromArgv,
+  spawnDirectSession,
+  syntheticDirectWorktree,
+} from "../services/spawn.js";
 import { cleanupSessionDataDir, cleanupDirectSessionDataDir, worktreePath } from "../services/paths.js";
 import { broadcastAll } from "../broadcaster.js";
 import { resolvePlugin } from "../agent-plugins/registry.js";
@@ -679,17 +684,16 @@ export function registerSessionRoutes(app: FastifyInstance): void {
 
         const plugin = resolvePlugin(mode.cli);
 
-        // Ask plugin for restore argv (only for worktree sessions with worktree context)
-        const restoreArgv = isWorktreeSession
-          ? await plugin.getRestoreCommand?.({
-              session,
-              project,
-              worktree: worktree!,
-              model: mode.model,
-            })
-          : null; // Direct sessions don't support restore yet
+        // Ask plugin for restore argv. `cwd` is the worktree checkout or, for a
+        // direct session, project.absolutePath — so direct sessions restore too.
+        const restoreArgv = await plugin.getRestoreCommand?.({
+          session,
+          project,
+          cwd,
+          model: mode.model,
+        });
 
-        if (restoreArgv && isWorktreeSession) {
+        if (restoreArgv) {
           // Resume path: spawn from explicit restore argv
           restoredFromHistory = true;
 
@@ -698,11 +702,20 @@ export function registerSessionRoutes(app: FastifyInstance): void {
             await plugin.setupWorkspaceHooks(cwd);
           }
 
-          const launchCfg = { project, worktree: worktree!, session, daemonPort: 0, ...(mode.model ? { model: mode.model } : {}) };
+          // getEnvironment still takes a LaunchConfig with a worktree; direct
+          // sessions reuse the same synthetic record spawnDirectSession builds.
+          const launchCfg = {
+            project,
+            worktree: worktree ?? syntheticDirectWorktree(project, session),
+            session,
+            daemonPort: 0,
+            ...(mode.model ? { model: mode.model } : {}),
+          };
           const env: Record<string, string> = {
             VST_SESSION: session.id,
             VST_SPAWN_TOKEN: session.id,
-            VST_WORKTREE: worktree!.id,
+            // Direct sessions have no worktree — omit rather than fake it.
+            ...(worktree ? { VST_WORKTREE: worktree.id } : {}),
             VST_PROJECT: project.id,
             VST_DATA_DIR: `${process.env.HOME ?? "~"}/.vibe-station/projects/${project.id}`,
             VST_DAEMON_URL: `http://127.0.0.1:${(app.server.address() as { port?: number })?.port ?? 7421}`,
@@ -711,7 +724,8 @@ export function registerSessionRoutes(app: FastifyInstance): void {
 
           await spawnSessionFromArgv({
             project,
-            worktree: worktree!,
+            cwd,
+            worktreeId: worktree?.id,
             session,
             argv: restoreArgv,
             env,
@@ -719,7 +733,7 @@ export function registerSessionRoutes(app: FastifyInstance): void {
           });
 
           // Capture chat ID for future resumes (self-healing for legacy sessions)
-          const capturedId = await plugin.captureChatId?.({ session, project, worktree: worktree! }) ?? null;
+          const capturedId = await plugin.captureChatId?.({ session, project, cwd }) ?? null;
           if (capturedId) {
             session.agentChatId = capturedId;
           }

--- a/daemon/src/services/doctor.ts
+++ b/daemon/src/services/doctor.ts
@@ -58,10 +58,13 @@ async function checkOrphanSessions(): Promise<DoctorCheck> {
     const sessions = await listSessions();
     const vrSessions = sessions.filter((s) => s.startsWith("vr-"));
     const projects = getAllProjects();
+    // Must include direct sessions: they are real, live panes. Counting only
+    // worktree sessions reports them as orphans and advises killing them.
     const knownTmuxNames = new Set(
-      projects.flatMap((p) =>
-        p.worktrees.flatMap((w) => w.sessions.map((s) => s.tmuxName)),
-      ),
+      projects.flatMap((p) => [
+        ...p.worktrees.flatMap((w) => w.sessions.map((s) => s.tmuxName)),
+        ...p.directSessions.map((s) => s.tmuxName),
+      ]),
     );
 
     const orphans = vrSessions.filter((s) => !knownTmuxNames.has(s));

--- a/daemon/src/services/spawn.ts
+++ b/daemon/src/services/spawn.ts
@@ -16,7 +16,7 @@
  */
 
 import { mkdirSync, writeFileSync } from "node:fs";
-import { newSession, hasSession, capturePane, pasteBuffer, sendKeys } from "./tmux.js";
+import { newSession, hasSession, killSession, capturePane, pasteBuffer, sendKeys } from "./tmux.js";
 import { DirectPtyBackend } from "./directPty.js";
 import {
   worktreePath as getWorktreePath,
@@ -51,28 +51,40 @@ export interface AgentPlugin {
     launchCfg: LaunchConfig;
   }): { launchArgs?: string[]; postLaunchInput?: string; postLaunchSubmit?: boolean; useShell?: boolean; shellLine?: string };
   setupWorkspaceHooks?(workspacePath: string): Promise<void>;
-  /** Pre-spawn: obtain a chat id before launching (e.g. cursor-agent create-chat). */
+  /**
+   * Pre-spawn: obtain a chat id before launching (e.g. cursor-agent create-chat).
+   *
+   * `cwd` is the session's working directory — a worktree checkout, or
+   * project.absolutePath for a direct session. Plugins must use it rather than
+   * deriving a path from a worktree id: direct sessions have no worktree, and
+   * a fabricated one resolves to a nonexistent directory.
+   */
   provideChatId?(args: {
     session: SessionRecord;
     project: ProjectRecord;
-    worktree: WorktreeRecord;
+    cwd: string;
   }): Promise<string | null>;
   /** Post-ready: capture the agent's chat id written to a token file by a hook/plugin. */
   captureChatId?(args: {
     session: SessionRecord;
     project: ProjectRecord;
-    worktree: WorktreeRecord;
+    /** Session working directory — see provideChatId. */
+    cwd: string;
   }): Promise<string | null>;
   /**
    * Return the list of models available for this CLI.
    * Each plugin owns its own discovery strategy — callers never branch on CLI name.
    */
   listModels(): Promise<{ models: string[]; error?: string }>;
-  /** Return argv for resuming a prior session, or null for fresh launch. */
+  /**
+   * Return argv for resuming a prior session, or null for fresh launch.
+   * Works for direct sessions too — see `cwd` on provideChatId.
+   */
   getRestoreCommand?(args: {
     session: SessionRecord;
     project: ProjectRecord;
-    worktree: WorktreeRecord;
+    /** Session working directory — see provideChatId. */
+    cwd: string;
     /** Per-mode model override — plugin should include the model flag in the returned argv. */
     model?: string;
   }): Promise<string[] | null>;
@@ -118,11 +130,59 @@ export interface DirectLaunchConfig {
 
 export interface SpawnSessionFromArgvOptions {
   project: ProjectRecord;
-  worktree: WorktreeRecord;
+  /** Working directory: worktree checkout, or project.absolutePath for a direct session. */
+  cwd: string;
+  /** Worktree id, or undefined for a direct session (direct-pty bookkeeping only). */
+  worktreeId?: string;
   session: SessionRecord;
   argv: string[];
   env: Record<string, string>;
   fallbackMs: number;
+}
+
+/**
+ * Direct sessions have no worktree, but LaunchConfig — and therefore
+ * getLaunchCommand / getEnvironment / composeLaunchPrompt — still requires one.
+ * This synthesises a placeholder so those plugin methods keep working.
+ *
+ * WARNING: the `id` here does NOT correspond to a real directory.
+ * `worktreePath(project.id, syntheticDirectWorktree(...).id)` resolves to a
+ * path that does not exist. Never derive a filesystem path from it — take an
+ * explicit `cwd` instead (see AgentPlugin.provideChatId). Deriving paths from a
+ * fabricated worktree id is why direct-session restore silently found nothing.
+ */
+export function syntheticDirectWorktree(
+  project: ProjectRecord,
+  session: SessionRecord,
+): WorktreeRecord {
+  return {
+    id: `${project.id}-direct`,
+    branch: "direct",
+    baseBranch: project.defaultBranch ?? "main",
+    baseSha: "",
+    createdAt: new Date().toISOString(),
+    sessions: [session],
+  };
+}
+
+/**
+ * tmux refuses `new-session -s <name>` when a session of that name already
+ * exists ("duplicate session"), which surfaces to the user as a 500 rather
+ * than anything actionable.
+ *
+ * Every caller here is spawning what it believes is a *new* pane for this
+ * session id — a fresh spawn, or a resume that is about to restore the
+ * conversation from the agent's own history. An existing pane under that name
+ * is therefore stale by definition, so replace it rather than failing.
+ *
+ * Note this is a real (if intentional) process kill: it is safe only because
+ * the caller is committed to respawning the pane immediately.
+ */
+async function killStaleTmuxSession(name: string): Promise<void> {
+  if (await hasSession(name)) {
+    console.warn(`[spawn] tmux session ${name} already exists — killing stale pane before respawn`);
+    await killSession(name);
+  }
 }
 
 /**
@@ -131,21 +191,20 @@ export interface SpawnSessionFromArgvOptions {
  * Branches on useTmux: direct-pty spawns via DirectPtyBackend, tmux via newSession.
  */
 export async function spawnSessionFromArgv(opts: SpawnSessionFromArgvOptions): Promise<void> {
-  const { project, worktree, session, argv, env, fallbackMs } = opts;
-  const wtPath = getWorktreePath(project.id, worktree.id);
+  const { project, cwd, worktreeId, session, argv, env, fallbackMs } = opts;
 
   if (!session.useTmux) {
     // Direct-pty spawn
     await DirectPtyBackend.spawn({
       command: argv[0]!,
       args: argv.slice(1),
-      cwd: wtPath,
+      cwd,
       env,
       cols: 80,
       rows: 24,
       sessionId: session.id,
       projectId: project.id,
-      worktreeId: worktree.id,
+      worktreeId,
     });
 
     await sleep(fallbackMs);
@@ -154,9 +213,10 @@ export async function spawnSessionFromArgv(opts: SpawnSessionFromArgvOptions): P
 
   // Tmux spawn (existing code)
   try {
+    await killStaleTmuxSession(session.tmuxName);
     await newSession({
       name: session.tmuxName,
-      cwd: wtPath,
+      cwd,
       env,
       command: argv,
     });
@@ -192,7 +252,7 @@ export async function spawnSession(opts: SpawnOptions): Promise<void> {
 
   // Steps 2.5 + 3: provideChatId + setupWorkspaceHooks in parallel (both pre-spawn, independent)
   const [preSpawnChatId] = await Promise.all([
-    plugin.provideChatId?.({ session, project, worktree }) ?? Promise.resolve(null),
+    plugin.provideChatId?.({ session, project, cwd: wtPath }) ?? Promise.resolve(null),
     plugin.setupWorkspaceHooks ? plugin.setupWorkspaceHooks(wtPath) : Promise.resolve(),
   ]);
   if (preSpawnChatId) {
@@ -277,7 +337,7 @@ export async function spawnSession(opts: SpawnOptions): Promise<void> {
       }
 
       // Step 7.5: Capture chat ID written by agent hook/plugin
-      const capturedId = await plugin.captureChatId?.({ session, project, worktree }) ?? null;
+      const capturedId = await plugin.captureChatId?.({ session, project, cwd: wtPath }) ?? null;
       if (capturedId) {
         session.agentChatId = capturedId;
       }
@@ -293,6 +353,7 @@ export async function spawnSession(opts: SpawnOptions): Promise<void> {
 
   // Tmux path (existing logic)
   try {
+    await killStaleTmuxSession(session.tmuxName);
     await newSession({
       name: session.tmuxName,
       cwd: wtPath,
@@ -357,7 +418,7 @@ export async function spawnSession(opts: SpawnOptions): Promise<void> {
   }
 
   // Step 7.5: Capture chat ID written by agent hook/plugin
-  const capturedId = await plugin.captureChatId?.({ session, project, worktree }) ?? null;
+  const capturedId = await plugin.captureChatId?.({ session, project, cwd: wtPath }) ?? null;
   if (capturedId) {
     session.agentChatId = capturedId;
   }
@@ -371,17 +432,10 @@ export async function spawnDirectSession(opts: DirectSpawnOptions): Promise<void
   const { project, session, plugin, daemonPort, systemPrompt, taskPrompt, model } = opts;
   const cwd = project.absolutePath;
 
-  // Create a synthetic worktree-like config for the plugin (some plugins may not need it)
+  // Synthetic worktree purely to satisfy LaunchConfig — see the helper's warning.
   const launchCfg: LaunchConfig = {
     project,
-    worktree: {
-      id: `${project.id}-direct`,
-      branch: "direct",
-      baseBranch: project.defaultBranch ?? "main",
-      baseSha: "",
-      createdAt: new Date().toISOString(),
-      sessions: [session],
-    },
+    worktree: syntheticDirectWorktree(project, session),
     session,
     daemonPort,
     ...(model ? { model } : {}),
@@ -458,6 +512,13 @@ export async function spawnDirectSession(opts: DirectSpawnOptions): Promise<void
           stream.write("\r");
         }
       }
+
+      // Step 7.5: capture chat id — mirrors spawnSession. Without this a direct
+      // session has no agentChatId, so Resume can never restore its history.
+      const capturedId = await plugin.captureChatId?.({ session, project, cwd }) ?? null;
+      if (capturedId) {
+        session.agentChatId = capturedId;
+      }
     } catch (err) {
       if (stream) {
         stream.kill();
@@ -469,6 +530,7 @@ export async function spawnDirectSession(opts: DirectSpawnOptions): Promise<void
 
   // Tmux path
   try {
+    await killStaleTmuxSession(session.tmuxName);
     await newSession({
       name: session.tmuxName,
       cwd,
@@ -506,6 +568,12 @@ export async function spawnDirectSession(opts: DirectSpawnOptions): Promise<void
     if (postLaunchSubmit) {
       await sendKeys(session.tmuxName, "", true);
     }
+  }
+
+  // Step 7.5: capture chat id — see the direct-pty branch above.
+  const capturedId = await plugin.captureChatId?.({ session, project, cwd }) ?? null;
+  if (capturedId) {
+    session.agentChatId = capturedId;
   }
 }
 

--- a/daemon/src/ws/handlers/sessionInput.ts
+++ b/daemon/src/ws/handlers/sessionInput.ts
@@ -49,6 +49,7 @@ export function handleSessionInput(
     conn.send({
       type: "session:error",
       sessionId,
+      reason: "gone",
       message: `Session '${sessionId}' not found`,
     });
     return;
@@ -78,6 +79,7 @@ export function handleSessionInput(
       conn.send({
         type: "session:error",
         sessionId,
+        reason: "transient",
         message: err instanceof Error ? err.message : "Failed to send input",
       });
     }
@@ -94,6 +96,7 @@ export function handleSessionInput(
     conn.send({
       type: "session:error",
       sessionId,
+      reason: "transient",
       message: err instanceof Error ? err.message : "Failed to send input",
     });
   }

--- a/daemon/src/ws/handlers/sessionLookup.ts
+++ b/daemon/src/ws/handlers/sessionLookup.ts
@@ -1,22 +1,41 @@
 import { getAllProjects } from "../../state/project-store.js";
-import type { ProjectRecord, WorktreeRecord, SessionRecord } from "../../types.js";
+import type { ProjectRecord, SessionRecord } from "../../types.js";
 
-/** Resolve a session ID to its full session record, or null if not found. */
+/**
+ * Resolve a session ID to its record — worktree sessions AND direct sessions.
+ *
+ * Direct sessions live in `project.directSessions` and have no worktree. This
+ * returns only `{ project, session }` because that is all any caller needs:
+ * sessionOpen, sessionInput and sessionResize each destructure `{ session }`
+ * alone.
+ *
+ * DO NOT add a non-optional `worktree` to this return type. Doing so is what
+ * originally made direct sessions structurally unrepresentable here, so this
+ * function silently returned null for them and session:open / session:input /
+ * session:resize all failed with "Session not found" — while the agent was
+ * alive and the REST layer (which uses its own direct-aware lookup) kept
+ * working. If a caller ever genuinely needs worktree context, add it as
+ * `worktree: WorktreeRecord | null` rather than making direct sessions
+ * unrepresentable again.
+ */
 export function findSessionRecord(
   sessionId: string,
 ): {
   project: ProjectRecord;
-  worktree: WorktreeRecord;
   session: SessionRecord;
 } | null {
   for (const project of getAllProjects()) {
     for (const worktree of project.worktrees) {
       const session = worktree.sessions.find((x) => x.id === sessionId);
       if (session) {
-        return { project, worktree, session };
+        return { project, session };
       }
+    }
+    // Direct sessions (no worktree) — must be scanned too.
+    const directSession = project.directSessions.find((x) => x.id === sessionId);
+    if (directSession) {
+      return { project, session: directSession };
     }
   }
   return null;
 }
-

--- a/daemon/src/ws/handlers/sessionOpen.ts
+++ b/daemon/src/ws/handlers/sessionOpen.ts
@@ -38,6 +38,8 @@ async function openSessionLocked(
     conn.send({
       type: "session:error",
       sessionId,
+      // No record in the manifest at all — the session is genuinely gone.
+      reason: "gone",
       message: `Session '${sessionId}' not found`,
     });
     return;
@@ -59,6 +61,8 @@ async function openSessionLocked(
         conn.send({
           type: "session:error",
           sessionId,
+          // Record exists but no PTY is registered — the process is gone.
+          reason: "gone",
           message: `Session '${sessionId}' not running`,
         });
         return;
@@ -103,6 +107,10 @@ async function openSessionLocked(
       conn.send({
         type: "session:error",
         sessionId,
+        // A stream/attach failure says nothing about pane liveness — e.g. a
+        // non-zero `tmux attach-session` exit races an alive pane. The
+        // lifecycle poller is authoritative for exit; never infer it here.
+        reason: "transient",
         message,
       });
     });
@@ -120,6 +128,8 @@ async function openSessionLocked(
     conn.send({
       type: "session:error",
       sessionId,
+      // Attach threw — the pane may still be alive. Not an exit signal.
+      reason: "transient",
       message: err instanceof Error ? err.message : "Unknown error",
     });
   }

--- a/daemon/src/ws/protocol.ts
+++ b/daemon/src/ws/protocol.ts
@@ -168,10 +168,21 @@ const SessionUpdatedEvent = z.object({
   pinnedAt: z.string().nullable().optional(),
 });
 
+/**
+ * `reason` is the machine-readable classification of the error. Clients must
+ * branch on it rather than regex-matching `message` (which is for humans and
+ * free to change).
+ *
+ * - "gone"       — the session/pane genuinely no longer exists. Safe for the
+ *                  client to treat as exited.
+ * - "transient"  — attach/stream hiccup; the session may well still be alive.
+ *                  Clients must NOT infer "exited" from this.
+ */
 const SessionErrorEvent = z.object({
   type: z.literal("session:error"),
   sessionId: z.string(),
   message: z.string(),
+  reason: z.enum(["gone", "transient"]).optional(),
 });
 
 // File/tree watcher events

--- a/web-ui/src/api/types.ts
+++ b/web-ui/src/api/types.ts
@@ -141,6 +141,13 @@ export type WSEvent =
       type: "session:error";
       sessionId: string;
       message: string;
+      /**
+       * Machine-readable classification. Branch on this — never regex-match
+       * `message`. "gone" = session genuinely absent; "transient" = attach or
+       * stream hiccup, the session may still be alive. Optional for
+       * compatibility with a daemon older than this field.
+       */
+      reason?: "gone" | "transient";
     }
   | {
       type: "session:resumed";

--- a/web-ui/src/components/layout/LeftSidebar.test.tsx
+++ b/web-ui/src/components/layout/LeftSidebar.test.tsx
@@ -487,4 +487,58 @@ describe("LeftSidebar", () => {
     expect(settings).toBeInTheDocument();
     expect(settings).toHaveAttribute("href", "/settings");
   });
+
+  // ─── Direct sessions ───────────────────────────────────────────────────
+  describe("direct sessions", () => {
+    /**
+     * The terminal dock auto-creates a shell for the project scope, which the
+     * daemon stores in project.directSessions alongside direct agents. The
+     * sidebar lists agents only, so that shell must not surface as a row —
+     * it previously did, appearing as a bogus top-level "Terminal 1".
+     */
+    function emitDirect(sessionId: string, type: "agent" | "terminal", label: string) {
+      api.__test.emit({
+        type: "session:created",
+        sessionId,
+        worktreeId: null,
+        projectId: "proj-a",
+        sessionType: type,
+        snapshot: {
+          id: sessionId,
+          worktreeId: null,
+          projectId: "proj-a",
+          modeId: type === "agent" ? "mode-1" : null,
+          type,
+          label,
+          slot: type === "agent" ? "d1" : "d2",
+          state: "idle",
+          lifecycleState: "idle",
+          tmuxName: `tm-${sessionId}`,
+          createdAt: new Date().toISOString(),
+        },
+      });
+    }
+
+    it("lists direct agent sessions but never direct terminals", async () => {
+      render(
+        <MemoryRouter>
+          <Harness api={api}>
+            <LeftSidebar api={api} />
+          </Harness>
+        </MemoryRouter>,
+      );
+      await screen.findByText("Proj A");
+
+      emitDirect("proj-a-d1", "agent", "direct 1");
+      emitDirect("proj-a-d2", "terminal", "Terminal 1");
+
+      // The agent row shows up...
+      await screen.findByRole("link", { name: /Open direct session direct 1/i });
+      // ...and the auto-created terminal never does.
+      expect(
+        screen.queryByRole("link", { name: /Open direct session Terminal 1/i }),
+      ).toBeNull();
+      expect(screen.queryByText("Terminal 1")).toBeNull();
+    });
+  });
 });

--- a/web-ui/src/components/layout/LeftSidebar.tsx
+++ b/web-ui/src/components/layout/LeftSidebar.tsx
@@ -102,11 +102,19 @@ export function LeftSidebar({
     }
     return m;
   }, [sessions]);
-  /** Direct sessions grouped by projectId. */
+  /**
+   * Direct *agent* sessions grouped by projectId.
+   *
+   * Agents only — the sidebar lists agents, never terminals. The terminal dock
+   * auto-creates a shell for the project scope (TabsStrip), which lands in
+   * project.directSessions; without this filter it surfaces as a bogus
+   * top-level "Terminal 1" row. The worktree path already filters terminals
+   * out (see worktreeIsInactive / worktreeRolledUpStatus).
+   */
   const directSessionMap = useMemo(() => {
     const m: Record<string, Session[]> = {};
     for (const s of sessions) {
-      if (s.worktreeId === null && s.projectId) {
+      if (s.worktreeId === null && s.projectId && s.type === "agent") {
         (m[s.projectId] ??= []).push(s);
       }
     }
@@ -161,7 +169,14 @@ export function LeftSidebar({
   const pinnedDirectSessions = useMemo(
     () =>
       sessions
-        .filter((s) => s.worktreeId === null && s.pinnedAt != null && !hiddenProjectIds.has(s.projectId))
+        // Agents only — same reasoning as directSessionMap above.
+        .filter(
+          (s) =>
+            s.worktreeId === null &&
+            s.type === "agent" &&
+            s.pinnedAt != null &&
+            !hiddenProjectIds.has(s.projectId),
+        )
         .slice()
         .sort((a, b) => (b.pinnedAt ?? "").localeCompare(a.pinnedAt ?? "")),
     [sessions, hiddenProjectIds],

--- a/web-ui/src/hooks/useSubscription.test.ts
+++ b/web-ui/src/hooks/useSubscription.test.ts
@@ -1,7 +1,8 @@
-import { renderHook, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import { createMockApi } from "@/api/mock";
-import { useSubscription } from "./useSubscription";
+import { useSubscription, useSessionOutput } from "./useSubscription";
+import { useWorkspaceStore } from "./useStore";
 
 describe("useSubscription", () => {
   it("calls subscribe and cleanup on unmount", async () => {
@@ -11,5 +12,87 @@ describe("useSubscription", () => {
     await waitFor(() => expect(unsub).toHaveBeenCalledWith(["sess-main"]));
     unmount();
     expect(unsub).toHaveBeenCalled();
+  });
+});
+
+/**
+ * The Resume banner is driven by this hook's sessionState. It used to be set by
+ * regex-matching session:error messages, which latched "exited" onto healthy
+ * sessions — "Session not found" (direct sessions were invisible to the WS
+ * lookup) and a non-zero `tmux attach-session` exit both matched while the
+ * agent was alive. The daemon now classifies errors via `reason`; only "gone"
+ * means exited.
+ */
+describe("useSessionOutput — exit inference", () => {
+  beforeEach(() => {
+    useWorkspaceStore.setState({ sessionStates: { "sess-1": "idle" } });
+  });
+
+  it('flips to exited on session:error with reason "gone"', async () => {
+    const api = createMockApi();
+    const { result } = renderHook(() => useSessionOutput(api, "sess-1"));
+
+    act(() => {
+      api.__test.emit({
+        type: "session:error",
+        sessionId: "sess-1",
+        reason: "gone",
+        message: "Session 'sess-1' not found",
+      });
+    });
+
+    await waitFor(() => expect(result.current.sessionState).toBe("exited"));
+  });
+
+  it('ignores reason "transient" even when the message says "exited"', async () => {
+    const api = createMockApi();
+    const { result } = renderHook(() => useSessionOutput(api, "sess-1"));
+
+    act(() => {
+      api.__test.emit({
+        type: "session:error",
+        sessionId: "sess-1",
+        reason: "transient",
+        // Wording the old regex matched on — must not flip state now.
+        message: "tmux attach-session exited with code 1",
+      });
+    });
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(result.current.sessionState).not.toBe("exited");
+  });
+
+  it("ignores an unclassified session:error (no reason)", async () => {
+    const api = createMockApi();
+    const { result } = renderHook(() => useSessionOutput(api, "sess-1"));
+
+    act(() => {
+      api.__test.emit({
+        type: "session:error",
+        sessionId: "sess-1",
+        message: "Session 'sess-1' not found",
+      });
+    });
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(result.current.sessionState).not.toBe("exited");
+  });
+
+  it('does not flip a session that is still spawning ("not_started")', async () => {
+    useWorkspaceStore.setState({ sessionStates: { "sess-1": "not_started" } });
+    const api = createMockApi();
+    const { result } = renderHook(() => useSessionOutput(api, "sess-1"));
+
+    act(() => {
+      api.__test.emit({
+        type: "session:error",
+        sessionId: "sess-1",
+        reason: "gone",
+        message: "Session 'sess-1' not running",
+      });
+    });
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(result.current.sessionState).not.toBe("exited");
   });
 });

--- a/web-ui/src/hooks/useSubscription.ts
+++ b/web-ui/src/hooks/useSubscription.ts
@@ -56,13 +56,16 @@ export function useSessionOutput(
     // window, "not running" errors are a race with spawnSession, not a real
     // exit, and the eventual session:state event will update us.
     const offError = api.on("session:error", (ev) => {
-      if (
-        ev.type !== "session:error" ||
-        ev.sessionId !== sessionId ||
-        !/not found|exited|not running|can't find pane/i.test(ev.message)
-      ) {
-        return;
-      }
+      if (ev.type !== "session:error" || ev.sessionId !== sessionId) return;
+      // Only the daemon's explicit "gone" classification implies an exit.
+      // We used to regex-match ev.message for /not found|exited|.../, which
+      // latched the Resume banner onto healthy sessions: a "Session not found"
+      // (direct sessions were invisible to the WS lookup) or a non-zero
+      // `tmux attach-session` exit both matched while the agent was alive.
+      // "transient" errors are stream hiccups and must never flip state — the
+      // daemon's lifecycle poller owns exit detection and broadcasts
+      // session:exited.
+      if (ev.reason !== "gone") return;
       const known = useWorkspaceStore.getState().sessionStates[sessionId];
       if (known === "not_started") return; // race during fresh spawn
       setSessionState("exited");


### PR DESCRIPTION
## The report

> I created a new project with a direct agent. The sidebar shows 2 items — one is a terminal that shouldn't be there. And **direct 1 shows "session exited" and can't be resumed.**

## The agent was never dead

`tmux` had a live pane running `claude` mid-conversation, the manifest said `lifecycle.state = "idle"`, and the daemon never persisted `exited` anywhere. The banner was a **client-side false positive**.

## Root cause: two lookup functions, only one direct-aware

| | scans `directSessions` | used by |
|---|---|---|
| `findSessionContext` (`routes/sessions.ts`) | ✅ | REST |
| `findSessionRecord` (`ws/handlers/`) | ❌ | **`session:open` / `:input` / `:resize`** |

The WS lookup's return type hardcoded a **non-optional `worktree`**, making direct sessions structurally unrepresentable. So the WS layer answered `Session not found` for every direct session — and the client **regex-matched that message** (`/not found|exited|.../`) and latched state to `exited`.

That one bug explains the banner, the dead terminal, **and** dead keyboard input — for *every* direct session. It also explains the oddity that the agent still replied: that went over REST, which was never broken.

```mermaid
flowchart LR
  A["session:open"] --> B["findSessionRecord<br/>worktree-only"]
  B -->|no match| C["'Session not found'"]
  C --> D["client regex"] --> E["'Session exited.' banner"]
  F["tmux: claude ALIVE<br/>manifest: idle"] -.->|never consulted| E
  style E fill:#f8d7da
  style F fill:#d4edda
```

Resume couldn't clear it either: direct restore was hardcoded `null`, and the fresh-spawn fallback hit tmux `duplicate session` → **500**.

## What changed

| # | Fix |
|---|---|
| 1 | **`sessionLookup` scans `directSessions`.** `worktree` dropped from the return type — no caller ever used it — with a comment against reintroducing it. |
| 2 | **Sidebar filters to agents.** The dock's auto-created shell is a real direct session; the worktree path already filtered terminals, the direct path didn't. |
| 3 | **`session:error` carries `reason: "gone" \| "transient"`.** The client branches on it instead of parsing prose, so an attach hiccup can't fake an exit. The lifecycle poller stays authoritative. |
| 4 | **Direct restore works.** Chat-id/restore plugin methods take `cwd`, not `worktree` — a fabricated worktree id resolved to a *nonexistent directory*, so lookups silently found nothing. `spawnDirectSession` now calls `captureChatId`, without which there was no `agentChatId` to restore from. |
| 5 | **`killStaleTmuxSession` guards all three spawners.** Resume means restart; an existing pane is stale, not a 500. |
| — | Same blind spot elsewhere: **`isModeInUse`** (live — a mode used only by a direct session could be deleted while in use), the boot sweep, and `doctor.ts`'s orphan check. |

## Verification — Docker sandbox, real direct agent session

**A/B in one container, same session, only the lookup differing:**

| Lookup | `session:open direct-test-d1` |
|---|---|
| Old | ❌ `Session 'direct-test-d1' not found` |
| New | ✅ `session:opened` |

- `session:input` reached the pane (marker echoed back)
- Resume on a **live** pane → **200** (was 500), with `[spawn] … killing stale pane` logged
- UI: **no** "Session exited." banner, **no** "Terminal 1" row — while the daemon really did hold a `type: "terminal"` direct session

## Tests

**+9 regression tests**, each confirmed to **fail against the pre-fix code**. Two stale expectations unrelated to this change were also fixed (`gemini` defaultModel moved to `auto` in 9c53fd0; claude restore argv gained `--chrome` in dc8dd36) — **the suite was red on `main`, and is now green: 367 passing.**

## Known gap — left for its own change

`getLaunchCommand` still derives paths from the synthetic worktree (`cursor.ts:51`, `opencode.ts:59`, `gemini.ts:51`), so cursor/opencode direct sessions likely get a bogus `--workspace`. Same class as fix #4 but on the *launch* path; not triggered by this report (claude doesn't use it). Documented on `syntheticDirectWorktree`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)