### PR TITLE
fix(daemon,web-ui): unblock the event loop after the SQLite migration

### DIFF
--- a/.feature-plans/pending/post-sqlite-daemon-latency-regressions.md
+++ b/.feature-plans/pending/post-sqlite-daemon-latency-regressions.md
@@ -1,0 +1,365 @@
+# Post-SQLite daemon latency regressions (PR #39 fallout)
+
+Three user-reported regressions after `sqlite-agent-naming` (PR #39) merged:
+
+1. Web-UI terminal pane accepts **no** input — not keyboard, not touch, not scroll.
+2. Switching between agent tabs in a worktree is slow (used to be instant).
+3. The agent tab bar takes seconds to appear; sometimes a second agent session
+   never renders in the strip.
+
+All three share ONE root cause plus one independent crash bug.
+
+---
+
+## Evidence
+
+### Route latency, pre-merge vs post-merge (same machine, same data)
+
+Median response time, from `~/.vibe-station/logs/daemon.log` (pre-merge,
+41,499 `/tree` samples across 59 daemon runs) vs `/tmp/vst-daemon.log`
+(post-merge):
+
+| route | PRE p50 | POST p50 | ratio |
+|---|---|---|---|
+| `/worktrees/:id/tree` | 1.33 ms | 2260.72 ms | **1694×** |
+| `/worktrees/:id/files/*` | 1.15 ms | 1095.99 ms | **956×** |
+| `/sessions/:id` | 0.16 ms | 4.23 ms | 26× |
+| `/projects` | 0.20 ms | 4.46 ms | 22× |
+| `/sessions?worktree=` | 0.22 ms | 4.09 ms | 19× |
+| `/worktrees/:id/changed-paths` | 8.91 ms | 13.46 ms | 1.5× |
+
+Bucketing the pre-merge log **by date** (2026-05-03 → 2026-08-07) shows p50
+flat at ~1.2 ms the whole time — so this is not gradual data growth, it is a
+step change at the merge.
+
+### CPU profile of the daemon (`--cpu-prof`, 45 s, isolated instance seeded with the real DB)
+
+```
+  self ms      %  function
+  24925.1   50.8  spawn  @node:internal/child_process:355
+  20833.1   42.5  (idle)
+   1282.7    2.6  run  @daemon/services/tmux.js:9
+     108.5    0.2  prepare @better-sqlite3/lib/methods/wrappers.js
+      86.4    0.2  (anonymous) @daemon/state/project-store.js:34
+      22.3    0.0  assembleProject @daemon/state/project-store.js:29
+```
+
+**50.8% of the daemon's main thread is `child_process.spawn`**, in ~1 s
+contiguous blocks. SQLite query time itself is a rounding error (~0.5%).
+
+### Where the spawns come from
+
+`services/lifecycle.ts` `pollAll()` runs at 1 Hz and calls
+`hasSession(session.tmuxName)` — one `execFile("tmux", ["has-session", ...])`
+per session per tick. The live DB has 237 sessions, 230 of them tmux-backed,
+so that is **230 process spawns per second**. Crucially it spawns for
+`done` (140) and `exited` (35) sessions too — `pollSession` awaits
+`hasSession` *before* checking those terminal states, so 169 of the 230
+spawns per tick are pure waste.
+
+Measured standalone against the live tmux server: one tick of 230
+`has-session` calls = 350 ms wall, **327 ms of contiguous event-loop lag**.
+
+### Why a pre-existing poller only became fatal now
+
+`uv_spawn` uses `fork()`, whose cost is proportional to the parent's mapped
+memory (page-table copy). Measured directly (`/tmp/vstbench/forkcost.mjs`):
+
+```
+rss= 44MB   1.36 ms/spawn (synchronous, main thread)
+rss=359MB   9.43 ms/spawn      -> 7x more expensive
+```
+
+PR #39 replaced the in-memory project store with uncached SQLite reads.
+`getAllProjects()` now assembles a **fresh object graph of 11 projects /
+129 worktrees / 237 sessions on every call** (`state/project-store.ts`
+`assembleProject`, N+1 queries, a fresh `db.prepare()` each time). It is
+called from:
+
+- every HTTP route that resolves a worktree/session (`findWorktreeContext`,
+  `routes/worktrees.ts:800`, `routes/sessions.ts:143`),
+- **every WS frame** — `ws/handlers/sessionLookup.ts` `findSessionRecord()`
+  is called by `session:open`, `session:resize` and `session:input`, i.e.
+  **once per keystroke**, and it linearly scans every project's every
+  worktree's every session,
+- `pollAll()` every second,
+- `tree:watch` / `file:watch` handlers.
+
+Measured cost: 3.5 ms of synchronous, event-loop-blocking work per call
+(`/tmp/vstbench/bench.mjs`). Pre-PR the same call was
+`Array.from(store.values())` on an in-memory `Map`.
+
+The resulting allocation churn drives daemon RSS to ~327 MB (measured on the
+isolated instance with no agents attached), which multiplies the pre-existing
+poller's per-spawn cost ~7×, tipping it from ~7% of the main loop to >50%.
+
+**Causal chain:** uncached SQLite reads → allocation churn → large RSS →
+`fork()` per `tmux has-session` becomes ~9 ms of main-thread time → 230/s →
+main loop blocked ~50% of the time in ~1 s chunks → every WS frame and HTTP
+request queues behind it.
+
+Note the WAL was ruled out explicitly: growing the WAL from 0 → 4 MB does not
+change read latency (`/tmp/vstbench/walbench.mjs`, 3.7 ms → 3.5 ms).
+
+### The crash (symptom 1's proximate cause)
+
+`/tmp/vst-daemon.log` ends with:
+
+```
+node:events:486
+      throw er; // Unhandled 'error' event
+Error: read ECONNRESET
+    at Pipe.onStreamRead (node:internal/stream_base_commons:216:20)
+Emitted 'error' event on Socket instance
+```
+
+The daemon **died** after ~7 minutes. The `vst-control` tmux transcript shows
+the user asking for a daemon restart four separate times. A dead daemon
+explains symptom 1 exactly, including the detail that touch and scroll are
+dead too: xterm is mounted and shows old scrollback, but every interaction
+path — keystrokes, `attachTouchScroll` (which sends tmux copy-mode keys), and
+the jump-to-latest button — is a WS round-trip to the daemon.
+
+The unhandled `error` is on a **child-process stdio pipe**. `child.on("error")`
+does not catch stream errors on `child.stdout`; several places consume a
+child's stdout with no `error` listener:
+`services/fileList.ts:131` (`rg --files`), and the readline consumers in
+`agent-plugins/claude.ts:499`, `agy.ts:443`, `cursor.ts:343`,
+`opencode.ts:307`. This is pre-existing (one occurrence in the historical
+log), but it is firing constantly now, and the >50% main-loop saturation
+makes abrupt child teardown far more likely.
+
+### Symptom-by-symptom attribution
+
+| symptom | cause |
+|---|---|
+| 1 — terminal totally dead (keys/touch/scroll) | daemon crashes on unhandled child-pipe `ECONNRESET`; while it *is* alive, WS frames queue behind ~1 s main-loop blocks, and every keystroke additionally pays a full-store scan in `findSessionRecord` |
+| 2 — slow agent-tab switch | a tab switch is `session:close` + `session:open` over WS; both go through `findSessionRecord` (full store assemble) and both land in the middle of the poller's main-loop blocks |
+| 3 — tab bar slow / second session missing | tab strip renders off `GET /sessions?worktree=` (19× slower) and the `session:created` WS broadcast; both queue behind the same blocks. The "missing second session" is the strip rendering before the delayed response/broadcast arrives |
+
+---
+
+## Review feedback incorporated (fable reviewer)
+
+- **Accepted:** `capture-pane` also spawns per tick and survives F2 (~61 spawns/s
+  remain). Target relaxed from "<2%" to "measure and report"; the overlap guard
+  is promoted from afterthought to load-bearing.
+- **Accepted:** symptom 3 has a real client-side lost-update race, not just
+  latency → new **F6**.
+- **Accepted:** write amplification (full project rewrite per lifecycle flip)
+  → new **F5**.
+- **Accepted:** the RSS narrative rested on an unmeasured pre-merge baseline.
+  Native `db.prepare()` churn (better-sqlite3 `Statement`s are native objects
+  finalized only on GC, invisible to V8 heap pressure) is the likelier RSS
+  driver than V8 allocation churn. F1's statement caching fixes that variant
+  too, so the fix is robust either way — but RSS is now measured before/after
+  rather than asserted.
+- **Accepted:** `listSessions()` swallows all errors and returns `[]`, so one
+  transient tmux failure would mass-mark every session exited. F2 must
+  distinguish "no server running" from an unexpected error and skip the tick.
+- **Accepted:** blanket `uncaughtException` "keep running" is wrong. F4 now
+  allowlists only `EPIPE`/`ECONNRESET` on pipe streams; anything else logs and
+  exits.
+- **Accepted:** verification must exercise the reported symptoms (WS keystroke
+  round-trip, tab-switch), not only daemon-internal counters.
+- **Noted, not changed:** `has-session -t` does prefix/target matching while a
+  `Set.has()` is exact. Verified against live data that all 61 alive sessions
+  match tmux `list-sessions` output exactly, and generated names contain no
+  `.`/`:` that tmux would rewrite, so exact matching is correct here.
+- **Rejected (scope):** a separate id→session index for F3. With F1 in place
+  `findSessionRecord` scans ~366 in-memory objects (microseconds); an extra
+  index is redundant state to keep in sync for no measurable gain.
+- **Verified, not assumed:** nothing outside the daemon opens
+  `vibe-station.db` — the `vst` CLI is HTTP-only (`cli/src/lib/daemon-client.ts`)
+  and has no `better-sqlite3` usage; the daemon holds an exclusive lockfile.
+  Single-writer holds, so a process-local cache is safe.
+
+## Fixes
+
+### F1 — `state/project-store.ts`: cache reads in memory again (primary)
+
+SQLite stays the durable source of truth; add a process-local cache in front
+of it. The daemon holds `~/.vibe-station/.daemon.lock`, so it is the only
+writer — a process-local cache cannot go stale from outside.
+
+- Load all projects into a `Map<string, ProjectRecord>` lazily on first read.
+- `getProject` / `getAllProjects` serve from the map (no clone — this is the
+  hot path).
+- `mutateProject` passes a **clone** to `fn` and installs the result into the
+  cache only after the transaction commits, so a throwing `writeProjectFull`
+  cannot leave a mutation in the cache that never reached the DB.
+- Under vitest (`NODE_ENV === "test"`) deep-freeze cached records, so any
+  caller that mutates a returned record in place fails loudly in tests instead
+  of silently corrupting the cache in production.
+- Cache the prepared statements per `Database` handle instead of calling
+  `db.prepare()` on every query (also removes the native-`Statement` churn
+  that is the likeliest RSS driver).
+- Tie the cache to the `Database` handle identity, so `getDb()` reopening a
+  different path (per-test temp DBs) drops it automatically; also cleared by
+  `_clearStoreForTest()` and after `loadAll()`'s migration writes rows directly.
+
+**Verify:** `getAllProjects()` drops from 3.5 ms to <0.01 ms; daemon RSS
+measured before/after; existing `project-store.test.ts` still passes.
+
+### F2 — `services/lifecycle.ts`: kill the spawn storm (primary)
+
+- **One** `tmux list-sessions -F '#{session_name}'` per tick, into a `Set`;
+  `pollSession` tests membership instead of spawning `has-session` per
+  session. 230 spawns/tick → 1.
+- The liveness probe must distinguish **"no server running"** (authoritative:
+  every session really is gone) from **any other tmux failure** (transient).
+  On an unexpected failure, skip the tick entirely — otherwise one hiccup
+  mass-marks 200+ sessions exited, each with a broadcast and a project rewrite.
+- Return early for `done` / `exited` sessions **before** the liveness check.
+  Traced and confirmed behaviour-neutral: today those states fall through to
+  no-ops after the check either way.
+- Guard against overlapping ticks (load-bearing — `setInterval` + async
+  `pollAll` is what lets a slow tick compound into multi-second blocks).
+
+**Verify:** re-profile. `capture-pane` still spawns once per tick per
+`working`/`idle` agent session (~61/s) and is NOT removed here, so the target
+is "spawn self-time down from 50.8% to under ~10%", with the residual
+attributed to `capture-pane` and reported honestly.
+
+### F3 — session lookup
+
+`findSessionRecord` stays a scan, but with F1 it scans in-memory objects
+(~366 iterations) instead of re-querying SQLite. No separate index.
+
+### F4 — crash containment
+
+- Attach `error` handlers to every child-process stdio stream the daemon
+  consumes: `services/fileList.ts` (`rg --files` stdout) and the four agent
+  plugins' `createInterface(child.stdout)` consumers (`claude.ts`, `agy.ts`,
+  `cursor.ts`, `opencode.ts`), plus their `stderr`/`stdin`.
+- Last-resort `process.on("uncaughtException")` in `main.ts` that **only**
+  swallows `EPIPE`/`ECONNRESET` (the diagnosed child-pipe class) and logs the
+  code + stack. Any other uncaught exception is logged and then re-thrown /
+  exits, because resuming from arbitrary corrupted state is unsafe. Add
+  `unhandledRejection` logging too — the process currently has neither.
+- The crash attribution is **plausible but unproven** (one occurrence in the
+  556 MB historical log, one in the 7-minute post-merge run). The added
+  logging is how it gets confirmed, not optional polish.
+
+### F5 — `services/lifecycle.ts` + `project-store.ts`: stop rewriting the world per state flip
+
+`persistLifecycleState` → `mutateProject` → `writeProjectFull` deletes and
+re-inserts **every** worktree and session row of a project to flip one
+session's `state`. Add a targeted `updateSessionLifecycle(projectId,
+sessionId, lifecycle)` doing a single `UPDATE sessions SET state = ?, reason =
+?, lastTransitionAt = ? WHERE id = ?` plus an in-place cache patch; keep
+`mutateProject`'s full replace for structural changes.
+
+### F6 — `web-ui/TabsStrip.tsx`: fix the lost-update race (symptom 3's "missing session")
+
+`TabsStrip`'s effect calls `api.listSessions(worktreeId)` and, on resolve,
+**replaces** the list with `setSessions(ss)`. The `session:created` WS handler
+appends to the same list. If the broadcast lands while the fetch is in flight
+and the fetch's server snapshot predates the insert, the resolve overwrites
+the list *without* the new session — and nothing invalidates it, so the tab
+stays missing until the next refetch. Multi-second latency blows the window
+wide open, but the race exists at any latency and none of F1–F5 fix it.
+
+Fix: track sessions that arrived via `session:created` while a fetch was in
+flight and union them into the fetch result instead of blind-replacing.
+
+---
+
+## Verification RESULTS
+
+A/B on an identical harness: isolated daemon (`HOME=/tmp/vstfake`) seeded with a
+copy of the real `vibe-station.db` (11 projects / 129 worktrees / 237 sessions),
+real worktree dirs symlinked in, polling the real tmux server. Same machine,
+same data, only the build differs.
+
+### CPU profile (`--cpu-prof`, 45 s)
+
+| | before | after |
+|---|---|---|
+| `child_process.spawn` self-time | **50.8%** (24.9 s) | **5.0%** (2.4 s) |
+| idle | 42.5% | **93.4%** |
+| `project-store` / `assembleProject` / `better-sqlite3 prepare` | present | gone from the profile |
+
+The residual 5% is `capture-pane`, which F2 deliberately does NOT remove (it
+still runs once per tick per `working`/`idle` agent session, ~61/s). Reviewer
+was right that it survives; it is now the largest remaining item and a
+reasonable follow-up.
+
+### WS frame round-trip — the keystroke / tab-switch path
+
+200 pings over 20 s under live poller load:
+
+| | before | after |
+|---|---|---|
+| p50 | 0.6 ms | 0.6 ms |
+| **p90** | **50.6 ms** | **0.8 ms** |
+| p99 | 91.3 ms | 36.2 ms |
+| frames actually serviced in 20 s | **127 / 200** | **200 / 200** |
+
+The dropped/delayed 73 frames are the measurable form of "typing feels dead"
+and "switching tabs is slow": frames sat behind the poller's main-loop blocks.
+
+### Routes
+
+| route | before | after |
+|---|---|---|
+| `/worktrees/:id/tree` | 5.0–20.3 ms | 0.9–1.8 ms |
+| `/sessions?worktree=` | 3.9–6.1 ms | 0.6–1.6 ms |
+| `/sessions` (all) | 5.3–6.5 ms | 1.2–2.3 ms |
+
+Note the sandbox is much lighter than the user's live daemon (no attached
+terminals, no live agents), so the *before* column here understates production,
+where `/tree` p50 was 2260 ms. Direction and magnitude match.
+
+### Memory
+
+RSS after 60 s idle: **300 MB → 151 MB**; during the probe **266 MB → 141 MB**.
+This is the link in the chain the reviewer challenged, now measured rather than
+asserted — and it confirms native prepared-statement churn was a major driver,
+since statement caching is most of what changed here.
+
+### Suites
+
+- `cd cli && npx vitest run` — 62 files, **589 passed**. (One "unhandled
+  rejection" is reported; verified by stashing the change that it is
+  **pre-existing on `main`**, in `sessions.test.ts`'s deliberate spawn-failure
+  test.)
+- `cd web-ui && npx vitest run` — 56 files, **321 passed**.
+- `npx tsc -b --noEmit` clean in both packages.
+
+The F6 regression test was verified to FAIL against the unfixed component
+before being kept.
+
+## Verification plan (as designed)
+
+- **Repro/measure:** isolated daemon (`HOME=/tmp/vstfake`) seeded with a copy
+  of the real `vibe-station.db` (11 projects / 129 worktrees / 237 sessions)
+  and the real worktree dirs symlinked in. Confirmed it reproduces ~1 s
+  main-loop blocks (`tree` and `changed-paths` both spiking to ~0.98 s in the
+  same sample). Re-run `--cpu-prof` after the fix.
+- **Targets:** `spawn` self-time <2% (from 50.8%); `/tree` p50 back to
+  single-digit ms; `/sessions?worktree=` back to <1 ms.
+- **Regression tests:**
+  - `project-store`: repeated `getAllProjects()` issues no additional SQL
+    after the first call, and a `mutateProject` write is reflected in the
+    next read (cache invalidation).
+  - `lifecycle`: one poll tick issues exactly one tmux liveness call
+    regardless of session count; `done`/`exited` sessions are never probed.
+  - `sessionLookup`: resolves worktree AND direct sessions (guard the
+    documented direct-session trap) without a full scan.
+  - `fileList`: a child stdout `error` does not reject/throw out of the
+    promise.
+- **Suites:** `cd cli && npx vitest run`, `cd web-ui && npx vitest run`,
+  `npx tsc -b --noEmit`.
+
+---
+
+## Explicitly NOT fixed here (found, but out of scope / not the reported bugs)
+
+- ~123 orphaned `vst-repo-*-t-*` tmux sessions on the host, created in bursts
+  of 3 between Aug 7 and now. They match the daemon test suite's project
+  fixture (`repo`), i.e. the tests leak real tmux sessions. Test-hygiene bug,
+  worth a follow-up.
+- The UI polls `GET /sessions/ipo-1-a1` every ~9 s and gets a 404 every time,
+  both pre- and post-merge — a stale persisted `activeSessionId` that is
+  never cleared. Cosmetic, pre-existing.

--- a/daemon/src/__tests__/childStreams.test.ts
+++ b/daemon/src/__tests__/childStreams.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Regression: an unhandled `'error'` on a child process's stdio pipe used to
+ * take the WHOLE DAEMON down.
+ *
+ * Observed in production as:
+ *
+ *     Error: read ECONNRESET
+ *         at Pipe.onStreamRead (node:internal/stream_base_commons:216:20)
+ *     Emitted 'error' event on Socket instance
+ *
+ * Which the user experiences as "the web terminal accepts no input at all" —
+ * not keyboard, not touch, not scroll — because every one of those is a
+ * WebSocket round-trip to a daemon that is no longer running.
+ *
+ * The trap is that `child.on("error")` does NOT cover errors emitted on
+ * `child.stdin`/`stdout`/`stderr`; those are separate streams with their own
+ * `'error'` events, and Node's default for an unhandled one is to throw out of
+ * the event loop.
+ */
+import { describe, it, expect } from "vitest";
+import { EventEmitter } from "node:events";
+import type { ChildProcess } from "node:child_process";
+import { guardChildStdio } from "../services/childStreams.js";
+
+function fakeChild(): ChildProcess {
+  const child = new EventEmitter() as unknown as ChildProcess;
+  (child as unknown as Record<string, unknown>).stdin = new EventEmitter();
+  (child as unknown as Record<string, unknown>).stdout = new EventEmitter();
+  (child as unknown as Record<string, unknown>).stderr = new EventEmitter();
+  return child;
+}
+
+function errno(code: string): NodeJS.ErrnoException {
+  const err = new Error(`read ${code}`) as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+}
+
+describe("guardChildStdio", () => {
+  it("swallows ECONNRESET/EPIPE on every stdio stream instead of letting it kill the process", () => {
+    const child = fakeChild();
+    guardChildStdio(child, "test");
+
+    // Without a listener, EventEmitter rethrows an 'error' emit — which is
+    // exactly the crash. With the guard installed these must be inert.
+    for (const stream of [child.stdin, child.stdout, child.stderr]) {
+      expect(() => stream!.emit("error", errno("ECONNRESET"))).not.toThrow();
+      expect(() => stream!.emit("error", errno("EPIPE"))).not.toThrow();
+    }
+  });
+
+  it("does not throw on an unexpected stream error either (it is logged, not fatal)", () => {
+    const child = fakeChild();
+    guardChildStdio(child, "test");
+    expect(() => child.stdout!.emit("error", errno("EACCES"))).not.toThrow();
+  });
+
+  it("tolerates a child with no piped stdio", () => {
+    const child = new EventEmitter() as unknown as ChildProcess;
+    expect(() => guardChildStdio(child, "test")).not.toThrow();
+  });
+
+  it("demonstrates the unguarded behaviour it protects against", () => {
+    // Sanity check that the hazard is real and this guard is what prevents it.
+    const unguarded = new EventEmitter();
+    expect(() => unguarded.emit("error", errno("ECONNRESET"))).toThrow(/ECONNRESET/);
+  });
+});

--- a/daemon/src/__tests__/lifecycle.test.ts
+++ b/daemon/src/__tests__/lifecycle.test.ts
@@ -35,6 +35,9 @@ vi.mock("../services/paths.js", async () => {
 
 vi.mock("../services/tmux.js", () => ({
   hasSession: vi.fn(),
+  // The poller takes ONE `list-sessions` snapshot per tick instead of a
+  // `tmux has-session` subprocess per session — see `listSessionNames`.
+  listSessionNames: vi.fn(),
   capturePane: vi.fn(),
 }));
 
@@ -120,10 +123,12 @@ describe("lifecycle polling behavior", () => {
     await mkdir(join(tempDir, "repo"), { recursive: true });
     _resetIdleTrackingForTest();
     tmux.hasSession.mockReset();
+    tmux.listSessionNames.mockReset();
     tmux.capturePane.mockReset();
     broadcaster.notifySession.mockClear();
     broadcaster.broadcastAll.mockClear();
-    tmux.hasSession.mockResolvedValue(true);
+    // "pane-l" is the seeded session's tmuxName — present == alive.
+    tmux.listSessionNames.mockResolvedValue(new Set(["pane-l"]));
   });
 
   afterEach(async () => {
@@ -202,7 +207,7 @@ describe("lifecycle polling behavior", () => {
 
     // Now the tmux pane disappears. The poller should broadcast session:exited
     // and clean up the tracking entry.
-    tmux.hasSession.mockResolvedValue(false);
+    tmux.listSessionNames.mockResolvedValue(new Set());
     await runLifecyclePollOnce();
 
     expect(await getCurrentState()).toBe("exited");
@@ -214,7 +219,7 @@ describe("lifecycle polling behavior", () => {
     // Indirect check that the tracking map was cleaned: if we revive the pane
     // and call again, idle hash tracking restarts cleanly without throwing
     // and the session stays exited (poller skips non-working/idle states).
-    tmux.hasSession.mockResolvedValue(true);
+    tmux.listSessionNames.mockResolvedValue(new Set(["pane-l"]));
     tmux.capturePane.mockResolvedValue("second");
     await expect(runLifecyclePollOnce()).resolves.toBeUndefined();
   });
@@ -289,5 +294,66 @@ describe("lifecycle polling behavior", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  // --- Regressions: the poller's tmux subprocess storm (PR #39 fallout) ---
+
+  it("takes ONE tmux liveness snapshot per tick, not one subprocess per session", async () => {
+    // This is the regression that made the whole daemon unusable: `pollSession`
+    // ran `tmux has-session` per session per second (230 subprocesses/second on
+    // the reporting user's install). fork() cost scales with the daemon's RSS,
+    // so that consumed >50% of the event loop and every keystroke, tab switch
+    // and tab-bar fetch queued behind it.
+    await seedProject("working");
+    tmux.capturePane.mockResolvedValue("output");
+
+    await runLifecyclePollOnce();
+
+    expect(tmux.listSessionNames).toHaveBeenCalledTimes(1);
+    expect(tmux.hasSession).not.toHaveBeenCalled();
+  });
+
+  it("never probes liveness for done/exited sessions", async () => {
+    // 175 of the user's 237 sessions were done/exited. The old code spawned
+    // `has-session` for each of them every tick and then did nothing with the
+    // answer — every branch below the check excludes those two states.
+    for (const state of ["done", "exited"] as const) {
+      await seedProject(state);
+      tmux.capturePane.mockReset();
+      await runLifecyclePollOnce();
+      expect(await getCurrentState()).toBe(state);
+      // No pane capture either — a terminal-state session is fully skipped.
+      expect(tmux.capturePane).not.toHaveBeenCalled();
+    }
+  });
+
+  it("skips the tick when tmux fails unexpectedly, instead of mass-marking every session exited", async () => {
+    // `listSessionNames` returns null for a failure it cannot interpret. If a
+    // transient tmux error collapsed to "no sessions", one hiccup would mark
+    // every session exited — hundreds of broadcasts and DB writes — and blank
+    // the user's whole workspace.
+    await seedProject("working");
+    tmux.capturePane.mockResolvedValue("output");
+    tmux.listSessionNames.mockResolvedValue(null);
+
+    await runLifecyclePollOnce();
+
+    expect(await getCurrentState()).toBe("working");
+    const exitCalls = broadcaster.broadcastAll.mock.calls.filter(
+      ([msg]) => (msg as { type?: string }).type === "session:exited",
+    );
+    expect(exitCalls).toHaveLength(0);
+  });
+
+  it("still marks sessions exited when tmux reports no server running (empty set)", async () => {
+    // The counterpart to the above: an EMPTY set is authoritative ("no server
+    // running" really does mean everything is gone) and must still be acted on.
+    await seedProject("working");
+    tmux.capturePane.mockResolvedValue("output");
+    tmux.listSessionNames.mockResolvedValue(new Set());
+
+    await runLifecyclePollOnce();
+
+    expect(await getCurrentState()).toBe("exited");
   });
 });

--- a/daemon/src/__tests__/project-store.test.ts
+++ b/daemon/src/__tests__/project-store.test.ts
@@ -70,6 +70,107 @@ describe("project-store (SQL-backed)", () => {
     expect(getProject("conc-proj")?.nextWorktreeNum).toBe(before + 20);
   });
 
+  // --- Regressions: read caching (PR #39 fallout) ---
+
+  it("serves repeat reads from memory instead of re-querying SQLite every call", async () => {
+    // The first SQLite cut re-assembled the whole object graph on EVERY read.
+    // These functions run on genuinely hot paths — `findSessionRecord` is
+    // called once per WS frame, i.e. once per keystroke — so that was ~3.5 ms
+    // of synchronous, event-loop-blocking work per keypress on a real install,
+    // plus native prepared-statement churn that drove RSS (and therefore the
+    // cost of every fork()) through the roof.
+    const { addProject, getAllProjects } = await import("../state/project-store.js");
+    const { getDb } = await import("../state/db.js");
+    await addProject(makeProject("cache-proj"));
+
+    getAllProjects(); // warm
+    const db = getDb();
+    const spy = vi.spyOn(db, "prepare");
+    try {
+      for (let i = 0; i < 25; i++) getAllProjects();
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("a write is visible to the very next read (cache invalidation)", async () => {
+    const { addProject, mutateProject, getProject, deleteProject } = await import(
+      "../state/project-store.js"
+    );
+    await addProject(makeProject("inval-proj"));
+    expect(getProject("inval-proj")?.nextWorktreeNum).toBe(1);
+
+    await mutateProject("inval-proj", (p) => ({ ...p, nextWorktreeNum: 42 }));
+    expect(getProject("inval-proj")?.nextWorktreeNum).toBe(42);
+
+    await deleteProject("inval-proj");
+    expect(getProject("inval-proj")).toBeUndefined();
+  });
+
+  it("a mutation that throws leaves neither the DB nor the cache changed", async () => {
+    // `fn` gets a CLONE and the result is installed only after the transaction
+    // commits, so a failed write can never leave the cache holding a value the
+    // DB never got.
+    const { addProject, mutateProject, getProject } = await import("../state/project-store.js");
+    await addProject(makeProject("rollback-proj"));
+
+    await expect(
+      mutateProject("rollback-proj", (p) => {
+        // Mutating the argument in place must not touch the cached record.
+        p.nextWorktreeNum = 999;
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    expect(getProject("rollback-proj")?.nextWorktreeNum).toBe(1);
+  });
+
+  it("updateSessionLifecycle writes one row and is reflected in the cached graph", async () => {
+    // The lifecycle fast path: `mutateProject` would DELETE and re-INSERT every
+    // worktree + session row of the project just to flip one session's state.
+    const { addProject, updateSessionLifecycle, getProject } = await import(
+      "../state/project-store.js"
+    );
+    const project = makeProject("lc-proj");
+    project.worktrees = [
+      {
+        id: "lc-wt",
+        branch: "b",
+        baseBranch: "main",
+        baseSha: "a".repeat(40),
+        createdAt: new Date().toISOString(),
+        sessions: [
+          {
+            id: "lc-sess",
+            type: "agent",
+            modeId: "m",
+            tmuxName: "lc-pane",
+            isMain: true,
+            sortOrder: 0,
+            lifecycle: { state: "working", lastTransitionAt: new Date().toISOString() },
+          },
+        ],
+      },
+    ];
+    await addProject(project);
+
+    const ok = await updateSessionLifecycle("lc-proj", "lc-sess", {
+      state: "idle",
+      lastTransitionAt: new Date().toISOString(),
+    });
+
+    expect(ok).toBe(true);
+    expect(getProject("lc-proj")!.worktrees[0]!.sessions[0]!.lifecycle.state).toBe("idle");
+    // Unknown session id is a no-op, not a throw.
+    expect(
+      await updateSessionLifecycle("lc-proj", "nope", {
+        state: "idle",
+        lastTransitionAt: new Date().toISOString(),
+      }),
+    ).toBe(false);
+  });
+
   it("2.T3 POST /worktrees -> GET /worktrees round-trips correctly through the SQL-backed store", async () => {
     const { buildServer } = await import("../server.js");
     const repoDir = join(tempDir, "repo");

--- a/daemon/src/__tests__/tmux.listSessionNames.test.ts
+++ b/daemon/src/__tests__/tmux.listSessionNames.test.ts
@@ -1,0 +1,66 @@
+/**
+ * `listSessionNames` failure semantics.
+ *
+ * The lifecycle poller uses this one snapshot per tick to decide which
+ * sessions are still alive, so the difference between "tmux says nothing is
+ * running" and "the tmux call failed" is load-bearing: collapsing the latter
+ * to an empty set would mark EVERY session exited in a single tick — hundreds
+ * of `session:exited` broadcasts and DB writes — from one transient hiccup.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const execFileMock = vi.fn();
+
+vi.mock("node:child_process", () => ({
+  execFile: (
+    _cmd: string,
+    _args: string[],
+    _opts: unknown,
+    cb: (err: unknown, res: { stdout: string; stderr: string }) => void,
+  ) => execFileMock(cb),
+}));
+
+/** Shape `promisify(execFile)` rejects with: an Error carrying `stderr`. */
+function tmuxError(stderr: string): Error & { stderr: string } {
+  const err = new Error(`Command failed: tmux list-sessions\n${stderr}`) as Error & {
+    stderr: string;
+  };
+  err.stderr = stderr;
+  return err;
+}
+
+describe("listSessionNames", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+  });
+
+  it("returns the set of live session names", async () => {
+    execFileMock.mockImplementation((cb) => cb(null, { stdout: "alpha\nbeta\n", stderr: "" }));
+    const { listSessionNames } = await import("../services/tmux.js");
+    expect(await listSessionNames()).toEqual(new Set(["alpha", "beta"]));
+  });
+
+  it("treats 'no server running' as an authoritative empty set", async () => {
+    execFileMock.mockImplementation((cb) =>
+      cb(tmuxError("no server running on /tmp/tmux-1000/default"), { stdout: "", stderr: "" }),
+    );
+    const { listSessionNames } = await import("../services/tmux.js");
+    // Empty set, NOT null: nothing is running, so every session really is gone
+    // and the poller should act on it.
+    expect(await listSessionNames()).toEqual(new Set());
+  });
+
+  it("returns null (skip the tick) for a failure it cannot interpret", async () => {
+    execFileMock.mockImplementation((cb) =>
+      cb(tmuxError("tmux: unexpected catastrophe"), { stdout: "", stderr: "" }),
+    );
+    const { listSessionNames } = await import("../services/tmux.js");
+    expect(await listSessionNames()).toBeNull();
+  });
+
+  it("listSessions() keeps its array contract on top of the set", async () => {
+    execFileMock.mockImplementation((cb) => cb(null, { stdout: "one\ntwo\n", stderr: "" }));
+    const { listSessions } = await import("../services/tmux.js");
+    expect(await listSessions()).toEqual(["one", "two"]);
+  });
+});

--- a/daemon/src/agent-plugins/agy.ts
+++ b/daemon/src/agent-plugins/agy.ts
@@ -51,6 +51,7 @@ import { promises as fs, mkdirSync, writeFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 import { spawn } from "node:child_process";
+import { guardChildStdio } from "../services/childStreams.js";
 import { randomUUID } from "node:crypto";
 import { createInterface } from "node:readline";
 import type { AgentPlugin, LaunchConfig, TurnInput, TurnContext } from "../services/spawn.js";
@@ -445,6 +446,7 @@ export function createAgyPlugin(): AgentPlugin {
         detached: true, // own process group for group-kill on abort
         stdio: ["ignore", "pipe", "pipe"],
       });
+      guardChildStdio(child, "agy");
       if (child.pid) ctx.onSpawn?.(child.pid);
 
       let stderr = "";

--- a/daemon/src/agent-plugins/claude.ts
+++ b/daemon/src/agent-plugins/claude.ts
@@ -9,6 +9,7 @@
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
 import { spawn } from "node:child_process";
+import { guardChildStdio } from "../services/childStreams.js";
 import { randomUUID } from "node:crypto";
 import { createInterface } from "node:readline";
 import type { AgentPlugin, LaunchConfig, TurnInput, TurnContext } from "../services/spawn.js";
@@ -501,6 +502,9 @@ export function createClaudePlugin(): AgentPlugin {
         detached: true, // own process group for group-kill on abort
         stdio: ["pipe", "pipe", "pipe"],
       });
+      // `claude` also gets its prompt on stdin below, so an EPIPE on a child
+      // that died during spawn is directly reachable here.
+      guardChildStdio(child, "claude");
       if (child.pid) ctx.onSpawn?.(child.pid);
 
       let stderr = "";

--- a/daemon/src/agent-plugins/cursor.ts
+++ b/daemon/src/agent-plugins/cursor.ts
@@ -14,6 +14,7 @@
  */
 
 import { execFile as execFileCb, spawn } from "node:child_process";
+import { guardChildStdio } from "../services/childStreams.js";
 import { promisify } from "node:util";
 import { promises as fs } from "node:fs";
 import { randomUUID } from "node:crypto";
@@ -345,6 +346,7 @@ export function createCursorPlugin(): AgentPlugin {
         detached: true,
         stdio: ["ignore", "pipe", "pipe"],
       });
+      guardChildStdio(child, "cursor-agent");
       if (child.pid) ctx.onSpawn?.(child.pid);
 
       let stderr = "";

--- a/daemon/src/agent-plugins/opencode.ts
+++ b/daemon/src/agent-plugins/opencode.ts
@@ -9,6 +9,7 @@
  */
 
 import { execFile, spawn } from "node:child_process";
+import { guardChildStdio } from "../services/childStreams.js";
 import { promisify } from "node:util";
 import { promises as fs } from "node:fs";
 import { randomUUID } from "node:crypto";
@@ -310,6 +311,7 @@ export function createOpencodePlugin(): AgentPlugin {
         stdio: ["ignore", "pipe", "pipe"],
         env: { ...process.env, OPENCODE_CONFIG: configPath },
       });
+      guardChildStdio(child, "opencode");
       if (child.pid) ctx.onSpawn?.(child.pid);
 
       let stderr = "";

--- a/daemon/src/main.ts
+++ b/daemon/src/main.ts
@@ -89,7 +89,51 @@ async function releaseLock(): Promise<void> {
   }
 }
 
+/**
+ * Last-resort process guards.
+ *
+ * The daemon owns every browser terminal, every attached agent stream and
+ * every file watcher, so dying takes all of them down at once — a real
+ * production failure mode here was an unhandled `read ECONNRESET` on a child
+ * process's stdio pipe killing the whole daemon, which the user experiences as
+ * "the web terminal accepts no input at all" (no keys, no touch, no scroll —
+ * every one of those is a WS round-trip).
+ *
+ * The individual pipes are guarded at the source (`services/childStreams.ts`,
+ * `services/fileList.ts`). This is the backstop for one we missed, and it is
+ * deliberately NOT a blanket "log and carry on": after an arbitrary uncaught
+ * exception the process state is undefined and continuing is unsafe. Only the
+ * broken-pipe family — which is always benign and always about a child that is
+ * already gone — is swallowed. Anything else is logged with its stack and then
+ * rethrown so the process still dies loudly rather than limping on corrupted
+ * state.
+ */
+function installProcessGuards(): void {
+  process.on("uncaughtException", (err: NodeJS.ErrnoException) => {
+    if (err?.code === "EPIPE" || err?.code === "ECONNRESET") {
+      console.warn(
+        `[daemon] survived an unhandled ${err.code} on a pipe — a child's stdio went away. ` +
+          `Guard its stream at the source (services/childStreams.ts).\n${err.stack ?? ""}`,
+      );
+      return;
+    }
+    console.error("[daemon] uncaught exception — exiting:", err?.stack ?? err);
+    throw err;
+  });
+
+  // The process had no rejection handler at all, so an unawaited rejection
+  // vanished silently (or killed the daemon, depending on Node's mode).
+  process.on("unhandledRejection", (reason) => {
+    console.error(
+      "[daemon] unhandled promise rejection:",
+      reason instanceof Error ? (reason.stack ?? reason.message) : reason,
+    );
+  });
+}
+
 async function main() {
+  installProcessGuards();
+
   // `acquireLock()` (pid-checked, `.daemon.lock`) already guarantees only one
   // daemon process runs against `~/.vibe-station` at a time (Risk #4 /
   // Phase 1.7) — since `vibe-station.db` lives inside that same directory,
@@ -98,8 +142,8 @@ async function main() {
   await acquireLock();
 
   // One-time migration of every project's manifest.json into vibe-station.db
-  // (idempotent — a no-op after the first successful boot), then every read
-  // below goes straight to SQLite (no in-memory project cache anymore).
+  // (idempotent — a no-op after the first successful boot). Reads then go
+  // through project-store's in-memory cache in front of SQLite.
   await loadAll();
 
   await recoverNotStartedSessions();

--- a/daemon/src/services/childStreams.ts
+++ b/daemon/src/services/childStreams.ts
@@ -1,0 +1,39 @@
+/**
+ * Guard a spawned child's stdio pipes against unhandled stream errors.
+ *
+ * `child.on("error")` only covers spawn/kill failures — it does NOT cover
+ * errors emitted on `child.stdin`/`stdout`/`stderr`, which are separate
+ * streams. An `EPIPE` (writing to a child that already died) or `ECONNRESET`
+ * (its end of the pipe torn down mid-read) on one of those streams with no
+ * listener is an unhandled `'error'` event, and Node's default for that is to
+ * throw out of the event loop and **kill the process**.
+ *
+ * For this daemon that means every browser terminal, every attached agent and
+ * every watcher dies because one `rg` or one agent turn was SIGKILLed at an
+ * awkward moment. Observed in production as:
+ *
+ *     Error: read ECONNRESET
+ *         at Pipe.onStreamRead (node:internal/stream_base_commons:216:20)
+ *     Emitted 'error' event on Socket instance
+ *
+ * Call this immediately after every `spawn()` whose stdio the daemon touches.
+ * Real read/write failures still surface through the normal paths (the child
+ * exits, readline ends, the promise settles) — this only stops the process
+ * from dying over a pipe that is already going away.
+ */
+import type { ChildProcess } from "node:child_process";
+
+export function guardChildStdio(child: ChildProcess, label: string): void {
+  for (const [name, stream] of [
+    ["stdin", child.stdin],
+    ["stdout", child.stdout],
+    ["stderr", child.stderr],
+  ] as const) {
+    stream?.on("error", (err: NodeJS.ErrnoException) => {
+      // EPIPE/ECONNRESET on a dying child is expected and not worth logging at
+      // warn level on every abort; anything else is genuinely unusual.
+      if (err?.code === "EPIPE" || err?.code === "ECONNRESET") return;
+      console.warn(`[child:${label}] ${name} stream error: ${err?.message ?? String(err)}`);
+    });
+  }
+}

--- a/daemon/src/services/fileList.ts
+++ b/daemon/src/services/fileList.ts
@@ -128,6 +128,17 @@ function listFilesWithRipgrep(wtPath: string): Promise<FileListResult> {
       resolve({ files, truncated, source: "ripgrep" });
     };
 
+    // `child.on("error")` does NOT cover stream errors on the child's stdio
+    // pipes. Without this listener an ECONNRESET/EPIPE while reading rg's
+    // stdout (very reachable: `killChild` SIGKILLs it on timeout or on hitting
+    // the entry cap, with data still in flight) is an unhandled 'error' event,
+    // which takes the WHOLE DAEMON DOWN — every browser terminal with it.
+    child.stdout?.on("error", () => {
+      // Treat a broken pipe as end-of-output: keep whatever we collected.
+      truncated = true;
+      finish();
+    });
+
     child.stdout?.on("data", (chunk: Buffer) => {
       if (truncated) return;
       buffer += chunk.toString("utf8");

--- a/daemon/src/services/lifecycle.ts
+++ b/daemon/src/services/lifecycle.ts
@@ -17,8 +17,8 @@
  */
 
 import { createHash } from "node:crypto";
-import { hasSession, capturePane } from "./tmux.js";
-import { getAllProjects, mutateProject } from "../state/project-store.js";
+import { listSessionNames, capturePane } from "./tmux.js";
+import { getAllProjects, updateSessionLifecycle } from "../state/project-store.js";
 import { broadcastAll } from "../broadcaster.js";
 import { directPtyRegistry } from "../state/directPtyRegistry.js";
 import { sessionChannel } from "./channel.js";
@@ -65,9 +65,13 @@ function hashPane(output: string): string {
   return createHash("sha1").update(output, "utf8").digest("hex");
 }
 
+/**
+ * @param _worktreeId Retained for call-site compatibility only — the row is now
+ * located by the DB-wide-unique session id, so the worktree is not needed.
+ */
 export async function persistLifecycleState(
   projectId: string,
-  worktreeId: string | undefined,
+  _worktreeId: string | undefined,
   sessionId: string,
   newState: LifecycleState,
 ): Promise<void> {
@@ -79,46 +83,17 @@ export async function persistLifecycleState(
     state: newState,
   });
 
-  if (worktreeId) {
-    // Worktree session
-    await mutateProject(projectId, (p) => ({
-      ...p,
-      worktrees: p.worktrees.map((w) =>
-        w.id === worktreeId
-          ? {
-              ...w,
-              sessions: w.sessions.map((s) =>
-                s.id === sessionId
-                  ? {
-                      ...s,
-                      lifecycle: {
-                        state: newState,
-                        lastTransitionAt: new Date().toISOString(),
-                      },
-                    }
-                  : s,
-              ),
-            }
-          : w,
-      ),
-    }));
-  } else {
-    // Direct session
-    await mutateProject(projectId, (p) => ({
-      ...p,
-      directSessions: p.directSessions.map((s) =>
-        s.id === sessionId
-          ? {
-              ...s,
-              lifecycle: {
-                state: newState,
-                lastTransitionAt: new Date().toISOString(),
-              },
-            }
-          : s,
-      ),
-    }));
-  }
+  // Single-row UPDATE, not a `mutateProject` read-modify-write. The latter
+  // routes through `writeProjectFull`, which DELETEs and re-INSERTs every
+  // worktree + session row of the project (~290 statements plus an fsync on a
+  // real install) just to change one session's `state`. Lifecycle transitions
+  // fire continuously as agents flip working<->idle, so that write
+  // amplification was a standing tax on the event loop. `worktreeId` is no
+  // longer needed to locate the row — session ids are unique DB-wide.
+  await updateSessionLifecycle(projectId, sessionId, {
+    state: newState,
+    lastTransitionAt: new Date().toISOString(),
+  });
 }
 
 /** Lines of ring buffer used for idle hashing in direct-pty mode. */
@@ -128,8 +103,17 @@ async function pollSession(
   projectId: string,
   worktreeId: string | undefined,
   session: SessionRecord,
+  /** Names of every tmux session alive right now — see `pollAll`. */
+  aliveTmuxNames: ReadonlySet<string>,
 ): Promise<void> {
   if (session.lifecycle.state === "not_started") return;
+
+  // `done` and `exited` are terminal: whatever the liveness check says, every
+  // branch below is a no-op for them (traced: the `!alive` branch excludes
+  // both, and the idle/working hash branch requires `working`/`idle`). Bailing
+  // here is behaviour-neutral and skips the majority of the work — on a real
+  // install 175 of 237 sessions are in one of these two states.
+  if (session.lifecycle.state === "done" || session.lifecycle.state === "exited") return;
 
   // JSON channel (Decision 11): turn/queue state is authoritative — there is no
   // tmux pane or direct-pty stream to poll. `JsonAgentSession` drives lifecycle,
@@ -141,8 +125,8 @@ async function pollSession(
   // session.useTmux is coerced to boolean at loadAll time, but guard against undefined
   // from tests that construct records directly — treat undefined as true (tmux default).
   if (session.useTmux === false) {
-    if (session.lifecycle.state === "exited") return;
-
+    // (An `exited` check used to live here; the terminal-state early return
+    // above already covers it.)
     const stream = directPtyRegistry.get(session.id);
     if (!stream) {
       // Stream gone but state not yet exited — event-driven path will handle it.
@@ -182,10 +166,16 @@ async function pollSession(
     return;
   }
 
-  // Tmux path (existing behavior).
-  const alive = await hasSession(session.tmuxName);
+  // Tmux path. Membership in the single per-tick `list-sessions` snapshot,
+  // NOT a `tmux has-session` subprocess per session — that was one fork() per
+  // session per second (230/s on a real install), and fork() cost scales with
+  // the daemon's RSS, so it was consuming over half the event loop.
+  const alive = aliveTmuxNames.has(session.tmuxName);
 
-  if (!alive && session.lifecycle.state !== "exited" && session.lifecycle.state !== "done") {
+  // The `state !== "exited" && state !== "done"` guard that used to be here is
+  // now redundant — the terminal-state early return at the top of this
+  // function already excludes both.
+  if (!alive) {
     idleTracking.delete(session.id);
     broadcastAll({
       type: "session:exited",
@@ -194,8 +184,6 @@ async function pollSession(
     await persistLifecycleState(projectId, worktreeId, session.id, "exited");
     return;
   }
-
-  if (!alive) return;
 
   // Terminal sessions don't have user-meaningful idle/working states — skip
   // the hash-based detection. They stay "working" until exited (handled above).
@@ -279,20 +267,28 @@ export async function runLifecyclePollOnce(): Promise<void> {
 }
 
 async function pollAll(): Promise<void> {
+  // ONE tmux round-trip for the whole tick. `listSessionNames` returns null
+  // when tmux failed for a reason OTHER than "no server running" — a transient
+  // failure must not be read as "every session died", or a single hiccup would
+  // mass-mark hundreds of sessions exited and fire a broadcast + a DB write for
+  // each. Skip the tick and try again in a second.
+  const aliveTmuxNames = await listSessionNames();
+  if (aliveTmuxNames === null) return;
+
   const projects = getAllProjects();
   await Promise.all(
     projects.flatMap((project) => [
       // Poll worktree sessions
       ...project.worktrees.flatMap((worktree) =>
         worktree.sessions.map((session) =>
-          pollSession(project.id, worktree.id, session).catch((err) => {
+          pollSession(project.id, worktree.id, session, aliveTmuxNames).catch((err) => {
             console.error(`[lifecycle] Poll error for ${session.id}:`, err);
           }),
         ),
       ),
       // Poll direct sessions
       ...project.directSessions.map((session) =>
-        pollSession(project.id, undefined, session).catch((err) => {
+        pollSession(project.id, undefined, session, aliveTmuxNames).catch((err) => {
           console.error(`[lifecycle] Poll error for ${session.id}:`, err);
         }),
       ),
@@ -302,8 +298,18 @@ async function pollAll(): Promise<void> {
 
 export function startLifecyclePoller(): void {
   if (pollerHandle) return;
+  // Overlap guard: `pollAll` is async but `setInterval` fires regardless of
+  // whether the previous tick finished. Without this, a tick that runs long
+  // (many sessions, a slow tmux) stacks on the next one and the in-flight work
+  // compounds without bound — which is how a merely-expensive tick turns into
+  // multi-second event-loop stalls.
+  let inFlight = false;
   pollerHandle = setInterval(() => {
-    void pollAll();
+    if (inFlight) return;
+    inFlight = true;
+    void pollAll().finally(() => {
+      inFlight = false;
+    });
   }, POLL_INTERVAL_MS);
   if (typeof pollerHandle === "object" && "unref" in pollerHandle) {
     (pollerHandle as { unref(): void }).unref();

--- a/daemon/src/services/tmux.ts
+++ b/daemon/src/services/tmux.ts
@@ -78,13 +78,36 @@ export async function capturePane(
   return run(args);
 }
 
-/** List all tmux sessions, returning their names. */
+/** List all tmux sessions, returning their names. Errors collapse to `[]`. */
 export async function listSessions(): Promise<string[]> {
+  return [...((await listSessionNames()) ?? [])];
+}
+
+/**
+ * Names of every live tmux session, as a set — or `null` if tmux failed for a
+ * reason we cannot interpret.
+ *
+ * The null case matters. The lifecycle poller uses this snapshot to decide
+ * which sessions are still alive, so an error silently collapsing to "empty"
+ * would mark EVERY session exited in one tick — hundreds of `session:exited`
+ * broadcasts and DB writes from a single transient tmux hiccup. "No server
+ * running" is the one failure that genuinely does mean "nothing is alive", so
+ * it maps to an empty set; anything else maps to `null` and the caller skips.
+ */
+export async function listSessionNames(): Promise<Set<string> | null> {
   try {
     const output = await run(["list-sessions", "-F", "#{session_name}"]);
-    return output.split("\n").filter(Boolean);
-  } catch {
-    return [];
+    return new Set(output.split("\n").filter(Boolean));
+  } catch (err) {
+    // tmux prints "no server running on /tmp/tmux-1000/default" (and exits 1)
+    // when nothing is up at all — authoritative, and the common case on a
+    // fresh machine.
+    const text = `${(err as { stderr?: string })?.stderr ?? ""}${(err as Error)?.message ?? ""}`;
+    if (/no server running|error connecting to|No such file or directory/i.test(text)) {
+      return new Set();
+    }
+    console.warn(`[tmux] list-sessions failed, skipping liveness check: ${text.trim()}`);
+    return null;
   }
 }
 

--- a/daemon/src/state/project-store.ts
+++ b/daemon/src/state/project-store.ts
@@ -1,13 +1,51 @@
 /**
- * Project store — SQLite-backed (`vibe-station.db` is the sole source of
- * truth, no in-memory cache). Every read hits the DB directly; the
- * per-project mutex (`withProjectLock`) still serializes writes within one
- * process so a read-modify-write via `mutateProject` can't lose an update.
+ * Project store — SQLite-backed (`vibe-station.db` is the durable source of
+ * truth) with a process-local read cache in front of it.
+ *
+ * ## Why the cache exists (do not remove it)
+ *
+ * The first SQLite cut had no cache: every `getProject`/`getAllProjects`
+ * re-queried the DB and re-assembled the whole object graph. That is a
+ * *synchronous, event-loop-blocking* ~3.5 ms per call on a real install
+ * (11 projects / 129 worktrees / 237 sessions), and these functions sit on
+ * genuinely hot paths — `findSessionRecord` runs on EVERY WS frame, i.e. once
+ * per keystroke; the 1 Hz lifecycle poller calls it; so does every route that
+ * resolves a worktree. It also called `db.prepare()` fresh per query, and
+ * better-sqlite3 `Statement`s are native objects finalized only on GC, so the
+ * churn showed up as native memory growth invisible to V8's heap pressure.
+ * Daemon RSS climbed past 300 MB, and because `uv_spawn` uses `fork()` — whose
+ * cost scales with the parent's mapped memory — that made every `tmux`
+ * subprocess the poller spawns ~7x more expensive (1.4 ms -> 9.4 ms of
+ * synchronous main-thread time). Net effect measured on the user's install:
+ * over 50% of the daemon's main thread stuck in `child_process.spawn`, and
+ * `/worktrees/:id/tree` going from 1.3 ms to 2260 ms (p50).
+ *
+ * ## Why a process-local cache is safe
+ *
+ * The daemon holds an exclusive `~/.vibe-station/.daemon.lock` and is the only
+ * writer to `vibe-station.db`. The `vst` CLI talks to it over HTTP only
+ * (`cli/src/lib/daemon-client.ts`) and never opens the DB. So nothing can
+ * change these tables behind the cache's back.
+ *
+ * ## Invariants
+ *
+ *  - Reads return the CACHED object graph directly (no clone — cloning on the
+ *    hot path would reintroduce the allocation cost we are removing).
+ *    Callers MUST treat returned records as immutable. Under vitest the cached
+ *    records are deep-frozen so an in-place mutation throws instead of
+ *    silently corrupting the cache.
+ *  - `mutateProject` hands `fn` a CLONE and installs the result only after the
+ *    transaction commits, so a failed write can never leave the cache holding
+ *    a mutation the DB never got.
+ *  - The cache is tied to the `Database` handle identity, so `getDb()`
+ *    reopening a different path (tests use a fresh temp dir per file) drops it
+ *    for free.
  *
  * Public function signatures are byte-identical to the pre-SQLite version —
  * every route handler and service depends on them staying that way,
  * INCLUDING `mutateProject`'s `Promise<ProjectRecord>` return (not `void`).
  */
+import type { Database as DB, Statement } from "better-sqlite3";
 import type { ProjectRecord, SessionRecord, WorktreeRecord } from "../types.js";
 import { withProjectLock } from "../services/mutex.js";
 import { getDb } from "./db.js";
@@ -25,46 +63,158 @@ import {
 } from "./sqliteRowMappers.js";
 
 /**
+ * Prepared statements, cached per `Database` handle.
+ *
+ * `db.prepare()` compiles a fresh native `Statement` every call. On the read
+ * path that meant ~151 native allocations per `getAllProjects()`, each
+ * finalized only when V8 happens to GC — the main driver of the daemon's RSS
+ * growth (see the module doc comment). Preparing once per handle removes it.
+ */
+interface Prepared {
+  selectProject: Statement;
+  selectAllProjects: Statement;
+  selectWorktrees: Statement;
+  selectWorktreeSessions: Statement;
+  selectDirectSessions: Statement;
+  updateSessionLifecycle: Statement;
+}
+
+/** Per-handle cache: prepared statements + the assembled project graph. */
+interface StoreCache {
+  db: DB;
+  stmts: Prepared;
+  /** `undefined` until the first read populates it from the DB. */
+  projects?: Map<string, ProjectRecord>;
+}
+
+let cache: StoreCache | null = null;
+
+/**
+ * Opt-in tripwire (`VST_FREEZE_STORE=1`): deep-freeze cached records so any
+ * caller mutating one in place throws instead of editing the cache silently.
+ *
+ * Off by default, deliberately. Turning it on today fails ~15 pre-existing
+ * call sites (`routes/sessions.ts`, `routes/worktrees.ts`, `routes/projects.ts`)
+ * that do `session.lifecycle = {...}` on a store-derived record and then
+ * persist the same value via `mutateProject` — an idiom that predates this
+ * cache. Those are all "mutate then immediately write the identical value", so
+ * the cache still converges; the residual risk (a mutation surviving a FAILED
+ * write) is closed by invalidating the project on write failure instead — see
+ * `writeProjectFull`'s caller. Flipping those call sites to be non-mutating is
+ * a worthwhile follow-up, and this flag is how you find them.
+ */
+const FREEZE_CACHED_RECORDS = process.env.VST_FREEZE_STORE === "1";
+
+/**
+ * Get the cache bound to the CURRENT `Database` handle, rebuilding it if the
+ * handle changed. Identity-checking the handle is what makes per-test temp
+ * databases isolated for free: `getDb()` reopens when `dbPath()` changes, and
+ * the new handle can never match the old cache entry.
+ */
+function store(): StoreCache {
+  const db = getDb();
+  if (cache && cache.db === db) return cache;
+  cache = {
+    db,
+    stmts: {
+      selectProject: db.prepare("SELECT * FROM projects WHERE id = ?"),
+      selectAllProjects: db.prepare("SELECT * FROM projects"),
+      selectWorktrees: db.prepare("SELECT * FROM worktrees WHERE projectId = ? ORDER BY sortOrder ASC"),
+      selectWorktreeSessions: db.prepare("SELECT * FROM sessions WHERE worktreeId = ? ORDER BY sortOrder ASC"),
+      selectDirectSessions: db.prepare(
+        "SELECT * FROM sessions WHERE projectId = ? AND worktreeId IS NULL ORDER BY sortOrder ASC",
+      ),
+      updateSessionLifecycle: db.prepare(
+        "UPDATE sessions SET state = ?, reason = ?, lastTransitionAt = ? WHERE id = ?",
+      ),
+    },
+  };
+  return cache;
+}
+
+/** Drop the assembled-project cache, keeping the prepared statements. */
+function invalidateProjects(): void {
+  if (cache) delete cache.projects;
+}
+
+/**
+ * Recursively freeze a record so an in-place mutation by a caller throws
+ * (ES modules are strict mode) instead of silently corrupting the cache.
+ * Test-only: the cost is paid once per cache fill, but the risk of turning a
+ * latent mutation into a production crash isn't worth taking on the user's
+ * daemon — tests are where we want to find those callers.
+ */
+function deepFreeze<T>(value: T): T {
+  if (value === null || typeof value !== "object" || Object.isFrozen(value)) return value;
+  Object.freeze(value);
+  for (const v of Object.values(value as Record<string, unknown>)) deepFreeze(v);
+  return value;
+}
+
+/** Populate (or return) the assembled project map for the current handle. */
+function projects(): Map<string, ProjectRecord> {
+  const s = store();
+  if (s.projects) return s.projects;
+  const rows = s.stmts.selectAllProjects.all() as ProjectRow[];
+  const map = new Map<string, ProjectRecord>();
+  for (const row of rows) {
+    const record = assembleProject(row);
+    map.set(row.id, FREEZE_CACHED_RECORDS ? deepFreeze(record) : record);
+  }
+  s.projects = map;
+  return map;
+}
+
+/**
  * Boot-time entry point: migrate every project's `manifest.json` into
- * `vibe-station.db` (idempotent, see `dbMigration.ts`). There is no in-memory
- * store to "load" anymore — every read already goes straight to SQLite — this
- * just runs the one-time migration and kept its old name so `main.ts`'s boot
- * sequence didn't need to change shape.
+ * `vibe-station.db` (idempotent, see `dbMigration.ts`), then drop the read
+ * cache — the migration writes rows directly, bypassing `mutateProject`.
+ * Kept its old name so `main.ts`'s boot sequence didn't need to change shape.
  */
 export async function loadAll(): Promise<void> {
   await migrateManifestsToSqlite(getDb());
+  invalidateProjects();
 }
 
-/** Read one project (with its worktrees + sessions) straight from the DB. No caching. */
+/**
+ * Read one project (with its worktrees + sessions). Served from the in-memory
+ * cache; the returned record MUST be treated as immutable (see module doc).
+ */
 export function getProject(id: string): ProjectRecord | undefined {
-  const db = getDb();
-  const projectRow = db.prepare("SELECT * FROM projects WHERE id = ?").get(id) as ProjectRow | undefined;
-  if (!projectRow) return undefined;
-  return assembleProject(projectRow);
+  return projects().get(id);
 }
 
-/** Read every project from the DB. No caching. */
+/**
+ * Read every project. Served from the in-memory cache; the returned records
+ * MUST be treated as immutable (see module doc).
+ */
 export function getAllProjects(): ProjectRecord[] {
-  const db = getDb();
-  const rows = db.prepare("SELECT * FROM projects").all() as ProjectRow[];
-  return rows.map(assembleProject);
+  return Array.from(projects().values());
 }
 
 function assembleProject(projectRow: ProjectRow): ProjectRecord {
-  const db = getDb();
-  const worktreeRows = db
-    .prepare("SELECT * FROM worktrees WHERE projectId = ? ORDER BY sortOrder ASC")
-    .all(projectRow.id) as WorktreeRow[];
+  const { stmts } = store();
+  const worktreeRows = stmts.selectWorktrees.all(projectRow.id) as WorktreeRow[];
   const worktrees = worktreeRows.map((wRow) => {
-    const sessionRows = db
-      .prepare("SELECT * FROM sessions WHERE worktreeId = ? ORDER BY sortOrder ASC")
-      .all(wRow.id) as SessionRow[];
+    const sessionRows = stmts.selectWorktreeSessions.all(wRow.id) as SessionRow[];
     return rowToWorktree(wRow, sessionRows.map(rowToSession));
   });
-  const directRows = db
-    .prepare("SELECT * FROM sessions WHERE projectId = ? AND worktreeId IS NULL ORDER BY sortOrder ASC")
-    .all(projectRow.id) as SessionRow[];
+  const directRows = stmts.selectDirectSessions.all(projectRow.id) as SessionRow[];
   return rowToProject(projectRow, worktrees, directRows.map(rowToSession));
+}
+
+/** Re-read ONE project from the DB and install it in the cache. */
+function refreshProject(id: string): ProjectRecord | undefined {
+  const s = store();
+  const row = s.stmts.selectProject.get(id) as ProjectRow | undefined;
+  const map = projects();
+  if (!row) {
+    map.delete(id);
+    return undefined;
+  }
+  const record = assembleProject(row);
+  map.set(id, FREEZE_CACHED_RECORDS ? deepFreeze(record) : record);
+  return record;
 }
 
 /**
@@ -135,9 +285,68 @@ export async function mutateProject(
     if (!existing) {
       throw new Error(`Project '${id}' not found`);
     }
-    const updated = fn(existing);
-    writeProjectFull(updated);
+    // Hand `fn` a CLONE, never the cached object. Two reasons:
+    //  1. Most callers build the new record with spreads, but any that mutate
+    //     a nested array/record in place would otherwise be editing the cache.
+    //  2. If `writeProjectFull` throws, the transaction rolls back — and
+    //     because `fn` only ever touched the clone, the cache is still exactly
+    //     what the DB holds. Installing the result only AFTER the commit keeps
+    //     cache and DB atomically in step.
+    const updated = fn(structuredClone(existing));
+    try {
+      writeProjectFull(updated);
+      // Cache the DB ROUND-TRIP, not the in-memory record the caller built:
+      // `projectToRow`/`rowToSession` apply column defaults and drop anything
+      // that isn't a column, so the two can legitimately differ. Caching what
+      // was actually stored keeps "read your own write" honest.
+      refreshProject(id);
+    } catch (err) {
+      // The transaction rolled back, so the DB is unchanged — but a caller may
+      // have mutated its own reference into the cached graph before calling us
+      // (a pre-existing idiom, see FREEZE_CACHED_RECORDS). Drop this project so
+      // the next read re-syncs from the DB rather than serving a mutation that
+      // was never persisted.
+      invalidateProjects();
+      throw err;
+    }
+    // Return the caller's record, not the refreshed one — the public contract
+    // (`Promise<ProjectRecord>` of exactly what `fn` produced) predates the
+    // cache and callers rely on it.
     return updated;
+  });
+}
+
+/**
+ * Fast path for a lifecycle-state transition (F5).
+ *
+ * `persistLifecycleState` used to go through `mutateProject`, which means
+ * `writeProjectFull` DELETEs and re-INSERTs every worktree and session row of
+ * the project just to flip one session's `state`. On a real install that is
+ * ~290 statements plus an fsync per transition, and transitions fire
+ * continuously as agents go working<->idle. This does the single UPDATE the
+ * change actually needs and patches the cached record in place.
+ *
+ * Returns false if the session isn't in the DB (caller treats it as a no-op).
+ */
+export async function updateSessionLifecycle(
+  projectId: string,
+  sessionId: string,
+  lifecycle: SessionRecord["lifecycle"],
+): Promise<boolean> {
+  return withProjectLock(projectId, async () => {
+    const s = store();
+    const res = s.stmts.updateSessionLifecycle.run(
+      lifecycle.state,
+      lifecycle.reason ?? null,
+      lifecycle.lastTransitionAt,
+      sessionId,
+    );
+    if (res.changes === 0) return false;
+    // Re-assemble just this project from the DB rather than patching the
+    // frozen graph by hand — one project's worth of queries, only on an actual
+    // transition, and it cannot drift from what was just written.
+    refreshProject(projectId);
+    return true;
   });
 }
 
@@ -151,6 +360,9 @@ export async function addProject(record: ProjectRecord): Promise<void> {
       throw new Error(`Project '${record.id}' already exists`);
     }
     writeProjectFull(record);
+    // Cache the DB round-trip (see `mutateProject`) — the caller's record can
+    // omit fields that the schema defaults, and it keeps its own reference.
+    refreshProject(record.id);
   });
 }
 
@@ -165,6 +377,7 @@ export async function deleteProject(id: string): Promise<void> {
       throw new Error(`Project '${id}' not found`);
     }
     db.prepare("DELETE FROM projects WHERE id = ?").run(id);
+    projects().delete(id);
   });
 }
 
@@ -174,6 +387,7 @@ export function _clearStoreForTest(): void {
   db.prepare("DELETE FROM sessions").run();
   db.prepare("DELETE FROM worktrees").run();
   db.prepare("DELETE FROM projects").run();
+  invalidateProjects();
 }
 
 // Re-exported so callers that previously imported types alongside this module

--- a/web-ui/src/components/layout/TabsStrip.test.tsx
+++ b/web-ui/src/components/layout/TabsStrip.test.tsx
@@ -497,4 +497,57 @@ describe("TabsStrip", () => {
     expect(archivedTab).toBeTruthy();
     expect(within(archivedTab!).getByText(/archived/i)).toBeInTheDocument();
   });
+
+  it("keeps a session announced by session:created while the initial fetch was still in flight", async () => {
+    // Regression: "sometimes a second agent session doesn't show up in the tab
+    // bar". The mount effect fetched `listSessions` and REPLACED state with the
+    // result. If `session:created` landed while that GET was in flight — and
+    // the server snapshot it returns predates the insert — the resolve dropped
+    // the new session, and nothing ever invalidated it, so the tab stayed
+    // missing until an unrelated refetch.
+    //
+    // This is a lost update, not slowness: a slow daemon only widens the window
+    // from microseconds to seconds, so no amount of latency work fixes it.
+    const localApi = createMockApi();
+    const staleSnapshot = await localApi.listSessions("wt-1");
+
+    let releaseFetch: (() => void) | null = null;
+    vi.spyOn(localApi, "listSessions").mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          releaseFetch = () => resolve(structuredClone(staleSnapshot));
+        }),
+    );
+
+    render(
+      <MemoryRouter>
+        <TabsStrip api={localApi} worktreeId="wt-1" kind="agent" />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(releaseFetch).not.toBeNull());
+
+    // The daemon announces a new agent BEFORE our in-flight GET resolves.
+    const newSession = {
+      ...staleSnapshot.find((s) => s.type === "agent")!,
+      id: "sess-raced",
+      name: "Raced Agent",
+      label: "Raced Agent",
+      isMain: false,
+      sortOrder: Date.now(),
+    };
+    await act(async () => {
+      localApi.__test.emit({ type: "session:created", sessionId: newSession.id, snapshot: newSession });
+    });
+
+    // Now the older snapshot lands. It must not erase the raced-in session.
+    await act(async () => {
+      releaseFetch!();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /raced agent/i })).toBeInTheDocument();
+    });
+  });
 });

--- a/web-ui/src/components/layout/TabsStrip.tsx
+++ b/web-ui/src/components/layout/TabsStrip.tsx
@@ -277,6 +277,11 @@ export function TabsStrip({ api, worktreeId, kind, scope = "worktree" }: TabsStr
     if (pick) setActiveSession(pick);
   }, [isProject, projectSessions, isAgent, setActiveSession]);
 
+  /** Sessions announced by `session:created` while a `listSessions` fetch was
+   *  in flight. See `mergeArrivedDuringFetch` below — without this, the fetch's
+   *  older snapshot overwrites them and the tab never appears. */
+  const arrivedDuringFetch = useRef<Session[]>([]);
+
   useEffect(() => {
     if (isProject) return; // project scope derives from the server store above
     if (!worktreeId) {
@@ -286,9 +291,23 @@ export function TabsStrip({ api, worktreeId, kind, scope = "worktree" }: TabsStr
     }
     setSessionsLoaded(false);
     const matches = (s: Session) => s.type === kind;
+    arrivedDuringFetch.current = [];
     void (async () => {
       const all = await api.listSessions(worktreeId);
-      const ss = all.filter(matches);
+      // Union, never blind-replace. `session:created` can fire while this GET
+      // is in flight, and the server snapshot it returns may predate the new
+      // session — so `setSessions(ss)` alone silently drops a tab that was
+      // already announced, and nothing ever invalidates it. That is the
+      // "second agent session sometimes doesn't show up in the tab bar" bug;
+      // it is a lost update, not slowness, so it survives any latency fix (a
+      // slow daemon just widens the window from microseconds to seconds).
+      const ss = [
+        ...all.filter(matches),
+        ...arrivedDuringFetch.current.filter(
+          (s) => matches(s) && !all.some((a) => a.id === s.id),
+        ),
+      ];
+      arrivedDuringFetch.current = [];
       setSessions(ss);
       setSessionsLoaded(true);
       const store = useWorkspaceStore.getState();
@@ -313,6 +332,13 @@ export function TabsStrip({ api, worktreeId, kind, scope = "worktree" }: TabsStr
       if (ev.type !== "session:created" || !ev.snapshot) return;
       if (ev.snapshot.worktreeId !== worktreeId) return;
       if (!matches(ev.snapshot)) return;
+      // Also record it for the in-flight fetch to merge in — appending to
+      // state alone is not enough, because a `listSessions` response that is
+      // still in flight will replace this array wholesale when it lands.
+      arrivedDuringFetch.current = [
+        ...arrivedDuringFetch.current.filter((s) => s.id !== ev.snapshot!.id),
+        ev.snapshot,
+      ];
       setSessions((prev) => {
         const exists = prev.some((s) => s.id === ev.snapshot!.id);
         return exists ? prev : [...prev, ev.snapshot!];


### PR DESCRIPTION
## Summary

PR #39 (manifest.json → SQLite) removed the in-memory project store, so every `getProject`/`getAllProjects` re-queried SQLite and rebuilt the whole object graph (11 projects / 129 worktrees / 237 sessions on the reporting install) synchronously on every call — including `findSessionRecord`, which runs on **every WS frame** (i.e. once per keystroke). That ~3.5ms/call cost pushed daemon RSS past 300MB, which made every `fork()`-based subprocess ~7x more expensive, and the lifecycle poller was already spawning one `tmux has-session` per session per second (230/s). Measured: **over 50% of the daemon's main thread stuck in `child_process.spawn`**.

Reported symptoms, all traced to this (plus one independent race):
- Web-UI terminal accepted no input at all — keyboard, touch, **and** scroll. Root cause: the daemon was also occasionally crashing outright on an unhandled `ECONNRESET` on a child's stdio pipe. A dead daemon means every one of those interactions (all WS round-trips) goes nowhere.
- Agent tab switching within a worktree, previously instant, became slow — queuing behind the blocked event loop.
- The agent tab bar was sometimes slow to appear, and a second agent session sometimes didn't show up at all. The first half is the same event-loop blocking; the second half is a genuine, independent race in `TabsStrip`: a `listSessions` fetch could blindly overwrite a `session:created` broadcast that arrived while it was in flight — a lost update, not just slowness, so it survives every latency fix below.

## Fixes

- **`project-store.ts`**: reinstate a process-local in-memory read cache in front of SQLite (safe — the daemon holds an exclusive lock and is the sole writer; the CLI is HTTP-only). Cache prepared statements per DB handle. `mutateProject` hands callers a clone and only installs the cache entry after the DB transaction commits, invalidating on failure.
- **`lifecycle.ts`**: one `tmux list-sessions` snapshot per tick instead of one subprocess per session; skip `done`/`exited` sessions entirely (175/237 on the reporting install); guard against overlapping ticks; a single-row `UPDATE` fast path for lifecycle transitions instead of a full delete+reinsert of every row in the project (~290 statements + fsync per transition, and transitions fire continuously).
- **Crash containment**: `child.on("error")` doesn't cover `stdin`/`stdout`/`stderr` streams — guard those at every spawn site, plus a last-resort process handler for `EPIPE`/`ECONNRESET` only (anything else still crashes loudly rather than limping on undefined state).
- **`TabsStrip.tsx`**: union the `listSessions` result with any `session:created` events that arrived mid-fetch, instead of blindly replacing.

## Verification

A/B on an isolated daemon seeded with a copy of the real database:

| | before | after |
|---|---|---|
| `spawn` self-time | 50.8% | 5.0% |
| WS frame RTT p90 | 50.6ms | 0.8ms |
| `/sessions?worktree=` | 3.9–6.1ms | 0.6–1.6ms |
| RSS | 300MB | 151MB |

- `cli`: 589/589 tests passing, `tsc -b --noEmit` clean.
- `web-ui`: 321/321 tests passing (new `TabsStrip.test.tsx` covers the race, confirmed failing without the fix).
- Plan was reviewed by an independent pass before implementation; findings incorporated (write-amplification fast path, tmux-poll error semantics, RSS measurement).

## Known follow-ups (not fixed here, documented in the plan)

- `VST_FREEZE_STORE=1` is an opt-in tripwire that deep-freezes cached records; ~15 pre-existing call sites mutate a store-derived record in place before persisting the identical value back. They don't corrupt the cache today, but should be migrated to non-mutating updates — left as-is here to avoid scope creep in a bugfix.
- Residual ~5% spawn time is `capture-pane`, out of scope for this pass.
- The stdio-pipe crash was well-evidenced but not reproduced on demand; the new crash-containment guards double as instrumentation if it recurs.
- ~123 orphaned `vst-repo-*` tmux sessions found on the host matching daemon test fixtures — the test suite appears to leak real tmux sessions. Not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)