### PR TITLE
fix(sessions): preserve agent high-water on delete (legacy worktrees restart at a1)

### DIFF
--- a/daemon/src/__tests__/sessionId.test.ts
+++ b/daemon/src/__tests__/sessionId.test.ts
@@ -201,3 +201,39 @@ describe("reserveNextAgentSlot", () => {
     expect(reserveNextAgentSlot(wt)).toBe("a1");
   });
 });
+
+describe("agentHighWaterMark", () => {
+  const wtWith = (agentSeq: number | undefined, aNums: number[]): WorktreeRecord => ({
+    ...makeWorktree("vs-1"),
+    ...(agentSeq != null ? { agentSeq } : {}),
+    sessions: aNums.map((n) => ({
+      id: `vs-1-a${n}`,
+      slot: `a${n}` as const,
+      type: "agent" as const,
+      tmuxName: `vr-vs-1-a${n}`,
+      useTmux: true,
+      lifecycle: { state: "working" as const, lastTransitionAt: new Date().toISOString() },
+    })),
+  });
+
+  it("is 0 for a fresh worktree", async () => {
+    const { agentHighWaterMark } = await import("../services/sessionId.js");
+    expect(agentHighWaterMark(wtWith(undefined, []))).toBe(0);
+  });
+
+  it("falls back to live slots when agentSeq is unset (legacy worktree)", async () => {
+    const { agentHighWaterMark } = await import("../services/sessionId.js");
+    expect(agentHighWaterMark(wtWith(undefined, [1, 2, 3]))).toBe(3);
+  });
+
+  it("prefers the persisted counter when it is higher than live slots", async () => {
+    const { agentHighWaterMark } = await import("../services/sessionId.js");
+    // agentSeq=5 survives after a1/a2 were the only ones left, then deleted.
+    expect(agentHighWaterMark(wtWith(5, [1, 2]))).toBe(5);
+  });
+
+  it("prefers live slots when the counter is stale/lower", async () => {
+    const { agentHighWaterMark } = await import("../services/sessionId.js");
+    expect(agentHighWaterMark(wtWith(2, [3, 4, 5]))).toBe(5);
+  });
+});

--- a/daemon/src/__tests__/sessions.test.ts
+++ b/daemon/src/__tests__/sessions.test.ts
@@ -309,4 +309,36 @@ describe("Session routes", () => {
     expect(second.slot).toBe("a2");
     expect(second.id).not.toBe(first.id);
   });
+
+  it("legacy worktree: deleting ALL agents does not restart the next one at a1", async () => {
+    const create = () =>
+      app.inject({
+        method: "POST",
+        url: "/sessions",
+        payload: { worktreeId, type: "agent", modeId: "bugfix" },
+      });
+
+    // Create a1 and a2, then simulate a LEGACY worktree by stripping agentSeq —
+    // as if these agents predated the monotonic-slot counter.
+    const a1 = (await create()).json<SessionRecord>();
+    const a2 = (await create()).json<SessionRecord>();
+    expect([a1.slot, a2.slot]).toEqual(["a1", "a2"]);
+
+    const { mutateProject } = await import("../state/project-store.js");
+    await mutateProject(projectId, (p) => ({
+      ...p,
+      worktrees: p.worktrees.map((w) =>
+        w.id === worktreeId ? { ...w, agentSeq: undefined } : w,
+      ),
+    }));
+
+    // Delete every agent BEFORE creating a new one — the reported failure mode.
+    expect((await app.inject({ method: "DELETE", url: `/sessions/${a1.id}` })).statusCode).toBe(200);
+    expect((await app.inject({ method: "DELETE", url: `/sessions/${a2.id}` })).statusCode).toBe(200);
+
+    // The delete handler captured the high-water, so the next slot is a3 — not a1.
+    const next = (await create()).json<SessionRecord>();
+    expect(next.slot).toBe("a3");
+    expect(next.id).toBe(`${worktreeId}-a3`);
+  });
 });

--- a/daemon/src/routes/sessions.ts
+++ b/daemon/src/routes/sessions.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { getAllProjects, getProject, mutateProject } from "../state/project-store.js";
 import {
   reserveNextAgentSlot,
+  agentHighWaterMark,
   reserveNextTerminalSlot,
   reserveNextDirectSlot,
   buildTmuxName,
@@ -688,12 +689,22 @@ export function registerSessionRoutes(app: FastifyInstance): void {
     if (ctx.kind === "worktree") {
       // Worktree session: cleanup worktree-scoped data dir
       cleanupSessionDataDir(project.id, ctx.worktree.id, id);
-      // Remove from worktree's sessions array
+      // Remove from worktree's sessions array, preserving the monotonic agent
+      // high-water. `agentSeq` is otherwise only written on agent CREATE, so a
+      // legacy worktree (agents created before agentSeq existed) that has all
+      // its agents deleted would lose the high-water and restart at a1. Capture
+      // it here — max over every current agent slot number (including the one
+      // being removed) — so a deleted slot is never reused.
       await mutateProject(project.id, (p) => ({
         ...p,
         worktrees: p.worktrees.map((w) =>
           w.id === ctx.worktree.id
-            ? { ...w, sessions: w.sessions.filter((s) => s.id !== id) }
+            ? {
+                ...w,
+                // Capture the high-water BEFORE filtering out the session.
+                agentSeq: agentHighWaterMark(w),
+                sessions: w.sessions.filter((s) => s.id !== id),
+              }
             : w,
         ),
       }));

--- a/daemon/src/services/sessionId.ts
+++ b/daemon/src/services/sessionId.ts
@@ -41,29 +41,40 @@ export function reserveNextWorktreeNum(project: ProjectRecord): number {
 }
 
 /**
+ * Highest agent slot number ever assigned in a worktree — the monotonic
+ * high-water mark for `a{n}` slots.
+ *
+ * Returns `max(worktree.agentSeq ?? 0, ...current agent slot numbers)`. Taking
+ * the max of BOTH the persisted counter and the live slots (rather than trusting
+ * `agentSeq` alone) matters for two cases:
+ *   - Legacy worktrees whose agents predate `agentSeq`: the counter is unset, so
+ *     the live slots supply the mark.
+ *   - A stale/hand-edited counter lower than a live slot: the live slots win, so
+ *     we never hand out a colliding, already-in-use number.
+ * The `Number.isFinite` filter is REQUIRED so a non-numeric slot can't poison
+ * the result to NaN.
+ *
+ * Callers persist this (or `+1`) back to `agentSeq` so the mark survives even
+ * after every agent is deleted.
+ */
+export function agentHighWaterMark(worktree: WorktreeRecord): number {
+  const existing = worktree.sessions
+    .filter((s) => typeof s.slot === "string" && (s.slot as string).startsWith("a"))
+    .map((s) => parseInt((s.slot as string).slice(1), 10))
+    .filter(Number.isFinite);
+  return Math.max(worktree.agentSeq ?? 0, 0, ...existing);
+}
+
+/**
  * Reserve the next agent slot (a{n}) for a worktree — monotonic, never reused.
- *
- * Uses the persisted high-water counter `worktree.agentSeq`. Legacy worktrees
- * (no counter yet) lazily seed from `max(existing agent slot nums)`. The
- * `Number.isFinite` filter is REQUIRED so a non-numeric slot can't poison the
- * counter to NaN. A deleted agent's number is never recycled.
- *
- * We take `max(agentSeq, maxExisting)` rather than trusting `agentSeq` alone:
- * if a manifest ever carried a counter lower than a live `a{n}` slot (hand-edit,
- * or a future writer that appends without bumping it), trusting the counter
- * would hand out a colliding, already-in-use slot. The `max` guarantees the
- * result is always strictly greater than every existing slot number.
+ * Returns one past the high-water mark; a deleted agent's number is never
+ * recycled.
  *
  * Pure: the caller MUST persist the returned number as `agentSeq` in the same
  * `mutateProject` update that appends the session record.
  */
 export function reserveNextAgentSlot(worktree: WorktreeRecord): `a${number}` {
-  const existing = worktree.sessions
-    .filter((s) => typeof s.slot === "string" && (s.slot as string).startsWith("a"))
-    .map((s) => parseInt((s.slot as string).slice(1), 10))
-    .filter(Number.isFinite);
-  const seed = Math.max(0, ...existing);
-  const n = Math.max(worktree.agentSeq ?? 0, seed) + 1;
+  const n = agentHighWaterMark(worktree) + 1;
   return `a${n}`;
 }
 


### PR DESCRIPTION
## Problem

Follow-up to #30 (monotonic agent slots). That change made agent slots monotonic via a per-worktree `agentSeq` high-water counter — but the counter was only written on agent **create**.

A **legacy worktree** (agents created before `agentSeq` existed, so the field is unset) that has **all its agents deleted before a new one is created** loses the high-water mark: deletion never recorded it, and the create-time seed reads *current* slots, which are now empty → it collapses to `0` and the next agent restarts at `a1` with a reused id.

Reproduced on a real instance: `unl-34` had 6 agents (pre-fix), all deleted, then a new agent came back as `unl-34-a1`.

New worktrees created since #30 are unaffected — they get `agentSeq` written on every create and it survives deletion.

## Fix

Capture the high-water in the **DELETE** handler: when removing an agent, persist
`agentSeq = max(agentSeq ?? 0, highest current agent-slot number)` **before** filtering the session out. So deleting `a6…a1` records `agentSeq = 6`, and the next create is `a7` — for legacy worktrees too.

- Extracted the shared logic as `agentHighWaterMark(worktree)` in `sessionId.ts`; both `reserveNextAgentSlot()` and the delete path now use it (single source of truth).
- Scope unchanged: agents in worktrees only; terminals/direct sessions untouched.

## Tests

- Unit (`sessionId.test.ts`) — `agentHighWaterMark`: fresh → 0; legacy (unset counter) falls back to live slots; persisted counter wins when higher; live slots win when the counter is stale/lower.
- Integration (`sessions.test.ts`) — legacy worktree: create a1/a2, strip `agentSeq`, delete **both**, then create → asserts `a3` (fails at `a1` without this fix).
- Full affected suite green: 32 tests (sessionId 16, sessions 16).

## Note

This prevents recurrence everywhere going forward. It cannot retroactively restore a worktree (like `unl-34`) whose slots were already deleted before this shipped — that one is now correctly monotonic, just continuing from its current number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
