### PR TITLE
fix(sessions): mark-as-done truly releases tmux/pty/Rich-Chat resources

### DIFF
--- a/.feature-plans/done/done-releases-resources/plan-done-releases-resources.md
+++ b/.feature-plans/done/done-releases-resources/plan-done-releases-resources.md
@@ -1,0 +1,531 @@
+<!--
+RULES — read before writing or implementing:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. REQUIREMENTS: One crisp line each — no verbose descriptions
+3. CHECKLIST: Mark items [x] as you complete them — this is your persistent todo list
+4. READING TIME: Optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+# Mini-Design: Mark-as-done releases all session resources
+
+> `POST /sessions/:id/done` and `POST /worktrees/:id/done` must kill the tmux pane / direct-PTY / `JsonAgentSession` instead of only writing a label — while keeping the session fully resumable.
+
+**Issue:** done-releases-resources
+**Branch:** `marking-as-done-resources`
+**Status:** Done
+**PRD:** — (small feature, no PRD)
+**Parent design:** —
+**Reviewed:** yes — subagent review folded in (P0 items 1-5 below are review findings, not speculation)
+
+**Reference files:**
+- Done routes: `daemon/src/routes/sessions.ts:778-795`, `daemon/src/routes/worktrees.ts:543-556`
+- Existing teardown (reference impl): `daemon/src/routes/sessions.ts:669-687`, `daemon/src/routes/worktrees.ts:570-593`
+- tmux: `daemon/src/services/tmux.ts:27` (`killSession`)
+- JSON agent: `daemon/src/services/jsonAgent.ts:375` (`settled`), `:386` (`abortAndDrain`), `:410` (`dispose`), `:708` (drain's `persistLifecycle("idle")`), `:907` (`persist`); registry `daemon/src/state/jsonAgentRegistry.ts:15`
+- Lifecycle: `daemon/src/services/lifecycle.ts:60` (`clearIdleTracking`), `:188` (poller skips `done`), `:261` (`markSessionExited` guard)
+- Resume: `daemon/src/routes/sessions.ts:798-984`
+- UI banner: `web-ui/src/components/layout/TerminalPane.tsx:388,395`, `web-ui/src/components/layout/AgentPaneSlot.tsx:38`
+- Chat attach: `daemon/src/ws/handlers/chatOpen.ts:50-76`; disk meta reader `daemon/src/services/jsonAgentChat.ts:252-281` (`readSessionMeta`)
+
+---
+
+## Problem
+
+- `POST /sessions/:id/done` (`daemon/src/routes/sessions.ts:778-795`) is documented "metadata only; no process kill" — it writes `lifecycle.state = "done"` and nothing else.
+- Every resource survives: tmux pane (agent CLI process tree), direct-PTY child, `JsonAgentSession` (SQLite WAL fds ×3, `JsonAgentStream` listeners, in-flight turn process group).
+- No reaper exists (`daemon/src` has no `reaper|maxIdle|staleAfter|gc(`), so a done session leaks until an explicit `DELETE`.
+- Users mark many sessions done per day → dozens of idle `claude`/`cursor` process trees held in RAM.
+
+## Out of Scope
+
+- Auto-reaping idle-but-not-done sessions (no timeout GC).
+- Deleting the worktree checkout, session data dir, or CLI-side transcript — those must survive for resume.
+- Changing what `DELETE /sessions/:id` or `DELETE /worktrees/:id` do (beyond delegating to the shared helper).
+- `lifecycle.reason` plumbing — `persistLifecycleState` (`daemon/src/services/lifecycle.ts:68-72`) takes 4 params and persists only `{state, lastTransitionAt}`; adding a reason is a signature change with no user-visible payoff. Dropped.
+- Fixing `POST /sessions/:id/resume` for `channel:"json"` sessions (it wrongly takes the tmux branch — pre-existing, unreachable from the UI; see Risk 7).
+
+## Concept
+
+- Extract the teardown already present in `DELETE /sessions/:id` into one reusable service: `releaseSessionRuntime()`.
+- `done` calls it → tmux killed, PTY killed, `JsonAgentSession` released (abort → settle → dispose) and unregistered, idle-tracking dropped.
+- Session record, data dir, attachments, worktree checkout, and CLI history are untouched → `POST /sessions/:id/resume` still works.
+- UI: the existing "Session exited / Resume" banner also renders for `done`, with copy "Session marked done."
+- Worktree-level done additionally tears down that worktree's **terminal** sessions and marks them `exited`.
+
+## Requirements
+
+| # | Requirement |
+|---|-------------|
+| 1 | `POST /sessions/:id/done` kills the session's tmux pane or direct-PTY child |
+| 2 | `POST /sessions/:id/done` aborts in-flight JSON turns, disposes the SQLite store, and removes the registry entry |
+| 3 | `POST /worktrees/:id/done` applies R1+R2 to every agent session, and additionally kills + marks `exited` every terminal session in that worktree |
+| 4 | Staged attachments are **kept** on done (`clearSessionAttachments` is NOT called) |
+| 5 | A TTY (`tmux`/`pty`) agent session stays resumable via `POST /sessions/:id/resume` with full history; a JSON session resumes by sending a chat message |
+| 6 | Terminal pane shows a Resume banner for `done`, not just `exited` |
+| 7 | Opening a done JSON session's chat renders transcript **and meta** from disk without re-creating a `JsonAgentSession` |
+| 8 | Done is idempotent — a repeat call is a no-op that returns 200 and does not inflate `updated` |
+| 9 | Nothing may demote `done` afterwards: not the lifecycle poller, not the JSON drain's `idle` persist, not the direct-PTY exit callback |
+
+---
+
+## Research
+
+### `POST /sessions/:id/done`
+
+- **File:** `daemon/src/routes/sessions.ts:778-795`
+- **Trigger:** UI `web-ui/src/components/layout/LeftSidebar.tsx:1175` → `api.markSessionDone` (`web-ui/src/api/client.ts:390-396`)
+- **Current:** sets `ctx.session.lifecycle`, calls `persistLifecycleState(..., "done")` (which broadcasts `session:state`), returns `{ok:true}`
+- **Risk:** LOW
+
+### `POST /worktrees/:id/done`
+
+- **File:** `daemon/src/routes/worktrees.ts:543-556`
+- **Trigger:** UI `LeftSidebar.tsx:1077`; CLI `cli/src/commands/worktree/done.ts:13`
+- **Current:** loops `type === "agent"` only; counts unconditionally (`:548-554`); double-broadcasts (`persistLifecycleState` already broadcasts)
+- **Risk:** LOW
+
+### Existing teardown to reuse
+
+- **File:** `daemon/src/routes/sessions.ts:669-687` (`app.delete` starts at `:653`)
+- Order that matters: `abortAndDrain()` → `jsonAgentRegistry.delete(id)` → `dispose()` → kill PTY/tmux
+- `dispose()` doc (`daemon/src/services/jsonAgent.ts:398-409`): dropping the registry ref without `dispose()` leaks 3 fds/session
+- **Risk:** MEDIUM — ordering must be preserved when extracted
+
+### P0-1 — JSON drain re-persists `idle` after done
+
+- **File:** `daemon/src/services/jsonAgent.ts:386` (`abortAndDrain` does not await), `:695-709` (`drain()`'s `finally` → `await this.persistLifecycle("idle")`)
+- **Trigger:** mark a JSON session done while a turn is running
+- **Effect:** the unwinding drain broadcasts `session:state {idle}` AFTER the route returned → overwrites `done` in the manifest and in `useServerSync` (`web-ui/src/hooks/useServerSync.ts:111-115`)
+- **Risk:** HIGH — persist-before-kill does NOT help; this lands later, asynchronously
+
+### P0-2 — direct-PTY kill demotes `done` → `exited`
+
+- **File:** `daemon/src/services/directPty.ts:105-108` (`onExit` → `markSessionExited`), guard at `daemon/src/services/lifecycle.ts:261` only excludes `"exited"`
+- **Effect:** killing a `channel:"pty"` agent's child broadcasts `session:exited` and persists `exited`
+- **Why delete is unaffected:** the record is already removed there; under done it is not
+- **Risk:** HIGH
+
+### P0-3 — `dispose()` can close SQLite under a live turn
+
+- **File:** `daemon/src/services/jsonAgent.ts:907-910` (`persist()` → `store.append`, unguarded) vs `:410-416` (`dispose()` → `store.close()`)
+- **Effect:** a straggler event after dispose throws
+- **Risk:** MEDIUM
+
+### P0-4 — naive `chat:open` done-guard leaks and blanks meta
+
+- **File:** `daemon/src/ws/handlers/chatOpen.ts:50-76`
+- `conn.unregisterChatStream(sessionId)` only runs in the LIVE branch (`:57`) → an early `sendSnapshot` return leaves the prior `ChatStreamEntry` registered (`daemon/src/ws/connection.ts:162-172`), pinning the just-disposed agent
+- The early return never sends `session:meta`; `useChat` has no other meta source (`web-ui/src/hooks/useChat.ts:161-163` — REST `getMeta` at `web-ui/src/api/client.ts:842-846` is not wired in) → ModelSwitch / usage / turn-state go blank
+- **Risk:** HIGH — the guard would cause the leak it is meant to prevent
+- Non-reviving disk reader already exists: `readSessionMeta` (`daemon/src/services/jsonAgentChat.ts:252-281`)
+
+### P1 — killing tmux sends NO exit signal to the browser
+
+- **File:** `daemon/src/ws/handlers/sessionOpen.ts:113-118` (`stream.once("close")` sends nothing), `:102-115` (error path sends `reason:"transient"`), ignored by `web-ui/src/hooks/useSubscription.ts:66-72`
+- **Effect:** the banner appears ONLY because of the `session:state {done}` broadcast + the `showBanner` change
+- **Risk:** HIGH if Phase 3 does not ship with Phase 2 — done would leave a frozen, unrecoverable terminal
+
+### Revive paths that must be guarded
+
+| Path | File | Revives? |
+|------|------|----------|
+| `chat:open` | `daemon/src/ws/handlers/chatOpen.ts:50` | YES → guard (2.5) |
+| `PATCH /sessions/:id/chat/model` | `daemon/src/routes/sessions.ts:1218-1219` | YES → guard (2.7) |
+| `POST /sessions/:id/chat` (enqueue) | `daemon/src/services/jsonAgentChat.ts:170` | YES — intended: this IS the JSON resume, and it persists `working` |
+| `GET /sessions/:id/transcript` | `daemon/src/routes/sessions.ts:1551` | NO — disk fallback |
+| `GET /sessions/:id/meta` | `daemon/src/routes/sessions.ts:1584` | NO — disk fallback |
+
+### Lifecycle poller / boot recovery (no change needed)
+
+- `daemon/src/services/lifecycle.ts:188` — `if (!alive && state !== "exited" && state !== "done")` already excludes `done`
+- `daemon/src/services/lifecycle.ts:135` — poller returns early for JSON sessions (so `clearIdleTracking` on a JSON session is a harmless no-op; do not assert it in tests)
+- `daemon/src/services/recover.ts:194,248` — only `not_started` sessions are reconciled; `recoverJsonSession` (`:104-113`) leaves `done` alone
+
+### Resume path (verified intact)
+
+- `daemon/src/routes/sessions.ts:798-984`; `spawnSessionFromArgv` (`daemon/src/services/spawn.ts:272`) calls `killStaleTmuxSession` (`:260`) then `newSession` → a missing pane is fine
+- Survives done: manifest record (`agentChatId`, `modeId`, `tmuxName`, `useTmux`, `channel`), worktree checkout, session data dir, `~/.claude/projects/<slug>/<uuid>.jsonl`
+- `JsonAgentSession.firstTurnDone` rebuilds from disk (`daemon/src/services/jsonAgent.ts:294` → `hasPersistedTurn()`), so a re-created agent does not re-inject the system prompt
+
+## Root Cause
+
+- "Done" was implemented as a pure UI label; the teardown routine lives inline inside `DELETE /sessions/:id` and was never factored out.
+  - Secondary: three independent code paths (`drain()`'s idle persist, `markSessionExited`, the poller) can write session state, and only the poller knows about `done`.
+  - Secondary: `chat:open` and `PATCH /chat/model` lazily *create* a `JsonAgentSession`, so any release needs "don't revive on read" guards.
+
+---
+
+## System Context
+
+```mermaid
+flowchart LR
+    UI[web-ui LeftSidebar] -->|POST /sessions/:id/done| R[routes/sessions.ts]
+    CLI[cli worktree done] -->|POST /worktrees/:id/done| RW[routes/worktrees.ts]
+    R --> S[services/sessionRuntime.ts<br/>releaseSessionRuntime]
+    RW --> S
+    S --> T[tmux.killSession]
+    S --> P[directPtyRegistry.kill]
+    S --> J[JsonAgentSession.release<br/>abort → settle → dispose]
+    S --> L[lifecycle.clearIdleTracking]
+    R -->|persistLifecycleState done| WS[broadcast session:state]
+    WS --> UI
+    J -.blocked by released flag.-> WS
+```
+
+## Entities & Modules
+
+| Module | Responsibility | Public interface | Owns |
+|--------|---------------|------------------|------|
+| `daemon/src/services/sessionRuntime.ts` (new) | Release every live runtime resource of one session; never touches persisted state | `releaseSessionRuntime(session: SessionRecord, opts?: { clearAttachments?: boolean }): Promise<void>` | nothing (operates on registries it does not own) |
+| `JsonAgentSession.release()` (new method) | Abort → settle → dispose, with a `released` latch that blocks all later writes | `release(): Promise<void>` | its queue, PIDs, SQLite handle |
+
+---
+
+## Architecture
+
+```
+POST /sessions/:id/done
+   → findSessionContext(id)
+   → guard: type === "agent"                (400 otherwise — unchanged)
+   → guard: already "done" → 200 no-op      (R8)
+   → await releaseSessionRuntime(session)   ← NEW (awaits JSON settle first)
+   → persistLifecycleState(..., "done")     → broadcast session:state
+   → 200 {ok:true}
+
+POST /worktrees/:id/done
+   → agents:    await releaseSessionRuntime → persist "done"
+   → terminals: persist "exited" FIRST, then await releaseSessionRuntime
+                (the PTY onExit → markSessionExited race is then a no-op)
+   → 200 {ok:true, updated, terminalsReleased}
+```
+
+- **Ordering rule:** release BEFORE persisting `done` (the `released` latch already blocks the drain's `idle`, and `markSessionExited` gains a `done` guard, so either order is safe — release-first also guarantees the broadcast the UI receives is the last word).
+
+---
+
+## Design Details
+
+### System Boundaries
+
+| Boundary | Fields + types | Errors | Source of truth |
+|----------|----------------|--------|-----------------|
+| web-ui/CLI ↔ daemon `POST /sessions/:id/done` | req: `—` · res: `{ ok: true }` | `404 Session '<id>' not found` · `400 Only agent sessions can be marked done.` | daemon manifest |
+| web-ui/CLI ↔ daemon `POST /worktrees/:id/done` | req: `—` · res: `{ ok: true, updated: number, terminalsReleased: number }` | `404 Worktree '<id>' not found` | daemon manifest |
+| daemon → web-ui WS `session:state` | `{ type:"session:state", sessionId: string, state: "done"\|"exited" }` (existing, `daemon/src/ws/protocol.ts:219`) | — | daemon |
+| daemon → web-ui WS `session:meta` (done JSON session) | `{ type:"session:meta", sessionId: string, meta: SessionMeta }` built by `readSessionMeta` (`daemon/src/services/jsonAgentChat.ts:252`) | — | on-disk SQLite transcript |
+| routes ↔ `services/sessionRuntime.ts` | `releaseSessionRuntime(session: SessionRecord, opts?: { clearAttachments?: boolean }): Promise<void>` — never throws; every step best-effort | none (swallowed) | registries in `daemon/src/state/` |
+| daemon ↔ tmux | `killSession(name: string)` (`daemon/src/services/tmux.ts:27`) — best-effort | — | tmux server |
+
+### Critical User Journeys (CUJs)
+
+#### CUJ 1 — Mark a TTY agent session done, resume later
+
+```
+User right-clicks session in LeftSidebar → "Mark as done"
+  → POST /sessions/:id/done
+  → daemon kills tmux pane vr-<n>-m (claude process tree dies)
+  → persist + broadcast session:state {state:"done"}
+  → attached TerminalPane receives ONLY session:state (no exit frame — P1)
+  → showBanner(done) → "Session marked done." + [Resume]
+User later clicks Resume
+  → POST /sessions/:id/resume → claude --resume <agentChatId> in a fresh pane
+  → state → working, history restored
+```
+
+- **Error path:** tmux pane already gone → `killSession` swallows, state still becomes `done`
+- **Edge case:** already `done` → 200, no kill attempted
+
+#### CUJ 2 — Mark a Rich Chat (`channel:"json"`) session done mid-turn
+
+```
+Turn is streaming (child process group alive)
+  → User marks done
+  → agent.release(): released=true → abortAndDrain() (SIGSTOP-freeze → SIGKILL
+    of the group) → await settled() (≤2s) → dispose() closes SQLite
+  → the drain's finally-block persistLifecycle("idle") is swallowed by `released`
+  → persist + broadcast session:state {state:"done"}
+  → ChatPane keeps rendering transcript + meta from disk (no live stream)
+User types a new message later
+  → POST /sessions/:id/chat → resolveJsonAgent re-creates the agent
+  → persistLifecycleState(..., "working") → session live again
+```
+
+- **Error path:** transcript DB missing → `withDiskStore` returns the empty fallback; chat renders empty
+- **Edge case:** a second tab has the chat open → gets `session:state {done}`; its live stream ends, transcript stays
+
+#### CUJ 3 — Mark a whole worktree done
+
+```
+User → worktree menu → "Mark as done"
+  → POST /worktrees/:id/done
+  → agents:    released + state "done"
+  → terminals: state "exited" persisted first, then released
+  → zero vr-* tmux sessions remain for that worktree
+```
+
+- **Error path:** placeholder `__direct__-*` tmuxName → the direct-PTY branch runs; no tmux call
+- **Edge case:** no sessions → `{ok:true, updated:0, terminalsReleased:0}`
+
+### Data Model
+
+- No schema change. `SessionRecord.lifecycle.state` already supports `"done"` (`daemon/src/types.ts:8`).
+- **Migration:** N.
+
+### API Contracts
+
+```
+POST /sessions/:id/done
+  Request:  —
+  Response: { ok: true }
+  Errors:   404 `Session '<id>' not found`
+            400 `Only agent sessions can be marked done.`
+  NEW side effects: kill tmux pane / direct-PTY; JsonAgentSession.release();
+                    unregister; clearIdleTracking
+  Preserved:        session record, data dir, attachments, checkout, agentChatId
+
+POST /worktrees/:id/done
+  Request:  —
+  Response: { ok: true, updated: number, terminalsReleased: number }
+  Errors:   404 `Worktree '<id>' not found`
+  NEW side effects: agents → release + "done"; terminals → "exited" + release
+
+PATCH /sessions/:id/chat/model                             (NEW guard)
+  Errors:   409 `Session is done — send a message to resume it before switching model.`
+
+POST /sessions/:id/resume        (UNCHANGED — restated for the reader)
+  Response: Session · Errors: 404, 500 `Failed to resume session: <err>`
+```
+
+### Key Decisions
+
+#### Decision 1: Extract teardown into `releaseSessionRuntime()`
+
+- **Decision:** new `daemon/src/services/sessionRuntime.ts`; `DELETE /sessions/:id`, `DELETE /worktrees/:id`, and both done routes all call it
+- **Rationale:** the kill order is subtle and already duplicated in two delete sites; a third copy would drift
+- **Where:** new file; callers `daemon/src/routes/sessions.ts:669-687`, `daemon/src/routes/worktrees.ts:570-593`
+
+```ts
+// daemon/src/services/sessionRuntime.ts
+export async function releaseSessionRuntime(
+  session: SessionRecord,
+  opts: { clearAttachments?: boolean } = {},
+): Promise<void> {
+  const agent = jsonAgentRegistry.get(session.id);
+  jsonAgentRegistry.delete(session.id);
+  if (agent) await agent.release();          // abort → settle(≤2s) → dispose
+  if (opts.clearAttachments) clearSessionAttachments(session.id);
+  if (!session.useTmux) {
+    directPtyRegistry.get(session.id)?.kill?.();
+  } else {
+    try { await killSession(session.tmuxName); } catch { /* best-effort */ }
+  }
+  clearIdleTracking(session.id);
+}
+```
+
+#### Decision 2: `JsonAgentSession.release()` with a `released` latch
+
+- **Decision:** add `private released = false` + `async release()`; `persistLifecycle()` (`jsonAgent.ts:712`) and `persist()` (`:907`) both early-return when `released`
+- **Rationale:** fixes P0-1 (drain's late `idle` clobbering `done`) and P0-3 (append after `store.close()`); a latch is race-free where ordering alone is not
+- **Where:** `daemon/src/services/jsonAgent.ts` — new method next to `dispose()` (`:410`)
+
+```ts
+private released = false;
+
+/** Abort, wait for the drain to unwind, then close SQLite. Idempotent. */
+async release(): Promise<void> {
+  if (this.released) return;
+  this.released = true;               // blocks persistLifecycle() + persist()
+  this.abortAndDrain();
+  await Promise.race([
+    this.settled().catch(() => {}),
+    new Promise((r) => setTimeout(r, 2000)),
+  ]);
+  this.dispose();
+}
+```
+
+#### Decision 3: `markSessionExited` must not demote `done`
+
+- **Decision:** `daemon/src/services/lifecycle.ts:261` → `if (!session || session.lifecycle.state === "exited" || session.lifecycle.state === "done") return;`
+- **Rationale:** fixes P0-2 — `DirectPtyStream.onExit` (`daemon/src/services/directPty.ts:105-108`) fires on our own kill
+- **Where:** `daemon/src/services/lifecycle.ts:261`
+
+#### Decision 4: `chat:open` done-branch — unregister + disk meta
+
+- **Decision:** when `ctx.session.lifecycle.state === "done"`, skip `resolveJsonAgent`, call `conn.unregisterChatStream(sessionId)`, `sendSnapshot(...)`, and send `session:meta` from `readSessionMeta`
+- **Rationale:** fixes P0-4 — a bare early return pins the disposed agent via the stale `ChatStreamEntry` and leaves `useChat`'s `meta` null
+- **Where:** `daemon/src/ws/handlers/chatOpen.ts:50-56`
+
+```ts
+const isDone = ctx.session.lifecycle.state === "done";
+if (isDone) {
+  conn.unregisterChatStream(sessionId);         // drop any stale live entry
+  sendSnapshot(conn, ctx, sessionId, sinceSeq); // disk-only transcript
+  conn.send({ type: "session:meta", sessionId, meta: await readSessionMeta(ctx, 0) });
+  return;
+}
+```
+
+#### Decision 5: Keep staged attachments on done
+
+- **Decision:** done calls `releaseSessionRuntime(session)` (`clearAttachments` defaults false); delete keeps `{ clearAttachments: true }`
+- **Rationale:** attachments are staged for the next prompt; dropping them makes resume lossy. Delete is destructive by definition, done is not
+- **Where:** `daemon/src/routes/sessions.ts` done vs. delete handlers
+
+#### Decision 6: Worktree done also releases terminals
+
+- **Decision:** `POST /worktrees/:id/done` releases terminal sessions and marks them `exited` (terminals have no `done` state); persist `exited` BEFORE the kill so the `onExit` callback is a no-op
+- **Rationale:** a worktree "put to rest" with live shells still holds a tmux server and any long-running dev process. Terminals resume via `POST /sessions/:id/resume`'s terminal branch (`daemon/src/routes/sessions.ts:926-955`), which spawns a fresh shell
+- **Where:** `daemon/src/routes/worktrees.ts:543-556`
+- **Note:** single-session `POST /sessions/:id/done` still 400s for terminals — unchanged
+
+#### Decision 7: Reuse the exited banner for done, checking `done` first
+
+- **Decision:** `showBanner = state === "done" || state === "exited" || sessionState === "exited"`; the message tests `done` FIRST
+- **Rationale:** identical recovery action; and the dying pty can push a local `sessionState` that must not win over the store's `done`
+- **Where:** `web-ui/src/components/layout/TerminalPane.tsx:388,395`; `web-ui/src/components/layout/AgentPaneSlot.tsx:38`
+
+#### Decision 8: `PATCH /chat/model` 409s on a done session
+
+- **Decision:** guard the route before `resolveJsonAgent` (`daemon/src/routes/sessions.ts:1218`) — 409 when the session is `done`
+- **Rationale:** it is the last remaining silent-revive path; a 409 is cheaper than teaching the route to write `modelOverride` without an agent
+- **Where:** `daemon/src/routes/sessions.ts:1218`
+
+---
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `daemon/src/services/sessionRuntime.ts` | NEW — `releaseSessionRuntime()` |
+| `daemon/src/services/jsonAgent.ts` | NEW `release()` + `released` latch guarding `persistLifecycle()` and `persist()` |
+| `daemon/src/services/lifecycle.ts` | `markSessionExited` skips `done` |
+| `daemon/src/routes/sessions.ts` | done route releases; delete delegates; `/chat/model` 409 guard; comment fix |
+| `daemon/src/routes/worktrees.ts` | worktree-done releases agents + terminals; delete loop delegates; idempotent count |
+| `daemon/src/ws/handlers/chatOpen.ts` | done branch: unregister + disk snapshot + disk meta |
+| `cli/src/commands/worktree/done.ts` | Report `terminalsReleased` |
+| `web-ui/src/components/layout/TerminalPane.tsx` | Banner + copy for `done`; skip `openSession` when done |
+| `web-ui/src/components/layout/AgentPaneSlot.tsx` | `terminalLive` excludes `done` |
+| `web-ui/src/api/client.ts` | `markWorktreeDone` return type + doc comments |
+| `web-ui/src/api/mock.ts` | `markSessionDone` emits `session:state` (parity with `markWorktreeDone`) |
+| `docs/SESSION-EXECUTION.md` | Document that done releases runtime resources |
+
+## Risks / Open Questions
+
+| # | Question | Notes |
+|---|----------|-------|
+| 1 | **Does killing tmux mid-agent lose work?** | The CLI writes its transcript incrementally; an in-flight tool call is lost — same as today's `DELETE`. Done is an explicit user action |
+| 2 | **Poller race?** | `lifecycle.ts:188` skips `done`; release-then-persist plus the `released` latch closes the window |
+| 3 | **Does the browser learn the pane died?** | NO — `sessionOpen.ts:113-118` sends nothing on close and `reason:"transient"` is ignored (`useSubscription.ts:66-72`). The banner depends entirely on Phase 3 → Phase 2 must not ship alone |
+| 4 | **direct-PTY exit overwrites `done`?** | Yes today (`lifecycle.ts:261`) — fixed by Decision 3 |
+| 5 | **Second done call?** | Idempotent — `released` latch, registry miss, and `killSession` on a dead pane all no-op; the worktree loop skips already-done sessions |
+| 6 | **`settled()` never resolves (stuck child)?** | `Promise.race` with a 2 s timeout; `dispose()` runs regardless, and `released` already blocks further writes |
+| 7 | **Resume of a done `channel:"json"` session** | `POST /sessions/:id/resume` takes the tmux branch and spawns a pane despite `useTmux:false` — pre-existing bug, unreachable from the UI (`AgentPaneSlot` passes `sessionId={null}` for json). Out of scope; JSON resumes by sending a message |
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Shared teardown service + write-latch
+
+- [x] **1.1** `daemon/src/services/jsonAgent.ts`: add `private released = false` and `async release()` (Decision 2); early-return in `persistLifecycle()` (`:712`) and `persist()` (`:907`) when `released`
+- [x] **1.2** Create `daemon/src/services/sessionRuntime.ts` with `releaseSessionRuntime(session, opts)` (Decision 1)
+- [x] **1.3** `daemon/src/services/lifecycle.ts:261`: `markSessionExited` early-returns for `done` too (Decision 3)
+- [x] **1.4** Refactor `DELETE /sessions/:id` (`daemon/src/routes/sessions.ts:669-687`) to `await releaseSessionRuntime(session, { clearAttachments: true })`
+- [x] **1.5** Refactor the `DELETE /worktrees/:id` loop (`daemon/src/routes/worktrees.ts:570-593`) to the same helper
+
+**Verify phase 1:**
+- [x] **1.T1** Unit — `daemon/src/__tests__/sessionRuntime.test.ts` (NEW): with a fake json agent registered, `releaseSessionRuntime` awaits `release()` and leaves `jsonAgentRegistry.get(id)` undefined
+- [x] **1.T2** Unit — same file: `useTmux:false` session kills via `directPtyRegistry` and never calls `killSession`; `useTmux:true` calls `killSession(session.tmuxName)`
+- [x] **1.T3** Unit — same file: `clearSessionAttachments` is NOT called unless `{clearAttachments:true}`
+- [x] **1.T4** Unit — `daemon/src/__tests__/jsonAgent.test.ts` (extend): after `release()`, a late `persistLifecycle("idle")` from the unwinding drain performs no `persistLifecycleState` call, and `persist()` does not throw
+- [x] **1.T5** Unit — `daemon/src/__tests__/lifecycle.test.ts` (extend): `markSessionExited` on a `done` session is a no-op (state stays `done`, no `session:exited` broadcast)
+- [x] **1.T6** Regression — `pnpm --filter @vibestation/cli test` (427 tests green at baseline)
+
+---
+
+### Phase 2 — Done routes release resources
+
+- [x] **2.1** `POST /sessions/:id/done` (`daemon/src/routes/sessions.ts:778-795`): early-return 200 when already `done`; otherwise `await releaseSessionRuntime(session)` then `persistLifecycleState(..., "done")`
+- [x] **2.2** `POST /worktrees/:id/done` (`daemon/src/routes/worktrees.ts:543-556`): agents (skip already-`done`) → release + persist `done`; terminals → persist `exited` FIRST, then release
+- [x] **2.3** Drop the redundant explicit `broadcastAll({type:"session:state"})` — `persistLifecycleState` already broadcasts
+- [x] **2.4** Return `{ ok:true, updated, terminalsReleased }`; update `web-ui/src/api/client.ts:312-318` and `cli/src/commands/worktree/done.ts`
+- [x] **2.5** `daemon/src/ws/handlers/chatOpen.ts:50-56`: done branch → `unregisterChatStream` + `sendSnapshot` + disk `session:meta` (Decision 4)
+- [x] **2.6** `daemon/src/routes/sessions.ts:778`: update the "metadata only; no process kill" comment
+- [x] **2.7** `PATCH /sessions/:id/chat/model` (`daemon/src/routes/sessions.ts:1218`): 409 when the session is `done` (Decision 8)
+
+**Verify phase 2:**
+- [x] **2.T1** Integration — `daemon/src/__tests__/sessions.test.ts` (extend; `killSession` already mocked at `:34-36`): `POST /sessions/:id/done` on a tmux agent → `killSession` called with `session.tmuxName`; the session record is still present in the manifest
+- [x] **2.T2** Integration — same file: done → `POST /sessions/:id/resume` on a TTY session → 200, `lifecycleState === "working"`, spawn invoked
+- [x] **2.T3** Integration — same file: done on a json session → registry entry gone; `GET /sessions/:id/transcript` and `GET /sessions/:id/meta` still return data and do NOT re-register an agent
+- [x] **2.T4** Integration — `daemon/src/__tests__/worktrees.test.ts` (extend the existing done test at `:445`): all agents `done`, all terminals `exited`, `killSession` called once per session
+- [x] **2.T5** Integration — same file: second `POST /worktrees/:id/done` returns `updated: 0` and does not throw
+- [x] **2.T6** Integration — `daemon/src/__tests__/ws.test.ts` (extend): `chat:open` on a `done` json session creates no registry entry and still sends `chat:replay` + `session:meta`
+- [x] **2.T7** Integration — `daemon/src/__tests__/jsonChatRoutes.test.ts` (extend): `PATCH /chat/model` on a done session → 409, no registry entry created
+
+---
+
+### Phase 3 — UI resume affordance (MUST ship with Phase 2 — see Risk 3)
+
+- [x] **3.1** `web-ui/src/components/layout/TerminalPane.tsx:388,395`: `showBanner` includes `done`; message tests `done` FIRST → "Session marked done." (Decision 7)
+- [x] **3.2** `web-ui/src/components/layout/AgentPaneSlot.tsx:38`: `terminalLive` excludes `done` as well as `exited`
+- [x] **3.3** `web-ui/src/components/layout/TerminalPane.tsx`: skip `api.openSession` when the store state is `done` (avoids a failed `tmux has-session` round-trip per mount)
+- [x] **3.4** `web-ui/src/api/mock.ts:536-543`: `markSessionDone` emits `session:state` (parity with `markWorktreeDone` at `:415`)
+- [x] **3.5** Update `docs/SESSION-EXECUTION.md` — done releases runtime resources; resume path unchanged
+
+**Verify phase 3:**
+- [x] **3.T1** Unit — `web-ui/src/components/layout/TerminalPane.test.tsx` (EXISTS — extend): renders "Session marked done." + Resume for `lifecycleState: "done"`
+- [x] **3.T2** Unit — same file: `done` does not trigger `api.openSession`; clicking Resume calls `api.resumeSession` and patches state to `working`
+- [x] **3.T3** Unit — `web-ui/src/components/layout/AgentPaneSlot.test.tsx` (EXISTS — extend): attachment overlay hidden for `done`
+- [x] **3.T4** Regression — `pnpm --filter @vibestation/web test` (251 tests green at baseline), `pnpm lint`, `pnpm --filter @vibestation/cli lint`, `pnpm typecheck`
+
+---
+
+### Phase 4 — Docker container verification
+
+- [x] **4.0** A sibling sandbox (`vs-26-vst-dev-1`) already owned port 5174 and the globally-named volumes `vst-dev-data` / `vst-dev-projects`. Verification used a throwaway overlay file (not committed) with `ports: !override ["5175:5173"]` — Compose MERGES list fields, so without `!override` the base 5174 binding is kept and collides — plus `vst-vs29-*` volume names. Torn down with `down -v` afterwards; the sibling was never touched
+- [x] **4.1** `docker compose -f docker-compose.dev.yml -f docker-compose.dev.vs29.yml -p vs29 up -d --build`
+- [x] **4.2** In the UI at `http://localhost:5175`, create a worktree with one TTY agent + one terminal + one Rich Chat session
+- [x] **4.3** Baseline inside the container: `docker exec vs29-vst-dev-1 tmux ls` and `pgrep -fa claude`
+- [x] **4.4** Mark the TTY agent done → its `vr-*` tmux session and CLI process are gone; the pane shows "Session marked done." + Resume
+- [x] **4.5** Click Resume → session returns with history; the tmux session reappears
+- [x] **4.6** Mark the worktree done → zero `vr-*` tmux sessions remain for that worktree
+- [x] **4.7** Rich Chat: mark done mid-turn → state stays `done` (does NOT flip to `idle`), transcript + model still render, `ls -l /proc/1/fd | grep -c transcript` drops
+
+**Verify phase 4:**
+- [x] **4.T1** `tmux ls` before/after single-session done: `vr-fsd-1-m` present → gone; state `done`
+- [x] **4.T2** Resume after done → `working`, pane re-created (verified on the terminal session: `vr-fsd-1-t1` reappeared)
+- [x] **4.T3** Rich Chat done → the 3 `messages.db` / `-wal` / `-shm` fds held by the daemon dropped to 0; state still `done` after ~8 s of polling; `GET /transcript`, `GET /meta` and WS `chat:open` all served from disk with 0 fds re-opened; `PATCH /chat/model` → 409; sending a message revived it (fds back to 3, state `idle`)
+- [x] **4.T4** Worktree done → `{updated:2, terminalsReleased:1}`, tmux server itself shut down ("no server running"); second call → `{updated:0, terminalsReleased:0}`
+- [x] **4.T5** UI at :5175 — banner flipped live to "Session marked done." with a working Resume; done worktree rolled up under FINISHED; done Rich Chat rendered its transcript from disk
+- [x] **4.T6** Daemon log clean (no errors / unhandled rejections / EMFILE / SQLITE)
+- [x] **4.T7** Regression — `pnpm test` (702 tests, run twice), `pnpm lint` (0 errors), `pnpm typecheck` clean
+
+---
+
+## Files Summary
+
+| File | Phase | Change |
+|------|-------|--------|
+| `daemon/src/services/jsonAgent.ts` | 1.1 | `release()` + `released` latch |
+| `daemon/src/services/sessionRuntime.ts` | 1.2 | NEW — shared `releaseSessionRuntime()` |
+| `daemon/src/services/lifecycle.ts` | 1.3 | `markSessionExited` skips `done` |
+| `daemon/src/routes/sessions.ts` | 1.4, 2.1, 2.6, 2.7 | Delete delegates; done releases; comment; `/chat/model` 409 |
+| `daemon/src/routes/worktrees.ts` | 1.5, 2.2-2.4 | Delete delegates; worktree-done releases agents + terminals |
+| `daemon/src/ws/handlers/chatOpen.ts` | 2.5 | Done branch: unregister + disk snapshot + disk meta |
+| `cli/src/commands/worktree/done.ts` | 2.4 | Report `terminalsReleased` |
+| `web-ui/src/api/client.ts` | 2.4 | Return type + doc comment |
+| `web-ui/src/components/layout/TerminalPane.tsx` | 3.1, 3.3 | Banner for `done`; no open when done |
+| `web-ui/src/components/layout/AgentPaneSlot.tsx` | 3.2 | `terminalLive` excludes `done` |
+| `web-ui/src/api/mock.ts` | 3.4 | Emit `session:state` on done |
+| `docs/SESSION-EXECUTION.md` | 3.5 | Document new done semantics |
+| `daemon/src/__tests__/sessionRuntime.test.ts` | 1.T1-1.T3 | NEW unit tests |
+| `daemon/src/__tests__/jsonAgent.test.ts` | 1.T4 | Extend — latch tests |
+| `daemon/src/__tests__/lifecycle.test.ts` | 1.T5 | Extend — `done` guard |
+| `daemon/src/__tests__/sessions.test.ts` | 2.T1-2.T3 | Extend — done/resume |
+| `daemon/src/__tests__/worktrees.test.ts` | 2.T4-2.T5 | Extend — worktree done |
+| `daemon/src/__tests__/ws.test.ts` | 2.T6 | Extend — chat:open guard |
+| `daemon/src/__tests__/jsonChatRoutes.test.ts` | 2.T7 | Extend — model 409 |
+| `web-ui/src/components/layout/TerminalPane.test.tsx` | 3.T1-3.T2 | Extend |
+| `web-ui/src/components/layout/AgentPaneSlot.test.tsx` | 3.T3 | Extend |

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ coverage/
 # package-lock.json
 # yarn.lock
 # pnpm-lock.yaml
+.vibe-station/

--- a/cli/src/commands/worktree/done.ts
+++ b/cli/src/commands/worktree/done.ts
@@ -6,13 +6,17 @@ import { die, success } from "../../lib/output.js";
 export function registerWorktreeDone(worktree: Command): void {
   worktree
     .command("done <id>")
-    .description("Mark all agent sessions in a worktree as done")
+    .description("Mark all agent sessions done and release the worktree's tmux/agent processes")
     .action(async (id: string) => {
       await preflight();
-      const result = await daemonPost<{ ok: true; updated: number }>(
+      const result = await daemonPost<{ ok: true; updated: number; terminalsReleased: number }>(
         `/worktrees/${encodeURIComponent(id)}/done`,
       );
       if (!result.ok) die(result.error, result.status === 404 ? 2 : 1);
-      success(`Worktree marked as done: ${id}`);
+      const { updated, terminalsReleased } = result.data;
+      success(
+        `Worktree marked as done: ${id} ` +
+          `(${updated} agent session(s) done, ${terminalsReleased} terminal(s) released)`,
+      );
     });
 }

--- a/daemon/src/__tests__/jsonAgentRelease.test.ts
+++ b/daemon/src/__tests__/jsonAgentRelease.test.ts
@@ -1,0 +1,206 @@
+/**
+ * `JsonAgentSession.release()` — the teardown used by "mark as done" (and by
+ * delete). The interesting property is not that it frees things, but that it
+ * LATCHES the session so nothing can write after it: the aborted turn's drain
+ * would otherwise persist a trailing lifecycle `idle` that lands after the
+ * caller has written `done`, silently un-doing the user's action.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentPlugin, TurnContext, TurnInput } from "../services/spawn.js";
+import type { ProjectRecord, SessionRecord, NormalizedEvent } from "../types.js";
+
+let tempDir: string;
+
+vi.mock("../services/paths.js", async () => {
+  const { join: pathJoin } = await import("node:path");
+  const base = () => tempDir;
+  const directDataDir = (p: string, s: string) => pathJoin(base(), "projects", p, "sessions", s);
+  return {
+    vstHome: () => base(),
+    projectDir: (id: string) => pathJoin(base(), "projects", id),
+    manifestPath: (id: string) => pathJoin(base(), "projects", id, "manifest.json"),
+    manifestTmpPath: (id: string) => pathJoin(base(), "projects", id, "manifest.json.tmp"),
+    worktreePath: (id: string, wtId: string) => pathJoin(base(), "projects", id, "worktrees", wtId),
+    configPath: () => pathJoin(base(), "config.json"),
+    modesPath: () => pathJoin(base(), "modes.json"),
+    daemonLogPath: () => pathJoin(base(), "logs", "daemon.log"),
+    sessionDataDir: (p: string, w: string, s: string) =>
+      pathJoin(base(), "projects", p, "session-data", w, s),
+    directSessionDataDir: directDataDir,
+    systemPromptPath: (p: string, w: string, s: string) =>
+      pathJoin(base(), "projects", p, "session-data", w, s, "system-prompt.md"),
+    directSystemPromptPath: (p: string, s: string) => pathJoin(directDataDir(p, s), "system-prompt.md"),
+    cleanupDirectSessionDataDir: () => {},
+  };
+});
+
+const PROJECT_ID = "proj-rel";
+
+function makeSession(): SessionRecord {
+  return {
+    id: `${PROJECT_ID}-d1`,
+    slot: "d1",
+    type: "agent",
+    modeId: "m",
+    tmuxName: "__direct__-x",
+    useTmux: false,
+    channel: "json",
+    lifecycle: { state: "working", lastTransitionAt: new Date().toISOString() },
+  };
+}
+
+/** A plugin whose turn blocks forever until aborted. */
+function makeGatePlugin(): { plugin: AgentPlugin; running: () => boolean } {
+  let started = false;
+  const plugin = {
+    name: "claude",
+    defaultModel: "sonnet",
+    promptDelivery: "inline",
+    async listModels() {
+      return { models: [] };
+    },
+    getLaunchCommand() {
+      return ["claude"];
+    },
+    getEnvironment() {
+      return {};
+    },
+    getReadySignal() {
+      return { fallbackMs: 0 };
+    },
+    composeLaunchPrompt() {
+      return {};
+    },
+    supportsJson() {
+      return true;
+    },
+    async *runTurn(_input: TurnInput, ctx: TurnContext, signal: AbortSignal): AsyncIterable<NormalizedEvent> {
+      started = true;
+      yield {
+        id: "init",
+        sessionId: ctx.session.id,
+        ts: new Date().toISOString(),
+        provider: "claude",
+        kind: "session_init",
+        agentChatId: "chat-1",
+      } as NormalizedEvent;
+      await new Promise<void>((resolve) => {
+        signal.addEventListener("abort", () => resolve(), { once: true });
+      });
+      // A straggler event emitted as the aborted turn unwinds — this is what
+      // would hit a closed SQLite handle without the `released` latch.
+      yield {
+        id: "straggler",
+        sessionId: ctx.session.id,
+        ts: new Date().toISOString(),
+        provider: "claude",
+        kind: "text",
+        text: "late",
+      } as NormalizedEvent;
+    },
+  } as unknown as AgentPlugin;
+  return { plugin, running: () => started };
+}
+
+async function waitFor(pred: () => boolean, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!pred()) {
+    if (Date.now() > deadline) throw new Error("waitFor timed out");
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+describe("1.T4 — JsonAgentSession.release()", () => {
+  let project: ProjectRecord;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "vst-jsonrel-"));
+    const { _clearStoreForTest, addProject } = await import("../state/project-store.js");
+    _clearStoreForTest();
+    project = {
+      id: PROJECT_ID,
+      absolutePath: join(tempDir, "repo"),
+      prefix: "pr",
+      isGit: true,
+      defaultBranch: "main",
+      createdAt: new Date().toISOString(),
+      directSessions: [makeSession()],
+      worktrees: [],
+    };
+    await addProject(project);
+  });
+
+  afterEach(async () => {
+    const { jsonAgentRegistry } = await import("../state/jsonAgentRegistry.js");
+    jsonAgentRegistry.clear();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("does not persist a trailing `idle` after release (would demote a done session)", async () => {
+    const { JsonAgentSession } = await import("../services/jsonAgent.js");
+    const { getAllProjects } = await import("../state/project-store.js");
+    const { plugin, running } = makeGatePlugin();
+    const session = project.directSessions[0]!;
+    const agent = new JsonAgentSession({
+      project,
+      worktree: null,
+      session,
+      plugin,
+      daemonPort: 0,
+      cli: "claude",
+    });
+
+    agent.enqueue({ message: "hello" });
+    await waitFor(() => running());
+
+    await agent.release();
+    // Let any late drain callback land — without the latch this is exactly the
+    // window in which `persistLifecycle("idle")` used to fire.
+    await new Promise((r) => setTimeout(r, 100));
+
+    const stored = getAllProjects()
+      .find((p) => p.id === PROJECT_ID)!
+      .directSessions.find((s) => s.id === session.id)!;
+    expect(stored.lifecycle.state).not.toBe("idle");
+  });
+
+  it("survives a straggler event emitted after the store is closed", async () => {
+    const { JsonAgentSession } = await import("../services/jsonAgent.js");
+    const { plugin, running } = makeGatePlugin();
+    const session = project.directSessions[0]!;
+    const agent = new JsonAgentSession({
+      project,
+      worktree: null,
+      session,
+      plugin,
+      daemonPort: 0,
+      cli: "claude",
+    });
+
+    agent.enqueue({ message: "hello" });
+    await waitFor(() => running());
+
+    await expect(agent.release()).resolves.toBeUndefined();
+    await new Promise((r) => setTimeout(r, 100));
+  });
+
+  it("is idempotent — a second release is a no-op", async () => {
+    const { JsonAgentSession } = await import("../services/jsonAgent.js");
+    const { plugin } = makeGatePlugin();
+    const session = project.directSessions[0]!;
+    const agent = new JsonAgentSession({
+      project,
+      worktree: null,
+      session,
+      plugin,
+      daemonPort: 0,
+      cli: "claude",
+    });
+
+    await agent.release();
+    await expect(agent.release()).resolves.toBeUndefined();
+  });
+});

--- a/daemon/src/__tests__/jsonChatRoutes.test.ts
+++ b/daemon/src/__tests__/jsonChatRoutes.test.ts
@@ -463,6 +463,90 @@ describe("JSON chat REST + WS", () => {
     expect(body.turnState).toBe("idle");
   });
 
+  it("2.T3/2.T6 — a done JSON session serves transcript + meta from disk without reviving the agent", async () => {
+    const { jsonAgentRegistry } = await import("../state/jsonAgentRegistry.js");
+
+    // Run a turn so there is a transcript on disk, then mark the session done.
+    await app.inject({ method: "POST", url: `/sessions/${SESSION_ID}/chat`, payload: { message: "hi" } });
+    await jsonAgentRegistry.get(SESSION_ID)?.settled();
+
+    const done = await app.inject({ method: "POST", url: `/sessions/${SESSION_ID}/done` });
+    expect(done.statusCode).toBe(200);
+    // Marking done released the JsonAgentSession (SQLite handle + queue).
+    expect(jsonAgentRegistry.get(SESSION_ID)).toBeUndefined();
+
+    // Reading the transcript must NOT re-register an agent...
+    const transcript = await app.inject({ method: "GET", url: `/sessions/${SESSION_ID}/transcript` });
+    expect(transcript.statusCode).toBe(200);
+    expect(transcript.json<{ events: NormalizedEvent[] }>().events.length).toBeGreaterThan(0);
+    expect(jsonAgentRegistry.get(SESSION_ID)).toBeUndefined();
+
+    // ...and neither must chat:open — it serves a disk snapshot plus meta, so
+    // the status bar/model switcher still render on a done session.
+    const frames = await new Promise<any[]>((resolve, reject) => {
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+      const seen: any[] = [];
+      const t = setTimeout(() => {
+        ws.close();
+        resolve(seen);
+      }, 800);
+      ws.on("open", () => ws.send(JSON.stringify({ type: "chat:open", sessionId: SESSION_ID })));
+      ws.on("message", (data: Buffer) => {
+        seen.push(JSON.parse(data.toString("utf8")));
+      });
+      ws.on("error", (err) => {
+        clearTimeout(t);
+        reject(err);
+      });
+    });
+    expect(frames.some((f) => f.type === "chat:replay")).toBe(true);
+    expect(frames.some((f) => f.type === "session:meta")).toBe(true);
+    expect(jsonAgentRegistry.get(SESSION_ID)).toBeUndefined();
+
+    // Sending a message is the deliberate way back — it re-creates the agent.
+    const resume = await app.inject({
+      method: "POST",
+      url: `/sessions/${SESSION_ID}/chat`,
+      payload: { message: "back" },
+    });
+    expect(resume.statusCode).toBe(202);
+    expect(jsonAgentRegistry.get(SESSION_ID)).toBeDefined();
+    await jsonAgentRegistry.get(SESSION_ID)?.settled();
+  });
+
+  it("2.T8 — the auto-enqueued turn 1 is suppressed when the session was marked done during create", async () => {
+    // Create schedules startJsonCreateTurn in the background; a user who marks
+    // the brand-new session done before that lands must not have turn 1 spawn
+    // (and re-create the JsonAgentSession the release just tore down).
+    const { jsonAgentRegistry } = await import("../state/jsonAgentRegistry.js");
+    const { startJsonCreateTurn } = await import("../services/jsonAgentChat.js");
+    jsonAgentRegistry.clear();
+
+    await app.inject({ method: "POST", url: `/sessions/${SESSION_ID}/done` });
+    expect(jsonAgentRegistry.get(SESSION_ID)).toBeUndefined();
+
+    await startJsonCreateTurn({ sessionId: SESSION_ID, prompt: "turn one", daemonPort: 0 });
+
+    expect(jsonAgentRegistry.get(SESSION_ID)).toBeUndefined();
+    const state = await app.inject({ method: "GET", url: `/sessions/${SESSION_ID}` });
+    expect(state.json<{ state: string }>().state).toBe("done");
+  });
+
+  it("2.T7 — PATCH …/chat/model on a done session → 409, and does not revive the agent", async () => {
+    const { jsonAgentRegistry } = await import("../state/jsonAgentRegistry.js");
+    await app.inject({ method: "POST", url: `/sessions/${SESSION_ID}/chat`, payload: { message: "hi" } });
+    await jsonAgentRegistry.get(SESSION_ID)?.settled();
+    await app.inject({ method: "POST", url: `/sessions/${SESSION_ID}/done` });
+
+    const patch = await app.inject({
+      method: "PATCH",
+      url: `/sessions/${SESSION_ID}/chat/model`,
+      payload: { model: "opus" },
+    });
+    expect(patch.statusCode).toBe(409);
+    expect(jsonAgentRegistry.get(SESSION_ID)).toBeUndefined();
+  });
+
   // 1.T5 — queue-controls REST error mapping (happy-path mechanics unit-tested
   // in jsonChatQueue.test.ts; here we assert the route wiring + status codes).
   it("queue-controls — edit / promote / resubmit on a non-queued turn → 404", async () => {

--- a/daemon/src/__tests__/lifecycle.test.ts
+++ b/daemon/src/__tests__/lifecycle.test.ts
@@ -242,6 +242,32 @@ describe("lifecycle polling behavior", () => {
     }
   });
 
+  it("markSessionExited leaves a `done` session alone (mark-as-done kills the pane on purpose)", async () => {
+    await seedProject("done");
+    const { markSessionExited } = await import("../services/lifecycle.js");
+
+    // This is exactly what DirectPtyStream.onExit fires after `releaseSessionRuntime`
+    // kills the child of a session the user just marked done.
+    await markSessionExited("proj-l", "wt-l", "sess-l");
+
+    expect(await getCurrentState()).toBe("done");
+    expect(emittedStateChanges()).not.toContain("exited");
+    expect(
+      broadcaster.broadcastAll.mock.calls.some(
+        ([msg]) => (msg as { type?: string }).type === "session:exited",
+      ),
+    ).toBe(false);
+  });
+
+  it("markSessionExited still marks a working session exited", async () => {
+    await seedProject("working");
+    const { markSessionExited } = await import("../services/lifecycle.js");
+
+    await markSessionExited("proj-l", "wt-l", "sess-l");
+
+    expect(await getCurrentState()).toBe("exited");
+  });
+
   it("clearIdleTracking called at teardown avoids the stale-idle flip on the next respawn", async () => {
     await seedProject("working");
     tmux.capturePane.mockResolvedValue("same splash text");

--- a/daemon/src/__tests__/projects.test.ts
+++ b/daemon/src/__tests__/projects.test.ts
@@ -143,6 +143,40 @@ describe("GET /projects + POST /projects + DELETE /projects/:id", () => {
     expect(getRes.json<ProjectRecord[]>()).toHaveLength(0);
   });
 
+  it("DELETE /projects/:id releases direct-pty / json sessions, not just tmux panes", async () => {
+    // Regression: this path used to call killSession() only. A `useTmux: false`
+    // session (every direct-pty and every json session) has no pane, so its pty
+    // child and its JsonAgentSession — turn process group + open SQLite handles
+    // — survived while the project data dir they point at was rm -rf'd.
+    const createRes = await app.inject({
+      method: "POST",
+      url: "/projects",
+      payload: { path: repoDir },
+    });
+    const project = createRes.json<ProjectRecord>();
+
+    const { mutateProject } = await import("../state/project-store.js");
+    const ptySession = {
+      id: `${project.id}-d1`,
+      slot: "d1" as const,
+      type: "agent" as const,
+      modeId: "m",
+      tmuxName: `__direct__-${project.id}-d1`,
+      useTmux: false,
+      lifecycle: { state: "working" as const, lastTransitionAt: new Date().toISOString() },
+    };
+    await mutateProject(project.id, (p) => ({ ...p, directSessions: [ptySession] }));
+
+    const { directPtyRegistry } = await import("../state/directPtyRegistry.js");
+    const kill = vi.fn();
+    directPtyRegistry.set(ptySession.id, { kill } as never);
+
+    const delRes = await app.inject({ method: "DELETE", url: `/projects/${project.id}` });
+    expect(delRes.statusCode).toBe(200);
+    expect(kill).toHaveBeenCalledOnce();
+    directPtyRegistry.delete(ptySession.id);
+  });
+
   it("DELETE /projects/:id 404 for unknown project", async () => {
     const res = await app.inject({ method: "DELETE", url: "/projects/nonexistent" });
     expect(res.statusCode).toBe(404);

--- a/daemon/src/__tests__/sessionRuntime.test.ts
+++ b/daemon/src/__tests__/sessionRuntime.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { SessionRecord } from "../types.js";
+
+// Mock tmux so no real tmux server is needed.
+vi.mock("../services/tmux.js", () => ({
+  killSession: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../services/lifecycle.js", () => ({
+  clearIdleTracking: vi.fn(),
+}));
+
+vi.mock("../state/attachmentRegistry.js", () => ({
+  clearSessionAttachments: vi.fn(),
+}));
+
+import { releaseSessionRuntime } from "../services/sessionRuntime.js";
+import { killSession } from "../services/tmux.js";
+import { clearIdleTracking } from "../services/lifecycle.js";
+import { clearSessionAttachments } from "../state/attachmentRegistry.js";
+import { jsonAgentRegistry } from "../state/jsonAgentRegistry.js";
+import { directPtyRegistry } from "../state/directPtyRegistry.js";
+import type { JsonAgentSession } from "../services/jsonAgent.js";
+
+function makeSession(over: Partial<SessionRecord> = {}): SessionRecord {
+  return {
+    id: "s-release-1",
+    slot: "a1",
+    type: "agent",
+    name: "agent",
+    tmuxName: "vr-1-a1",
+    useTmux: true,
+    lifecycle: { state: "idle", lastTransitionAt: new Date().toISOString() },
+    ...over,
+  } as SessionRecord;
+}
+
+/** Minimal JsonAgentSession stand-in — only `release()` is exercised. */
+function fakeAgent(): { agent: JsonAgentSession; released: () => number } {
+  let calls = 0;
+  const agent = {
+    release: vi.fn(async () => {
+      calls += 1;
+    }),
+  } as unknown as JsonAgentSession;
+  return { agent, released: () => calls };
+}
+
+describe("releaseSessionRuntime", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    jsonAgentRegistry.clear();
+    directPtyRegistry.clear?.();
+  });
+
+  it("1.T1 — releases and unregisters the JsonAgentSession", async () => {
+    const session = makeSession({ id: "s-json", useTmux: false });
+    const { agent, released } = fakeAgent();
+    jsonAgentRegistry.set(session.id, agent);
+
+    await releaseSessionRuntime(session);
+
+    expect(released()).toBe(1);
+    expect(jsonAgentRegistry.get(session.id)).toBeUndefined();
+  });
+
+  it("1.T1b — awaits release() before returning (so a late lifecycle write can't outlive the call)", async () => {
+    const session = makeSession({ id: "s-json-slow", useTmux: false });
+    let finished = false;
+    const agent = {
+      release: vi.fn(async () => {
+        await new Promise((r) => setTimeout(r, 20));
+        finished = true;
+      }),
+    } as unknown as JsonAgentSession;
+    jsonAgentRegistry.set(session.id, agent);
+
+    await releaseSessionRuntime(session);
+
+    expect(finished).toBe(true);
+  });
+
+  it("1.T2 — tmux session: kills the pane by name, never touches the pty registry", async () => {
+    const session = makeSession({ id: "s-tmux", useTmux: true, tmuxName: "vr-7-m" });
+    const kill = vi.fn();
+    directPtyRegistry.set(session.id, { kill } as never);
+
+    await releaseSessionRuntime(session);
+
+    expect(killSession).toHaveBeenCalledWith("vr-7-m");
+    expect(kill).not.toHaveBeenCalled();
+  });
+
+  it("1.T2b — direct-pty session: kills the child, never calls tmux", async () => {
+    const session = makeSession({ id: "s-pty", useTmux: false });
+    const kill = vi.fn();
+    directPtyRegistry.set(session.id, { kill } as never);
+
+    await releaseSessionRuntime(session);
+
+    expect(kill).toHaveBeenCalledOnce();
+    expect(killSession).not.toHaveBeenCalled();
+  });
+
+  it("1.T2c — a missing pane / unregistered pty is not an error", async () => {
+    vi.mocked(killSession).mockRejectedValueOnce(new Error("can't find session"));
+    await expect(releaseSessionRuntime(makeSession({ id: "s-gone" }))).resolves.toBeUndefined();
+  });
+
+  it("1.T3 — keeps staged attachments by default, clears them only when asked", async () => {
+    await releaseSessionRuntime(makeSession({ id: "s-keep" }));
+    expect(clearSessionAttachments).not.toHaveBeenCalled();
+
+    await releaseSessionRuntime(makeSession({ id: "s-clear" }), { clearAttachments: true });
+    expect(clearSessionAttachments).toHaveBeenCalledWith("s-clear");
+  });
+
+  it("1.T3b — always clears the lifecycle poller's idle-hash entry", async () => {
+    await releaseSessionRuntime(makeSession({ id: "s-idle" }));
+    expect(clearIdleTracking).toHaveBeenCalledWith("s-idle");
+  });
+});

--- a/daemon/src/__tests__/sessions.test.ts
+++ b/daemon/src/__tests__/sessions.test.ts
@@ -51,6 +51,9 @@ vi.mock("../services/spawn.js", async (importOriginal) => {
     spawnSessionFromArgv: vi.fn(async () => {
       // Mock: do nothing
     }),
+    spawnDirectSession: vi.fn(async () => {
+      // Mock: do nothing
+    }),
   };
 });
 
@@ -315,6 +318,149 @@ describe("Session routes", () => {
     // killed and replaced by a racing resume.
     expect(spawnMock).not.toHaveBeenCalled();
     expect(spawnArgvMock).not.toHaveBeenCalled();
+  });
+
+  // ─── POST /sessions/:id/done — releases resources, stays resumable ───────
+  describe("POST /sessions/:id/done releases runtime resources", () => {
+    async function mainSession(): Promise<SessionRecord> {
+      const listRes = await app.inject({ method: "GET", url: `/sessions?worktree=${worktreeId}` });
+      return listRes.json<SessionRecord[]>()[0]!;
+    }
+
+    it("2.T1 — kills the tmux pane and keeps the session record", async () => {
+      const tmux = await import("../services/tmux.js");
+      vi.mocked(tmux.killSession).mockClear();
+      const main = await mainSession();
+
+      const res = await app.inject({ method: "POST", url: `/sessions/${main.id}/done` });
+      expect(res.statusCode).toBe(200);
+
+      expect(vi.mocked(tmux.killSession)).toHaveBeenCalledWith(main.tmuxName);
+
+      // The record survives — "done" is a pause, not a delete.
+      const after = await app.inject({ method: "GET", url: `/sessions/${main.id}` });
+      expect(after.statusCode).toBe(200);
+      expect(after.json<{ state: string }>().state).toBe("done");
+    });
+
+    it("2.T1b — is idempotent: a second call is a no-op that does not re-kill", async () => {
+      const tmux = await import("../services/tmux.js");
+      const main = await mainSession();
+
+      expect((await app.inject({ method: "POST", url: `/sessions/${main.id}/done` })).statusCode).toBe(200);
+      vi.mocked(tmux.killSession).mockClear();
+      const second = await app.inject({ method: "POST", url: `/sessions/${main.id}/done` });
+
+      expect(second.statusCode).toBe(200);
+      expect(vi.mocked(tmux.killSession)).not.toHaveBeenCalled();
+    });
+
+    it("2.T2 — a done session still resumes (record + agentChatId survived the release)", async () => {
+      const main = await mainSession();
+      await app.inject({ method: "POST", url: `/sessions/${main.id}/done` });
+
+      const res = await app.inject({ method: "POST", url: `/sessions/${main.id}/resume` });
+      expect(res.statusCode).toBe(200);
+      expect(res.json<{ state: string }>().state).toBe("working");
+    });
+
+    it("2.T1c — DIRECT (project-level) agent: done kills its pane and stays resumable", async () => {
+      const tmux = await import("../services/tmux.js");
+      // Direct sessions live in project.directSessions and have no worktree —
+      // the same release path has to reach them.
+      const created = await app.inject({
+        method: "POST",
+        url: "/sessions",
+        payload: { projectId, target: "direct", type: "agent", modeId: "bugfix" },
+      });
+      expect(created.statusCode).toBe(201);
+      const direct = created.json<SessionRecord>();
+      expect(direct.slot).toMatch(/^d\d+$/);
+
+      vi.mocked(tmux.killSession).mockClear();
+      const res = await app.inject({ method: "POST", url: `/sessions/${direct.id}/done` });
+      expect(res.statusCode).toBe(200);
+      expect(vi.mocked(tmux.killSession)).toHaveBeenCalledWith(direct.tmuxName);
+
+      const after = await app.inject({ method: "GET", url: `/sessions/${direct.id}` });
+      expect(after.json<{ state: string }>().state).toBe("done");
+
+      const resumed = await app.inject({ method: "POST", url: `/sessions/${direct.id}/resume` });
+      expect(resumed.statusCode).toBe(200);
+      expect(resumed.json<{ state: string }>().state).toBe("working");
+    });
+
+    it("2.T1d — done DURING spawn: the spawn job must not resurrect the session", async () => {
+      // Marking done while an agent is still spawning is easy to do (a spawn
+      // takes seconds). The background job must neither clobber `done` nor
+      // leave behind the pane it created after the release already ran.
+      const spawnModule = await import("../services/spawn.js");
+      const tmux = await import("../services/tmux.js");
+      let releaseSpawn!: () => void;
+      const gate = new Promise<void>((r) => {
+        releaseSpawn = r;
+      });
+      vi.mocked(spawnModule.spawnSession).mockImplementationOnce(async () => {
+        await gate;
+      });
+
+      const created = await app.inject({
+        method: "POST",
+        url: "/sessions",
+        payload: { worktreeId, type: "agent", modeId: "bugfix" },
+      });
+      const sess = created.json<SessionRecord>();
+
+      // Retire it while the spawn is parked.
+      expect((await app.inject({ method: "POST", url: `/sessions/${sess.id}/done` })).statusCode).toBe(200);
+
+      vi.mocked(tmux.killSession).mockClear();
+      releaseSpawn();
+      await new Promise((r) => setTimeout(r, 100));
+
+      // State survived the job's completion write...
+      const after = await app.inject({ method: "GET", url: `/sessions/${sess.id}` });
+      expect(after.json<{ state: string }>().state).toBe("done");
+      // ...and the pane the spawn created after our kill was reaped.
+      expect(vi.mocked(tmux.killSession)).toHaveBeenCalledWith(sess.tmuxName);
+    });
+
+    it("2.T1e — done DURING a FAILING spawn also stays done", async () => {
+      const spawnModule = await import("../services/spawn.js");
+      let failSpawn!: () => void;
+      const gate = new Promise<void>((_, rej) => {
+        failSpawn = () => rej(new Error("boom"));
+      });
+      vi.mocked(spawnModule.spawnSession).mockImplementationOnce(async () => {
+        await gate;
+      });
+
+      const created = await app.inject({
+        method: "POST",
+        url: "/sessions",
+        payload: { worktreeId, type: "agent", modeId: "bugfix" },
+      });
+      const sess = created.json<SessionRecord>();
+      await app.inject({ method: "POST", url: `/sessions/${sess.id}/done` });
+
+      failSpawn();
+      await new Promise((r) => setTimeout(r, 100));
+
+      const after = await app.inject({ method: "GET", url: `/sessions/${sess.id}` });
+      // The failure path used to write `exited` over the user's `done`.
+      expect(after.json<{ state: string }>().state).toBe("done");
+    });
+
+    it("2.T2b — terminals are still rejected", async () => {
+      const created = await app.inject({
+        method: "POST",
+        url: "/sessions",
+        payload: { worktreeId, type: "terminal" },
+      });
+      const term = created.json<SessionRecord>();
+      const res = await app.inject({ method: "POST", url: `/sessions/${term.id}/done` });
+      expect(res.statusCode).toBe(400);
+    });
   });
 
   it("1.T4 — channel:json create carries channel through serializeSession and does NOT spawn", async () => {

--- a/daemon/src/__tests__/worktrees.test.ts
+++ b/daemon/src/__tests__/worktrees.test.ts
@@ -442,7 +442,9 @@ describe("Worktree routes", () => {
     vi.mocked(spawnModule.spawnSession).mockResolvedValue(undefined);
   });
 
-  it("POST /worktrees/:id/done marks agent sessions as done", async () => {
+  it("POST /worktrees/:id/done marks agent sessions as done and kills their panes", async () => {
+    const tmux = await import("../services/tmux.js");
+    const killSpy = vi.spyOn(tmux, "killSession"); // calls through: really kills the pane
     const res = await app.inject({
       method: "POST",
       url: "/worktrees",
@@ -456,7 +458,7 @@ describe("Worktree routes", () => {
       url: `/worktrees/${wt.id}/done`,
     });
     expect(doneRes.statusCode).toBe(200);
-    const body = doneRes.json<{ ok: boolean; updated: number }>();
+    const body = doneRes.json<{ ok: boolean; updated: number; terminalsReleased: number }>();
     expect(body.ok).toBe(true);
     expect(body.updated).toBeGreaterThanOrEqual(1);
 
@@ -465,7 +467,64 @@ describe("Worktree routes", () => {
       url: `/sessions/${wt.id}-m`,
     });
     expect(sessRes.statusCode).toBe(200);
-    expect(sessRes.json<{ state: string }>().state).toBe("done");
+    const main = sessRes.json<{ state: string; tmuxName: string }>();
+    expect(main.state).toBe("done");
+    // The whole point of the feature: the pane is actually gone.
+    expect(killSpy).toHaveBeenCalledWith(main.tmuxName);
+    killSpy.mockRestore();
+  });
+
+  it("2.T4 — POST /worktrees/:id/done also releases terminals (marked exited)", async () => {
+    const tmux = await import("../services/tmux.js");
+    const killSpy = vi.spyOn(tmux, "killSession"); // calls through: really kills the pane
+    const wtRes = await app.inject({
+      method: "POST",
+      url: "/worktrees",
+      payload: { projectId, branch: `done-term-${Date.now()}`, modeId: "bug-fix" },
+    });
+    const wt = wtRes.json<{ id: string }>();
+
+    const termRes = await app.inject({
+      method: "POST",
+      url: "/sessions",
+      payload: { worktreeId: wt.id, type: "terminal" },
+    });
+    expect(termRes.statusCode).toBe(201);
+    const term = termRes.json<{ id: string; tmuxName: string }>();
+
+    const doneRes = await app.inject({ method: "POST", url: `/worktrees/${wt.id}/done` });
+    const body = doneRes.json<{ updated: number; terminalsReleased: number }>();
+    expect(body.terminalsReleased).toBe(1);
+
+    const after = await app.inject({ method: "GET", url: `/sessions/${term.id}` });
+    // Terminals have no `done` state of their own — they retire as `exited`,
+    // which is also what the UI's Resume banner keys off.
+    expect(after.json<{ state: string }>().state).toBe("exited");
+    expect(killSpy).toHaveBeenCalledWith(term.tmuxName);
+    killSpy.mockRestore();
+  });
+
+  it("2.T5 — POST /worktrees/:id/done is idempotent (second call updates nothing)", async () => {
+    const tmux = await import("../services/tmux.js");
+    const killSpy = vi.spyOn(tmux, "killSession"); // calls through: really kills the pane
+    const wtRes = await app.inject({
+      method: "POST",
+      url: "/worktrees",
+      payload: { projectId, branch: `done-idem-${Date.now()}`, modeId: "bug-fix" },
+    });
+    const wt = wtRes.json<{ id: string }>();
+
+    const first = await app.inject({ method: "POST", url: `/worktrees/${wt.id}/done` });
+    expect(first.json<{ updated: number }>().updated).toBeGreaterThanOrEqual(1);
+
+    killSpy.mockClear();
+    const second = await app.inject({ method: "POST", url: `/worktrees/${wt.id}/done` });
+    expect(second.statusCode).toBe(200);
+    const body = second.json<{ updated: number; terminalsReleased: number }>();
+    expect(body.updated).toBe(0);
+    expect(body.terminalsReleased).toBe(0);
+    expect(killSpy).not.toHaveBeenCalled();
+    killSpy.mockRestore();
   });
 
   // ─── PATCH /worktrees/:id/pin ───────────────────────────────────────────

--- a/daemon/src/routes/projects.ts
+++ b/daemon/src/routes/projects.ts
@@ -26,6 +26,7 @@ import { slugify, isSafeProjectId } from "../services/slugify.js";
 import { projectDir, assertSafeToDelete } from "../services/paths.js";
 import { readSettings } from "../services/config.js";
 import { broadcastAll } from "../broadcaster.js";
+import { releaseSessionRuntime } from "../services/sessionRuntime.js";
 import type { ProjectRecord, SessionRecord } from "../types.js";
 
 /**
@@ -801,29 +802,19 @@ export function registerProjectRoutes(app: FastifyInstance): void {
       return reply.status(404).send({ error: `Project '${id}' not found` });
     }
 
-    // Cascade: kill all tmux sessions and remove worktree dirs
-    // (tmux kills and git worktree removes happen here; import lazily to avoid
-    //  circular deps — these services may not be available in Phase 3 yet)
-
-    // Kill direct sessions first
+    // Cascade: release every session's runtime, then remove the worktree dirs.
+    // This MUST go through releaseSessionRuntime, not a bare `killSession`: a
+    // `useTmux: false` session (direct-pty, and every json session) has no pane
+    // to kill, so tmux-only teardown left its pty child and its JsonAgentSession
+    // — turn process group and open SQLite handles — running while the code
+    // below rm -rf's the very data dir those handles point at.
     for (const session of project.directSessions) {
-      try {
-        const { killSession } = await import("../services/tmux.js");
-        await killSession(session.tmuxName);
-      } catch {
-        // best-effort
-      }
+      await releaseSessionRuntime(session, { clearAttachments: true });
     }
 
-    // Then kill worktree sessions and remove worktrees
     for (const wt of project.worktrees) {
       for (const session of wt.sessions) {
-        try {
-          const { killSession } = await import("../services/tmux.js");
-          await killSession(session.tmuxName);
-        } catch {
-          // best-effort
-        }
+        await releaseSessionRuntime(session, { clearAttachments: true });
       }
       try {
         const { worktreeRemove } = await import("../services/git.js");

--- a/daemon/src/routes/sessions.ts
+++ b/daemon/src/routes/sessions.ts
@@ -41,7 +41,8 @@ import {
   resolveJsonAgent,
 } from "../services/jsonAgentChat.js";
 import { resolveCliModels } from "./modes.js";
-import { getAttachment, clearSessionAttachments } from "../state/attachmentRegistry.js";
+import { getAttachment } from "../state/attachmentRegistry.js";
+import { releaseSessionRuntime } from "../services/sessionRuntime.js";
 import type { SessionRecord, WorktreeRecord, ProjectRecord, Channel, Attachment, SessionMeta } from "../types.js";
 
 /**
@@ -149,6 +150,31 @@ function findWorktreeContext(
   return null;
 }
 
+/**
+ * A spawn job finished — but the user may have marked the session `done` (or
+ * dismissed it) while the spawn was still in flight, which is easy to do since
+ * a spawn takes seconds. Two things then go wrong unless we re-check:
+ *
+ *  1. The job's completion write would clobber `done` with `working`/`exited`
+ *     (it also writes back a STALE captured `session` object).
+ *  2. Worse, the spawn created its pane/child AFTER the release already killed
+ *     everything — a leaked process the user believes they retired.
+ *
+ * So: if the session is no longer live by the time the spawn lands, release
+ * whatever it just created and skip the lifecycle write entirely.
+ *
+ * Returns true when the caller should skip its own persist/broadcast.
+ */
+async function releaseIfRetiredDuringSpawn(sessionId: string): Promise<boolean> {
+  const ctx = findSessionContext(sessionId);
+  // Gone entirely (dismissed mid-spawn) — nothing left to write to, but the
+  // spawn may still have produced a pane after DELETE's teardown ran.
+  if (!ctx) return true;
+  if (ctx.session.lifecycle.state !== "done") return false;
+  await releaseSessionRuntime(ctx.session);
+  return true;
+}
+
 async function runAgentSpawnJob(opts: {
   project: ProjectRecord;
   worktree: WorktreeRecord;
@@ -182,6 +208,7 @@ async function runAgentSpawnJob(opts: {
       taskPrompt: builtPrompt.taskPrompt,
       model: mode.model,
     });
+    if (await releaseIfRetiredDuringSpawn(sessionId)) return;
     session.lifecycle = { state: "working", lastTransitionAt: new Date().toISOString() };
     await mutateProject(project.id, (p) => ({
       ...p,
@@ -194,6 +221,7 @@ async function runAgentSpawnJob(opts: {
     broadcastAll({ type: "session:state", sessionId, state: "working" });
   } catch (err) {
     const reason = String(err);
+    if (await releaseIfRetiredDuringSpawn(sessionId)) return;
     session.lifecycle = { state: "exited", lastTransitionAt: new Date().toISOString() };
     await mutateProject(project.id, (p) => ({
       ...p,
@@ -239,6 +267,7 @@ async function runDirectAgentSpawnJob(opts: {
       taskPrompt: builtPrompt.taskPrompt,
       model: mode.model,
     });
+    if (await releaseIfRetiredDuringSpawn(sessionId)) return;
     session.lifecycle = { state: "working", lastTransitionAt: new Date().toISOString() };
     await mutateProject(project.id, (p) => ({
       ...p,
@@ -247,6 +276,7 @@ async function runDirectAgentSpawnJob(opts: {
     broadcastAll({ type: "session:state", sessionId, state: "working" });
   } catch (err) {
     const reason = String(err);
+    if (await releaseIfRetiredDuringSpawn(sessionId)) return;
     session.lifecycle = { state: "exited", lastTransitionAt: new Date().toISOString() };
     await mutateProject(project.id, (p) => ({
       ...p,
@@ -666,27 +696,11 @@ export function registerSessionRoutes(app: FastifyInstance): void {
       });
     }
 
-    // Abort any live JSON turn BEFORE purge (Decision 13): kill the turn's
-    // process group so no orphaned child keeps mutating the checkout, and drop
-    // the queue. Cheap no-op for TTY sessions (registry miss). dispose() closes
-    // the session's own SQLite handle — the registry delete alone leaks the
-    // fd (better-sqlite3 has no reliable GC finalizer to fall back on).
-    const jsonAgentToClose = jsonAgentRegistry.get(id);
-    jsonAgentToClose?.abortAndDrain();
-    jsonAgentRegistry.delete(id);
-    jsonAgentToClose?.dispose();
-    clearSessionAttachments(id);
-
-    // Kill session (tmux or direct-pty)
-    if (!session.useTmux) {
-      directPtyRegistry.get(id)?.kill?.();
-    } else {
-      try {
-        await killSession(session.tmuxName);
-      } catch {
-        // best-effort
-      }
-    }
+    // Release every live resource BEFORE purge (Decision 13): the JSON turn's
+    // process group (so no orphaned child keeps mutating the checkout), its
+    // SQLite handle, the tmux pane / direct-pty child, and the idle tracker.
+    // Delete is destructive, so staged attachments go too.
+    await releaseSessionRuntime(session, { clearAttachments: true });
 
     if (ctx.kind === "worktree") {
       // Worktree session: cleanup worktree-scoped data dir
@@ -775,8 +789,12 @@ export function registerSessionRoutes(app: FastifyInstance): void {
     return reply.send({ ok: true, pinnedAt: nextPinnedAt ?? null });
   });
 
-  // POST /sessions/:id/done — mark an agent session as done (metadata only; no
-  // process kill). Terminals have no "done" concept, so reject them.
+  // POST /sessions/:id/done — retire an agent session: RELEASE its runtime
+  // resources (tmux pane / direct-pty child / JsonAgentSession + SQLite handle)
+  // and mark it `done`. Everything needed for a later `POST /:id/resume`
+  // survives — the manifest record with its `agentChatId`, the session data
+  // dir, staged attachments, and the CLI's own history — so "done" is a pause,
+  // not a delete. Terminals have no "done" concept, so reject them.
   app.post("/sessions/:id/done", async (req, reply) => {
     const { id } = req.params as { id: string };
     const ctx = findSessionContext(id);
@@ -784,6 +802,14 @@ export function registerSessionRoutes(app: FastifyInstance): void {
     if (ctx.session.type !== "agent") {
       return reply.status(400).send({ error: "Only agent sessions can be marked done." });
     }
+    // Idempotent: a repeat call has nothing left to release.
+    if (ctx.session.lifecycle.state === "done") return reply.send({ ok: true });
+
+    // Release BEFORE persisting so the `done` broadcast is the last word the
+    // clients hear: releasing a JSON session unwinds its drain, which would
+    // otherwise persist a trailing `idle` (the `released` latch inside
+    // `JsonAgentSession` suppresses it, but ordering costs nothing).
+    await releaseSessionRuntime(ctx.session);
 
     ctx.session.lifecycle = { state: "done", lastTransitionAt: new Date().toISOString() };
     // persistLifecycleState handles both the worktree and direct branches and
@@ -1266,6 +1292,18 @@ export function registerSessionRoutes(app: FastifyInstance): void {
       .safeParse(req.body);
     if (!parsed.success) return reply.status(400).send({ error: "invalid model" });
 
+    // `resolveJsonAgent` lazily re-creates a released JsonAgentSession (and
+    // reopens its SQLite handles). For a session the user marked `done` that
+    // would resurrect the very resources "mark as done" freed — without even
+    // moving the session out of `done`. Refuse instead; sending a message is
+    // the deliberate way to bring a done session back.
+    const modelCtx = findSessionContext(id);
+    if (modelCtx?.session.lifecycle.state === "done") {
+      return reply.status(409).send({
+        error: "Session is done — send a message to resume it before switching model.",
+      });
+    }
+
     const daemonPort = (app.server.address() as { port?: number })?.port ?? 7421;
     const resolved = await resolveJsonAgent(id, daemonPort);
     if (!resolved.ok) {
@@ -1437,9 +1475,8 @@ export function registerSessionRoutes(app: FastifyInstance): void {
         // dispose() closes the SQLite handle so a repeated json→tty→json cycle
         // doesn't accumulate one open store per toggle.
         const jsonAgentToClose = jsonAgentRegistry.get(id);
-        jsonAgentToClose?.abortAndDrain();
         jsonAgentRegistry.delete(id);
-        jsonAgentToClose?.dispose();
+        await jsonAgentToClose?.release();
         // Allocate the real terminal tmux name + flip the useTmux/channel
         // invariant BEFORE spawning so the pane attaches to a live window.
         session.tmuxName = ttyTmuxName;

--- a/daemon/src/routes/worktrees.ts
+++ b/daemon/src/routes/worktrees.ts
@@ -8,8 +8,6 @@ import { getProject, getAllProjects, mutateProject } from "../state/project-stor
 import { validateBranch, branchExistsInRepo } from "../services/branchValidator.js";
 import { reserveNextWorktreeNum, buildTmuxName } from "../services/sessionId.js";
 import { worktreeAdd, worktreeRemove, revParse, fetchOrigin, branchExists } from "../services/git.js";
-import { killSession } from "../services/tmux.js";
-import { directPtyRegistry } from "../state/directPtyRegistry.js";
 import { rollbackWorktreeCreate } from "../services/rollback.js";
 import { spawnSession } from "../services/spawn.js";
 import { worktreePath as getWorktreePath, cleanupSessionDataDir, sessionDataDir } from "../services/paths.js";
@@ -21,9 +19,8 @@ import { serializeSession } from "./sessions.js";
 import { resolvePlugin } from "../agent-plugins/registry.js";
 import { resolveUseTmux } from "../services/resolveUseTmux.js";
 import { resolveChannel } from "../services/channel.js";
-import { jsonAgentRegistry } from "../state/jsonAgentRegistry.js";
 import { startJsonCreateTurn } from "../services/jsonAgentChat.js";
-import { clearSessionAttachments } from "../state/attachmentRegistry.js";
+import { releaseSessionRuntime } from "../services/sessionRuntime.js";
 import type { AgentPlugin } from "../services/spawn.js";
 import type { WorktreeRecord, SessionRecord, ProjectRecord, Channel } from "../types.js";
 
@@ -539,8 +536,13 @@ export function registerWorktreeRoutes(app: FastifyInstance): void {
     return reply.send({ ok: true, worktree: apiWorktree });
   });
 
-  // POST /worktrees/:id/done — mark all agent sessions as done (metadata only; no process kill)
-
+  // POST /worktrees/:id/done — put the whole worktree to rest: every agent
+  // session is released + marked `done`, and every TERMINAL session is released
+  // + marked `exited` (terminals have no `done` state of their own). Releasing
+  // the terminals is the point — a worktree "done" that leaves shells running
+  // still holds a tmux server and whatever long-running dev process was in it.
+  // Nothing on disk is removed, so every session stays resumable via
+  // `POST /sessions/:id/resume`.
   app.post("/worktrees/:id/done", async (req, reply) => {
     const { id: wtId } = req.params as { id: string };
     const project = getAllProjects().find((p) => p.worktrees.some((w) => w.id === wtId));
@@ -548,13 +550,32 @@ export function registerWorktreeRoutes(app: FastifyInstance): void {
 
     const worktree = project.worktrees.find((w) => w.id === wtId)!;
     let updated = 0;
-    for (const session of worktree.sessions.filter((s) => s.type === "agent")) {
-      session.lifecycle = { state: "done", lastTransitionAt: new Date().toISOString() };
-      await persistLifecycleState(project.id, wtId, session.id, "done");
-      broadcastAll({ type: "session:state", sessionId: session.id, state: "done" });
-      updated += 1;
+    let terminalsReleased = 0;
+
+    for (const session of worktree.sessions) {
+      if (session.type === "agent") {
+        // Idempotent — a second call must not re-count already-done agents.
+        if (session.lifecycle.state === "done") continue;
+        await releaseSessionRuntime(session);
+        session.lifecycle = { state: "done", lastTransitionAt: new Date().toISOString() };
+        // persistLifecycleState broadcasts `session:state` itself.
+        await persistLifecycleState(project.id, wtId, session.id, "done");
+        updated += 1;
+        continue;
+      }
+
+      if (session.lifecycle.state === "exited") continue;
+      // Terminals: persist `exited` BEFORE the kill. Killing a direct-pty child
+      // fires `DirectPtyStream.onExit` → `markSessionExited`, which early-
+      // returns once the state is already `exited` — so writing first turns
+      // that callback into a no-op instead of a duplicate broadcast.
+      session.lifecycle = { state: "exited", lastTransitionAt: new Date().toISOString() };
+      await persistLifecycleState(project.id, wtId, session.id, "exited");
+      await releaseSessionRuntime(session);
+      terminalsReleased += 1;
     }
-    return reply.send({ ok: true, updated });
+
+    return reply.send({ ok: true, updated, terminalsReleased });
   });
 
   // DELETE /worktrees/:id
@@ -571,23 +592,10 @@ export function registerWorktreeRoutes(app: FastifyInstance): void {
 
     // Kill all sessions (tmux or direct-pty)
     for (const session of worktree.sessions) {
-      // Abort any live JSON turn BEFORE purge (Decision 13) so no orphaned turn
-      // child keeps writing into the worktree mid-removal. dispose() closes the
-      // session's own SQLite handle (registry delete alone leaks the fd).
-      const jsonAgentToClose = jsonAgentRegistry.get(session.id);
-      jsonAgentToClose?.abortAndDrain();
-      jsonAgentRegistry.delete(session.id);
-      jsonAgentToClose?.dispose();
-      clearSessionAttachments(session.id);
-      if (!session.useTmux) {
-        directPtyRegistry.get(session.id)?.kill?.();
-      } else {
-        try {
-          await killSession(session.tmuxName);
-        } catch {
-          // best-effort
-        }
-      }
+      // Release every live resource BEFORE purge (Decision 13) so no orphaned
+      // turn child keeps writing into the worktree mid-removal. Deleting is
+      // destructive, so staged attachments go too.
+      await releaseSessionRuntime(session, { clearAttachments: true });
       // Best-effort cleanup of per-session data dir
       cleanupSessionDataDir(project.id, wtId, session.id);
     }

--- a/daemon/src/services/jsonAgent.ts
+++ b/daemon/src/services/jsonAgent.ts
@@ -46,6 +46,15 @@ import type {
 } from "../types.js";
 
 /**
+ * How long `release()` waits for an aborted turn's drain to unwind before
+ * closing the SQLite handle anyway. The wait exists so the common case closes
+ * a quiescent store; the cap exists so a wedged child can never hang the
+ * `POST /sessions/:id/done` request. Safe to expire: `released` has already
+ * neutralised every writer, and the child's process group is already SIGKILLed.
+ */
+const RELEASE_DRAIN_TIMEOUT_MS = 2000;
+
+/**
  * Inject absolute attachment paths into a user message (Decision 5). The agent
  * reads the files by absolute path (they live under `sessionDataDir`, not the
  * checkout). Applied at RUN time (not enqueue) so the queued turn retains the
@@ -264,6 +273,21 @@ export class JsonAgentSession {
   /** Live per-turn child PIDs (own process groups) for orphan-kill safety (Decision 13). */
   private readonly livePids = new Set<number>();
 
+  /**
+   * Set by `release()` — this instance is being torn down and must never write
+   * again. Two late writers exist and both would corrupt state after release:
+   *
+   * 1. `drain()`'s `finally` persists lifecycle `idle` as the aborted turn
+   *    unwinds. That lands AFTER the caller has persisted `done`, silently
+   *    demoting a deliberately-done session back to idle.
+   * 2. `persist()` appends to the SQLite store, which `dispose()` has closed —
+   *    a straggler event would throw.
+   *
+   * Both check this latch. It is a latch rather than an ordering rule because
+   * the unwinding is asynchronous and cannot be awaited race-free otherwise.
+   */
+  private released = false;
+
   constructor(opts: JsonAgentSessionOptions) {
     this.project = opts.project;
     this.worktree = opts.worktree;
@@ -413,6 +437,28 @@ export class JsonAgentSession {
     } catch {
       /* already closed / best-effort */
     }
+  }
+
+  /**
+   * Full teardown for a session that is being retired but KEPT on disk
+   * (`POST /sessions/:id/done`, `POST /worktrees/:id/done`, delete, worktree
+   * delete). Latches `released` first so neither the unwinding drain nor a
+   * straggler event can write after us, aborts the active turn + queue, waits
+   * (bounded) for the drain to unwind, then closes the SQLite handle.
+   *
+   * Idempotent. Never throws. The 2 s cap means a wedged child cannot hang the
+   * HTTP request — `released` has already neutralised anything it might write,
+   * and `abortAndDrain` has already SIGKILLed its process group.
+   */
+  async release(): Promise<void> {
+    if (this.released) return;
+    this.released = true;
+    this.abortAndDrain();
+    await Promise.race([
+      this.settled().catch(() => {}),
+      new Promise<void>((resolve) => setTimeout(resolve, RELEASE_DRAIN_TIMEOUT_MS)),
+    ]);
+    this.dispose();
   }
 
   /**
@@ -711,6 +757,9 @@ export class JsonAgentSession {
 
   /** Persist the session lifecycle to the manifest (JSON channel, Decision 11). */
   private async persistLifecycle(state: LifecycleState): Promise<void> {
+    // Released sessions are terminal (`done`) — the drain's trailing `idle`
+    // must not demote them. See the `released` field comment.
+    if (this.released) return;
     try {
       const { persistLifecycleState } = await import("./lifecycle.js");
       await persistLifecycleState(this.project.id, this.worktree?.id, this.session.id, state);
@@ -905,6 +954,9 @@ export class JsonAgentSession {
   }
 
   private persist(ev: NormalizedEvent): void {
+    // The store handle is closed once released — a straggler event from the
+    // unwinding turn would throw against a closed database.
+    if (this.released) return;
     // Append-only through the store; assigns + stamps the durable `logSeq`
     // synchronously before the WS send (N3).
     this.store.append(ev);

--- a/daemon/src/services/jsonAgentChat.ts
+++ b/daemon/src/services/jsonAgentChat.ts
@@ -200,6 +200,14 @@ export async function startJsonCreateTurn(opts: {
   daemonPort: number;
 }): Promise<void> {
   if (!opts.prompt || !opts.prompt.trim()) return;
+  // The user can mark the session done (or dismiss it) between create and this
+  // background call. Enqueuing then RE-CREATES the JsonAgentSession that the
+  // release just tore down and spawns turn 1 against it — a session the user
+  // believes is retired quietly starts burning tokens. A later, deliberate
+  // `POST /chat` is still the documented way to resume; only this automatic
+  // turn-1 is suppressed.
+  const preCtx = findJsonSessionContext(opts.sessionId);
+  if (!preCtx || preCtx.session.lifecycle.state === "done") return;
   const res = await enqueueChatTurn({
     sessionId: opts.sessionId,
     message: opts.prompt,

--- a/daemon/src/services/lifecycle.ts
+++ b/daemon/src/services/lifecycle.ts
@@ -259,7 +259,14 @@ export async function markSessionExited(
     session = project.directSessions.find((s) => s.id === sessionId);
   }
 
-  if (!session || session.lifecycle.state === "exited") return;
+  // `done` is deliberate and terminal — marking a session done kills its pane
+  // on purpose, and the direct-pty `onExit` callback fires right back into
+  // here. Without this guard that callback would demote the session to
+  // `exited` moments after the user marked it done (and the broadcast would
+  // overwrite `done` in every connected client's store).
+  if (!session || session.lifecycle.state === "exited" || session.lifecycle.state === "done") {
+    return;
+  }
 
   idleTracking.delete(sessionId);
   broadcastAll({ type: "session:exited", sessionId });

--- a/daemon/src/services/sessionRuntime.ts
+++ b/daemon/src/services/sessionRuntime.ts
@@ -1,0 +1,64 @@
+import type { SessionRecord } from "../types.js";
+import { jsonAgentRegistry } from "../state/jsonAgentRegistry.js";
+import { directPtyRegistry } from "../state/directPtyRegistry.js";
+import { clearSessionAttachments } from "../state/attachmentRegistry.js";
+import { killSession } from "./tmux.js";
+import { clearIdleTracking } from "./lifecycle.js";
+
+/**
+ * Release every LIVE runtime resource a session holds, without touching
+ * anything persisted.
+ *
+ * Freed here:
+ * - the `JsonAgentSession` (in-flight turn's process group, turn queue, its own
+ *   SQLite WAL handle = 3 fds, stream listeners) and its registry entry
+ * - the tmux pane (and with it the agent CLI's whole process tree) or, for
+ *   `useTmux: false`, the direct-pty child
+ * - the lifecycle poller's idle-hash entry
+ *
+ * NOT touched (so the session stays resumable):
+ * - the `SessionRecord` in the manifest — including `agentChatId`, which is
+ *   what `POST /sessions/:id/resume` feeds to `--resume`
+ * - the session data dir (system prompt, JSON transcript SQLite file)
+ * - the worktree checkout and the agent CLI's own history files
+ * - staged attachments, unless `clearAttachments` is set
+ *
+ * Callers:
+ * - `POST /sessions/:id/done` / `POST /worktrees/:id/done` — reclaim resources
+ *   while keeping the session resumable (attachments kept)
+ * - `DELETE /sessions/:id` / `DELETE /worktrees/:id` — same teardown as the
+ *   first step of a destructive removal (`clearAttachments: true`)
+ *
+ * Best-effort throughout: a missing pane, an unregistered pty, or a
+ * already-released agent are all normal, so nothing here throws.
+ */
+export async function releaseSessionRuntime(
+  session: SessionRecord,
+  opts: { clearAttachments?: boolean } = {},
+): Promise<void> {
+  // Unregister BEFORE releasing so a concurrent request can't hand out a
+  // handle that is mid-teardown; `release()` is idempotent either way.
+  const agent = jsonAgentRegistry.get(session.id);
+  jsonAgentRegistry.delete(session.id);
+  // Awaited: `release()` latches the session against late writes, kills the
+  // turn's process group, waits (bounded) for the drain to unwind, and only
+  // then closes SQLite. Without the await, the drain's trailing lifecycle
+  // persist would land after the caller writes `done` and demote it to `idle`.
+  if (agent) await agent.release();
+
+  if (opts.clearAttachments) clearSessionAttachments(session.id);
+
+  if (!session.useTmux) {
+    // Direct-pty (and json, which is always `useTmux: false` — a registry miss
+    // there, since json sessions spawn per turn and hold no long-lived pty).
+    directPtyRegistry.get(session.id)?.kill?.();
+  } else {
+    try {
+      await killSession(session.tmuxName);
+    } catch {
+      // Pane already gone — nothing to reclaim.
+    }
+  }
+
+  clearIdleTracking(session.id);
+}

--- a/daemon/src/ws/handlers/chatOpen.ts
+++ b/daemon/src/ws/handlers/chatOpen.ts
@@ -24,6 +24,7 @@ import {
   resolveJsonAgent,
   readSessionTail,
   readSessionSince,
+  readSessionMeta,
   type JsonSessionContext,
 } from "../../services/jsonAgentChat.js";
 import type { NormalizedEvent, SessionMeta } from "../../types.js";
@@ -44,6 +45,24 @@ export async function handleChatOpen(
   }
 
   conn.subscribe([sessionId]);
+
+  // A session marked `done` has had its JsonAgentSession released — SQLite
+  // handle closed, turn queue dropped. `resolveJsonAgent` would lazily
+  // RE-CREATE it (reopening 3 WAL fds) just to render a read-only transcript,
+  // silently undoing the release that "mark as done" performed. Serve it from
+  // disk instead. Sending a message resumes the session for real (the enqueue
+  // path re-creates the agent and flips lifecycle back to `working`).
+  if (ctx.session.lifecycle.state === "done") {
+    // Drop any live entry from a PREVIOUS open of this same session — the
+    // early return below skips the unregister in the live branch, and a stale
+    // entry would pin the just-released agent (and its listeners) alive.
+    conn.unregisterChatStream(sessionId);
+    sendSnapshot(conn, ctx, sessionId, sinceSeq);
+    // `useChat` has no other meta source, so without this the status bar,
+    // model switcher and usage read blank on every done session.
+    conn.send({ type: "session:meta", sessionId, meta: await readSessionMeta(ctx, 0) });
+    return;
+  }
 
   // Resolve (lazily create) the JsonAgentSession so we can attach to its stream
   // and read its current meta. No spawn happens here — only on enqueue.

--- a/docs/SESSION-EXECUTION.md
+++ b/docs/SESSION-EXECUTION.md
@@ -68,3 +68,70 @@ daemon
 | Output | `tmuxOutput.ts` | `directPtyOutput.ts` | NDJSON → `NormalizedEvent` (WS `session:message`) |
 | Web pane | `TerminalPane` | `TerminalPane` | `ChatPane` |
 | Survive restart | yes | no | yes (resume via chat id) |
+
+## Retiring a session: `done` vs `delete`
+
+Both go through one shared teardown — `releaseSessionRuntime()`
+(`daemon/src/services/sessionRuntime.ts`) — which frees every LIVE resource a
+session holds and touches nothing on disk:
+
+| Freed by `releaseSessionRuntime` | Kept |
+|---|---|
+| tmux pane (and the agent CLI process tree under it) | `SessionRecord` in the manifest, incl. `agentChatId` |
+| direct-pty child (`useTmux: false`) | session data dir (system prompt, transcript SQLite) |
+| `JsonAgentSession`: in-flight turn's process group, turn queue, SQLite WAL handle (3 fds), stream listeners | the worktree checkout |
+| lifecycle poller's idle-hash entry | the CLI's own history (`~/.claude/projects/<slug>/<uuid>.jsonl`) |
+| staged attachments — **only** with `{ clearAttachments: true }` (delete does; done does not) | |
+
+- `POST /sessions/:id/done` — release + mark `done`. Agent sessions only (400 for
+  terminals). Idempotent.
+- `POST /worktrees/:id/done` — same for every agent in the worktree, plus every
+  TERMINAL session (released and marked `exited`, since terminals have no `done`
+  state). Returns `{ ok, updated, terminalsReleased }`.
+- `DELETE /sessions/:id` / `DELETE /worktrees/:id` — the same release, then the
+  destructive part (data dir, manifest record, optionally the checkout).
+
+### Coming back
+
+- TTY session → `POST /sessions/:id/resume` (`getRestoreCommand` → `--resume <agentChatId>`
+  in a fresh pane). The UI surfaces this as the "Session marked done. / Resume"
+  banner, which `TerminalPane` renders for `done` exactly as it does for `exited`.
+- JSON session → just send a message; `POST /sessions/:id/chat` re-creates the
+  `JsonAgentSession` and flips the lifecycle back to `working`. Read-only paths
+  (`chat:open`, `GET /transcript`, `GET /meta`) deliberately serve a done session
+  from disk WITHOUT re-creating the agent, so browsing a done chat does not undo
+  the release. `PATCH /chat/model` refuses with `409` for the same reason.
+
+### What must never demote `done`
+
+`done` is deliberate and terminal, and three code paths would otherwise write
+over it — all three now check for it explicitly:
+
+1. The lifecycle poller's dead-pane detection (`lifecycle.ts` — skips `done`).
+2. `markSessionExited`, which `DirectPtyStream.onExit` fires when the release
+   kills the pty child.
+3. `JsonAgentSession`'s drain, whose `finally` persists a trailing `idle` as the
+   aborted turn unwinds — suppressed by the `released` latch that `release()`
+   sets before it aborts anything.
+
+### Every retire path, and what it frees
+
+| User action | Endpoint | Releases runtime? | Record kept? |
+|---|---|---|---|
+| Session menu → **Mark as done** (agents, worktree AND direct) | `POST /sessions/:id/done` | yes | yes — resumable |
+| Session menu → **Dismiss (keep files)** | `DELETE /sessions/:id` | yes | no — record + data dir removed ("files" = your checkout) |
+| Worktree menu → **Mark as done** | `POST /worktrees/:id/done` | yes, every agent + terminal | yes |
+| Worktree menu / dashboard → **Dismiss (keep files)** | `DELETE /worktrees/:id` | yes, every session | no — checkout stays on disk |
+| Worktree menu → **Delete worktree…** | `DELETE /worktrees/:id?purge=true` | yes | no — checkout removed too |
+| Terminal tab **×** | `DELETE /sessions/:id` | yes | no |
+| Project menu → **Hide project** | `PATCH /projects/:id` | **NO** — everything keeps running | yes |
+
+- "Dismiss" is never client-side — both variants are real daemon deletes.
+- `POST /sessions/:id/done` works for direct (project-level) sessions too: `findSessionContext` resolves both, and `releaseSessionRuntime` branches on `useTmux`, not on worktree-ness.
+- There is no bulk retire for a project's direct sessions (no `POST /projects/:id/done`) — the only bulk path is the worktree one.
+
+### Retiring mid-spawn
+
+- An agent spawn takes seconds, and the user can mark done inside that window.
+- Both spawn jobs (`runAgentSpawnJob`, `runDirectAgentSpawnJob`) re-check the session's CURRENT state before their completion write, via `releaseIfRetiredDuringSpawn`. If it is `done` (or the record is gone), they release whatever the spawn just created and skip the write — otherwise the job would clobber `done` with `working`/`exited` AND leak the pane it created after the release ran.
+- `startJsonCreateTurn` (the auto-enqueued turn 1) is likewise suppressed for a session already marked `done`, so a retired session never starts spending tokens on its own. A deliberate `POST /chat` is still the resume path.

--- a/web-ui/src/api/client.ts
+++ b/web-ui/src/api/client.ts
@@ -309,12 +309,20 @@ export function createClientApi() {
       return parseJson<{ ok: true }>(res);
     },
 
-    async markWorktreeDone(id: string): Promise<{ ok: true; updated: number }> {
+    /**
+     * Mark every agent session in a worktree done and RELEASE the worktree's
+     * runtime resources: agent panes/processes are killed, terminals are killed
+     * and marked exited. Nothing on disk is removed — each session resumes via
+     * `resumeSession` (or, for Rich Chat, by sending a message).
+     */
+    async markWorktreeDone(
+      id: string,
+    ): Promise<{ ok: true; updated: number; terminalsReleased: number }> {
       const root = baseUrl();
       const res = await apiFetch(`${root}/worktrees/${encodeURIComponent(id)}/done`, {
         method: "POST",
       });
-      return parseJson<{ ok: true; updated: number }>(res);
+      return parseJson<{ ok: true; updated: number; terminalsReleased: number }>(res);
     },
 
     async pinWorktree(id: string): Promise<{ ok: true; worktree: Worktree }> {
@@ -386,7 +394,11 @@ export function createClientApi() {
       return parseJson<{ ok: true; pinnedAt: string | null }>(res);
     },
 
-    /** Mark an agent session as done (metadata only; no process kill). */
+    /**
+     * Mark an agent session done: the daemon kills its tmux pane / pty child and
+     * releases its Rich Chat session. The session record, its history and any
+     * staged attachments survive, so `resumeSession` brings it back.
+     */
     async markSessionDone(id: string): Promise<{ ok: true }> {
       const root = baseUrl();
       const res = await apiFetch(`${root}/sessions/${encodeURIComponent(id)}/done`, {

--- a/web-ui/src/api/mock.ts
+++ b/web-ui/src/api/mock.ts
@@ -404,18 +404,31 @@ export function createMockApi() {
       return { ok: true };
     },
 
-    async markWorktreeDone(id: string): Promise<{ ok: true; updated: number }> {
+    async markWorktreeDone(
+      id: string,
+    ): Promise<{ ok: true; updated: number; terminalsReleased: number }> {
       const wtExists = worktrees.some((w) => w.id === id);
-      const agents = sessions.filter((s) => s.worktreeId === id && s.type === "agent");
       if (!wtExists) throw new ApiError("not found", 404);
       let updated = 0;
-      for (const s of agents) {
-        s.state = "done";
-        s.lifecycleState = "done";
-        emit({ type: "session:state", sessionId: s.id, state: "done" });
-        updated += 1;
+      let terminalsReleased = 0;
+      // Mirrors the daemon: agents → done, terminals → exited (their processes
+      // are released too, which the mock has no equivalent of).
+      for (const s of sessions.filter((x) => x.worktreeId === id)) {
+        if (s.type === "agent") {
+          if (s.lifecycleState === "done") continue;
+          s.state = "done";
+          s.lifecycleState = "done";
+          emit({ type: "session:state", sessionId: s.id, state: "done" });
+          updated += 1;
+        } else {
+          if (s.lifecycleState === "exited") continue;
+          s.state = "exited";
+          s.lifecycleState = "exited";
+          emit({ type: "session:state", sessionId: s.id, state: "exited" });
+          terminalsReleased += 1;
+        }
       }
-      return { ok: true, updated };
+      return { ok: true, updated, terminalsReleased };
     },
 
     async pinWorktree(id: string): Promise<{ ok: true; worktree: Worktree }> {
@@ -539,6 +552,10 @@ export function createMockApi() {
       if (s.type !== "agent") throw new ApiError("only agent sessions can be marked done", 400);
       s.state = "done";
       s.lifecycleState = "done";
+      // Parity with markWorktreeDone (and with the daemon, which broadcasts via
+      // persistLifecycleState) — without this the pane never learns it is done
+      // and no Resume banner appears.
+      emit({ type: "session:state", sessionId: id, state: "done" });
       return { ok: true };
     },
 

--- a/web-ui/src/components/layout/AgentPaneSlot.test.tsx
+++ b/web-ui/src/components/layout/AgentPaneSlot.test.tsx
@@ -122,6 +122,16 @@ describe("AgentPaneSlot remount invariant (4.T5 / Decision 14)", () => {
     expect(container.querySelector('[data-testid="attachment-upload"]')).not.toBeNull();
   });
 
+  it("3.T3 — hides the upload overlay for a session marked done (its pane is released)", () => {
+    // "Mark as done" kills the tmux/pty process just like an exit does, so the
+    // live-terminal-only upload overlay must be gated for `done` too.
+    const done: Session = { ...session("tty1", "tmux"), lifecycleState: "done" };
+    const { container } = render(<AgentPaneSlot api={api} sessionId="tty1" session={done} />);
+    expect(container.querySelector('[data-testid="terminal"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="channel-toggle"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="attachment-upload"]')).toBeNull();
+  });
+
   it("keeps handing TerminalPane the channel toggle when exited, but hides the upload overlay (Resume banner bug)", () => {
     // The channel toggle now lives inside TerminalPane, which renders it in
     // normal flow BELOW its own "Session exited / Resume" banner (no overlap),

--- a/web-ui/src/components/layout/AgentPaneSlot.tsx
+++ b/web-ui/src/components/layout/AgentPaneSlot.tsx
@@ -35,7 +35,11 @@ export function AgentPaneSlot({ api, sessionId, session }: AgentPaneSlotProps) {
     !isJson && session ? <TerminalChannelToggle api={api} session={session} /> : null;
   // The attachment-upload overlay is still a plain top-corner overlay that only
   // makes sense on a live terminal, so keep gating it out once the pane exits.
-  const terminalLive = !isJson && session?.lifecycleState !== "exited";
+  // `done` releases the pane exactly like `exited` does (the daemon kills the
+  // tmux/pty process), so the upload overlay — which only makes sense against a
+  // live terminal — is hidden for both.
+  const terminalLive =
+    !isJson && session?.lifecycleState !== "exited" && session?.lifecycleState !== "done";
   return (
     <div className="agent-pane-slot">
       <div

--- a/web-ui/src/components/layout/TerminalPane.test.tsx
+++ b/web-ui/src/components/layout/TerminalPane.test.tsx
@@ -85,6 +85,45 @@ describe("TerminalPane", () => {
     expect(screen.getByText(/Session exited/i)).toBeInTheDocument();
   });
 
+  it("3.T1 — resume banner shown with done copy when the session was marked done", () => {
+    useWorkspaceStore.setState({
+      sessionStates: { "sess-main": "done" },
+    });
+    render(<TerminalPane api={api} sessionId="sess-main" />);
+    // Marking done kills the pane on the daemon, so the pane must offer the
+    // same one-click recovery as an exit — with copy that says why.
+    expect(screen.getByText(/Session marked done/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Session exited/i)).toBeNull();
+    expect(screen.getByRole("button", { name: /Resume/i })).toBeInTheDocument();
+  });
+
+  it("3.T2 — a done session never opens a stream (its pane is already gone)", () => {
+    const spy = vi.spyOn(api, "openSession");
+    useWorkspaceStore.setState({
+      sessionStates: { "sess-main": "done" },
+    });
+    render(<TerminalPane api={api} sessionId="sess-main" />);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("3.T2b — clicking Resume on a done session resumes and re-opens the stream", async () => {
+    const user = userEvent.setup();
+    const resumeSpy = vi.spyOn(api, "resumeSession");
+    const openSpy = vi.spyOn(api, "openSession");
+    useWorkspaceStore.setState({
+      sessionStates: { "sess-main": "done" },
+    });
+    render(<TerminalPane api={api} sessionId="sess-main" />);
+    await user.click(screen.getByRole("button", { name: /Resume/i }));
+    await waitFor(() => {
+      expect(resumeSpy).toHaveBeenCalledWith("sess-main");
+      expect(openSpy).toHaveBeenCalledWith("sess-main", expect.any(Number), expect.any(Number));
+    });
+    resumeSpy.mockRestore();
+    openSpy.mockRestore();
+  });
+
   it("clicking Resume calls api.resumeSession", async () => {
     const user = userEvent.setup();
     const spy = vi.spyOn(api, "resumeSession");

--- a/web-ui/src/components/layout/TerminalPane.tsx
+++ b/web-ui/src/components/layout/TerminalPane.tsx
@@ -91,6 +91,19 @@ export function TerminalPane({ api, sessionId, session, channelToggle }: Termina
     lifecycleState != null &&
     lifecycleState !== "not_started";
 
+  // "Mark as done" releases the session's runtime: the daemon kills the tmux
+  // pane / pty child, so there is nothing left to attach to. Every open would
+  // just cost a failed `tmux has-session` round-trip and a transient error
+  // frame. The terminal still MOUNTS (so its existing scrollback stays
+  // readable) — it simply never re-opens a stream until Resume.
+  const paneReleased = lifecycleState === "done";
+  // Read through a ref inside the mount effect: making it a dependency would
+  // tear down and rebuild the whole xterm instance the moment a session is
+  // marked done — exactly the remount churn the stable-tree-position rule
+  // (web-ui AGENTS.md §7-41) exists to avoid.
+  const paneReleasedRef = useRef(paneReleased);
+  paneReleasedRef.current = paneReleased;
+
   const spawnReason = lifecycleState === "not_started" ? "spawning" : "reconnecting";
 
   const { sessionState } = useSessionOutput(api, activeSessionId);
@@ -221,9 +234,12 @@ export function TerminalPane({ api, sessionId, session, channelToggle }: Termina
     });
 
     // Open session synchronously after fit. Daemon won't emit chunks
-    // until openSession lands.
-    markSessionAttachPending(activeSessionId);
-    void api.openSession(activeSessionId, term.cols, term.rows);
+    // until openSession lands. Skipped for a released (done) session — its
+    // pane is gone; Resume is what brings it back.
+    if (!paneReleasedRef.current) {
+      markSessionAttachPending(activeSessionId);
+      void api.openSession(activeSessionId, term.cols, term.rows);
+    }
 
     // Mobile vertical-swipe scrolling. In normal buffer it scrolls xterm's
     // scrollback; in alternate buffer (vim/htop/tmux copy-mode) it sends
@@ -352,7 +368,8 @@ export function TerminalPane({ api, sessionId, session, channelToggle }: Termina
         everOnline &&
         activeSessionId &&
         termRef.current &&
-        mountTerminal
+        mountTerminal &&
+        !paneReleasedRef.current
       ) {
         termRef.current.reset();
         markSessionAttachPending(activeSessionId);
@@ -385,14 +402,22 @@ export function TerminalPane({ api, sessionId, session, channelToggle }: Termina
   }
 
   const state = activeSessionId ? sessionStates[activeSessionId] : undefined;
-  const showBanner = state === "exited" || sessionState === "exited";
+  // `done` gets the same banner as `exited`: the daemon has killed the pane in
+  // both cases and Resume is the same one-click recovery. Without this a
+  // done session would render a frozen, dead terminal with no way back — the
+  // daemon sends no exit frame when it kills the pane under an attached
+  // client, so this store state is the ONLY signal the pane gets.
+  const showBanner = state === "done" || state === "exited" || sessionState === "exited";
+  // `done` is checked before the local `sessionState`, which the dying pty can
+  // push to "exited" — the deliberate state must win over the side effect.
+  const bannerMsg = state === "done" ? "Session marked done." : "Session exited.";
 
   return (
     <div className="terminal-pane-root">
       {showBanner ? (
         <>
           <div className="terminal-resume-banner">
-            <span className="terminal-resume-banner__msg">Session exited.</span>
+            <span className="terminal-resume-banner__msg">{bannerMsg}</span>
             <span className="terminal-resume-banner__action">
               {resumePending ? (
                 <span className="terminal-resume-busy" role="status" aria-live="polite" aria-label="Resuming session">


### PR DESCRIPTION
## Problem

"Mark as done" was metadata-only — its own code comment said so ("metadata only; no process kill"). It wrote `lifecycle.state = "done"` and freed nothing:

- the tmux pane, and the whole agent CLI process tree under it
- the direct-pty child, for `useTmux: false` sessions
- the Rich Chat `JsonAgentSession` — in-flight turn's process group, turn queue, SQLite WAL handle (3 fds), stream listeners

There is no reaper anywhere in the daemon, so all of that survived until an explicit delete. A day of marking sessions done leaves dozens of idle process trees resident.

## Approach

All teardown now goes through one shared service, `releaseSessionRuntime()` (`daemon/src/services/sessionRuntime.ts`), used by both done routes *and* every delete path. It frees every live resource and touches nothing on disk, so a done session stays fully resumable: manifest record with `agentChatId`, session data dir, staged attachments, and the checkout all survive.

- `POST /sessions/:id/done` — release + mark `done`. Works for worktree **and** direct (project-level) agents. Idempotent.
- `POST /worktrees/:id/done` — same for every agent, plus every terminal (released and marked `exited`, since terminals have no `done` state). Returns `{ ok, updated, terminalsReleased }`.
- Delete paths (`DELETE /sessions/:id`, `DELETE /worktrees/:id`, `DELETE /projects/:id`) delegate to the same helper.

Staged attachments are kept on done (delete still clears them) — they're staged for the next prompt, so dropping them would make resume lossy.

## Bugs found and fixed along the way

Six paths could silently demote a just-retired session or leak the resources it was meant to free. Each has a test that fails when the fix is reverted.

1. **The Rich Chat drain un-did "done".** `abortAndDrain()` isn't awaited; the unwinding drain's `finally` persists a trailing lifecycle `idle` that lands *after* the route wrote `done`, demoting it in both the manifest and every connected client. Fixed with a `released` latch that `release()` sets before it aborts anything — ordering alone can't win this race.
2. **`markSessionExited` demoted `done`.** `DirectPtyStream.onExit` fires when the release kills our own pty child, and its guard only excluded `exited`.
3. **Retiring mid-spawn was unsafe.** A spawn takes seconds and the user can mark done inside that window; both spawn jobs then wrote their captured `working`/`exited` over the user's `done` **and** left behind the pane they created after the release had already run. Not a corner case — the plain "mark a direct agent done" flow hit it, since its spawn job lands moments after create.
4. **Rich Chat turn-1 resurrected a retired session.** `startJsonCreateTurn` re-created the `JsonAgentSession` the release had torn down and started spending tokens on a session the user believed was retired.
5. **Read paths revived released sessions.** `chat:open` and `PATCH /chat/model` both lazily *create* a `JsonAgentSession`, so merely browsing a done chat re-opened its SQLite handles. Read paths now serve from disk; `chat:open` also unregisters any stale stream entry (which would pin the released agent) and sends meta from disk so the status bar doesn't blank. `PATCH /chat/model` returns `409`.
6. **`DELETE /projects/:id` leaked everything non-tmux.** It cascaded with a bare `killSession`, so every `useTmux: false` session — all direct-pty and all Rich Chat sessions — kept its pty child, turn process group and open SQLite handles, while the code a few lines below `rm -rf`'d the data dir those handles pointed at.

## UI

The daemon sends **no** exit frame when it kills a pane under an attached client (`stream.once("close")` sends nothing, and the non-zero-exit path is classified `transient`, which the client deliberately ignores). The pane learns about this only via `session:state {done}` — so without the UI change, done left a frozen, unrecoverable terminal.

`TerminalPane` now renders its Resume banner for `done` with "Session marked done.", stops opening streams for a released pane, and `AgentPaneSlot` hides the live-terminal upload overlay.

## Verification

- 707 tests pass (452 daemon + 255 web-ui), run repeatedly; `pnpm lint` 0 errors, `pnpm typecheck` and `pnpm build` clean.
- Every fix above was mutation-checked: revert the fix, watch the test fail, restore.
- Exercised end-to-end in the dev container (isolated overlay so a sibling worktree sandbox was untouched):
  - single-session done → pane gone, state held at `done` through polling
  - worktree done → `{updated: 2, terminalsReleased: 1}`, **the tmux server itself shut down**
  - Rich Chat done → 3 SQLite fds → 0; `GET /transcript`, `GET /meta` and WS `chat:open` all served from disk with zero fds re-opened; `PATCH /chat/model` → 409; sending a message revived it properly
  - direct agent done + dismiss, and the mark-done-mid-spawn race
  - `DELETE /projects/:id` with a live Rich Chat session → 3 fds → 0, nothing stranded on deleted files
  - UI: banner flipped live to "Session marked done." with a working Resume; done worktree rolled up under FINISHED

## Known gaps (not addressed here)

- **"Hide project" leaves everything running** — every session in that project keeps its processes and just disappears from the sidebar and dashboard. Arguably correct for something named "hide", but it is now the only UI path that leaks.
- **No bulk retire for a project's direct agents** — no `POST /projects/:id/done` analogous to the worktree one, so N direct agents means N menu interactions. The "Hide done" sidebar filter also only applies to worktrees, so a done direct agent stays in the sidebar indefinitely.
- **`POST /sessions/:id/resume` on a `channel:"json"` session** takes the tmux branch and spawns a pane despite `useTmux: false` — pre-existing, unreachable from the UI (the JSON resume path is sending a message).

Plan: `.feature-plans/done/done-releases-resources/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
