### PR TITLE
fix(direct-sessions): stop the open file clearing + first-class agent context

### DIFF
--- a/.feature-plans/pending/direct-session-live-file-watch.md
+++ b/.feature-plans/pending/direct-session-live-file-watch.md
@@ -1,0 +1,60 @@
+# Direct-session live file watching (deferred Stage 3)
+
+**Status:** pending. Split out of the "first-class agent context" PR (Stages 1+2) after review.
+
+## Why this was deferred
+
+The bug that PR fixed was a direct session's open file getting **cleared** (a client state bug — Stage 1) plus fabricated-worktree path bugs in the spawn/plugin layer (Stage 2). This is a *different, pre-existing* gap: a direct session's file tree and open file never **live-update** when files change on disk.
+
+It was deferred because, on its own, it does **not** improve the architecture — it adds surface rather than removing it:
+
+- It introduces a **third** encoding of "worktree | project" on the wire (`WsContextRef` `{kind,id}`), alongside the daemon's `AgentContextRef` (`{kind,projectId,worktreeId}`) and the client's pre-existing `FileScope` + overloaded `worktreeId` prop.
+- It needs a dual-field back-compat shape (`context` + legacy `worktreeId`) on every watch message and event, and a more complex event matcher.
+
+It becomes a genuine simplification only if done **together with the client unification** (the "Stage 4" below), where `FileScope` and the `worktreeId`-carrying-a-project-id props collapse into a single context model. Shipping the watch change alone would lock in the third encoding that Stage 4 then has to clean up.
+
+## The gap (verified)
+
+- `daemon/src/ws/protocol.ts` — `file:watch`/`tree:watch`/`file:changed`/`tree:changed` take `worktreeId: z.string()` (non-optional), so a direct session (no worktree) cannot express a watch.
+- `daemon/src/ws/handlers/fileWatch.ts` / `treeWatch.ts` — resolve via `getAllProjects().find(p => p.worktrees.some(...))` + `worktreePath(...)`; a direct session's project id matches no worktree → `system:error: "Worktree '<id>' not found"`.
+- `web-ui/src/hooks/useSubscription.ts` — `useFileWatch`/`useTreeWatch` early-return `if (scope === "project")` with a comment that the daemon has no project watcher. So `lastChanged` stays `0` forever and the preview/tree never refetch.
+- REST file **reads** already work for direct sessions (`routes/projects.ts` `/projects/:id/tree|file-list|files/*`); only the **watch** subsystem is worktree-only.
+
+## Prerequisite: this depends on the daemon context module
+
+Stages 1+2 shipped `daemon/src/services/context.ts` with `AgentContextRef`, `ResolvedContext`, `resolvedContextOf`, and the `*For(ctx,…)` path helpers. Stage 3 will re-introduce two helpers that were removed from that module because nothing used them without Stage 3:
+
+- `resolveContext(ref: AgentContextRef)` — resolve a ref against the store.
+- `resolveWorktreeById(id)` — resolve a bare worktree id (the legacy wire shape has no projectId).
+
+Add them back to `context.ts` as part of this work.
+
+## Implementation sketch (from the original, verified-working diff)
+
+Daemon:
+- `protocol.ts`: add `WsContextRef = { kind: "worktree" | "project"; id }`. Make `context` optional on watch/unwatch messages and events; keep `worktreeId` as an optional legacy alias. Add `contextRefFromMessage(msg)` normaliser (prefers `context`, falls back to `worktreeId`).
+- NEW `ws/handlers/watchContext.ts`: `resolveWatchContext(wireRef)` — `kind:"project"` → `resolveContext({kind:"project",projectId:id})`; `kind:"worktree"` → `resolveWorktreeById(id)`. Deliberately no worktree→project fallback (a dead worktree id must resolve to null, not a same-named project).
+- `fileWatch.ts`/`treeWatch.ts`: resolve via `resolveWatchContext`, watch `ctx.cwd`, `watchKey = \`file:${kind}:${id}:${path}\``, emit `context` always plus legacy `worktreeId` only when `ctx.worktree`.
+- `fileUnwatch.ts`/`treeUnwatch.ts`: rebuild the **byte-identical** key via the same normaliser (a mismatch leaks inotify handles).
+
+Client:
+- `useSubscription.ts`: delete the `scope === "project"` early-returns; `watchTarget(id, scope)` (sends `context`, plus `worktreeId` alias for worktree scope); `matchesContext(ev, id, scope)` (context events match kind+id; legacy events match worktree scope only).
+- `api/client.ts`: re-key `fileWatches`/`treeWatches` maps by `${kind}:${id}` (not worktreeId) so **direct watches survive a reconnect**; `watchWire(ref)` for replay.
+- `api/types.ts`: `WsContextRef` + `context` on events.
+
+## Back-compat (both directions)
+
+- Old client → new daemon: sends `worktreeId` only → normalised to a worktree ref; worktree events still carry `worktreeId`. ✔
+- New client → old daemon: worktree scope works (old zod strips unknown `context`, `worktreeId` still present). Project scope fails parse on the old daemon (its `worktreeId` was required) → noisy `system:error`, functionally today's no-op. Acceptable during a mixed-version window.
+
+## Tests to bring back
+
+- `web-ui/src/hooks/useFileWatch.test.ts` / `useTreeWatch.test.ts`: project-scope watch sends `context` with no `worktreeId` alias; project-scope event bumps `lastChanged`; a worktree event with a colliding id does NOT match a project watcher; a legacy `worktreeId`-only event still matches.
+- Daemon: a watch-then-unwatch with a legacy `worktreeId`-only message actually removes the watcher (proves key symmetry — currently only guaranteed by comments).
+- Also update `docs/API-CONTRACT.md` for the `context` field (the source-of-truth doc the protocol cites).
+
+## The larger prize — do this as part of "Stage 4"
+
+The client still carries three names for one concept (`FileScope`, `WsContextRef`, and the overloaded `worktreeId` prop threaded through `ToolPanel`/`TabsStrip`/`QuickOpen`/`FilePreviewPane`). Collapsing the store's `activeWorktreeId`/`activeDirectContextId`/`activeProjectId` triple into a single `activeContext: AgentContextRef`, and replacing the `worktreeId` + `scope` prop pair with one `context` prop, is what makes the watch-protocol change a net simplification. Sequence Stage 3 *inside* that work, not before it.
+
+The reference implementation for everything above is preserved in the branch history: commit `c327e40` ("feat(direct-sessions): live file/tree updates via context-aware watch"), verified live in Docker (a project-scoped `file:watch` fired `file:changed` + `tree:changed` on disk edits).

--- a/.feature-plans/pending/direct-session-live-file-watch.md
+++ b/.feature-plans/pending/direct-session-live-file-watch.md
@@ -57,4 +57,9 @@ Client:
 
 The client still carries three names for one concept (`FileScope`, `WsContextRef`, and the overloaded `worktreeId` prop threaded through `ToolPanel`/`TabsStrip`/`QuickOpen`/`FilePreviewPane`). Collapsing the store's `activeWorktreeId`/`activeDirectContextId`/`activeProjectId` triple into a single `activeContext: AgentContextRef`, and replacing the `worktreeId` + `scope` prop pair with one `context` prop, is what makes the watch-protocol change a net simplification. Sequence Stage 3 *inside* that work, not before it.
 
-The reference implementation for everything above is preserved in the branch history: commit `c327e40` ("feat(direct-sessions): live file/tree updates via context-aware watch"), verified live in Docker (a project-scoped `file:watch` fired `file:changed` + `tree:changed` on disk edits).
+The reference implementation for everything above is preserved at the git tag
+**`archive/direct-session-live-watch`** (commit `c327e40`, "feat(direct-sessions):
+live file/tree updates via context-aware watch") — verified live in Docker (a
+project-scoped `file:watch` fired `file:changed` + `tree:changed` on disk edits).
+Recover it with `git show archive/direct-session-live-watch` or
+`git cherry-pick c327e40`.

--- a/daemon/src/__tests__/context.test.ts
+++ b/daemon/src/__tests__/context.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { vi } from "vitest";
+import type { ProjectRecord, WorktreeRecord } from "../types.js";
+import {
+  resolvedContextOf,
+  sessionDataDirFor,
+  systemPromptPathFor,
+  opencodeConfigPathFor,
+} from "../services/context.js";
+
+vi.mock("../services/paths.js", () => ({
+  worktreePath: (p: string, w: string) => `/home/vst/.vibe-station/projects/${p}/worktrees/${w}`,
+  sessionDataDir: (p: string, w: string, s: string) => `/data/${p}/wt/${w}/${s}`,
+  directSessionDataDir: (p: string, s: string) => `/data/${p}/direct/${s}`,
+  systemPromptPath: (p: string, w: string, s: string) => `/data/${p}/wt/${w}/${s}/system-prompt.md`,
+  directSystemPromptPath: (p: string, s: string) => `/data/${p}/direct/${s}/system-prompt.md`,
+  opencodeConfigPath: (p: string, w: string, s: string) => `/data/${p}/wt/${w}/${s}/oc.json`,
+  directOpencodeConfigPath: (p: string, s: string) => `/data/${p}/direct/${s}/oc.json`,
+}));
+
+const project = { id: "proj-1", absolutePath: "/repos/proj-1" } as unknown as ProjectRecord;
+const worktree = { id: "proj-1-w1" } as unknown as WorktreeRecord;
+
+describe("resolvedContextOf", () => {
+  it("worktree context: cwd is the worktree checkout, worktree present", () => {
+    const ctx = resolvedContextOf(project, worktree);
+    expect(ctx.ref).toEqual({ kind: "worktree", projectId: "proj-1", worktreeId: "proj-1-w1" });
+    expect(ctx.worktree).toBe(worktree);
+    expect(ctx.cwd).toBe("/home/vst/.vibe-station/projects/proj-1/worktrees/proj-1-w1");
+  });
+
+  it("project (direct) context: cwd is the project dir, worktree is null", () => {
+    const ctx = resolvedContextOf(project, null);
+    expect(ctx.ref).toEqual({ kind: "project", projectId: "proj-1" });
+    expect(ctx.worktree).toBeNull();
+    expect(ctx.cwd).toBe("/repos/proj-1");
+  });
+});
+
+describe("context path helpers route by kind", () => {
+  it("worktree context → worktree data dirs", () => {
+    const ctx = resolvedContextOf(project, worktree);
+    expect(sessionDataDirFor(ctx, "s1")).toBe("/data/proj-1/wt/proj-1-w1/s1");
+    expect(systemPromptPathFor(ctx, "s1")).toBe("/data/proj-1/wt/proj-1-w1/s1/system-prompt.md");
+    expect(opencodeConfigPathFor(ctx, "s1")).toBe("/data/proj-1/wt/proj-1-w1/s1/oc.json");
+  });
+
+  it("project context → direct data dirs (no fabricated worktree in the path)", () => {
+    const ctx = resolvedContextOf(project, null);
+    expect(sessionDataDirFor(ctx, "s1")).toBe("/data/proj-1/direct/s1");
+    expect(systemPromptPathFor(ctx, "s1")).toBe("/data/proj-1/direct/s1/system-prompt.md");
+    expect(opencodeConfigPathFor(ctx, "s1")).toBe("/data/proj-1/direct/s1/oc.json");
+    // The old synthetic-worktree bug put "<project>-direct" in these paths.
+    expect(sessionDataDirFor(ctx, "s1")).not.toContain("proj-1-direct");
+  });
+});

--- a/daemon/src/__tests__/plugins.test.ts
+++ b/daemon/src/__tests__/plugins.test.ts
@@ -10,6 +10,33 @@ import type { LaunchConfig } from "../services/spawn.js";
 
 let tempDir: string;
 
+/**
+ * ResolvedContext stub for a WORKTREE context. Plugins read `ctx.cwd` and the
+ * `*For(ctx, …)` path helpers rather than deriving paths from a worktree id.
+ */
+function wtCtx(projectId: string, worktreeId: string) {
+  return {
+    ref: { kind: "worktree", projectId, worktreeId },
+    project: { id: projectId, absolutePath: `/repos/${projectId}` },
+    worktree: { id: worktreeId },
+    cwd: `${tempDir || "/tmp/vst-test"}/projects/${projectId}/worktrees/${worktreeId}`,
+  } as never;
+}
+
+/**
+ * ResolvedContext stub for a DIRECT (project) context — no worktree, cwd is the
+ * project checkout. This is the shape that used to be faked with a synthetic
+ * worktree whose id resolved to a directory that did not exist.
+ */
+function projCtx(projectId: string, absolutePath = `/repos/${projectId}`) {
+  return {
+    ref: { kind: "project", projectId },
+    project: { id: projectId, absolutePath },
+    worktree: null,
+    cwd: absolutePath,
+  } as never;
+}
+
 vi.mock("../services/paths.js", async () => {
   const { join: pathJoin } = await import("node:path");
   return {
@@ -29,6 +56,15 @@ vi.mock("../services/paths.js", async () => {
       pathJoin(tempDir || "/tmp/vst-test", "projects", p, "session-data", w, s, "system-prompt.md"),
     opencodeConfigPath: (p: string, w: string, s: string) =>
       pathJoin(tempDir || "/tmp/vst-test", "projects", p, "session-data", w, s, "opencode-config.json"),
+    // Direct (no-worktree) family — services/context.ts routes to these for a
+    // project context, so the mock must provide them too.
+    directSessionDataDir: (p: string, s: string) =>
+      pathJoin(tempDir || "/tmp/vst-test", "projects", p, "sessions", s),
+    directSystemPromptPath: (p: string, s: string) =>
+      pathJoin(tempDir || "/tmp/vst-test", "projects", p, "sessions", s, "system-prompt.md"),
+    directOpencodeConfigPath: (p: string, s: string) =>
+      pathJoin(tempDir || "/tmp/vst-test", "projects", p, "sessions", s, "opencode-config.json"),
+    cleanupDirectSessionDataDir: () => {},
   };
 });
 
@@ -185,7 +221,7 @@ describe("Agent plugins", () => {
         systemPromptFile: "/tmp/system-prompt.md",
         launchCfg: {
           project: { id: "p1" },
-          worktree: { id: "w1" },
+          ctx: wtCtx("p1", "w1"),
           session: { id: "sess-test" },
           daemonPort: 7421,
         } as unknown as LaunchConfig,
@@ -204,7 +240,7 @@ describe("Agent plugins", () => {
       const plugin = resolvePlugin("cursor");
       const cmd = plugin.getLaunchCommand({
         project: { id: "test-proj" },
-        worktree: { id: "wt-1" },
+        ctx: wtCtx("test-proj", "wt-1"),
       } as any);
       expect(cmd).toContain("--force");
       expect(cmd).toContain("--sandbox");
@@ -225,7 +261,7 @@ describe("Agent plugins", () => {
         systemPromptFile: "/tmp/system-prompt.md",
         launchCfg: {
           project: { id: "p1" },
-          worktree: { id: "w1" },
+          ctx: wtCtx("p1", "w1"),
           session: { id: "sess-test" },
           daemonPort: 7421,
         } as unknown as LaunchConfig,
@@ -266,7 +302,7 @@ describe("Agent plugins", () => {
       const plugin = resolvePlugin("gemini");
       const cmd = plugin.getLaunchCommand({
         project: { id: "p1" },
-        worktree: { id: "w1" },
+        ctx: wtCtx("p1", "w1"),
         session: { id: "s1", agentChatId: undefined },
         daemonPort: 7421,
         model: "gemini-3.1-pro-preview",
@@ -279,7 +315,7 @@ describe("Agent plugins", () => {
       const plugin = resolvePlugin("gemini");
       const cmd = plugin.getLaunchCommand({
         project: { id: "p1" },
-        worktree: { id: "w1" },
+        ctx: wtCtx("p1", "w1"),
         session: { id: "s1", agentChatId: undefined },
         daemonPort: 7421,
         model: "auto",
@@ -292,7 +328,7 @@ describe("Agent plugins", () => {
       const plugin = resolvePlugin("gemini");
       const cmd = plugin.getLaunchCommand({
         project: { id: "p1" },
-        worktree: { id: "w1" },
+        ctx: wtCtx("p1", "w1"),
         session: { id: "s1", agentChatId: undefined },
         daemonPort: 7421,
       } as LaunchConfig);
@@ -304,7 +340,7 @@ describe("Agent plugins", () => {
       const plugin = resolvePlugin("gemini");
       const cmd = plugin.getLaunchCommand({
         project: { id: "p1" },
-        worktree: { id: "w1" },
+        ctx: wtCtx("p1", "w1"),
         session: { id: "s1", agentChatId: "my-uuid-1234" },
         daemonPort: 7421,
       } as LaunchConfig);
@@ -318,7 +354,7 @@ describe("Agent plugins", () => {
       const plugin = resolvePlugin("gemini");
       const env = plugin.getEnvironment({
         project: { id: "p1" },
-        worktree: { id: "w1" },
+        ctx: wtCtx("p1", "w1"),
         session: { id: "s1" },
         daemonPort: 7421,
       } as LaunchConfig);
@@ -647,7 +683,7 @@ describe("Cursor plugin — chat-id capture", () => {
     const plugin = createCursorPlugin();
     const cmd = plugin.getLaunchCommand({
       project: { id: "p1" },
-      worktree: { id: "w1" },
+      ctx: wtCtx("p1", "w1"),
       session: { id: "s1", agentChatId: "uuid-abc" },
     } as any);
     expect(cmd).toContain("--resume");
@@ -659,7 +695,7 @@ describe("Cursor plugin — chat-id capture", () => {
     const plugin = createCursorPlugin();
     const cmd = plugin.getLaunchCommand({
       project: { id: "p1" },
-      worktree: { id: "w1" },
+      ctx: wtCtx("p1", "w1"),
       session: { id: "s1" },
     } as any);
     expect(cmd).not.toContain("--resume");
@@ -671,7 +707,7 @@ describe("Cursor plugin — chat-id capture", () => {
     const result = await plugin.getRestoreCommand!({
       session: { agentChatId: "cursor-uuid-xyz" },
       project: { id: "p1" },
-      worktree: { id: "w1" },
+      ctx: wtCtx("p1", "w1"),
     });
     expect(result).not.toBeNull();
     expect(result).toContain("--resume");
@@ -737,5 +773,75 @@ describe("OpenCode plugin — chat-id capture", () => {
       worktree: {},
     });
     expect(result).toEqual(["opencode", "--session", "ses_abc"]);
+  });
+});
+
+/**
+ * Direct (project) contexts — regression coverage for three LIVE path bugs.
+ *
+ * Direct sessions used to be handed a fabricated worktree record whose id was
+ * `<project>-direct`. Plugins derived paths from that id, so they resolved to
+ * ~/.vibe-station/projects/<p>/worktrees/<p>-direct — a directory that never
+ * exists. cursor got a bogus --workspace; opencode read its config and system
+ * prompt from the wrong dir; gemini pointed GEMINI_SYSTEM_MD at nothing.
+ * Plugins now read ctx.cwd / the *For(ctx, …) helpers, which handle both shapes.
+ */
+describe("plugins in a direct (project) context", () => {
+  it("cursor: getLaunchCommand uses the project dir as --workspace", async () => {
+    const { createCursorPlugin } = await import("../agent-plugins/cursor.js");
+    const cmd = createCursorPlugin().getLaunchCommand({
+      project: { id: "p1" },
+      ctx: projCtx("p1", "/repos/p1"),
+      session: { id: "s1" },
+      daemonPort: 7421,
+    } as never);
+
+    const wsIdx = cmd.indexOf("--workspace");
+    expect(wsIdx).toBeGreaterThanOrEqual(0);
+    expect(cmd[wsIdx + 1]).toBe("/repos/p1");
+    // The fabricated-worktree path must not appear anywhere in the argv.
+    expect(cmd.join(" ")).not.toContain("p1-direct");
+    expect(cmd.join(" ")).not.toContain("worktrees");
+  });
+
+  it("gemini: GEMINI_SYSTEM_MD points at the direct session data dir", async () => {
+    const { resolvePlugin } = await import("../agent-plugins/registry.js");
+    const { directSystemPromptPath } = await import("../services/paths.js");
+    const env = resolvePlugin("gemini").getEnvironment({
+      project: { id: "p1" },
+      ctx: projCtx("p1"),
+      session: { id: "s1" },
+      daemonPort: 7421,
+    } as never);
+
+    expect(env.GEMINI_SYSTEM_MD).toBe(directSystemPromptPath("p1", "s1"));
+    expect(env.GEMINI_SYSTEM_MD).not.toContain("p1-direct");
+  });
+
+  it("gemini: still uses the worktree data dir for a worktree context", async () => {
+    const { resolvePlugin } = await import("../agent-plugins/registry.js");
+    const { systemPromptPath } = await import("../services/paths.js");
+    const env = resolvePlugin("gemini").getEnvironment({
+      project: { id: "p1" },
+      ctx: wtCtx("p1", "w1"),
+      session: { id: "s1" },
+      daemonPort: 7421,
+    } as never);
+
+    expect(env.GEMINI_SYSTEM_MD).toBe(systemPromptPath("p1", "w1", "s1"));
+  });
+
+  it("opencode: config + system prompt resolve to the direct session data dir", async () => {
+    const { resolvePlugin } = await import("../agent-plugins/registry.js");
+    const { directOpencodeConfigPath } = await import("../services/paths.js");
+    const env = resolvePlugin("opencode").getEnvironment({
+      project: { id: "p1" },
+      ctx: projCtx("p1"),
+      session: { id: "s1" },
+      daemonPort: 7421,
+    } as never);
+
+    expect(env.OPENCODE_CONFIG).toBe(directOpencodeConfigPath("p1", "s1"));
+    expect(env.OPENCODE_CONFIG).not.toContain("p1-direct");
   });
 });

--- a/daemon/src/__tests__/plugins.test.ts
+++ b/daemon/src/__tests__/plugins.test.ts
@@ -707,11 +707,14 @@ describe("Cursor plugin — chat-id capture", () => {
     const result = await plugin.getRestoreCommand!({
       session: { agentChatId: "cursor-uuid-xyz" },
       project: { id: "p1" },
-      ctx: wtCtx("p1", "w1"),
+      cwd: "/repos/p1",
     });
     expect(result).not.toBeNull();
     expect(result).toContain("--resume");
     expect(result).toContain("cursor-uuid-xyz");
+    // cwd must reach --workspace, not leak through as undefined.
+    expect(result).toContain("/repos/p1");
+    expect(result?.join(" ")).not.toContain("undefined");
   });
 
   it("3.T7 — getRestoreCommand without agentChatId → falls back to findLatestCursorChatId (returns null when no chats)", async () => {
@@ -770,7 +773,7 @@ describe("OpenCode plugin — chat-id capture", () => {
     const result = await plugin.getRestoreCommand!({
       session: { agentChatId: "ses_abc" },
       project: {},
-      worktree: {},
+      cwd: "/repos/p1",
     });
     expect(result).toEqual(["opencode", "--session", "ses_abc"]);
   });

--- a/daemon/src/agent-plugins/cursor.ts
+++ b/daemon/src/agent-plugins/cursor.ts
@@ -16,7 +16,6 @@
 import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
 import type { AgentPlugin, LaunchConfig } from "../services/spawn.js";
-import { worktreePath as getWorktreePath } from "../services/paths.js";
 import { sq } from "../services/shell.js";
 import { findLatestCursorChatId } from "./cursorRestore.js";
 
@@ -48,7 +47,7 @@ export function createCursorPlugin(): AgentPlugin {
     },
 
     getLaunchCommand(cfg: LaunchConfig): string[] {
-      const wtPath = getWorktreePath(cfg.project.id, cfg.worktree.id);
+      const wtPath = cfg.ctx.cwd;
       const argv: string[] = ["cursor-agent"];
       if (cfg.session?.agentChatId) {
         argv.push("--resume", cfg.session.agentChatId);
@@ -78,7 +77,7 @@ export function createCursorPlugin(): AgentPlugin {
       systemPromptFile: string;
       launchCfg: LaunchConfig;
     }) {
-      const wtPath = getWorktreePath(prompt.launchCfg.project.id, prompt.launchCfg.worktree.id);
+      const wtPath = prompt.launchCfg.ctx.cwd;
       // Mirror ao-142 agent-cursor/src/index.ts:190-198:
       // cursor-agent … -- "$(cat '<file>'; printf '\n\n'; printf %s '<task>')"
       const filePart = `cat ${sq(prompt.systemPromptFile)}`;

--- a/daemon/src/agent-plugins/gemini.ts
+++ b/daemon/src/agent-plugins/gemini.ts
@@ -16,8 +16,8 @@
 
 import { randomUUID } from "node:crypto";
 import type { AgentPlugin, LaunchConfig } from "../services/spawn.js";
-import { systemPromptPath } from "../services/paths.js";
-import type { SessionRecord, ProjectRecord, WorktreeRecord } from "../types.js";
+import { systemPromptPathFor } from "../services/context.js";
+import type { SessionRecord, ProjectRecord } from "../types.js";
 
 // "auto" = no -m flag passed; Gemini CLI picks the default model automatically.
 const GEMINI_MODELS = [
@@ -48,7 +48,7 @@ export function createGeminiPlugin(): AgentPlugin {
 
     getEnvironment(cfg: LaunchConfig): Record<string, string> {
       return {
-        GEMINI_SYSTEM_MD: systemPromptPath(cfg.project.id, cfg.worktree.id, cfg.session.id),
+        GEMINI_SYSTEM_MD: systemPromptPathFor(cfg.ctx, cfg.session.id),
       };
     },
 

--- a/daemon/src/agent-plugins/opencode.ts
+++ b/daemon/src/agent-plugins/opencode.ts
@@ -15,11 +15,11 @@ import { promises as fs } from "node:fs";
 const execFileAsync = promisify(execFile);
 import { join } from "node:path";
 import type { AgentPlugin, LaunchConfig } from "../services/spawn.js";
-import { opencodeConfigPath, systemPromptPath, worktreePath as getWorktreePath } from "../services/paths.js";
+import { opencodeConfigPathFor, systemPromptPathFor } from "../services/context.js";
 import { writeOpenCodeConfig } from "../services/opencodeConfig.js";
 import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
-import type { SessionRecord, ProjectRecord, WorktreeRecord } from "../types.js";
+import type { SessionRecord, ProjectRecord } from "../types.js";
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -56,8 +56,8 @@ export function createOpencodePlugin(): AgentPlugin {
     getEnvironment(cfg: LaunchConfig): Record<string, string> {
       // Write (or re-write) the opencode config pointing at the system-prompt file.
       // This runs both on fresh spawn and on restore — so updated AGENTS.md is always picked up.
-      const configPath = opencodeConfigPath(cfg.project.id, cfg.worktree.id, cfg.session.id);
-      const promptFile = systemPromptPath(cfg.project.id, cfg.worktree.id, cfg.session.id);
+      const configPath = opencodeConfigPathFor(cfg.ctx, cfg.session.id);
+      const promptFile = systemPromptPathFor(cfg.ctx, cfg.session.id);
       try {
         mkdirSync(dirname(configPath), { recursive: true });
         writeOpenCodeConfig(configPath, [promptFile]);

--- a/daemon/src/routes/sessions.ts
+++ b/daemon/src/routes/sessions.ts
@@ -10,12 +10,8 @@ import {
 } from "../services/sessionId.js";
 import { killSession, newSession, pasteBuffer, capturePane } from "../services/tmux.js";
 import { directPtyRegistry } from "../state/directPtyRegistry.js";
-import {
-  spawnSession,
-  spawnSessionFromArgv,
-  spawnDirectSession,
-  syntheticDirectWorktree,
-} from "../services/spawn.js";
+import { spawnSession, spawnSessionFromArgv, spawnDirectSession } from "../services/spawn.js";
+import { resolvedContextOf } from "../services/context.js";
 import { cleanupSessionDataDir, cleanupDirectSessionDataDir, worktreePath } from "../services/paths.js";
 import { broadcastAll } from "../broadcaster.js";
 import { resolvePlugin } from "../agent-plugins/registry.js";
@@ -702,11 +698,10 @@ export function registerSessionRoutes(app: FastifyInstance): void {
             await plugin.setupWorkspaceHooks(cwd);
           }
 
-          // getEnvironment still takes a LaunchConfig with a worktree; direct
-          // sessions reuse the same synthetic record spawnDirectSession builds.
+          // Same context object the spawners build — worktree or project-direct.
           const launchCfg = {
             project,
-            worktree: worktree ?? syntheticDirectWorktree(project, session),
+            ctx: resolvedContextOf(project, worktree ?? null),
             session,
             daemonPort: 0,
             ...(mode.model ? { model: mode.model } : {}),

--- a/daemon/src/services/context.ts
+++ b/daemon/src/services/context.ts
@@ -1,0 +1,111 @@
+/**
+ * Agent context — the thing an agent session runs *in*.
+ *
+ * An agent is first-class: it exists either inside a git worktree (many agents
+ * grouped under one worktree) or directly in the project directory (a "direct"
+ * agent, listed individually). Those are two shapes of the same idea, not a
+ * thing and the absence of a thing.
+ *
+ * WHY THIS EXISTS
+ *
+ * Direct sessions used to be encoded as an *absence* — `worktreeId === null`,
+ * or a fabricated placeholder worktree. That shape produced the same bug over
+ * and over: code asks "which worktree?", gets nothing, and misreads the absence
+ * as *deleted* / *not found* / *impossible*. Real instances:
+ *
+ *   - ws/handlers/sessionLookup.ts scanned only worktrees, so session:open for
+ *     a direct session answered "Session not found" while the agent was alive.
+ *   - routes/modes.ts isModeInUse ignored direct sessions, so a mode in use
+ *     could be deleted.
+ *   - A fabricated worktree (`<project>-direct`) resolved to a NONEXISTENT
+ *     directory, so plugins derived paths that silently pointed nowhere.
+ *
+ * Encoding the context as a *value* removes the null there is to misread: a
+ * direct context resolves successfully to its project, so "cannot resolve" can
+ * only ever mean genuinely gone.
+ *
+ * THE RULE
+ *
+ * Consumers may read `ResolvedContext.worktree` and gate on its presence —
+ * some things (git diff/branch, worktree lifecycle, VST_WORKTREE) are
+ * legitimately worktree-only. What they must NOT do is fabricate a worktree,
+ * or infer "direct" from an unrelated null.
+ */
+
+import type { ProjectRecord, WorktreeRecord } from "../types.js";
+import {
+  worktreePath,
+  sessionDataDir,
+  directSessionDataDir,
+  systemPromptPath,
+  directSystemPromptPath,
+  opencodeConfigPath,
+  directOpencodeConfigPath,
+} from "./paths.js";
+
+/**
+ * Serializable reference to a context. Safe to persist and to send over the
+ * wire. Carries projectId in both shapes because every consumer needs it.
+ */
+export type AgentContextRef =
+  | { kind: "worktree"; projectId: string; worktreeId: string }
+  | { kind: "project"; projectId: string };
+
+/**
+ * A ref resolved against the project store. Never persisted — always computed,
+ * so it cannot go stale.
+ */
+export interface ResolvedContext {
+  ref: AgentContextRef;
+  project: ProjectRecord;
+  /** null ⇔ ref.kind === "project". Gate on this; never fabricate one. */
+  worktree: WorktreeRecord | null;
+  /** Where the agent actually runs: the worktree checkout, or the project dir. */
+  cwd: string;
+}
+
+/**
+ * Resolve directly from records already in hand — the only resolver the spawn
+ * and resume paths need. (Store-lookup resolvers by ref or by bare id are
+ * added when the watch subsystem needs them; see
+ * .feature-plans/pending/direct-session-live-file-watch.md.)
+ */
+export function resolvedContextOf(
+  project: ProjectRecord,
+  worktree: WorktreeRecord | null,
+): ResolvedContext {
+  const ref: AgentContextRef = worktree
+    ? { kind: "worktree", projectId: project.id, worktreeId: worktree.id }
+    : { kind: "project", projectId: project.id };
+  return {
+    ref,
+    project,
+    worktree,
+    cwd: worktree ? worktreePath(project.id, worktree.id) : project.absolutePath,
+  };
+}
+
+// ── Context-keyed path helpers ───────────────────────────────────────────────
+// paths.ts keeps parallel worktree/direct families; these route to the right
+// one so callers never branch on "is this direct?" themselves.
+
+/** Per-session data dir for this context. */
+export function sessionDataDirFor(ctx: ResolvedContext, sessionId: string): string {
+  return ctx.worktree
+    ? sessionDataDir(ctx.project.id, ctx.worktree.id, sessionId)
+    : directSessionDataDir(ctx.project.id, sessionId);
+}
+
+/** <sessionDataDir>/system-prompt.md for this context. */
+export function systemPromptPathFor(ctx: ResolvedContext, sessionId: string): string {
+  return ctx.worktree
+    ? systemPromptPath(ctx.project.id, ctx.worktree.id, sessionId)
+    : directSystemPromptPath(ctx.project.id, sessionId);
+}
+
+/** <sessionDataDir>/opencode-config.json for this context. */
+export function opencodeConfigPathFor(ctx: ResolvedContext, sessionId: string): string {
+  return ctx.worktree
+    ? opencodeConfigPath(ctx.project.id, ctx.worktree.id, sessionId)
+    : directOpencodeConfigPath(ctx.project.id, sessionId);
+}

--- a/daemon/src/services/spawn.ts
+++ b/daemon/src/services/spawn.ts
@@ -18,14 +18,9 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { newSession, hasSession, killSession, capturePane, pasteBuffer, sendKeys } from "./tmux.js";
 import { DirectPtyBackend } from "./directPty.js";
-import {
-  worktreePath as getWorktreePath,
-  sessionDataDir,
-  systemPromptPath,
-  directSessionDataDir,
-  directSystemPromptPath,
-} from "./paths.js";
 import type { ProjectRecord, WorktreeRecord, SessionRecord } from "../types.js";
+import type { ResolvedContext } from "./context.js";
+import { resolvedContextOf, systemPromptPathFor, sessionDataDirFor } from "./context.js";
 
 /** Substring searched in pane output after paste (matches plugins' HTML tail marker). */
 export function promptVerificationNeedle(sessionId: string): string {
@@ -92,7 +87,16 @@ export interface AgentPlugin {
 
 export interface LaunchConfig {
   project: ProjectRecord;
-  worktree: WorktreeRecord;
+  /**
+   * The context this agent runs in — worktree or project-direct. Use
+   * `ctx.cwd` and the `*For(ctx, …)` path helpers rather than deriving paths
+   * from a worktree id: a direct session has no worktree, and the fabricated
+   * one this replaced resolved to a nonexistent directory.
+   *
+   * `ctx.worktree` is null for direct sessions. Gate on it for things that are
+   * genuinely worktree-only (branch metadata, VST_WORKTREE).
+   */
+  ctx: ResolvedContext;
   session: SessionRecord;
   daemonPort: number;
   /** Per-mode model override passed to the agent CLI when set. */
@@ -120,14 +124,6 @@ export interface DirectSpawnOptions {
   model?: string;
 }
 
-/** LaunchConfig variant for direct sessions (no worktree). */
-export interface DirectLaunchConfig {
-  project: ProjectRecord;
-  session: SessionRecord;
-  daemonPort: number;
-  model?: string;
-}
-
 export interface SpawnSessionFromArgvOptions {
   project: ProjectRecord;
   /** Working directory: worktree checkout, or project.absolutePath for a direct session. */
@@ -138,31 +134,6 @@ export interface SpawnSessionFromArgvOptions {
   argv: string[];
   env: Record<string, string>;
   fallbackMs: number;
-}
-
-/**
- * Direct sessions have no worktree, but LaunchConfig — and therefore
- * getLaunchCommand / getEnvironment / composeLaunchPrompt — still requires one.
- * This synthesises a placeholder so those plugin methods keep working.
- *
- * WARNING: the `id` here does NOT correspond to a real directory.
- * `worktreePath(project.id, syntheticDirectWorktree(...).id)` resolves to a
- * path that does not exist. Never derive a filesystem path from it — take an
- * explicit `cwd` instead (see AgentPlugin.provideChatId). Deriving paths from a
- * fabricated worktree id is why direct-session restore silently found nothing.
- */
-export function syntheticDirectWorktree(
-  project: ProjectRecord,
-  session: SessionRecord,
-): WorktreeRecord {
-  return {
-    id: `${project.id}-direct`,
-    branch: "direct",
-    baseBranch: project.defaultBranch ?? "main",
-    baseSha: "",
-    createdAt: new Date().toISOString(),
-    sessions: [session],
-  };
 }
 
 /**
@@ -240,11 +211,12 @@ export async function spawnSessionFromArgv(opts: SpawnSessionFromArgvOptions): P
  */
 export async function spawnSession(opts: SpawnOptions): Promise<void> {
   const { project, worktree, session, plugin, daemonPort, systemPrompt, taskPrompt, model } = opts;
-  const wtPath = getWorktreePath(project.id, worktree.id);
+  const ctx = resolvedContextOf(project, worktree);
+  const wtPath = ctx.cwd;
 
   const launchCfg: LaunchConfig = {
     project,
-    worktree,
+    ctx,
     session,
     daemonPort,
     ...(model ? { model } : {}),
@@ -260,9 +232,9 @@ export async function spawnSession(opts: SpawnOptions): Promise<void> {
   }
 
   // Write system-prompt file to per-session data dir
-  const dataDir = sessionDataDir(project.id, worktree.id, session.id);
+  const dataDir = sessionDataDirFor(ctx, session.id);
   mkdirSync(dataDir, { recursive: true });
-  const promptFile = systemPromptPath(project.id, worktree.id, session.id);
+  const promptFile = systemPromptPathFor(ctx, session.id);
   writeFileSync(promptFile, systemPrompt, "utf8");
 
   // Compose launch prompt
@@ -430,12 +402,15 @@ export async function spawnSession(opts: SpawnOptions): Promise<void> {
  */
 export async function spawnDirectSession(opts: DirectSpawnOptions): Promise<void> {
   const { project, session, plugin, daemonPort, systemPrompt, taskPrompt, model } = opts;
-  const cwd = project.absolutePath;
+  // A project context — no worktree. Plugins read ctx.cwd / ctx.worktree
+  // instead of the fabricated worktree record this replaced, whose id pointed
+  // at a directory that never existed.
+  const ctx = resolvedContextOf(project, null);
+  const cwd = ctx.cwd;
 
-  // Synthetic worktree purely to satisfy LaunchConfig — see the helper's warning.
   const launchCfg: LaunchConfig = {
     project,
-    worktree: syntheticDirectWorktree(project, session),
+    ctx,
     session,
     daemonPort,
     ...(model ? { model } : {}),
@@ -446,10 +421,10 @@ export async function spawnDirectSession(opts: DirectSpawnOptions): Promise<void
     await plugin.setupWorkspaceHooks(cwd);
   }
 
-  // Write system-prompt file to direct session data dir
-  const dataDir = directSessionDataDir(project.id, session.id);
+  // Write system-prompt file to this context's session data dir
+  const dataDir = sessionDataDirFor(ctx, session.id);
   mkdirSync(dataDir, { recursive: true });
-  const promptFile = directSystemPromptPath(project.id, session.id);
+  const promptFile = systemPromptPathFor(ctx, session.id);
   writeFileSync(promptFile, systemPrompt, "utf8");
 
   // Compose launch prompt

--- a/web-ui/src/hooks/useStore.test.ts
+++ b/web-ui/src/hooks/useStore.test.ts
@@ -139,3 +139,69 @@ describe("useWorkspaceStore - setActiveWorktree", () => {
     expect(state.activeFilePath).toBeNull();
   });
 });
+
+/**
+ * A direct session has no worktree — activeWorktreeId is always null and the
+ * context key is the project id (layoutKey = activeWorktreeId ?? activeDirectContextId).
+ * setActiveFile used to key on activeWorktreeId directly, so a direct session's
+ * open file was never remembered and could never be restored.
+ */
+describe("useWorkspaceStore - file memory per context", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useWorkspaceStore.persist.clearStorage?.();
+    useWorkspaceStore.setState({
+      activeProjectId: null,
+      activeWorktreeId: null,
+      activeDirectContextId: null,
+      activeSessionId: null,
+      activeFilePath: null,
+      lastFileByWorktree: {},
+    });
+  });
+
+  it("remembers a direct session's open file under the project key", () => {
+    useWorkspaceStore.getState().setActiveDirectContext(P1);
+    useWorkspaceStore.getState().setActiveFile("/docs/plan.md");
+
+    expect(useWorkspaceStore.getState().lastFileByWorktree[P1]).toBe("/docs/plan.md");
+  });
+
+  it("restores a direct session's last file on re-entering the context", () => {
+    useWorkspaceStore.getState().setActiveDirectContext(P1);
+    useWorkspaceStore.getState().setActiveFile("/docs/plan.md");
+
+    // Leave the direct context, then come back.
+    useWorkspaceStore.getState().setActiveDirectContext(null);
+    useWorkspaceStore.setState({ activeFilePath: null });
+    useWorkspaceStore.getState().setActiveDirectContext(P1);
+
+    expect(useWorkspaceStore.getState().activeFilePath).toBe("/docs/plan.md");
+  });
+
+  it("still keys worktree sessions by worktree id", () => {
+    useWorkspaceStore.setState({ activeWorktreeId: W1, activeDirectContextId: null });
+    useWorkspaceStore.getState().setActiveFile("/src/index.ts");
+
+    expect(useWorkspaceStore.getState().lastFileByWorktree[W1]).toBe("/src/index.ts");
+  });
+
+  it("keeps worktree and direct file memory in separate keys", () => {
+    useWorkspaceStore.setState({ activeWorktreeId: W1, activeDirectContextId: null });
+    useWorkspaceStore.getState().setActiveFile("/src/index.ts");
+
+    useWorkspaceStore.setState({ activeWorktreeId: null });
+    useWorkspaceStore.getState().setActiveDirectContext(P1);
+    useWorkspaceStore.getState().setActiveFile("/docs/plan.md");
+
+    const { lastFileByWorktree } = useWorkspaceStore.getState();
+    expect(lastFileByWorktree[W1]).toBe("/src/index.ts");
+    expect(lastFileByWorktree[P1]).toBe("/docs/plan.md");
+  });
+
+  it("does not record a file when there is no active context", () => {
+    useWorkspaceStore.getState().setActiveFile("/orphan.ts");
+    expect(useWorkspaceStore.getState().lastFileByWorktree).toEqual({});
+    expect(useWorkspaceStore.getState().activeFilePath).toBe("/orphan.ts");
+  });
+});

--- a/web-ui/src/hooks/useStore.ts
+++ b/web-ui/src/hooks/useStore.ts
@@ -234,8 +234,17 @@ export const useWorkspaceStore = create<WorkspaceState>()(
               activeFilePath: s.lastFileByWorktree[worktreeId] ?? null,
             };
           }),
+        // Restore the last file for this project context, mirroring what
+        // setActiveWorktree does for worktrees. Entering a direct session used
+        // to leave activeFilePath at whatever the previous context had.
         setActiveDirectContext: (projectId) =>
-          set({ activeDirectContextId: projectId }),
+          set((s) => {
+            if (projectId == null) return { activeDirectContextId: null };
+            return {
+              activeDirectContextId: projectId,
+              activeFilePath: s.lastFileByWorktree[projectId] ?? null,
+            };
+          }),
         setActiveSession: (sessionId) =>
           set((s) => {
             const key = layoutKey(s);
@@ -254,11 +263,17 @@ export const useWorkspaceStore = create<WorkspaceState>()(
                 : s.lastTerminalByWorktree;
             return { activeTerminalSessionId: sessionId, lastTerminalByWorktree: nextLast };
           }),
+        // Keyed by layoutKey (worktree id, or the direct-session project id) —
+        // NOT activeWorktreeId, which is always null for a direct session and
+        // so silently dropped their open file from the restore map.
+        // setActiveSession/setActiveTerminalSession above already do this.
         setActiveFile: (path) =>
           set((s) => {
-            const wt = s.activeWorktreeId;
+            const key = layoutKey(s);
             const nextLastFile =
-              path && wt ? { ...s.lastFileByWorktree, [wt]: path } : s.lastFileByWorktree;
+              path && key != null
+                ? { ...s.lastFileByWorktree, [key]: path }
+                : s.lastFileByWorktree;
             return { activeFilePath: path, lastFileByWorktree: nextLastFile };
           }),
         setFileScroll: (worktreeId, filePath, scrollTop) =>

--- a/web-ui/src/routes/Workspace.tsx
+++ b/web-ui/src/routes/Workspace.tsx
@@ -119,8 +119,18 @@ export function Workspace() {
   // worktree was deleted between sessions). Runs once the server bundle has
   // landed so it has fresh data to validate against; without this the
   // FilePreviewPane fires a doomed getFile() with a stale path on remount.
+  //
+  // Direct sessions are exempt: they have NO worktree by design (the mutual
+  // exclusion effect above nulls activeWorktreeId), so every check below reads
+  // "no worktree" as "worktree deleted" and wipes activeFilePath — clearing the
+  // user's open file. This effect re-runs whenever the `sessions` array identity
+  // changes, and applySessionUpdated rebuilds that array on EVERY session:state
+  // for ANY session, so an unrelated agent going idle elsewhere was enough to
+  // clear the file seconds after opening it. Direct-session staleness is already
+  // owned by the redirect effect above ("Redirect to dashboard if direct session
+  // not found"), so there is nothing for this effect to validate here.
   useEffect(() => {
-    if (!bundleLoaded) return;
+    if (!bundleLoaded || isDirectSession) return;
     const s = useWorkspaceStore.getState();
     const activeWt = s.activeWorktreeId
       ? worktrees.find((w) => w.id === s.activeWorktreeId)
@@ -148,7 +158,7 @@ export function Workspace() {
     } else if (!sessStillExists) {
       useWorkspaceStore.setState({ activeSessionId: null });
     }
-  }, [bundleLoaded, worktrees, sessions, projects, location.pathname, navigate]);
+  }, [bundleLoaded, isDirectSession, worktrees, sessions, projects, location.pathname, navigate]);
 
   useEffect(() => {
     if (!isMobile && mobileSidebarOpen) {


### PR DESCRIPTION
Follow-up to #26. Fixes the reported bug and removes the root cause behind a recurring class of direct-session bugs, **without** the scope creep the first cut had.

## The bug you reported

Opening a file in a direct session cleared it a few seconds later. Root cause in `Workspace.tsx`: a "drop stale selections" effect did `if (!activeWorktreeId's worktree) wipe activeFilePath`. A direct session **has no worktree by design**, so it read "no worktree" as "worktree deleted" — and since the effect re-runs on every `session:state` for *any* session (the shared `sessions` array identity changes), an unrelated agent going idle anywhere wiped your open file.

## Scope — deliberately trimmed after review

A `fable` review of the first attempt said **SIMPLIFY BEFORE SHIP**. This PR is the trimmed result:

| Stage | In this PR? | What |
|---|---|---|
| **1 — the bug** | ✅ | Effect early-returns for direct sessions (their staleness is owned by the redirect effect); `setActiveFile` keys on `layoutKey` so the file is remembered/restored. |
| **2 — context + live path bugs** | ✅ | `services/context.ts` (111 lines): `ResolvedContext` + `resolvedContextOf` + 3 path helpers. **Deletes `syntheticDirectWorktree`**, whose fake `<project>-direct` id resolved to a nonexistent dir — fixing 3 live bugs (cursor `--workspace`, opencode config/prompt, gemini `GEMINI_SYSTEM_MD` all pointed nowhere for direct sessions). |
| **3 — live file-watch** | ❌ **deferred** | Direct-session file trees don't live-update. Correct, but on its own it *adds* a third encoding of "worktree \| project" rather than removing surface — a net simplification only alongside the client unification. Moved to `.feature-plans/pending/direct-session-live-file-watch.md`; reference impl preserved at tag `archive/direct-session-live-watch`. |

## Why Stage 2 earns its keep (and Stage 3 didn't)

Stage 2 **removes** a fake concept (the fabricated worktree) and replaces it with one honest `ResolvedContext`. The context module was trimmed from 183 → 111 lines during review: five speculative exports and two Stage-3-only resolvers were cut, so every remaining export has real callers (spawn ×2, resume, 3 plugins). Stage 3 would have **added** a parallel wire encoding — so it waits for the work that lets it delete one instead.

## Verification

- **CI:** 0 typecheck errors, **380 tests** (+13 vs base), each new test confirmed to fail against pre-fix code. Lint unchanged (same 7 pre-existing findings on `main`, zero new).
- **`fable` verdict:** APPROVE FOR MERGE. Confirmed context.ts is correctly sized, no dangling refs, no null-unsafe `ctx.worktree` deref, the split is clean, and the pending plan accurately captures what to rebuild.
- Live Docker verification of the plugin path fixes and the file-clearing fix was done on the pre-split branch.

## Diff

12 files, +479 / −86 (down from +897/−160 before the trim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)