### PR TITLE
fix(cli): --prompt-file was never read — agents spawned with no task

### DIFF
--- a/.feature-plans/done/prompt-file-never-delivered.md
+++ b/.feature-plans/done/prompt-file-never-delivered.md
@@ -45,9 +45,10 @@ Each action handler hand-declares its own opts shape with the dashed key:
 ```ts
 opts: { …; "prompt-file"?: string }
 ```
-Commander's `.action()` types the callback loosely, so this fabricated annotation is accepted as-is.
-TS then happily type-checks a property access that can never exist at runtime. The type annotation
-is the thing that hides the bug.
+Commander's `.action()` types the callback as `(...args: any[])`, so this fabricated annotation is
+accepted as-is. TS then happily type-checks a property access that can never exist at runtime. The
+type annotation is the thing that hides the bug — and, importantly, correcting it to camelCase
+fixes the code without restoring any compile-time guarantee (see fix item 2).
 
 ### Why it fails silently rather than erroring
 
@@ -67,10 +68,18 @@ read-a-file-the-user-named failure that produces no diagnostic).
    - `mode/add.ts`: `opts.contextFile`
 
 2. **Delete the lying type annotations** — replace the hand-written dashed-key opts interfaces with
-   camelCase ones (`promptFile?: string`, `contextFile?: string`). This is what turns the class of
-   bug from silent into compile-time-visible: the dead property access stops type-checking.
+   camelCase ones (`promptFile?: string`, `contextFile?: string`).
 
-3. **Add a shared `resolveFileOrInline()` helper** in `cli/src/lib/` — items 4–6 below would
+   **This does not buy compile-time safety, and an earlier draft of this plan wrongly claimed it
+   did.** Commander types the callback as `action(fn: (...args: any[]) => void | Promise<void>)`
+   (`commander/typings/index.d.ts:547`), so the opts annotation is *never* checked against the
+   `.option()` strings. A typo'd `promptFyle?: string` read as `opts.promptFyle` would compile
+   exactly as cleanly as the original dashed version did. The code is now correct, but the only
+   thing standing between us and a recurrence is the regression test — which is precisely why the
+   test asserts on the POSTed body rather than on internals. The real structural fix is the
+   deferred `@commander-js/extra-typings` migration below.
+
+3. **Add a shared `resolveFileOrInline()` helper** in `cli/src/lib/text-source.ts` — items 4–6 below would
    otherwise be triplicated verbatim across three files. The helper owns: read-or-die, the
    conflict check, and the empty-file warning. One place to get right, one place to test.
 
@@ -82,8 +91,12 @@ read-a-file-the-user-named failure that produces no diagnostic).
    `new Option("--prompt-file <path>").conflicts("prompt")` rather than a hand-rolled `die()`.
    It yields standard commander error output and cooperates with `exitOverride()` in tests.
 
-6. **Warn on an empty prompt file** — an empty/whitespace-only file yields an agent with no task,
-   which is the exact symptom being fixed. Warn rather than fail.
+6. **Warn on an empty prompt file, and return `undefined` for it** — not the raw contents. A
+   whitespace-only file yields a *truthy* `"\n"`, and plugins gate on `if (prompt.taskPrompt)`
+   (`agent-plugins/claude.ts:86`), so it would be **submitted as the agent's task**. Returning
+   `undefined` takes the same path as "no prompt given", which is what the warning promises.
+   Warn rather than fail: an empty file is unambiguously not what the caller intended, but it is
+   not ours to block.
 
 ## Test plan
 
@@ -114,6 +127,9 @@ worth pinning.
 - `--prompt` + `--prompt-file` together → exits non-zero
 - `--prompt-file` pointing at a nonexistent path → exits non-zero with a readable message
 - multi-line file contents survive verbatim (no trimming/mangling of the body)
+- a whitespace-only file omits `prompt` rather than submitting `"\n"` as the task
+- `session create --type=terminal --prompt…` → exits non-zero (daemon would discard it)
+- `project create --prompt` without `--start-agent` → exits non-zero (body would omit it)
 
 Required args or the command dies before reaching the file logic: `mode add` needs `--name`/`--cli`
 (`mode/add.ts:29-34`); `worktree create` needs `--mode`.
@@ -137,9 +153,22 @@ of the POST is fine and is exercised daily by the working `--prompt` flag.
 `opts.file` is already correct. (It shares the raw-ENOENT roughness and could adopt the helper later;
 out of scope here.)
 
-Repo-wide sweep confirms no other instance of this bug class: commander is used only in `cli/`, and
-the only multi-word options in the repo are `--start-agent` (correct), `--prompt-file` ×2, and
-`--context-file`.
+Repo-wide sweep confirms no other instance of the camelCase bug class: commander is used only in
+`cli/`, and the only multi-word options in the repo are `--start-agent` (correct), `--prompt-file`
+×2, and `--context-file`.
+
+### Sibling silent-drops closed at the same time
+
+Review found two more places a prompt vanished without a word — same symptom, different mechanism,
+so they belong with this fix rather than in a follow-up:
+
+- `project create --prompt` **without** `--start-agent` built a body that omitted the prompt
+  entirely (`project/create.ts:94`). The inverse was already guarded (`--mode` required when
+  `--start-agent`), so this was an asymmetry, not a design.
+- `session create --type=terminal --prompt…` POSTed a prompt the daemon only ever consumes for
+  agent sessions (`daemon/src/routes/sessions.ts:420`), dropping it on the floor.
+
+Both now `die()`.
 
 ### Deferred follow-up
 

--- a/.feature-plans/done/prompt-file-never-delivered.md
+++ b/.feature-plans/done/prompt-file-never-delivered.md
@@ -1,0 +1,149 @@
+# `--prompt-file` is never delivered to the spawned agent
+
+## Symptom
+
+An agent runs `vst worktree create … --prompt-file=./task.md` (or `vst session create … --prompt-file=…`).
+The worktree and the agent session are created successfully. The agent starts — and just sits there with no task.
+No error, no warning, exit code 0. The prompt is silently dropped, 100% of the time.
+
+Perceived as intermittent ("quite a few times") only because agents that happen to use the inline
+`--prompt` flag work fine. The `--prompt-file` path has never worked.
+
+## Root cause
+
+Commander converts dashed long options to **camelCase** keys on the opts object. `--prompt-file`
+is exposed as `opts.promptFile`. The code reads `opts["prompt-file"]`, which is always `undefined`.
+
+`cli/src/commands/worktree/create.ts:43-45`
+```ts
+let prompt = opts.prompt;
+if (opts["prompt-file"]) {            // ← always undefined; branch is dead
+  prompt = readFileSync(opts["prompt-file"], "utf-8");
+}
+```
+Identical bug at `cli/src/commands/session/create.ts:35-37` and — same shape, different flag —
+`cli/src/commands/mode/add.ts:39-41` (`--context-file` → `opts["context-file"]`).
+
+So with only `--prompt-file` given, `prompt` stays `undefined`. `JSON.stringify` drops undefined
+keys (`cli/src/lib/daemon-client.ts:32`), so the wire body omits `prompt` **entirely** — the daemon
+cannot distinguish this from a deliberately prompt-less request.
+
+Empirically confirmed against the repo's own commander:
+```
+opts keys: [ 'promptFile' ]
+opts['prompt-file'] = undefined
+opts.promptFile     = "/tmp/x.md"
+```
+
+The same repo already reads the camelCase form correctly for `--start-agent` at
+`cli/src/commands/project/create.ts:64` (`opts.startAgent`) — proving the convention; the file-flag
+sites just got it wrong.
+
+### Why TypeScript didn't catch it
+
+Each action handler hand-declares its own opts shape with the dashed key:
+```ts
+opts: { …; "prompt-file"?: string }
+```
+Commander's `.action()` types the callback loosely, so this fabricated annotation is accepted as-is.
+TS then happily type-checks a property access that can never exist at runtime. The type annotation
+is the thing that hides the bug.
+
+### Why it fails silently rather than erroring
+
+`prompt` is `optional()` in every daemon Zod schema (`daemon/src/routes/worktrees.ts:135`,
+`daemon/src/routes/sessions.ts:38,48`). `{prompt: undefined}` is a fully valid "spawn an agent with
+no task" request — indistinguishable from a deliberately prompt-less session. Nothing downstream can
+tell that the user asked for a prompt and lost it, so nothing complains.
+
+Two independent defects compound: a **dead read** (wrong key) and a **silent swallow** (a
+read-a-file-the-user-named failure that produces no diagnostic).
+
+## Fix
+
+1. **Correct the reads** — use the camelCase keys commander actually provides:
+   - `worktree/create.ts`: `opts.promptFile`
+   - `session/create.ts`: `opts.promptFile`
+   - `mode/add.ts`: `opts.contextFile`
+
+2. **Delete the lying type annotations** — replace the hand-written dashed-key opts interfaces with
+   camelCase ones (`promptFile?: string`, `contextFile?: string`). This is what turns the class of
+   bug from silent into compile-time-visible: the dead property access stops type-checking.
+
+3. **Add a shared `resolveFileOrInline()` helper** in `cli/src/lib/` — items 4–6 below would
+   otherwise be triplicated verbatim across three files. The helper owns: read-or-die, the
+   conflict check, and the empty-file warning. One place to get right, one place to test.
+
+4. **Fail loudly on unreadable prompt files** — `die()` with a clear message if the path is
+   missing/unreadable, instead of throwing a raw ENOENT stack. A prompt the user explicitly asked
+   for must never be dropped without a word.
+
+5. **Reject mutually-exclusive flags** — use commander's native
+   `new Option("--prompt-file <path>").conflicts("prompt")` rather than a hand-rolled `die()`.
+   It yields standard commander error output and cooperates with `exitOverride()` in tests.
+
+6. **Warn on an empty prompt file** — an empty/whitespace-only file yields an agent with no task,
+   which is the exact symptom being fixed. Warn rather than fail.
+
+## Test plan
+
+New `cli/src/__tests__/prompt-file.test.ts`, driving the real `buildProgram()` and asserting on the
+**request body actually POSTed** — the bug lives at the CLI→daemon boundary, so that is the layer
+worth pinning.
+
+### Harness (three non-obvious constraints — the naive version is actively dangerous)
+
+- **`nock` cannot be used.** It is pinned at `^13` (`cli/package.json:40`), which only patches
+  `http.ClientRequest`. Both `daemon-client.ts:29` and `preflight.ts:11` use Node's global `fetch`
+  (undici); nock 13 does not intercept it. (It is also currently an unused devDep — not the
+  established tooling my first draft implied.) Use `vi.stubGlobal("fetch", …)` instead: no new deps,
+  and it records `(url, init)` so we can assert on `JSON.parse(init.body)` directly.
+- **`VST_DAEMON_URL` must be set in the test.** Otherwise `getDaemonUrl()` (`daemon-url.ts:11-28`)
+  falls back to the developer's real `~/.vibe-station/config.json` — on a machine with a live daemon,
+  an unstubbed "test" would **create real worktrees**.
+- **`process.exit` must be stubbed.** `die()` calls it (`output.ts:35-38`), which would kill the
+  vitest worker on the failure-path tests. `program.exitOverride()` only covers commander's own
+  exits, not `die()`. Stub it with a throwing mock and assert the thrown code.
+
+### Cases
+
+- `worktree create --prompt-file=<f>` POSTs `{prompt: <file contents>}` — **fails on current code**
+- `session create --prompt-file=<f>` POSTs `{prompt: <file contents>}` — **fails on current code**
+- `mode add --context-file=<f>` POSTs `{context: <file contents>}` — **fails on current code**
+- `--prompt` inline still POSTs the inline text (no regression)
+- `--prompt` + `--prompt-file` together → exits non-zero
+- `--prompt-file` pointing at a nonexistent path → exits non-zero with a readable message
+- multi-line file contents survive verbatim (no trimming/mangling of the body)
+
+Required args or the command dies before reaching the file logic: `mode add` needs `--name`/`--cli`
+(`mode/add.ts:29-34`); `worktree create` needs `--mode`.
+
+Each of the first three must be demonstrated red against unfixed code before the fix lands —
+otherwise the test isn't pinning the bug.
+
+## Verification
+
+- `pnpm --filter @vibestation/cli test` + `pnpm typecheck` + `pnpm lint`
+- End-to-end in the docker dev sandbox (`docker-compose.dev.yml`): build the CLI, run
+  `vst worktree create --prompt-file` against the sandbox daemon, and confirm via
+  `vst session output <id>` that the agent received and acted on the file's contents.
+
+## Scope / non-goals
+
+Confined to CLI argument handling. No daemon, plugin, or tmux changes — the delivery path downstream
+of the POST is fine and is exercised daily by the working `--prompt` flag.
+
+`vst send --file` (`cli/src/commands/send.ts:27`) is **not** affected: `--file` is a single word, so
+`opts.file` is already correct. (It shares the raw-ENOENT roughness and could adopt the helper later;
+out of scope here.)
+
+Repo-wide sweep confirms no other instance of this bug class: commander is used only in `cli/`, and
+the only multi-word options in the repo are `--start-agent` (correct), `--prompt-file` ×2, and
+`--context-file`.
+
+### Deferred follow-up
+
+`@commander-js/extra-typings` would infer opts types from the `.option()` strings and delete every
+hand-written opts interface — removing the root enabler of this bug class permanently. It touches
+every command file, so it belongs in its own PR, not this fix. A custom ESLint rule was considered
+and rejected: not worth it for a CLI with four multi-word options.

--- a/cli/src/__tests__/prompt-file.test.ts
+++ b/cli/src/__tests__/prompt-file.test.ts
@@ -19,6 +19,8 @@ import { buildProgram } from "../program";
  *    CLI uses global fetch (undici). We stub fetch directly instead.
  *  - VST_DAEMON_URL must be set, or getDaemonUrl() falls back to the developer's real
  *    ~/.vibe-station/config.json and the test could hit a live daemon and create real worktrees.
+ *    (It only covers the URL: getDaemonToken() reads that config unconditionally either way.
+ *    That read is harmless — read-only, and the stubbed fetch ignores the header.)
  *  - process.exit must be stubbed: die() calls it, which would otherwise kill the vitest worker.
  */
 
@@ -131,7 +133,19 @@ describe("--prompt-file / --context-file are actually read", () => {
     await run(["worktree", "create", "proj-1", "--mode=m1", "--branch=b1", `--prompt-file=${file}`]);
 
     const post = captured.find((c) => c.url.endsWith("/worktrees"));
+    expect(post, "expected a POST to /worktrees").toBeDefined();
     expect(post!.body.prompt).toBe(contents);
+  });
+
+  it("treats a whitespace-only prompt file as no prompt, not a whitespace task", async () => {
+    // A truthy "\n" would be *submitted* as the agent's task by plugins that gate on
+    // `if (prompt.taskPrompt)`. Omitting the key takes the same path as "no prompt given".
+    const file = writePrompt("\n\n  \n");
+    await run(["worktree", "create", "proj-1", "--mode=m1", "--branch=b1", `--prompt-file=${file}`]);
+
+    const post = captured.find((c) => c.url.endsWith("/worktrees"));
+    expect(post, "expected a POST to /worktrees").toBeDefined();
+    expect(post!.body).not.toHaveProperty("prompt");
   });
 });
 
@@ -175,5 +189,25 @@ describe("failure modes are loud, not silent", () => {
     expect(code).not.toBeNull();
     expect(code).not.toBe(0);
     expect(captured.find((c) => c.url.endsWith("/worktrees"))).toBeUndefined();
+  });
+
+  it("rejects a prompt on a terminal session the daemon would discard", async () => {
+    // The daemon only consumes `prompt` for agent sessions; a terminal session would accept it
+    // and drop it — the same silent loss this PR is about.
+    const code = await run(["session", "create", "wt-1", "--type=terminal", "--prompt=hi"]);
+
+    expect(code).not.toBeNull();
+    expect(code).not.toBe(0);
+    expect(captured.find((c) => c.url.endsWith("/sessions"))).toBeUndefined();
+  });
+
+  it("rejects project create --prompt without --start-agent", async () => {
+    // Without --start-agent there is no agent to receive the prompt, and the request body
+    // would omit it silently.
+    const code = await run(["project", "create", "proj-x", "--prompt=hi"]);
+
+    expect(code).not.toBeNull();
+    expect(code).not.toBe(0);
+    expect(captured.find((c) => c.url.endsWith("/projects"))).toBeUndefined();
   });
 });

--- a/cli/src/__tests__/prompt-file.test.ts
+++ b/cli/src/__tests__/prompt-file.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildProgram } from "../program";
+
+/**
+ * Regression tests for `--prompt-file` / `--context-file`.
+ *
+ * The bug: commander camelCases dashed options (`--prompt-file` → `opts.promptFile`), but the
+ * handlers read `opts["prompt-file"]` — always undefined. The file was never read, `prompt` stayed
+ * undefined, JSON.stringify dropped the key, and the agent spawned with no task. Silently, exit 0.
+ *
+ * These assert on the request body actually POSTed, because the CLI→daemon boundary is exactly
+ * where the prompt went missing.
+ *
+ * Harness notes (each of these is load-bearing):
+ *  - `nock` cannot be used: it is pinned at ^13, which patches http.ClientRequest only, while the
+ *    CLI uses global fetch (undici). We stub fetch directly instead.
+ *  - VST_DAEMON_URL must be set, or getDaemonUrl() falls back to the developer's real
+ *    ~/.vibe-station/config.json and the test could hit a live daemon and create real worktrees.
+ *  - process.exit must be stubbed: die() calls it, which would otherwise kill the vitest worker.
+ */
+
+class ExitError extends Error {
+  constructor(public code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+interface Captured {
+  url: string;
+  body: Record<string, unknown>;
+}
+
+let captured: Captured[] = [];
+let tmpDir: string;
+
+/** Run argv through the real program, returning the exit code die()/commander produced (if any). */
+async function run(argv: string[]): Promise<number | null> {
+  const program = buildProgram();
+  program.exitOverride();
+  program.configureOutput({ writeOut: () => {}, writeErr: () => {} });
+  try {
+    await program.parseAsync(["node", "vst", ...argv]);
+    return null;
+  } catch (err) {
+    if (err instanceof ExitError) return err.code;
+    // commander's own exitOverride errors (e.g. conflicting options) carry exitCode
+    const code = (err as { exitCode?: number }).exitCode;
+    if (typeof code === "number") return code;
+    throw err;
+  }
+}
+
+beforeEach(() => {
+  captured = [];
+  tmpDir = mkdtempSync(join(tmpdir(), "vst-prompt-file-"));
+  process.env.VST_DAEMON_URL = "http://127.0.0.1:9";
+
+  vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new ExitError(code ?? 0);
+  }) as never);
+
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(console, "log").mockImplementation(() => {});
+
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string, init?: { body?: string }) => {
+      if (url.endsWith("/health")) {
+        return { ok: true, status: 200, json: async () => ({}) };
+      }
+      captured.push({
+        url,
+        body: init?.body ? (JSON.parse(init.body) as Record<string, unknown>) : {},
+      });
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ id: "wt-1", branch: "b", projectId: "p", worktreeId: "wt-1", type: "agent", name: "m" }),
+      };
+    })
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  delete process.env.VST_DAEMON_URL;
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writePrompt(contents: string): string {
+  const p = join(tmpDir, "task.md");
+  writeFileSync(p, contents);
+  return p;
+}
+
+describe("--prompt-file / --context-file are actually read", () => {
+  it("worktree create --prompt-file sends the file contents as prompt", async () => {
+    const file = writePrompt("Fix the flaky test.");
+    await run(["worktree", "create", "proj-1", "--mode=m1", "--branch=b1", `--prompt-file=${file}`]);
+
+    const post = captured.find((c) => c.url.endsWith("/worktrees"));
+    expect(post, "expected a POST to /worktrees").toBeDefined();
+    expect(post!.body.prompt).toBe("Fix the flaky test.");
+  });
+
+  it("session create --prompt-file sends the file contents as prompt", async () => {
+    const file = writePrompt("Implement the parser.");
+    await run(["session", "create", "wt-1", "--mode=m1", `--prompt-file=${file}`]);
+
+    const post = captured.find((c) => c.url.endsWith("/sessions"));
+    expect(post, "expected a POST to /sessions").toBeDefined();
+    expect(post!.body.prompt).toBe("Implement the parser.");
+  });
+
+  it("mode add --context-file sends the file contents as context", async () => {
+    const file = writePrompt("Always write tests first.");
+    await run(["mode", "add", "--name=n1", "--cli=claude", `--context-file=${file}`]);
+
+    const post = captured.find((c) => c.url.endsWith("/modes"));
+    expect(post, "expected a POST to /modes").toBeDefined();
+    expect(post!.body.context).toBe("Always write tests first.");
+  });
+
+  it("preserves multi-line prompt files verbatim", async () => {
+    const contents = "# Task\n\nLine one.\nLine two.\n";
+    const file = writePrompt(contents);
+    await run(["worktree", "create", "proj-1", "--mode=m1", "--branch=b1", `--prompt-file=${file}`]);
+
+    const post = captured.find((c) => c.url.endsWith("/worktrees"));
+    expect(post!.body.prompt).toBe(contents);
+  });
+});
+
+describe("inline --prompt still works", () => {
+  it("worktree create --prompt sends the inline text", async () => {
+    await run(["worktree", "create", "proj-1", "--mode=m1", "--branch=b1", "--prompt=inline task"]);
+
+    const post = captured.find((c) => c.url.endsWith("/worktrees"));
+    expect(post!.body.prompt).toBe("inline task");
+  });
+
+  it("omits prompt entirely when neither flag is given", async () => {
+    await run(["worktree", "create", "proj-1", "--mode=m1", "--branch=b1"]);
+
+    const post = captured.find((c) => c.url.endsWith("/worktrees"));
+    // JSON.stringify drops undefined values, so the key is absent rather than null.
+    expect(post!.body).not.toHaveProperty("prompt");
+  });
+});
+
+describe("failure modes are loud, not silent", () => {
+  it("exits non-zero when --prompt-file does not exist", async () => {
+    const code = await run([
+      "worktree", "create", "proj-1", "--mode=m1", "--branch=b1",
+      `--prompt-file=${join(tmpDir, "nope.md")}`,
+    ]);
+
+    expect(code).not.toBeNull();
+    expect(code).not.toBe(0);
+    // Must fail before contacting the daemon — never spawn an agent with a prompt we failed to read.
+    expect(captured.find((c) => c.url.endsWith("/worktrees"))).toBeUndefined();
+  });
+
+  it("rejects --prompt and --prompt-file together", async () => {
+    const file = writePrompt("from file");
+    const code = await run([
+      "worktree", "create", "proj-1", "--mode=m1", "--branch=b1",
+      "--prompt=inline", `--prompt-file=${file}`,
+    ]);
+
+    expect(code).not.toBeNull();
+    expect(code).not.toBe(0);
+    expect(captured.find((c) => c.url.endsWith("/worktrees"))).toBeUndefined();
+  });
+});

--- a/cli/src/commands/mode/add.ts
+++ b/cli/src/commands/mode/add.ts
@@ -1,7 +1,7 @@
 import { Command, Option } from "commander";
 import { daemonPost } from "../../lib/daemon-client.js";
 import { preflight } from "../../lib/preflight.js";
-import { resolveFileOrInline } from "../../lib/prompt-source.js";
+import { resolveFileOrInline } from "../../lib/text-source.js";
 import { die, success } from "../../lib/output.js";
 
 interface ModeCreateResponse {

--- a/cli/src/commands/mode/add.ts
+++ b/cli/src/commands/mode/add.ts
@@ -1,7 +1,7 @@
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { daemonPost } from "../../lib/daemon-client.js";
 import { preflight } from "../../lib/preflight.js";
-import { readFileSync } from "fs";
+import { resolveFileOrInline } from "../../lib/prompt-source.js";
 import { die, success } from "../../lib/output.js";
 
 interface ModeCreateResponse {
@@ -16,14 +16,18 @@ export function registerModeAdd(mode: Command): void {
     .option("--name <name>", "Mode name (required)", "")
     .option("--cli <cmd>", "CLI command (required)", "")
     .option("--context <text>", "Context text")
-    .option("--context-file <path>", "Read context from file")
+    .addOption(
+      new Option("--context-file <path>", "Read context from file").conflicts("context")
+    )
     .option("--preset <preset>", "Preset name")
     .action(
+      // Keys must match commander's camelCased option names (--context-file → contextFile).
+      // Spelling them with dashes here type-checks but reads a property that never exists.
       async (opts: {
         name: string;
         cli: string;
         context?: string;
-        "context-file"?: string;
+        contextFile?: string;
         preset?: string;
       }) => {
         if (!opts.name) {
@@ -33,12 +37,9 @@ export function registerModeAdd(mode: Command): void {
           die("--cli is required", 1);
         }
 
-        await preflight();
+        const context = resolveFileOrInline(opts.context, opts.contextFile, "--context-file");
 
-        let context = opts.context;
-        if (opts["context-file"]) {
-          context = readFileSync(opts["context-file"], "utf-8");
-        }
+        await preflight();
 
         const result = await daemonPost<ModeCreateResponse>("/modes", {
           name: opts.name,

--- a/cli/src/commands/project/create.ts
+++ b/cli/src/commands/project/create.ts
@@ -58,12 +58,17 @@ export function registerProjectCreate(project: Command): void {
     .option("--prompt <text>", "Initial prompt for the agent")
     .option("--worktree", "Use worktree isolation (creates branch + worktree)")
     .action(async (name: string, opts: CreateProjectOptions) => {
-      await preflight();
-
       // Validate options
       if (opts.startAgent && !opts.mode) {
         die("--mode is required when using --start-agent", 1);
       }
+      // Without --start-agent there is no agent to give the prompt to, and the body below would
+      // drop it silently — the same invisible failure as the --prompt-file bug. Say so instead.
+      if (opts.prompt && !opts.startAgent) {
+        die("--prompt requires --start-agent (there is no agent to receive it otherwise)", 1);
+      }
+
+      await preflight();
 
       // Resolve dir if provided (relative to cwd)
       let dir: string | undefined;

--- a/cli/src/commands/session/create.ts
+++ b/cli/src/commands/session/create.ts
@@ -1,7 +1,7 @@
 import { Command, Option } from "commander";
 import { daemonPost } from "../../lib/daemon-client.js";
 import { preflight } from "../../lib/preflight.js";
-import { resolveFileOrInline } from "../../lib/prompt-source.js";
+import { resolveFileOrInline } from "../../lib/text-source.js";
 import { die } from "../../lib/output.js";
 import ora from "ora";
 
@@ -33,6 +33,13 @@ export function registerSessionCreate(session: Command): void {
           promptFile?: string;
         }
       ) => {
+        // The daemon only consumes `prompt` for agent sessions (routes/sessions.ts:420) — a
+        // terminal session would accept it over the wire and drop it on the floor. Same silent
+        // loss as the --prompt-file bug, so refuse it up front.
+        if ((opts.prompt || opts.promptFile) && opts.type !== "agent") {
+          die(`--prompt/--prompt-file only apply to --type=agent (got --type=${opts.type})`, 1);
+        }
+
         const prompt = resolveFileOrInline(opts.prompt, opts.promptFile, "--prompt-file");
 
         await preflight();

--- a/cli/src/commands/session/create.ts
+++ b/cli/src/commands/session/create.ts
@@ -1,7 +1,7 @@
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { daemonPost } from "../../lib/daemon-client.js";
 import { preflight } from "../../lib/preflight.js";
-import { readFileSync } from "fs";
+import { resolveFileOrInline } from "../../lib/prompt-source.js";
 import { die } from "../../lib/output.js";
 import ora from "ora";
 
@@ -18,23 +18,24 @@ export function registerSessionCreate(session: Command): void {
     .option("--type <type>", "Session type (agent|terminal)", "agent")
     .option("--mode <id>", "Mode ID")
     .option("--prompt <text>", "Initial prompt")
-    .option("--prompt-file <path>", "Read prompt from file")
+    .addOption(
+      new Option("--prompt-file <path>", "Read prompt from file").conflicts("prompt")
+    )
     .action(
       async (
         worktreeId: string,
+        // Keys must match commander's camelCased option names (--prompt-file → promptFile).
+        // Spelling them with dashes here type-checks but reads a property that never exists.
         opts: {
           type: string;
           mode?: string;
           prompt?: string;
-          "prompt-file"?: string;
+          promptFile?: string;
         }
       ) => {
-        await preflight();
+        const prompt = resolveFileOrInline(opts.prompt, opts.promptFile, "--prompt-file");
 
-        let prompt = opts.prompt;
-        if (opts["prompt-file"]) {
-          prompt = readFileSync(opts["prompt-file"], "utf-8");
-        }
+        await preflight();
 
         const spinner = ora("Creating session...").start();
 

--- a/cli/src/commands/worktree/create.ts
+++ b/cli/src/commands/worktree/create.ts
@@ -1,7 +1,7 @@
 import { Command, Option } from "commander";
 import { daemonPost } from "../../lib/daemon-client.js";
 import { preflight } from "../../lib/preflight.js";
-import { resolveFileOrInline } from "../../lib/prompt-source.js";
+import { resolveFileOrInline } from "../../lib/text-source.js";
 import { die } from "../../lib/output.js";
 import ora from "ora";
 

--- a/cli/src/commands/worktree/create.ts
+++ b/cli/src/commands/worktree/create.ts
@@ -1,7 +1,7 @@
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { daemonPost } from "../../lib/daemon-client.js";
 import { preflight } from "../../lib/preflight.js";
-import { readFileSync } from "fs";
+import { resolveFileOrInline } from "../../lib/prompt-source.js";
 import { die } from "../../lib/output.js";
 import ora from "ora";
 
@@ -20,29 +20,30 @@ export function registerWorktreeCreate(worktree: Command): void {
     .option("--base <branch>", "Base branch")
     .option("--branch <name>", "New branch name")
     .option("--prompt <text>", "Initial prompt")
-    .option("--prompt-file <path>", "Read prompt from file")
+    .addOption(
+      new Option("--prompt-file <path>", "Read prompt from file").conflicts("prompt")
+    )
     .action(
       async (
         projectId: string,
+        // Keys must match commander's camelCased option names (--prompt-file → promptFile).
+        // Spelling them with dashes here type-checks but reads a property that never exists.
         opts: {
           mode: string;
           name?: string;
           base?: string;
           branch?: string;
           prompt?: string;
-          "prompt-file"?: string;
+          promptFile?: string;
         }
       ) => {
         if (!opts.mode) {
           die("--mode is required", 1);
         }
 
-        await preflight();
+        const prompt = resolveFileOrInline(opts.prompt, opts.promptFile, "--prompt-file");
 
-        let prompt = opts.prompt;
-        if (opts["prompt-file"]) {
-          prompt = readFileSync(opts["prompt-file"], "utf-8");
-        }
+        await preflight();
 
         const spinner = ora("Creating worktree...").start();
 

--- a/cli/src/lib/prompt-source.ts
+++ b/cli/src/lib/prompt-source.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "fs";
+import { die, warn } from "./output.js";
+
+/**
+ * Resolve a text value supplied either inline or via a file path.
+ *
+ * Used by the `--prompt` / `--prompt-file` and `--context` / `--context-file` flag pairs.
+ *
+ * Reading the file is deliberately fail-loud: a prompt the caller explicitly asked for must never
+ * be silently dropped. Dropping it produces an agent that spawns fine and then sits with no task —
+ * a failure that is invisible at the CLI (exit 0) and indistinguishable, at the daemon, from a
+ * deliberately prompt-less session. That silence is what made the original `--prompt-file` bug
+ * survive so long.
+ *
+ * Mutual exclusion of the two flags is enforced declaratively by commander via
+ * `Option.conflicts()` at each call site, so it is not re-checked here.
+ *
+ * @param inline    value from the inline flag (e.g. `--prompt`)
+ * @param filePath  value from the file flag (e.g. `--prompt-file`)
+ * @param fileFlag  the file flag's name, for error messages (e.g. `--prompt-file`)
+ * @returns the resolved text, or undefined when neither flag was supplied
+ */
+export function resolveFileOrInline(
+  inline: string | undefined,
+  filePath: string | undefined,
+  fileFlag: string
+): string | undefined {
+  if (!filePath) return inline;
+
+  let contents: string;
+  try {
+    contents = readFileSync(filePath, "utf-8");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return die(`Cannot read ${fileFlag} ${filePath}: ${message}`, 1);
+  }
+
+  // An empty file yields an agent with no task — the exact symptom this flag's bug produced.
+  // Warn rather than fail: it is unambiguously not what the caller intended, but it is their call.
+  if (contents.trim() === "") {
+    warn(`${fileFlag} ${filePath} is empty — the agent will start with no task.`);
+  }
+
+  return contents;
+}

--- a/cli/src/lib/text-source.ts
+++ b/cli/src/lib/text-source.ts
@@ -35,10 +35,15 @@ export function resolveFileOrInline(
     return die(`Cannot read ${fileFlag} ${filePath}: ${message}`, 1);
   }
 
-  // An empty file yields an agent with no task — the exact symptom this flag's bug produced.
-  // Warn rather than fail: it is unambiguously not what the caller intended, but it is their call.
+  // Collapse a whitespace-only file to undefined rather than passing it through. A truthy "\n"
+  // is worse than nothing: plugins gate on `if (prompt.taskPrompt)` (agent-plugins/claude.ts:86),
+  // so whitespace would be *submitted* as the agent's task. Returning undefined takes the same
+  // path as "no prompt given" — which is what the warning below actually promises.
+  // Warn rather than fail: an empty file is unambiguously not what the caller intended, but it
+  // is not our call to block on.
   if (contents.trim() === "") {
     warn(`${fileFlag} ${filePath} is empty — the agent will start with no task.`);
+    return undefined;
   }
 
   return contents;

--- a/scripts/smoke-prompt-file-docker.sh
+++ b/scripts/smoke-prompt-file-docker.sh
@@ -31,14 +31,33 @@ Second line of the prompt file, to prove multi-line survives.
 EOF
 
 echo "== Install stub gemini that echoes its argv"
-cat > /usr/local/bin/gemini <<'STUB'
+# Container-only. Guard against clobbering a real binary: docker-compose.dev.yml mounts genuine
+# CLIs into /usr/local/bin, and this script must never overwrite one (see demo-seed.sh's
+# `if [ ! -x ... ]` precedent). We stash any existing gemini and restore it on exit.
+STUB_PATH=/usr/local/bin/gemini
+STUB_BACKUP=""
+if [[ -e "$STUB_PATH" ]]; then
+  STUB_BACKUP="${STUB_PATH}.smoke-backup.$$"
+  mv "$STUB_PATH" "$STUB_BACKUP"
+fi
+restore_stub() {
+  rm -f "$STUB_PATH"
+  [[ -n "$STUB_BACKUP" && -e "$STUB_BACKUP" ]] && mv "$STUB_BACKUP" "$STUB_PATH"
+  return 0
+}
+trap restore_stub EXIT
+
+cat > "$STUB_PATH" <<'STUB'
 #!/usr/bin/env bash
 # Stub gemini: print argv so the task prompt delivered by the daemon is observable.
+# The ╭ line is gemini.ts's getReadySignal() sentinel — without it every spawn burns the
+# full 10s fallback timeout (mirrors scripts/fake-gemini.sh).
 echo "STUB-GEMINI-ARGV: $*"
+echo "╭─ Fake Gemini CLI ─╮"
 echo "Ready."
 cat
 STUB
-chmod +x /usr/local/bin/gemini
+chmod +x "$STUB_PATH"
 
 echo "== Wait for daemon"
 until curl -sf "$BASE/health" >/dev/null 2>&1; do sleep 0.5; done

--- a/scripts/smoke-prompt-file-docker.sh
+++ b/scripts/smoke-prompt-file-docker.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# E2E: prove `vst worktree create --prompt-file` actually delivers the prompt to the agent.
+#
+# Runs INSIDE the dev sandbox container:
+#   docker compose -f docker-compose.dev.yml up --build -d
+#   docker compose -f docker-compose.dev.yml exec -T vst-dev bash /app/scripts/smoke-prompt-file-docker.sh
+#
+# Why gemini: its plugin uses promptDelivery:"inline" and passes the task prompt as
+# `-i <prompt>` in argv (daemon/src/agent-plugins/gemini.ts). We install a stub `gemini`
+# that echoes its own argv into the pane, so the prompt text reaching the agent process is
+# directly observable via the session-output API. That exercises the real path end to end:
+#   CLI --prompt-file → POST /worktrees → promptBuilder → spawn → agent argv.
+set -euo pipefail
+
+BASE="${VST_SMOKE_URL:-http://127.0.0.1:7421}"
+VST="node /app/cli/dist/main.js"
+export VST_DAEMON_URL="$BASE"
+
+need_bin() { command -v "$1" >/dev/null 2>&1 || { echo "missing dependency: $1" >&2; exit 1; }; }
+need_bin curl
+need_bin jq
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# A prompt distinctive enough that it cannot collide with incidental pane text.
+MARKER="VSTPROMPTFILE-$$-$(head -c8 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+PROMPT_FILE="/tmp/task-${MARKER}.md"
+cat > "$PROMPT_FILE" <<EOF
+${MARKER}
+Second line of the prompt file, to prove multi-line survives.
+EOF
+
+echo "== Install stub gemini that echoes its argv"
+cat > /usr/local/bin/gemini <<'STUB'
+#!/usr/bin/env bash
+# Stub gemini: print argv so the task prompt delivered by the daemon is observable.
+echo "STUB-GEMINI-ARGV: $*"
+echo "Ready."
+cat
+STUB
+chmod +x /usr/local/bin/gemini
+
+echo "== Wait for daemon"
+until curl -sf "$BASE/health" >/dev/null 2>&1; do sleep 0.5; done
+
+echo "== Create gemini mode"
+MID="$(curl -sf -X POST "$BASE/modes" -H 'Content-Type: application/json' \
+  -d "$(jq -nc --arg n "promptfile-smoke-$$" '{name:$n,cli:"gemini",context:"Smoke."}')" | jq -r .id)"
+[[ -n "$MID" && "$MID" != "null" ]] || fail "could not create mode"
+
+echo "== Seed a git repo to host the worktree (worktrees require git)"
+REPO="${VST_SMOKE_REPO:-/home/vst/projects/promptfile-smoke}"
+if [[ ! -d "$REPO/.git" ]]; then
+  mkdir -p "$REPO"
+  git -C "$REPO" init -q -b main
+  git -C "$REPO" config user.email smoke@example.com
+  git -C "$REPO" config user.name "Smoke Test"
+  echo "# promptfile smoke repo" > "$REPO/README.md"
+  git -C "$REPO" add -A
+  git -C "$REPO" commit -qm "init"
+fi
+
+echo "== Resolve project id for $REPO"
+PID="$(curl -sf "$BASE/projects" | jq -r --arg p "$REPO" '(first(.[] | select(.path == $p)) // empty).id')"
+if [[ -z "$PID" || "$PID" == "null" ]]; then
+  PID="$(curl -sf -X POST "$BASE/projects" -H 'Content-Type: application/json' \
+    -d "$(jq -nc --arg p "$REPO" '{path:$p}')" | jq -r .id)"
+fi
+[[ -n "$PID" && "$PID" != "null" ]] || fail "could not resolve project"
+
+BRANCH="smoke/prompt-file-$$"
+echo "== vst worktree create --prompt-file=$PROMPT_FILE"
+OUT="$($VST worktree create "$PID" --mode="$MID" --branch="$BRANCH" --prompt-file="$PROMPT_FILE" 2>&1)" \
+  || fail "worktree create exited non-zero:\n$OUT"
+echo "$OUT"
+WTID="$(echo "$OUT" | tail -1 | tr -d '[:space:]')"
+[[ -n "$WTID" ]] || fail "no worktree id returned"
+
+echo "== Find main agent session"
+SID=""
+for _ in $(seq 1 60); do
+  SID="$(curl -sf "$BASE/sessions?worktree=${WTID}" | jq -r '(.[] | select(.slot=="m") | .id) // empty' | head -1)"
+  [[ -n "$SID" ]] && break
+  sleep 0.5
+done
+[[ -n "$SID" ]] || fail "main session never appeared for worktree $WTID"
+
+echo "== Assert the prompt-file contents reached the agent process (session $SID)"
+for _ in $(seq 1 60); do
+  PANE="$($VST session output "$SID" --lines=200 2>/dev/null || true)"
+  if grep -q "$MARKER" <<<"$PANE"; then
+    echo "PASS: prompt-file contents delivered to agent argv"
+    grep -o "STUB-GEMINI-ARGV.*" <<<"$PANE" | head -1 || true
+    exit 0
+  fi
+  sleep 0.5
+done
+
+echo "---- last pane output ----" >&2
+$VST session output "$SID" --lines=200 >&2 || true
+fail "marker '$MARKER' never reached the agent — prompt-file was dropped"


### PR DESCRIPTION
## The bug

`vst worktree create --prompt-file=./task.md` creates the worktree, spawns the agent — and the agent sits there with no task. Exit code 0, no error, no warning.

**`--prompt-file` has never worked, in any command.** It looked intermittent only because inline `--prompt` works fine, so failures tracked which flag the calling agent happened to reach for.

## Root cause

Commander camelCases dashed long options: `--prompt-file` is exposed as `opts.promptFile`. Every file-flag call site read `opts["prompt-file"]` — a key that cannot exist.

```ts
let prompt = opts.prompt;
if (opts["prompt-file"]) {            // ← always undefined; branch is dead
  prompt = readFileSync(opts["prompt-file"], "utf-8");
}
```

The file was never read, `prompt` stayed `undefined`, `JSON.stringify` dropped the key, and the daemon — where `prompt` is `z.string().optional()` — received a request indistinguishable from a deliberately prompt-less one. It spawned a perfectly healthy agent with no task.

The same repo already reads `opts.startAgent` correctly for `--start-agent`, proving the convention; the file flags just got it wrong.

**Two things kept it alive.** The hand-written opts interfaces declared `"prompt-file"?: string`, so TypeScript type-checked a property access that can never exist — *the annotation was the camouflage*. And nothing downstream could tell a lost prompt from an intentional one, so nothing complained.

## Fix

- Read the camelCase keys commander actually provides (`worktree create`, `session create`, `mode add --context-file`)
- Replace the fabricated dashed-key interfaces with camelCase ones
- New `resolveFileOrInline()` (`cli/src/lib/text-source.ts`): read-or-die, plus empty-file handling. Resolution runs **before** `preflight()`, so a bad path fails instantly instead of after a daemon round-trip
- `--prompt-file`/`--context-file` declared mutually exclusive with their inline counterparts via commander's native `Option.conflicts()`

### Sibling silent-drops closed at the same time

Same symptom, different mechanism — found in review, so they belong here:

- `project create --prompt` **without** `--start-agent` silently discarded the prompt. The inverse was already guarded, so this was an asymmetry, not a design.
- `session create --type=terminal --prompt…` POSTed a prompt the daemon only consumes for agent sessions.

Both now `die()`.

## Verification

**Unit** (`cli/src/__tests__/prompt-file.test.ts`) — asserts on the request body actually POSTed, since that's exactly where the prompt went missing. **Confirmed red against the unfixed code** (6/8 fail with `expected undefined to be 'Fix the flaky test.'`), green after. 242 tests pass.

Three harness constraints, each load-bearing — the naive version is actively dangerous:
- `nock` **cannot** be used: pinned at `^13`, which patches `http.ClientRequest` only, while the CLI uses global `fetch` (undici). It was also an unused devDep. `fetch` is stubbed instead.
- `VST_DAEMON_URL` must be set, or `getDaemonUrl()` falls back to the developer's real `~/.vibe-station/config.json` — an unstubbed test would **create real worktrees on a machine with a live daemon**.
- `process.exit` must be stubbed: `die()` calls it and would kill the vitest worker.

**Docker E2E** (`scripts/smoke-prompt-file-docker.sh`) — drives the real CLI → daemon → spawn path against a stub `gemini` that echoes its argv. The negative control reproduces the reported symptom exactly:

| | result |
|---|---|
| unfixed | worktree created, agent spawned, argv `--yolo --skip-trust --session-id …` — **no `-i` flag** |
| fixed | prompt delivered to agent argv |

Typecheck and lint clean (the 4 pre-existing `no-control-regex` errors in `web-ui` are unchanged on a clean tree).

## Notes for the reviewer

- **No compile-time protection was gained, despite appearances.** Commander types `.action()` as `(...args: any[])`, so the opts annotation is never checked against the `.option()` strings — a typo'd `promptFyle` would compile just as cleanly as the original. An earlier draft of the plan claimed otherwise; the claim is corrected in the plan rather than shipped. The regression test is the only real guard. The structural fix (`@commander-js/extra-typings`, which would delete every hand-written opts interface) is deliberately deferred to its own PR.
- A repo-wide sweep found no other camelCase instances: the only multi-word options are `--start-agent` (already correct), `--prompt-file` ×2, `--context-file`.
- `vst send --file` is unaffected (`--file` is a single word).
- Scope: CLI argument handling only. The delivery path downstream of the POST is sound and is exercised daily by the working `--prompt` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)