### PR TITLE
Make left sidebar width draggable on desktop

### DIFF
--- a/web-ui/src/components/layout/Layout.tsx
+++ b/web-ui/src/components/layout/Layout.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useRef, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { useLayout } from "@/hooks/useLayout";
 import { PaneFullscreenChrome, type PaneFullscreenPlacement } from "@/components/layout/PaneFullscreenChrome";
-import { useWorkspaceStore } from "@/hooks/useStore";
+import { useWorkspaceStore, LEFT_SIDEBAR_MIN_WIDTH, LEFT_SIDEBAR_MAX_WIDTH } from "@/hooks/useStore";
 
 interface LayoutProps {
   topBar: ReactNode;
@@ -18,6 +18,10 @@ interface LayoutProps {
   /** Bottom region — terminal dock. Pass `null` when unavailable. */
   terminalDock?: ReactNode;
   leftColumnPx: number;
+  /** Whether the desktop sidebar is collapsed to its icon rail (hides the drag handle). */
+  leftSidebarCollapsed?: boolean;
+  /** Commits a new desktop sidebar width (px) once a drag ends. Omit to disable dragging. */
+  onLeftSidebarResize?: (px: number) => void;
   isMobile: boolean;
   mobileSidebarOpen: boolean;
   onMobileSidebarClose: () => void;
@@ -31,6 +35,8 @@ export function Layout({
   toolPanel,
   terminalDock,
   leftColumnPx,
+  leftSidebarCollapsed,
+  onLeftSidebarResize,
   isMobile,
   mobileSidebarOpen,
   onMobileSidebarClose,
@@ -38,6 +44,39 @@ export function Layout({
   const { toolPanelVisible, terminalDockVisible, toolSplitOrientation, activeWorktreeId, activeDirectContextId } = useLayout();
 
   const mainContentRef = useRef<HTMLDivElement>(null);
+
+  // Live width while dragging the sidebar's right-edge handle; null when not dragging.
+  // Kept local (not round-tripped through the store) so drag motion is jank-free —
+  // the store (and its localStorage write) is only updated once, on mouseup.
+  const [dragWidth, setDragWidth] = useState<number | null>(null);
+
+  function startSidebarResize(e: React.MouseEvent) {
+    if (!onLeftSidebarResize) return;
+    e.preventDefault();
+    const startX = e.clientX;
+    const startWidth = leftColumnPx;
+    const prevUserSelect = document.body.style.userSelect;
+    const prevCursor = document.body.style.cursor;
+    document.body.style.userSelect = "none";
+    document.body.style.cursor = "col-resize";
+
+    function clamp(px: number) {
+      return Math.min(LEFT_SIDEBAR_MAX_WIDTH, Math.max(LEFT_SIDEBAR_MIN_WIDTH, px));
+    }
+    function onMove(ev: MouseEvent) {
+      setDragWidth(clamp(startWidth + (ev.clientX - startX)));
+    }
+    function onUp(ev: MouseEvent) {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+      document.body.style.userSelect = prevUserSelect;
+      document.body.style.cursor = prevCursor;
+      onLeftSidebarResize?.(clamp(startWidth + (ev.clientX - startX)));
+      setDragWidth(null);
+    }
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+  }
 
   // Must be called unconditionally — before any early returns — to satisfy Rules of Hooks.
   const paneFullscreen = useWorkspaceStore((s) => s.workspacePaneFullscreen);
@@ -75,13 +114,24 @@ export function Layout({
     <div
       className="pane-left"
       style={{
-        width: leftColumnPx,
+        width: dragWidth ?? leftColumnPx,
         flexShrink: 0,
         borderRight: "var(--border-width) solid var(--border-default)",
         overflow: "hidden",
+        position: "relative",
       }}
     >
       {sidebarInner}
+      {onLeftSidebarResize && !leftSidebarCollapsed ? (
+        <div
+          className="pane-left-resize-handle"
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize sidebar"
+          data-dragging={dragWidth !== null}
+          onMouseDown={startSidebarResize}
+        />
+      ) : null}
     </div>
   );
 

--- a/web-ui/src/hooks/useStore.ts
+++ b/web-ui/src/hooks/useStore.ts
@@ -38,6 +38,14 @@ export const DEFAULT_WORKTREE_LAYOUT: WorktreeLayout = {
 /** IDE viewport fullscreen for the agent pane, tool panel, or terminal dock (not persisted). */
 export type WorkspacePaneFullscreen = "agent" | "tools" | "terminal";
 
+/** Draggable-resize bounds for the desktop left sidebar (px). */
+export const LEFT_SIDEBAR_MIN_WIDTH = 180;
+export const LEFT_SIDEBAR_MAX_WIDTH = 480;
+
+function clampLeftSidebarWidth(px: number): number {
+  return Math.min(LEFT_SIDEBAR_MAX_WIDTH, Math.max(LEFT_SIDEBAR_MIN_WIDTH, Math.round(px)));
+}
+
 export interface WorkspaceState {
   /** Per-worktree layout state. Falls back to DEFAULT_WORKTREE_LAYOUT. */
   layoutByWorktree: Record<string, WorktreeLayout>;
@@ -71,6 +79,8 @@ export interface WorkspaceState {
   fileTreeVisible: boolean;
   terminalFontScale: number;
   leftSidebarCollapsed: boolean;
+  /** Desktop left sidebar width in px when expanded (persisted, drag-resizable). */
+  leftSidebarWidthPx: number;
   /** Hide worktrees whose agent sessions are all explicitly marked done (not exited) */
   hideInactiveWorktrees: boolean;
   mobileSidebarOpen: boolean;
@@ -100,6 +110,7 @@ export interface WorkspaceState {
   toggleFileTree: () => void;
   bumpTerminalFont: (delta: number) => void;
   toggleLeftSidebarCollapsed: () => void;
+  setLeftSidebarWidthPx: (px: number) => void;
   setMobileSidebarOpen: (open: boolean) => void;
   toggleInactiveWorktreesFilter: () => void;
   clearWorkspaceSelection: () => void;
@@ -130,6 +141,7 @@ const initial = {
   fileTreeVisible: true,
   terminalFontScale: 1,
   leftSidebarCollapsed: false,
+  leftSidebarWidthPx: 220,
   hideInactiveWorktrees: true,
   mobileSidebarOpen: false,
   sessionAttachState: {} as Record<string, "pending" | "attached">,
@@ -295,6 +307,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
           })),
         toggleLeftSidebarCollapsed: () =>
           set((s) => ({ leftSidebarCollapsed: !s.leftSidebarCollapsed })),
+        setLeftSidebarWidthPx: (px) => set({ leftSidebarWidthPx: clampLeftSidebarWidth(px) }),
         setMobileSidebarOpen: (open) => set({ mobileSidebarOpen: open }),
         toggleInactiveWorktreesFilter: () =>
           set((s) => ({ hideInactiveWorktrees: !s.hideInactiveWorktrees })),
@@ -477,6 +490,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
         fileTreeVisible: s.fileTreeVisible,
         terminalFontScale: s.terminalFontScale,
         leftSidebarCollapsed: s.leftSidebarCollapsed,
+        leftSidebarWidthPx: s.leftSidebarWidthPx,
         hideInactiveWorktrees: s.hideInactiveWorktrees,
       }),
     },

--- a/web-ui/src/routes/Workspace.tsx
+++ b/web-ui/src/routes/Workspace.tsx
@@ -42,6 +42,8 @@ export function Workspace() {
   const activeSessionId = useWorkspaceStore((s) => s.activeSessionId);
   const leftSidebarCollapsed = useWorkspaceStore((s) => s.leftSidebarCollapsed);
   const toggleLeftSidebarCollapsed = useWorkspaceStore((s) => s.toggleLeftSidebarCollapsed);
+  const leftSidebarWidthPx = useWorkspaceStore((s) => s.leftSidebarWidthPx);
+  const setLeftSidebarWidthPx = useWorkspaceStore((s) => s.setLeftSidebarWidthPx);
   const mobileSidebarOpen = useWorkspaceStore((s) => s.mobileSidebarOpen);
   const setMobileSidebarOpen = useWorkspaceStore((s) => s.setMobileSidebarOpen);
 
@@ -168,7 +170,7 @@ export function Workspace() {
     }
   }, [isMobile, mobileSidebarOpen, setMobileSidebarOpen]);
 
-  const leftColumnPx = isMobile ? 280 : leftSidebarCollapsed ? 52 : 220;
+  const leftColumnPx = isMobile ? 280 : leftSidebarCollapsed ? 52 : leftSidebarWidthPx;
 
   const activeTerminalSessionId = useWorkspaceStore((s) => s.activeTerminalSessionId);
   const activeSession = activeSessionId
@@ -283,6 +285,8 @@ export function Workspace() {
           ) : isSettings ? <SettingsPanel api={api} /> : undefined
         }
         leftColumnPx={leftColumnPx}
+        leftSidebarCollapsed={leftSidebarCollapsed}
+        onLeftSidebarResize={setLeftSidebarWidthPx}
         isMobile={isMobile}
         mobileSidebarOpen={mobileSidebarOpen}
         onMobileSidebarClose={() => setMobileSidebarOpen(false)}

--- a/web-ui/src/styles/workspace.css
+++ b/web-ui/src/styles/workspace.css
@@ -258,6 +258,22 @@
   background: var(--border-strong);
 }
 
+.pane-left-resize-handle {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 6px;
+  height: 100%;
+  z-index: 3;
+  cursor: col-resize;
+  background: transparent;
+}
+
+.pane-left-resize-handle:hover,
+.pane-left-resize-handle[data-dragging="true"] {
+  background: var(--border-strong);
+}
+
 .sidebar-backdrop {
   position: absolute;
   inset: 0;


### PR DESCRIPTION
## Summary
- Adds a drag handle to the right edge of the desktop left sidebar (`.pane-left-resize-handle`) so its width can be resized by dragging.
- Width is clamped to 180–480px and persisted via the existing `useWorkspaceStore` zustand `persist` middleware (same localStorage key `vibestation:workspace` used for other layout prefs like `leftSidebarCollapsed`).
- The handle is hidden when the sidebar is collapsed to its icon rail, and never rendered on mobile (which already uses a separate drawer-style sidebar).

## Test plan
- [x] `pnpm typecheck` — passes
- [x] `pnpm lint` — clean (only pre-existing unrelated warnings)
- [x] `pnpm --filter @vibestation/web build` — succeeds
- [x] `pnpm --filter @vibestation/web test -- --run useStore` — 14/14 passing
- [x] Manual Playwright verification against a live dev instance (mock backend):
  - dragging the handle resizes the sidebar and the new width persists to `localStorage` and survives reload
  - dragging clamps to the 180px min / 480px max bounds
  - the handle is hidden when the sidebar is collapsed
  - the handle never renders on a mobile viewport