### PR TITLE
fix(modes): allow deleting an in-use mode; fall back gracefully when a session's mode is gone

### DIFF
--- a/daemon/src/__tests__/modeDeletedFallback.test.ts
+++ b/daemon/src/__tests__/modeDeletedFallback.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Deleting an in-use mode must not break an already-running JSON-channel
+ * agent, and a session whose mode later vanishes (e.g. after a registry
+ * reset / daemon restart) must fall back gracefully instead of erroring.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { FastifyInstance } from "fastify";
+import type { ProjectRecord, SessionRecord, NormalizedEvent } from "../types.js";
+
+let tempDir: string;
+
+const hoisted = vi.hoisted(() => ({
+  turnEvents: [] as NormalizedEvent[],
+  lastModeContext: undefined as string | undefined,
+}));
+
+vi.mock("../services/promptBuilder.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/promptBuilder.js")>();
+  return {
+    ...actual,
+    async buildDirectPrompt(opts: { modeContext?: string }) {
+      hoisted.lastModeContext = opts.modeContext;
+      return { systemPrompt: opts.modeContext ?? "", taskPrompt: undefined };
+    },
+  };
+});
+
+vi.mock("../services/paths.js", async () => {
+  const { join: pathJoin } = await import("node:path");
+  const { rmSync } = await import("node:fs");
+  const base = () => tempDir;
+  const directDataDir = (p: string, s: string) => pathJoin(base(), "projects", p, "sessions", s);
+  return {
+    vstHome: () => base(),
+    projectDir: (id: string) => pathJoin(base(), "projects", id),
+    manifestPath: (id: string) => pathJoin(base(), "projects", id, "manifest.json"),
+    manifestTmpPath: (id: string) => pathJoin(base(), "projects", id, "manifest.json.tmp"),
+    worktreePath: (id: string, wtId: string) => pathJoin(base(), "projects", id, "worktrees", wtId),
+    configPath: () => pathJoin(base(), "config.json"),
+    modesPath: () => pathJoin(base(), "modes.json"),
+    daemonLogPath: () => pathJoin(base(), "logs", "daemon.log"),
+    sessionDataDir: (p: string, w: string, s: string) => pathJoin(base(), "projects", p, "session-data", w, s),
+    directSessionDataDir: directDataDir,
+    systemPromptPath: (p: string, w: string, s: string) =>
+      pathJoin(base(), "projects", p, "session-data", w, s, "system-prompt.md"),
+    directSystemPromptPath: (p: string, s: string) => pathJoin(directDataDir(p, s), "system-prompt.md"),
+    cleanupSessionDataDir: (p: string, w: string, s: string) =>
+      rmSync(pathJoin(base(), "projects", p, "session-data", w, s), { recursive: true, force: true }),
+    cleanupDirectSessionDataDir: (p: string, s: string) => rmSync(directDataDir(p, s), { recursive: true, force: true }),
+  };
+});
+
+vi.mock("../agent-plugins/registry.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../agent-plugins/registry.js")>();
+  const mockPlugin = {
+    name: "claude",
+    defaultModel: "sonnet",
+    promptDelivery: "inline",
+    async listModels() {
+      return { models: [] };
+    },
+    getLaunchCommand() {
+      return ["claude"];
+    },
+    getEnvironment() {
+      return {};
+    },
+    getReadySignal() {
+      return { fallbackMs: 0 };
+    },
+    composeLaunchPrompt() {
+      return {};
+    },
+    supportsJson() {
+      return true;
+    },
+    async *runTurn(input: { message: string }, ctx: { session: { id: string } }) {
+      for (const e of hoisted.turnEvents) {
+        yield { ...e, sessionId: ctx.session.id };
+      }
+    },
+  };
+  // Every cli id resolves to the same mock plugin — good enough for asserting
+  // the fallback path doesn't throw, without needing per-CLI fidelity here.
+  return { ...actual, resolvePlugin: () => mockPlugin };
+});
+
+const PROJECT_ID = "proj-mode-fallback";
+const SESSION_ID = `${PROJECT_ID}-d1`;
+
+function ev(kind: NormalizedEvent["kind"], extra: Partial<NormalizedEvent> = {}): NormalizedEvent {
+  return {
+    id: `${kind}-${Math.random().toString(36).slice(2)}`,
+    sessionId: SESSION_ID,
+    ts: new Date().toISOString(),
+    provider: "claude",
+    kind,
+    ...extra,
+  };
+}
+
+const TURN = [
+  ev("session_init", { model: "claude-sonnet-4-5", agentChatId: "chat-1" }),
+  ev("text", { role: "assistant", text: "hello" }),
+  ev("result", { model: "claude-sonnet-4-5" }),
+];
+
+function makeSession(): SessionRecord {
+  return {
+    id: SESSION_ID,
+    slot: "d1",
+    type: "agent",
+    modeId: "m",
+    tmuxName: "__direct__-x",
+    useTmux: false,
+    channel: "json",
+    lifecycle: { state: "not_started", lastTransitionAt: new Date().toISOString() },
+  };
+}
+
+describe("Deleting an in-use mode", () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "vst-mode-fallback-"));
+    await mkdir(join(tempDir, "projects", PROJECT_ID), { recursive: true });
+    const { buildServer } = await import("../server.js");
+    app = await buildServer({ logger: false });
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  beforeEach(async () => {
+    hoisted.turnEvents = TURN;
+    // Recreated fresh each test since some tests delete it.
+    // cli is deliberately NOT "claude" (the fallback default) so a test can
+    // tell "kept the real mode config" apart from "fell back to defaults".
+    await writeFile(
+      join(tempDir, "modes.json"),
+      JSON.stringify([{ id: "m", name: "Test", cli: "cursor", context: "ctx", createdAt: new Date().toISOString() }]),
+    );
+    const { _clearStoreForTest, addProject } = await import("../state/project-store.js");
+    const { jsonAgentRegistry } = await import("../state/jsonAgentRegistry.js");
+    const { _resetModesCacheForTest } = await import("../routes/modes.js");
+    jsonAgentRegistry.clear();
+    _resetModesCacheForTest();
+    _clearStoreForTest();
+    await rm(join(tempDir, "projects", PROJECT_ID, "sessions", SESSION_ID), { recursive: true, force: true });
+    await addProject({
+      id: PROJECT_ID,
+      absolutePath: join(tempDir, "repo"),
+      prefix: "pmf",
+      isGit: true,
+      defaultBranch: "main",
+      createdAt: new Date().toISOString(),
+      directSessions: [makeSession()],
+      worktrees: [],
+    } as ProjectRecord);
+  });
+
+  afterEach(async () => {
+    const { jsonAgentRegistry } = await import("../state/jsonAgentRegistry.js");
+    jsonAgentRegistry.clear();
+  });
+
+  it("DELETE /modes/:id succeeds while a session is using it and reports affectedSessions", async () => {
+    const res = await app.inject({ method: "DELETE", url: "/modes/m" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ ok: true; affectedSessions: number }>().affectedSessions).toBe(1);
+
+    const list = await app.inject({ method: "GET", url: "/modes" });
+    expect(list.json()).toEqual([]);
+  });
+
+  it("an already-live JSON agent keeps working AND keeps reporting its real cli/modeName after its mode is deleted", async () => {
+    // First turn — creates + registers the JsonAgentSession, caching cli/modeId/modeName.
+    const first = await app.inject({
+      method: "POST",
+      url: `/sessions/${SESSION_ID}/chat`,
+      payload: { message: "hi" },
+    });
+    expect(first.statusCode).toBe(202);
+
+    // Mode is now gone.
+    const del = await app.inject({ method: "DELETE", url: "/modes/m" });
+    expect(del.statusCode).toBe(200);
+
+    // The same (still-registered) agent takes another turn without erroring.
+    const second = await app.inject({
+      method: "POST",
+      url: `/sessions/${SESSION_ID}/chat`,
+      payload: { message: "still there?" },
+    });
+    expect(second.statusCode).toBe(202);
+
+    // Real assertion: meta still reports the ORIGINAL cli/modeName ("cursor"/
+    // "Test"), not the bare "claude" fallback — proving the live agent's own
+    // cached fields (not a fresh, now-failing modes.json lookup) are the
+    // source of truth for an already-running agent.
+    const meta = await app.inject({ method: "GET", url: `/sessions/${SESSION_ID}/meta` });
+    expect(meta.statusCode).toBe(200);
+    const metaBody = meta.json<{ cli: string; modeName?: string }>();
+    expect(metaBody.cli).toBe("cursor");
+    expect(metaBody.modeName).toBe("Test");
+  });
+
+  it("resolveMode's fallback itself prefers a live agent's real cli over the bare claude default", async () => {
+    // Direct unit-level check on resolveMode's own return value (not GET
+    // /meta, which short-circuits to live.getMeta() and can't tell "resolveMode
+    // fell back correctly" apart from "resolveMode fell back to the wrong
+    // default" — see the review gap this closes).
+    const { resolveJsonAgent } = await import("../services/jsonAgentChat.js");
+    const daemonPort = (app.server.address() as { port?: number } | null)?.port ?? 0;
+
+    // Register the live agent (cli "cursor") before the mode is deleted.
+    const beforeDelete = await resolveJsonAgent(SESSION_ID, daemonPort);
+    expect(beforeDelete.ok && beforeDelete.mode.cli).toBe("cursor");
+
+    await app.inject({ method: "DELETE", url: "/modes/m" });
+
+    // Live agent still registered — resolveMode must report ITS real cli.
+    const withLiveAgent = await resolveJsonAgent(SESSION_ID, daemonPort);
+    expect(withLiveAgent.ok && withLiveAgent.mode.cli).toBe("cursor");
+
+    // Now drop the live agent too (daemon-restart simulation) — no source of
+    // truth left, must fall back to the bare default instead of crashing.
+    const { jsonAgentRegistry } = await import("../state/jsonAgentRegistry.js");
+    jsonAgentRegistry.clear();
+    const withNoLiveAgent = await resolveJsonAgent(SESSION_ID, daemonPort);
+    expect(withNoLiveAgent.ok && withNoLiveAgent.mode.cli).toBe("claude");
+  });
+
+  it("turn 1's system prompt still gets the mode's context even when the agent was pre-registered earlier (e.g. by chat:open)", async () => {
+    // Mirrors chat:open (ws/handlers/chatOpen.ts) — lazily registers the
+    // JsonAgentSession via resolveJsonAgent WITHOUT enqueueing a turn.
+    const { resolveJsonAgent } = await import("../services/jsonAgentChat.js");
+    const daemonPort = (app.server.address() as { port?: number } | null)?.port ?? 0;
+    const preRegistered = await resolveJsonAgent(SESSION_ID, daemonPort);
+    expect(preRegistered.ok).toBe(true);
+
+    // The user's actual first message arrives afterward — this must NOT lose
+    // the mode's context just because the agent object already existed.
+    hoisted.lastModeContext = undefined;
+    const res = await app.inject({
+      method: "POST",
+      url: `/sessions/${SESSION_ID}/chat`,
+      payload: { message: "hi" },
+    });
+    expect(res.statusCode).toBe(202);
+    expect(hoisted.lastModeContext).toBe("ctx");
+  });
+
+  it("a fresh agent (registry reset — e.g. after a daemon restart) falls back gracefully when its mode is gone", async () => {
+    await app.inject({ method: "DELETE", url: "/modes/m" });
+
+    // Simulate a daemon restart: no live JsonAgentSession for this id.
+    const { jsonAgentRegistry } = await import("../state/jsonAgentRegistry.js");
+    jsonAgentRegistry.clear();
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/sessions/${SESSION_ID}/chat`,
+      payload: { message: "resuming after mode deletion" },
+    });
+    // Falls back instead of 500ing.
+    expect(res.statusCode).toBe(202);
+
+    // No live agent survived to remember the real cli — falls all the way
+    // back to the bare "claude" default (documented, accepted degradation).
+    const meta = await app.inject({ method: "GET", url: `/sessions/${SESSION_ID}/meta` });
+    expect(meta.json<{ cli: string; modeName?: string }>().cli).toBe("claude");
+  });
+});

--- a/daemon/src/__tests__/modes.test.ts
+++ b/daemon/src/__tests__/modes.test.ts
@@ -161,6 +161,67 @@ describe("Mode routes", () => {
     expect(res.statusCode).toBe(404);
   });
 
+  it("DELETE /modes/:id succeeds even when a session is using it, reporting the count", async () => {
+    const createRes = await app.inject({
+      method: "POST",
+      url: "/modes",
+      payload: { name: "in-use", cli: "claude", context: "ctx" },
+    });
+    const modeId = createRes.json<Mode>().id;
+
+    const { addProject } = await import("../state/project-store.js");
+    await addProject({
+      id: "proj-in-use",
+      absolutePath: "/tmp/proj-in-use",
+      prefix: "piu",
+      isGit: true,
+      createdAt: new Date().toISOString(),
+      worktrees: [
+        {
+          id: "wt-1",
+          branch: "wt-1",
+          baseBranch: "main",
+          baseSha: "abc123",
+          createdAt: new Date().toISOString(),
+          sessions: [
+            {
+              id: "sess-1",
+              slot: "m",
+              type: "agent",
+              modeId,
+              tmuxName: "piu-wt-1-m",
+              useTmux: true,
+              lifecycle: { state: "not_started", lastTransitionAt: new Date().toISOString() },
+            },
+          ],
+        },
+      ],
+      directSessions: [
+        {
+          id: "sess-2",
+          slot: "d1",
+          type: "agent",
+          modeId,
+          tmuxName: "__direct__-sess-2",
+          useTmux: true,
+          lifecycle: { state: "not_started", lastTransitionAt: new Date().toISOString() },
+        },
+      ],
+    });
+
+    // Still shows up as normal before deletion.
+    const preList = await app.inject({ method: "GET", url: "/modes" });
+    expect(preList.json<Mode[]>()).toHaveLength(1);
+
+    const delRes = await app.inject({ method: "DELETE", url: `/modes/${modeId}` });
+    expect(delRes.statusCode).toBe(200);
+    // One worktree session + one direct session both reference this modeId.
+    expect(delRes.json<{ ok: true; affectedSessions: number }>().affectedSessions).toBe(2);
+
+    const postList = await app.inject({ method: "GET", url: "/modes" });
+    expect(postList.json<Mode[]>()).toHaveLength(0);
+  });
+
   it("GET /modes lists multiple created modes", async () => {
     await app.inject({
       method: "POST",

--- a/daemon/src/routes/modes.ts
+++ b/daemon/src/routes/modes.ts
@@ -150,22 +150,35 @@ export async function resolveCliModels(cli: CliId): Promise<{ models: string[]; 
 }
 
 /**
- * Check if any session references this modeId — worktree sessions AND direct
- * sessions. Missing directSessions here let a mode used only by a direct
- * session be deleted while in use.
+ * Count ACTIVE sessions referencing this modeId — worktree sessions AND
+ * direct sessions, excluding ones already `done`/`exited` (those aren't
+ * "active" and the UI copy specifically says "active sessions"). Missing
+ * directSessions here would undercount a mode used only by a direct session.
+ *
+ * This is informational only (surfaced in the DELETE response so the UI can
+ * tell the user how many sessions are affected) — it no longer blocks
+ * deletion. A currently-running session doesn't need the mode again once
+ * spawned (tmux/pty), and the JSON channel keeps its already-resolved
+ * cli/model/context cached in memory (see `resolveJsonAgent`). If a session
+ * later resumes/restarts and its mode is gone, mode resolution falls back
+ * gracefully (see `resolveMode` in jsonAgentChat.ts and the resume/channel
+ * handlers in routes/sessions.ts) rather than hard-failing.
  */
-function isModeInUse(modeId: string): boolean {
+function countSessionsUsingMode(modeId: string): number {
+  const isActive = (s: { lifecycle: { state: string } }) =>
+    s.lifecycle.state !== "done" && s.lifecycle.state !== "exited";
+  let count = 0;
   for (const project of getAllProjects()) {
     for (const wt of project.worktrees) {
       for (const session of wt.sessions) {
-        if (session.modeId === modeId) return true;
+        if (session.modeId === modeId && isActive(session)) count++;
       }
     }
     for (const session of project.directSessions) {
-      if (session.modeId === modeId) return true;
+      if (session.modeId === modeId && isActive(session)) count++;
     }
   }
-  return false;
+  return count;
 }
 
 export function registerModeRoutes(app: FastifyInstance): void {
@@ -276,21 +289,25 @@ export function registerModeRoutes(app: FastifyInstance): void {
   });
 
   // DELETE /modes/:id
+  //
+  // Deleting an in-use mode is allowed (Decision: modes can be deleted while
+  // sessions reference them). Sessions already running are unaffected — a
+  // spawned process doesn't need the mode config again, and a live JSON-channel
+  // agent keeps its own cached cli/model/context. Only a session that later
+  // resumes/restarts with this modeId gone falls back gracefully instead of
+  // erroring (see resolveMode/resolveJsonAgent and the resume/channel-toggle
+  // handlers). `affectedSessions` is informational so the UI can tell the user
+  // how many sessions reference the mode being removed.
   app.delete("/modes/:id", async (req, reply) => {
     const { id } = req.params as { id: string };
     const modes = await loadModes();
     const mode = modes.find((m) => m.id === id);
     if (!mode) return reply.status(404).send({ error: `Mode '${id}' not found` });
 
-    if (isModeInUse(id)) {
-      return reply.status(409).send({
-        error: `Mode '${id}' is in use by active sessions. Kill those sessions first.`,
-        conflictWith: id,
-      });
-    }
+    const affectedSessions = countSessionsUsingMode(id);
 
     await saveModes(modes.filter((m) => m.id !== id));
     broadcastAll({ type: "mode:deleted", modeId: id });
-    return reply.send({ ok: true });
+    return reply.send({ ok: true, affectedSessions });
   });
 }

--- a/daemon/src/routes/sessions.ts
+++ b/daemon/src/routes/sessions.ts
@@ -884,9 +884,24 @@ export function registerSessionRoutes(app: FastifyInstance): void {
     if (session.type === "agent" && session.modeId) {
       try {
         const modes = await (await import("../routes/modes.js")).loadModes();
-        const mode = modes.find((m) => m.id === session.modeId);
-        if (!mode) {
-          throw new Error(`Mode '${session.modeId}' not found`);
+        const found = modes.find((m) => m.id === session.modeId);
+        // Deleting an in-use mode is allowed — a session resuming after its
+        // mode was removed falls back instead of hard-failing the resume.
+        // Prefer a live JSON agent's own frozen cli (accurate — captured
+        // before the deletion) over the bare "claude" default; this mirrors
+        // the same fallback used by the JSON channel's resolveMode.
+        const liveAgentForFallback = found ? undefined : jsonAgentRegistry.get(session.id);
+        const mode = found ?? {
+          id: session.modeId!,
+          name: liveAgentForFallback?.getModeName() ?? "(deleted mode)",
+          cli: liveAgentForFallback?.getCli() ?? ("claude" as const),
+          context: "",
+          createdAt: new Date().toISOString(),
+        };
+        if (!found) {
+          console.warn(
+            `[resume] mode '${session.modeId}' not found for session ${session.id} — falling back to ${mode.cli} defaults`,
+          );
         }
 
         const plugin = resolvePlugin(mode.cli);
@@ -1438,10 +1453,25 @@ export function registerSessionRoutes(app: FastifyInstance): void {
     }
     const { worktree } = ctx;
 
-    // Resolve mode → plugin.
+    // Resolve mode → plugin. Deleting an in-use mode is allowed, so a missing
+    // mode falls back instead of hard-failing the toggle: prefer the cli a
+    // live JSON agent already captured at construction time (accurate — it
+    // predates the deletion), else default to claude with no saved model/context.
     const modes = await (await import("../routes/modes.js")).loadModes();
-    const mode = session.modeId ? modes.find((m) => m.id === session.modeId) : undefined;
-    if (!mode) return reply.status(400).send({ error: `Mode '${session.modeId}' not found` });
+    const found = session.modeId ? modes.find((m) => m.id === session.modeId) : undefined;
+    const liveAgentForFallback = found ? undefined : jsonAgentRegistry.get(id);
+    const mode = found ?? {
+      id: session.modeId ?? "",
+      name: liveAgentForFallback?.getModeName() ?? "(deleted mode)",
+      cli: liveAgentForFallback?.getCli() ?? ("claude" as const),
+      context: "",
+      createdAt: new Date().toISOString(),
+    };
+    if (!found) {
+      console.warn(
+        `[channel-toggle] mode '${session.modeId}' not found for session ${session.id} — falling back to ${mode.cli} defaults`,
+      );
+    }
     const plugin = resolvePlugin(mode.cli);
 
     const fromJson = current === "json";

--- a/daemon/src/services/context.ts
+++ b/daemon/src/services/context.ts
@@ -15,8 +15,9 @@
  *
  *   - ws/handlers/sessionLookup.ts scanned only worktrees, so session:open for
  *     a direct session answered "Session not found" while the agent was alive.
- *   - routes/modes.ts isModeInUse ignored direct sessions, so a mode in use
- *     could be deleted.
+ *   - routes/modes.ts's old in-use guard (since removed — deleting an in-use
+ *     mode is now allowed) ignored direct sessions, so a mode used only by a
+ *     direct session could slip past the "in use" check undercounted.
  *   - A fabricated worktree (`<project>-direct`) resolved to a NONEXISTENT
  *     directory, so plugins derived paths that silently pointed nowhere.
  *

--- a/daemon/src/services/jsonAgent.ts
+++ b/daemon/src/services/jsonAgent.ts
@@ -670,6 +670,23 @@ export class JsonAgentSession {
     return this.store.since(sinceSeq);
   }
 
+  /**
+   * The cli/modeId/modeName this instance was constructed with — frozen for
+   * its lifetime (set once from the mode resolved at creation time). Exposed
+   * so callers (e.g. `resolveJsonAgent`) can reuse an already-live agent's
+   * config instead of re-resolving `modeId → Mode`, which would break if the
+   * mode was since deleted (deleting an in-use mode is allowed).
+   */
+  getCli(): NormalizedEventProvider {
+    return this.cli;
+  }
+  getModeId(): string | undefined {
+    return this.modeId;
+  }
+  getModeName(): string | undefined {
+    return this.modeName;
+  }
+
   /** Latest cross-harness meta (rebuilt from transcript tail on construction). */
   getMeta(): SessionMeta {
     return {

--- a/daemon/src/services/jsonAgentChat.ts
+++ b/daemon/src/services/jsonAgentChat.ts
@@ -71,21 +71,61 @@ interface ResolvedMode {
   modeId?: string;
   modeName?: string;
   context?: string;
+  /** True when the mode was deleted (or the session never had one) and this
+   * is a best-effort fallback rather than the session's actual configured mode. */
+  isFallback?: boolean;
 }
 
+/** Default CLI used when a session's mode has been deleted — matches the
+ * existing fallback in `readSessionMeta` below. */
+const FALLBACK_CLI: NormalizedEventProvider = "claude";
+
+/**
+ * Resolve a session's mode → cli/model/context. Modes can be deleted while
+ * still referenced by a session (Decision: deleting an in-use mode is
+ * allowed), so a missing mode is NOT an error here — it falls back instead of
+ * throwing, so a session whose mode vanished stays chattable/resumable
+ * instead of hard-failing on every turn.
+ *
+ * Always re-resolved from `modes.json` (even when a live `JsonAgentSession`
+ * already exists) rather than short-circuited off the live agent's own cached
+ * fields — the live agent doesn't cache `context`, and callers need a FRESH
+ * `mode.context` for the first-turn system prompt (turn 1 can run well after
+ * the agent object was created, e.g. via `chat:open` lazily registering it).
+ * When the mode is gone, prefer an already-live agent's frozen `cli`/
+ * `modeId`/`modeName` (accurate — captured before the deletion) over the bare
+ * "claude" default, since callers like `/chat/fork`'s plugin-capability gate
+ * and the model-switcher's "clear override" default depend on the real CLI.
+ */
 async function resolveMode(session: SessionRecord): Promise<ResolvedMode> {
   const modeId = session.modeId;
+  // No modeId at all is a structural invariant violation (every JSON agent
+  // session is created with one) — distinct from "mode was deleted later",
+  // which falls back below instead of throwing.
   if (!modeId) throw new Error("Session has no mode; JSON chat requires an agent mode");
   const { loadModes } = await import("../routes/modes.js");
   const modes = await loadModes();
   const mode = modes.find((m) => m.id === modeId);
-  if (!mode) throw new Error(`Mode '${modeId}' not found`);
+  if (mode) {
+    return {
+      cli: mode.cli as NormalizedEventProvider,
+      ...(mode.model ? { model: mode.model } : {}),
+      modeId: mode.id,
+      modeName: mode.name,
+      ...(mode.context ? { context: mode.context } : {}),
+    };
+  }
+  const live = jsonAgentRegistry.get(session.id);
+  console.warn(
+    `[json-chat] mode '${modeId}' not found for session ${session.id} — falling back to ${live?.getCli() ?? FALLBACK_CLI}`,
+  );
   return {
-    cli: mode.cli as NormalizedEventProvider,
-    ...(mode.model ? { model: mode.model } : {}),
-    modeId: mode.id,
-    modeName: mode.name,
-    ...(mode.context ? { context: mode.context } : {}),
+    cli: live?.getCli() ?? FALLBACK_CLI,
+    // `modeId` is guaranteed truthy here (checked above) — always keep the
+    // session's own modeId so the UI can still show "mode deleted" for it.
+    modeId: live?.getModeId() ?? modeId,
+    ...(live?.getModeName() ? { modeName: live.getModeName() } : {}),
+    isFallback: true,
   };
 }
 
@@ -105,6 +145,7 @@ export async function resolveJsonAgent(
   if (sessionChannel(ctx.session) !== "json") {
     return { ok: false, reason: "not_json", message: `Session '${sessionId}' is not a JSON-channel session` };
   }
+
   const mode = await resolveMode(ctx.session);
   const plugin = resolvePlugin(mode.cli);
   // A per-session model override (live status-bar switch) wins over the mode's

--- a/web-ui/src/api/client.ts
+++ b/web-ui/src/api/client.ts
@@ -562,12 +562,12 @@ export function createClientApi() {
       return parseJson<Mode>(res);
     },
 
-    async deleteMode(id: string): Promise<{ ok: true }> {
+    async deleteMode(id: string): Promise<{ ok: true; affectedSessions: number }> {
       const root = baseUrl();
       const res = await apiFetch(`${root}/modes/${encodeURIComponent(id)}`, {
         method: "DELETE",
       });
-      return parseJson<{ ok: true }>(res);
+      return parseJson<{ ok: true; affectedSessions: number }>(res);
     },
 
     // ── Settings ────────────────────────────────────────────────────────────────

--- a/web-ui/src/api/mock.ts
+++ b/web-ui/src/api/mock.ts
@@ -760,12 +760,12 @@ export function createMockApi() {
       return structuredClone(m);
     },
 
-    async deleteMode(id: string): Promise<{ ok: true }> {
+    async deleteMode(id: string): Promise<{ ok: true; affectedSessions: number }> {
       const idx = modes.findIndex((m) => m.id === id);
       if (idx === -1) throw new ApiError("not found", 404);
       modes.splice(idx, 1);
       emit({ type: "mode:deleted", modeId: id });
-      return { ok: true };
+      return { ok: true, affectedSessions: 0 };
     },
 
     // ── Settings ────────────────────────────────────────────────────────────────

--- a/web-ui/src/components/settings/ModesSetting.tsx
+++ b/web-ui/src/components/settings/ModesSetting.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { Info, Pencil, Trash2 } from "lucide-react";
 import type { ApiInstance } from "@/api";
 import type { Mode } from "@/api/types";
-import { ApiError } from "@/api/errors";
 import { Button } from "@/components/ui/Button";
 import { NewModeDialog } from "@/components/dialogs/NewModeDialog";
 import { EditModeDialog } from "@/components/dialogs/EditModeDialog";
@@ -18,6 +17,10 @@ export function ModesSetting({ api }: ModesSettingProps) {
   const [editing, setEditing] = useState<Mode | null>(null);
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const [deleteError, setDeleteError] = useState<{ id: string; msg: string } | null>(null);
+  // Transient banner shown after deleting a mode that active sessions reference —
+  // the mode's own row disappears immediately (mode:deleted removes it from
+  // `modes`), so this can't be shown inline per-row.
+  const [deleteNotice, setDeleteNotice] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     const list = await api.listModes();
@@ -52,15 +55,28 @@ export function ModesSetting({ api }: ModesSettingProps) {
 
   async function confirmDelete(id: string) {
     setDeleteError(null);
+    // Clear any notice from a previous delete so a failed delete doesn't show
+    // stale "mode deleted" text alongside the new error.
+    setDeleteNotice(null);
     try {
-      await api.deleteMode(id);
+      const result = await api.deleteMode(id);
       setPendingDeleteId(null);
+      // Deleting an in-use mode is allowed — active sessions keep running with
+      // their original settings; only a later resume/restart falls back to
+      // defaults if the mode is gone by then. Let the user know when that
+      // applies to them.
+      if (result.affectedSessions > 0) {
+        const plural = result.affectedSessions === 1 ? "session" : "sessions";
+        setDeleteNotice(
+          `Mode deleted. ${result.affectedSessions} active ${plural} using it will keep running as-is; if one of them restarts later, it'll fall back to default settings.`,
+        );
+      } else {
+        setDeleteNotice(null);
+      }
     } catch (e) {
       // Always reset pending state so the row shows Edit/Delete again (not a stuck "Delete?")
       setPendingDeleteId(null);
-      const msg = e instanceof ApiError && e.status === 409
-        ? "This mode is being used by an active session. Stop the session first."
-        : (e instanceof Error ? e.message : String(e));
+      const msg = e instanceof Error ? e.message : String(e);
       setDeleteError({ id, msg });
     }
   }
@@ -86,9 +102,37 @@ export function ModesSetting({ api }: ModesSettingProps) {
         <Info size={14} style={{ marginTop: 2, flexShrink: 0, color: "var(--fg-muted)" }} />
         <span style={{ fontSize: "13px", color: "var(--fg-secondary)", lineHeight: 1.5 }}>
           Editing a mode only affects new sessions — running sessions continue with their original
-          settings.
+          settings. Deleting a mode is allowed even if sessions are using it.
         </span>
       </div>
+
+      {deleteNotice && (
+        <div
+          style={{
+            display: "flex",
+            gap: "var(--space-2)",
+            padding: "var(--space-3)",
+            borderRadius: "var(--radius-sm)",
+            border: "var(--border-width) solid var(--border-default)",
+            background: "var(--bg-input)",
+            marginBottom: "var(--space-5)",
+            alignItems: "flex-start",
+          }}
+        >
+          <Info size={14} style={{ marginTop: 2, flexShrink: 0, color: "var(--fg-muted)" }} />
+          <span style={{ fontSize: "13px", color: "var(--fg-secondary)", lineHeight: 1.5, flex: 1 }}>
+            {deleteNotice}
+          </span>
+          <button
+            type="button"
+            onClick={() => setDeleteNotice(null)}
+            aria-label="Dismiss"
+            style={{ background: "none", border: "none", color: "var(--fg-muted)", cursor: "pointer", padding: 0, font: "inherit" }}
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
 
       <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
         {modes.length === 0 && (


### PR DESCRIPTION
Deleting a mode previously 409'd if any session referenced it. Running
sessions don't need the mode again once spawned (tmux/pty), and a live
JSON-channel agent keeps chatting fine — so the block was unnecessary and
just made cleanup harder. Mode resolution now falls back instead of
throwing/500ing when a session's mode has been removed (resume,
channel-toggle, JSON chat), preferring a live agent's own cached cli when
available.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
