### PR TITLE
fix(terminal): make macOS Option key act as Alt so shortcuts reach the CLI

### DIFF
--- a/web-ui/src/components/layout/TerminalPane.tsx
+++ b/web-ui/src/components/layout/TerminalPane.tsx
@@ -128,6 +128,12 @@ export function TerminalPane({ api, sessionId, session, channelToggle }: Termina
       lineHeight: 1.2,
       scrollback: 10000,
       allowProposedApi: true,
+      // On macOS the Option key is not a true Alt/Meta key by default — the OS
+      // composes special characters (e.g. Option+P -> "π") before xterm.js can
+      // encode it as an ESC-prefixed escape sequence. Without this, Alt/Option
+      // shortcuts inside the PTY (e.g. Claude Code's Alt+P model selector)
+      // never reach the CLI. No-op on non-Mac platforms.
+      macOptionIsMeta: true,
       theme: {
         background: "#0f0f0f",
         foreground: "#e5e5e5",


### PR DESCRIPTION
## Summary
- xterm.js's `macOptionIsMeta` defaults to `false`, so on macOS the OS composes Option+key into a special character (e.g. Option+P → "π") before xterm can encode it as an ESC-prefixed escape sequence.
- This silently ate Alt/Option shortcuts inside the PTY session, including Claude Code's Alt+P model-selector shortcut, which simply did nothing on Mac.
- Setting `macOptionIsMeta: true` on the `Terminal` instance in `TerminalPane.tsx` fixes it; xterm.js only applies the option on macOS, so it's a no-op on Windows/Linux.

## Test plan
- [ ] On macOS, open a terminal session with Claude Code running and press Option+P — the model selector should open.
- [ ] Verify Option-key composed characters are no longer needed/expected for terminal input on Mac (no regression for anyone relying on accented-character composition inside the terminal).
- [ ] Confirm no behavior change on Windows/Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)