### PR TITLE
fix(daemon,test): stop the daemon test suite from leaking real tmux sessions

### DIFF
--- a/cli/vitest.config.ts
+++ b/cli/vitest.config.ts
@@ -8,5 +8,6 @@ export default defineConfig({
     environment: "node",
     globals: true,
     include: ["src/**/*.{test,spec}.ts", "src/**/__tests__/**/*.{test,spec}.ts"],
+    globalSetup: ["./vitest.global-setup.ts"],
   },
 });

--- a/cli/vitest.global-setup.ts
+++ b/cli/vitest.global-setup.ts
@@ -1,0 +1,48 @@
+/**
+ * Belt-and-suspenders safety net against real tmux session leaks from the
+ * test suite (see daemon/src/__tests__/sessions.reset.test.ts,
+ * sessions.handoff.test.ts, sessions.reorder.test.ts for the actual fixes).
+ *
+ * Individual tests should mock `daemon/src/services/tmux.js` so they never
+ * touch a real tmux server at all. This global hook is a defense-in-depth
+ * fallback for whatever we haven't caught yet: it snapshots the tmux session
+ * list before the run and diffs against the snapshot after the run, killing
+ * only sessions that appeared DURING this test run.
+ *
+ * This is deliberately a diff, not a name-pattern sweep — a pattern-based
+ * sweep of e.g. `vst-*` would be unsafe on a dev host that also runs a real
+ * vst daemon (which names its own real sessions `vst-<id>`) or other tools.
+ * Diffing against a snapshot never touches a pre-existing session, real or
+ * otherwise.
+ */
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCb);
+
+async function listSessionNames(): Promise<Set<string>> {
+  try {
+    const { stdout } = await execFile("tmux", ["list-sessions", "-F", "#{session_name}"]);
+    return new Set(stdout.split("\n").map((s) => s.trim()).filter(Boolean));
+  } catch {
+    // No tmux server running (or tmux not installed) — nothing to snapshot.
+    return new Set();
+  }
+}
+
+export default async function setup(): Promise<() => Promise<void>> {
+  const before = await listSessionNames();
+
+  return async function teardown(): Promise<void> {
+    const after = await listSessionNames();
+    const leaked = [...after].filter((name) => !before.has(name));
+    if (leaked.length === 0) return;
+
+    console.warn(
+      `[vitest globalTeardown] Killing ${leaked.length} tmux session(s) leaked by the test run: ${leaked.join(", ")}`,
+    );
+    await Promise.all(
+      leaked.map((name) => execFile("tmux", ["kill-session", "-t", name]).catch(() => {})),
+    );
+  };
+}

--- a/daemon/src/__tests__/sessions.handoff.test.ts
+++ b/daemon/src/__tests__/sessions.handoff.test.ts
@@ -33,6 +33,31 @@ vi.mock("../services/handoff.js", () => ({
   readHandoffFileOrNull: vi.fn(async () => null),
 }));
 
+// Without this, every worktree created in beforeEach spawns a REAL agent
+// process via spawnSession (which shells out through tmux.js), and 1.T3
+// creates a real terminal session via routes/sessions.ts's own direct
+// `newSession` call (it bypasses spawn.js entirely) — both leak real,
+// never-killed tmux sessions on every test run.
+vi.mock("../services/spawn.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../services/spawn.js")>();
+  return {
+    ...original,
+    spawnSession: vi.fn(async () => {}),
+    spawnDirectSession: vi.fn(async () => {}),
+  };
+});
+
+vi.mock("../services/tmux.js", () => ({
+  newSession: vi.fn().mockResolvedValue(undefined),
+  hasSession: vi.fn().mockResolvedValue(true),
+  killSession: vi.fn().mockResolvedValue(undefined),
+  capturePane: vi.fn().mockResolvedValue(""),
+  pasteBuffer: vi.fn().mockResolvedValue(undefined),
+  sendKeys: vi.fn().mockResolvedValue(undefined),
+  listSessionNames: vi.fn().mockResolvedValue(new Set()),
+  listSessions: vi.fn().mockResolvedValue([]),
+}));
+
 describe("POST /sessions/:id/handoff", () => {
   let app: FastifyInstance;
   let repoDir: string;

--- a/daemon/src/__tests__/sessions.reorder.test.ts
+++ b/daemon/src/__tests__/sessions.reorder.test.ts
@@ -36,6 +36,22 @@ vi.mock("../services/spawn.js", async (importOriginal) => {
   };
 });
 
+// Mock tmux so no real tmux server is needed — without this, the "works for a
+// direct (worktree-less) session too" test's `POST /sessions
+// {type: "terminal"}` calls the route's own direct `newSession` call
+// (routes/sessions.ts bypasses the mocked spawn.js for terminal sessions),
+// leaking a real orphaned tmux session on every test run.
+vi.mock("../services/tmux.js", () => ({
+  newSession: vi.fn().mockResolvedValue(undefined),
+  hasSession: vi.fn().mockResolvedValue(true),
+  killSession: vi.fn().mockResolvedValue(undefined),
+  capturePane: vi.fn().mockResolvedValue(""),
+  pasteBuffer: vi.fn().mockResolvedValue(undefined),
+  sendKeys: vi.fn().mockResolvedValue(undefined),
+  listSessionNames: vi.fn().mockResolvedValue(new Set()),
+  listSessions: vi.fn().mockResolvedValue([]),
+}));
+
 describe("PATCH /sessions/:id/reorder", () => {
   let app: FastifyInstance;
   let repoDir: string;

--- a/daemon/src/__tests__/sessions.reset.test.ts
+++ b/daemon/src/__tests__/sessions.reset.test.ts
@@ -37,6 +37,21 @@ vi.mock("../services/spawn.js", async (importOriginal) => {
   };
 });
 
+// Mock tmux so no real tmux server is needed — without this, `POST /sessions
+// {type: "terminal"}` in 4.T1 calls the route's own direct `newSession` call
+// (routes/sessions.ts bypasses the mocked spawn.js for terminal sessions),
+// leaking a real orphaned tmux session on every test run.
+vi.mock("../services/tmux.js", () => ({
+  newSession: vi.fn().mockResolvedValue(undefined),
+  hasSession: vi.fn().mockResolvedValue(true),
+  killSession: vi.fn().mockResolvedValue(undefined),
+  capturePane: vi.fn().mockResolvedValue(""),
+  pasteBuffer: vi.fn().mockResolvedValue(undefined),
+  sendKeys: vi.fn().mockResolvedValue(undefined),
+  listSessionNames: vi.fn().mockResolvedValue(new Set()),
+  listSessions: vi.fn().mockResolvedValue([]),
+}));
+
 vi.mock("../services/handoff.js", () => ({
   runHandoffTurn: vi.fn(async () => false),
   readHandoffFileOrNull: vi.fn(async () => null),


### PR DESCRIPTION
## Summary

A previous investigation (PR #40) found ~154 orphaned `vst-repo-*`/`vst-mr-*` tmux sessions accumulated on the dev host, matching a naming pattern used by daemon test fixtures. This PR root-causes and fixes it.

**Root cause:** `routes/sessions.ts` spawns terminal-type sessions by calling `newSession` from `daemon/src/services/tmux.ts` directly — bypassing `services/spawn.ts` entirely. Three test files mocked `spawn.js` (to avoid real agent-process spawns) but never mocked `tmux.js`:
- `sessions.reset.test.ts` (test "4.T1") and `sessions.reorder.test.ts` ("works for a direct session too") each create a real terminal session via `POST /sessions {type: "terminal"}` and never kill it.
- `sessions.handoff.test.ts` didn't mock `spawn.js` at all — every test's `beforeEach` worktree creation spawned a real agent-type tmux session too.

## Fix

- Added `vi.mock("../services/tmux.js", …)` to all three files (and the missing `spawn.js` mock to `sessions.handoff.test.ts`), matching the pattern already used by every other passing route test.
- Added `cli/vitest.global-setup.ts` as defense-in-depth: it snapshots `tmux list-sessions` before the whole test run and kills only sessions that appeared during it — a diff against a snapshot, not a name-pattern sweep, so it can never touch a pre-existing or real session (important on a shared dev host running a live `vst` daemon, whose own sessions are also named `vst-<id>`).

## Cleanup

Cross-checked the live daemon's real project list (`~/.vibe-station/vibe-station.db`) — no project named `repo`/`my-repo` exists there, confirming every matching session was a test artifact. Killed exactly 150 `vst-repo-*` and 4 `vst-mr-*` sessions (154 total). Left `vst-control` (the real daemon's own live session) and all other unrelated sessions on the host untouched.

## Verification

- Independently re-run: `cd cli && npx vitest run` — 589/589 tests passing (one pre-existing, unrelated flaky unhandled-rejection warning in `sessions.test.ts`), tmux session count unchanged (62 before and after the run — only `vst-control` matches `vst-*`).
- `npx tsc -b --noEmit` clean.
- `web-ui`: 56 files / 321 tests passing, unchanged.
- Original author verified across 4 consecutive test runs; I independently re-verified once more post-cleanup with the same result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)