### PR TITLE
feat(daemon,cli): support switching agent mode/CLI on session reset

### DIFF
--- a/cli/src/__tests__/session-reset.test.ts
+++ b/cli/src/__tests__/session-reset.test.ts
@@ -120,6 +120,42 @@ describe("session reset command registration", () => {
     expect(optionNames).toContain("handoff");
     expect(optionNames).toContain("prompt");
     expect(optionNames).toContain("handoff-file");
+    expect(optionNames).toContain("mode");
+  });
+});
+
+describe("1.T8 --mode sends modeId in the reset body (reset-with-mode-switch)", () => {
+  it("sends the raw --mode value as modeId, unresolved (the daemon resolves id-or-name)", async () => {
+    await run(["session", "reset", "sess-1", "--mode", "claude-sonnet"]);
+
+    const post = captured.find((c) => c.url.endsWith("/sessions/sess-1/reset"));
+    expect(post, "expected a POST to /sessions/sess-1/reset").toBeDefined();
+    expect(post!.body.modeId).toBe("claude-sonnet");
+  });
+
+  it("omits modeId entirely when --mode is not given (unchanged behavior)", async () => {
+    await run(["session", "reset", "sess-1"]);
+
+    const post = captured.find((c) => c.url.endsWith("/sessions/sess-1/reset"));
+    expect(post, "expected a POST to /sessions/sess-1/reset").toBeDefined();
+    expect(post!.body.modeId).toBeUndefined();
+  });
+
+  it("combines with --prompt and --handoff-file in the same call", async () => {
+    const file = writeHandoff("summary before switching modes");
+    await run([
+      "session", "reset", "sess-1",
+      "--mode", "claude-sonnet",
+      "--prompt", "focus on tests now",
+      `--handoff-file=${file}`,
+    ]);
+
+    const post = captured.find((c) => c.url.endsWith("/sessions/sess-1/reset"));
+    expect(post!.body).toMatchObject({
+      modeId: "claude-sonnet",
+      prompt: "focus on tests now",
+      handoffText: "summary before switching modes",
+    });
   });
 });
 

--- a/cli/src/commands/session/reset.ts
+++ b/cli/src/commands/session/reset.ts
@@ -16,6 +16,7 @@ export function registerSessionReset(session: Command): void {
     .description("Reset a session")
     .option("--handoff", "Generate a handoff summary before reset")
     .option("--prompt <text>", "Custom prompt for the new session")
+    .option("--mode <name-or-id>", "Switch to a different mode/CLI on reset")
     .addOption(
       new Option("--handoff-file <path>", "Read a handoff summary from file").conflicts("handoff")
     )
@@ -23,7 +24,7 @@ export function registerSessionReset(session: Command): void {
       async (
         id: string,
         // Keys must match commander's camelCased option names (--handoff-file → handoffFile).
-        opts: { handoff?: boolean; prompt?: string; handoffFile?: string }
+        opts: { handoff?: boolean; prompt?: string; handoffFile?: string; mode?: string }
       ) => {
         // The CLI is the only party that knows it's running INSIDE the target session — the
         // daemon can't distinguish this caller from the UI. `--handoff` here can never work: the
@@ -49,6 +50,9 @@ export function registerSessionReset(session: Command): void {
             handoff: opts.handoff,
             prompt: opts.prompt,
             handoffText,
+            // Sent as-is — the daemon resolves either a mode id or a mode
+            // name (resolveModeId), same as `session create --mode` already does.
+            modeId: opts.mode,
           }
         );
 

--- a/daemon/src/__tests__/plugins.test.ts
+++ b/daemon/src/__tests__/plugins.test.ts
@@ -526,6 +526,8 @@ describe("Claude plugin — chat-id capture", () => {
     expect(content).toContain("vst session reset $VST_SESSION --handoff-file <path>");
     expect(content).toContain("Do NOT pass `--handoff`");
     expect(content).not.toContain(".vibe-station/HANDOFF.md");
+    // reset-with-mode-switch: `reset --mode <name>` maps to a real --mode flag.
+    expect(content).toContain('vst session reset $VST_SESSION --mode "<name>"');
     expect(content).toContain("vst session handoff $VST_SESSION");
     expect(content).toContain('vst session rename $VST_SESSION "<name>"');
     expect(content).toContain('vst worktree rename $VST_WORKTREE "<name>"');
@@ -651,6 +653,7 @@ describe("Cursor plugin — setupWorkspaceHooks", () => {
     expect(content).toContain("vst session reset $VST_SESSION --handoff-file <path>");
     expect(content).toContain("Do NOT pass `--handoff`");
     expect(content).not.toContain(".vibe-station/HANDOFF.md");
+    expect(content).toContain('vst session reset $VST_SESSION --mode "<name>"');
     expect(content).toContain("vst session handoff $VST_SESSION");
     expect(content).toContain('vst session rename $VST_SESSION "<name>"');
     expect(content).toContain('vst worktree rename $VST_WORKTREE "<name>"');
@@ -752,6 +755,7 @@ describe("OpenCode plugin — chat-id capture", () => {
     expect(content).toContain("vst session reset $VST_SESSION --handoff-file <path>");
     expect(content).toContain("Do NOT pass `--handoff`");
     expect(content).not.toContain(".vibe-station/HANDOFF.md");
+    expect(content).toContain('vst session reset $VST_SESSION --mode "<name>"');
     expect(content).toContain("vst session handoff $VST_SESSION");
     expect(content).toContain('vst session rename $VST_SESSION "<name>"');
     expect(content).toContain('vst worktree rename $VST_WORKTREE "<name>"');

--- a/daemon/src/__tests__/sessions.reset.test.ts
+++ b/daemon/src/__tests__/sessions.reset.test.ts
@@ -75,6 +75,18 @@ describe("POST /sessions/:id/reset", () => {
       join(tempDir, "modes.json"),
       JSON.stringify([
         { id: "bug-fix", name: "Bug Fix", cli: "claude", context: "fix bugs", createdAt: new Date().toISOString() },
+        // Second mode for reset-with-mode-switch tests — deliberately a
+        // DIFFERENT `cli`, not just a different model, so 1.T4 actually
+        // exercises the motivating scenario (switching CLIs on reset, e.g.
+        // "agy main" -> "claude sonnet"), not just a same-CLI model change.
+        {
+          id: "plan-mode",
+          name: "Plan Mode",
+          cli: "cursor",
+          model: "opus",
+          context: "plan only",
+          createdAt: new Date().toISOString(),
+        },
       ]),
     );
     const modesModule = await import("../routes/modes.js");
@@ -255,6 +267,155 @@ describe("POST /sessions/:id/reset", () => {
     // "also" and "this" are stopwords (naming.ts) — only "rename" survives.
     expect(newRow.name).toBe("rename");
     expect(newRow.initialPrompt).toBe("Handoff: mid-refactor.\n\n---\n\nalso rename this");
+  });
+
+  // --- reset-with-mode-switch ---
+
+  it("1.T1 reset with { modeId: <other id> }: new session's modeId is the requested one, not the old session's", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: `/sessions/${mainSessionId}/reset`,
+      payload: { modeId: "plan-mode" },
+    });
+    expect(res.statusCode).toBe(200);
+    const { newSessionId } = res.json<{ newSessionId: string }>();
+
+    const { getProject } = await import("../state/project-store.js");
+    const project = getProject(projectId)!;
+    const newRow = project.worktrees.find((w) => w.id === worktreeId)!.sessions.find((s) => s.id === newSessionId)!;
+    expect(newRow.modeId).toBe("plan-mode");
+  });
+
+  it("1.T2 reset with { modeId: <name> } resolves by name, same as by id", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: `/sessions/${mainSessionId}/reset`,
+      payload: { modeId: "Plan Mode" },
+    });
+    expect(res.statusCode).toBe(200);
+    const { newSessionId } = res.json<{ newSessionId: string }>();
+
+    const { getProject } = await import("../state/project-store.js");
+    const project = getProject(projectId)!;
+    const newRow = project.worktrees.find((w) => w.id === worktreeId)!.sessions.find((s) => s.id === newSessionId)!;
+    expect(newRow.modeId).toBe("plan-mode");
+  });
+
+  it("1.T3 reset with an unknown modeId returns 400 and does not archive the old session", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: `/sessions/${mainSessionId}/reset`,
+      payload: { modeId: "does-not-exist" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json<{ error: string }>().error).toContain("does-not-exist");
+
+    const stillLive = await app.inject({ method: "GET", url: `/sessions/${mainSessionId}` });
+    expect(stillLive.json<{ archivedAt: string | null }>().archivedAt).toBeFalsy();
+  });
+
+  it("1.T4 the spawned process uses the NEW mode's CLI plugin and model, not the outgoing session's", async () => {
+    const spawnModule = await import("../services/spawn.js");
+    vi.mocked(spawnModule.spawnSession).mockClear();
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/sessions/${mainSessionId}/reset`,
+      payload: { modeId: "plan-mode" },
+    });
+    expect(res.statusCode).toBe(200);
+
+    // Fire-and-forget spawn — give it a tick to land (same pattern as the
+    // "Bug 2 fix — spawnSession failure" test above).
+    await new Promise((r) => setTimeout(r, 100));
+
+    // `mainSessionId`'s mode is "bug-fix" (cli: claude); "plan-mode" is a
+    // genuinely different CLI (cursor) — asserting on `plugin.name` (not
+    // just `model`) proves this exercises an actual CLI switch, the
+    // motivating scenario for this feature, not just a same-CLI model change.
+    expect(spawnModule.spawnSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "opus",
+        plugin: expect.objectContaining({ name: "cursor" }),
+      }),
+    );
+  });
+
+  it("1.T5 reset with no modeId at all: mode unchanged, identical to pre-existing behavior", async () => {
+    const res = await app.inject({ method: "POST", url: `/sessions/${mainSessionId}/reset`, payload: {} });
+    expect(res.statusCode).toBe(200);
+    const { newSessionId } = res.json<{ newSessionId: string }>();
+
+    const { getProject } = await import("../state/project-store.js");
+    const project = getProject(projectId)!;
+    const newRow = project.worktrees.find((w) => w.id === worktreeId)!.sessions.find((s) => s.id === newSessionId)!;
+    expect(newRow.modeId).toBe("bug-fix");
+  });
+
+  it("1.T6 switching to a mode whose CLI does not support JSON downgrades channel json -> tmux", async () => {
+    // Seed a json-channel session to reset. Direct sessions are simplest here
+    // since they don't need a worktree main-session dance. Uses the REAL
+    // jsonUnsupportedCli (claude genuinely supports json) so creation itself
+    // isn't rejected by the same create-time gate.
+    const directRes = await app.inject({
+      method: "POST",
+      url: "/sessions",
+      payload: { target: "direct", projectId, type: "agent", modeId: "bug-fix", channel: "json" },
+    });
+    const directId = directRes.json<{ id: string }>().id;
+
+    // No real CLI in this codebase currently lacks JSON support (all four
+    // plugins return true from supportsJson()) — exercise the downgrade logic
+    // itself by spying on jsonUnsupportedCli for just the reset call below,
+    // the same seam the route calls.
+    const modesModule = await import("../routes/modes.js");
+    const unsupportedSpy = vi
+      .spyOn(modesModule, "jsonUnsupportedCli")
+      .mockResolvedValueOnce("claude");
+
+    // Restore in `finally` — if the assertions below ever fail, the spy must
+    // not leak into later tests in this file (vi.clearAllMocks() in
+    // beforeEach clears mock state but does NOT restore a vi.spyOn override).
+    let newSessionId: string;
+    try {
+      const res = await app.inject({
+        method: "POST",
+        url: `/sessions/${directId}/reset`,
+        payload: { modeId: "plan-mode" },
+      });
+      expect(res.statusCode).toBe(200);
+      newSessionId = res.json<{ newSessionId: string }>().newSessionId;
+    } finally {
+      unsupportedSpy.mockRestore();
+    }
+
+    const { getProject } = await import("../state/project-store.js");
+    const project = getProject(projectId)!;
+    const newRow = project.directSessions.find((s) => s.id === newSessionId)!;
+    expect(newRow.channel).toBe("tmux");
+    expect(newRow.useTmux).toBe(true);
+  });
+
+  it("1.T7 switching to a mode whose CLI DOES support JSON keeps channel json (regression)", async () => {
+    const directRes = await app.inject({
+      method: "POST",
+      url: "/sessions",
+      payload: { target: "direct", projectId, type: "agent", modeId: "bug-fix", channel: "json" },
+    });
+    const directId = directRes.json<{ id: string }>().id;
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/sessions/${directId}/reset`,
+      payload: { modeId: "plan-mode" },
+    });
+    expect(res.statusCode).toBe(200);
+    const { newSessionId } = res.json<{ newSessionId: string }>();
+
+    const { getProject } = await import("../state/project-store.js");
+    const project = getProject(projectId)!;
+    const newRow = project.directSessions.find((s) => s.id === newSessionId)!;
+    expect(newRow.channel).toBe("json");
   });
 
   it("4.T7 the old session's tmux pane is actually released (releaseSessionRuntime called)", async () => {

--- a/daemon/src/agent-plugins/claude.ts
+++ b/daemon/src/agent-plugins/claude.ts
@@ -319,6 +319,7 @@ export function createClaudePlugin(): AgentPlugin {
           "- `reset --handoff` -> see \"Important — `reset --handoff` writes its own file\" below",
           '- `reset <text>` (any other text after `reset`) -> `vst session reset $VST_SESSION --prompt "<text>"`',
           '- `reset --handoff <text>` -> see "Important — `reset --handoff` writes its own file" below (final command includes both `--handoff-file <path>` and `--prompt "<text>"`)',
+          '- `reset --mode <name>` -> `vst session reset $VST_SESSION --mode "<name>"` (switches mode/CLI on reset — combine with other reset flags, e.g. `--mode "<name>" --prompt "<text>"`)',
           "- `handoff` -> `vst session handoff $VST_SESSION`",
           '- `rename <name>` -> `vst session rename $VST_SESSION "<name>"`',
           '- `rename --worktree <name>` -> `vst worktree rename $VST_WORKTREE "<name>"`',

--- a/daemon/src/agent-plugins/cursor.ts
+++ b/daemon/src/agent-plugins/cursor.ts
@@ -414,6 +414,7 @@ export function createCursorPlugin(): AgentPlugin {
           "- `reset --handoff` -> see \"Important — `reset --handoff` writes its own file\" below",
           '- `reset` followed by other text -> `vst session reset $VST_SESSION --prompt "<that text>"`',
           '- `reset --handoff` followed by other text -> see "Important — `reset --handoff` writes its own file" below (final command includes both `--handoff-file <path>` and `--prompt "<that text>"`)',
+          '- `reset --mode <name>` -> `vst session reset $VST_SESSION --mode "<name>"` (switches mode/CLI on reset — combine with other reset flags, e.g. `--mode "<name>" --prompt "<that text>"`)',
           "- `handoff` -> `vst session handoff $VST_SESSION`",
           '- `rename <name>` -> `vst session rename $VST_SESSION "<name>"`',
           '- `rename --worktree <name>` -> `vst worktree rename $VST_WORKTREE "<name>"`',

--- a/daemon/src/agent-plugins/opencode.ts
+++ b/daemon/src/agent-plugins/opencode.ts
@@ -415,6 +415,7 @@ export function createOpencodePlugin(): AgentPlugin {
           "- `reset --handoff` -> see \"Important — `reset --handoff` writes its own file\" below",
           '- `reset <text>` (any other text after `reset`) -> `vst session reset $VST_SESSION --prompt "<text>"`',
           '- `reset --handoff <text>` -> see "Important — `reset --handoff` writes its own file" below (final command includes both `--handoff-file <path>` and `--prompt "<text>"`)',
+          '- `reset --mode <name>` -> `vst session reset $VST_SESSION --mode "<name>"` (switches mode/CLI on reset — combine with other reset flags, e.g. `--mode "<name>" --prompt "<text>"`)',
           "- `handoff` -> `vst session handoff $VST_SESSION`",
           '- `rename <name>` -> `vst session rename $VST_SESSION "<name>"`',
           '- `rename --worktree <name>` -> `vst worktree rename $VST_WORKTREE "<name>"`',

--- a/daemon/src/routes/sessions.ts
+++ b/daemon/src/routes/sessions.ts
@@ -77,6 +77,11 @@ const ResetBody = z.object({
   handoff: z.boolean().optional(),
   prompt: z.string().optional(),
   handoffText: z.string().optional(),
+  // Accepts either a mode id or a mode name — resolved the same way
+  // session-create's `--mode` already is (see resolveModeId in routes/modes.ts).
+  // Absent means "keep the outgoing session's mode", unchanged from before
+  // this field existed.
+  modeId: z.string().min(1).optional(),
 });
 
 const InputBody = z.object({
@@ -1219,17 +1224,19 @@ export function registerSessionRoutes(app: FastifyInstance): void {
     ));
   });
 
-  // POST /sessions/:id/reset   { handoff?: boolean, prompt?: string }
+  // POST /sessions/:id/reset   { handoff?: boolean, prompt?: string, modeId?: string }
   // Archive the current session and spawn a fresh one in its place — same tab
   // position (isMain/sortOrder/worktreeId inherited), same name unless a new
-  // prompt re-derives it (Decision 2/4/5/6/7).
+  // prompt re-derives it (Decision 2/4/5/6/7). Optionally switches mode/CLI
+  // (reset-with-mode-switch Decision 1) — absent `modeId` keeps today's
+  // behavior exactly (reuse the outgoing session's mode).
   app.post("/sessions/:id/reset", async (req, reply) => {
     const { id } = req.params as { id: string };
     const parsed = ResetBody.safeParse(req.body);
     if (!parsed.success) {
       return reply.status(400).send({ error: "Validation error", details: parsed.error.issues });
     }
-    const { handoff, prompt, handoffText: handoffTextFromBody } = parsed.data;
+    const { handoff, prompt, handoffText: handoffTextFromBody, modeId: requestedModeId } = parsed.data;
 
     const ctx = findSessionContext(id);
     if (!ctx) return reply.status(404).send({ error: `Session '${id}' not found` });
@@ -1249,10 +1256,31 @@ export function registerSessionRoutes(app: FastifyInstance): void {
     if (!session.modeId) {
       return reply.status(400).send({ error: "Session has no mode; cannot reset" });
     }
-    const modes = await (await import("../routes/modes.js")).loadModes();
+    const { resolveModeId, jsonUnsupportedCli, loadModes } = await import("../routes/modes.js");
+    const modes = await loadModes();
     const mode = modes.find((m) => m.id === session.modeId);
     if (!mode) {
       return reply.status(400).send({ error: `Mode '${session.modeId}' not found` });
+    }
+
+    // reset-with-mode-switch, Decision 1: resolve + validate the REQUESTED
+    // mode (id or name, same convention as session-create's --mode) before
+    // any teardown — a typo'd/unknown mode must not archive the old session
+    // with nothing to replace it. Falls back to the outgoing session's own
+    // (already-validated) mode when no override was given.
+    let effectiveModeId = session.modeId;
+    if (requestedModeId) {
+      let resolvedId: string;
+      try {
+        resolvedId = await resolveModeId(requestedModeId);
+      } catch {
+        return reply.status(400).send({ error: `Mode '${requestedModeId}' not found` });
+      }
+      const requestedMode = modes.find((m) => m.id === resolvedId);
+      if (!requestedMode) {
+        return reply.status(400).send({ error: `Mode '${requestedModeId}' not found` });
+      }
+      effectiveModeId = resolvedId;
     }
 
     // Direct delivery (Decision 1): `--handoff-file` reads the summary locally via the CLI and
@@ -1281,7 +1309,21 @@ export function registerSessionRoutes(app: FastifyInstance): void {
 
     const scopeId = ctx.kind === "worktree" ? ctx.worktree.id : ctx.project.id;
     const newId = generateSessionId(scopeId, "agent");
-    const isJsonChannel = session.channel === "json";
+
+    // reset-with-mode-switch, Decision 2: a session switching INTO a mode
+    // whose CLI can't do JSON can't keep a "json" channel — silently
+    // downgrade to a normal tmux terminal rather than erroring, since
+    // "give me this CLI" implies "in whatever channel it can actually run".
+    // Every other combination (channel already non-json, or the new CLI
+    // also supports json) keeps today's behavior unchanged. Only checks
+    // `jsonUnsupportedCli` when the channel is actually json — no point
+    // paying for that lookup on the (much more common) non-json reset path.
+    const wantsJson = session.channel === "json";
+    const downgradeToTmux = wantsJson && (await jsonUnsupportedCli(effectiveModeId)) !== null;
+    const isJsonChannel = wantsJson && !downgradeToTmux;
+    const newChannel = downgradeToTmux ? "tmux" : session.channel;
+    const newUseTmux = downgradeToTmux ? true : session.useTmux;
+
     const newSession: SessionRecord = {
       id: newId,
       worktreeId: session.worktreeId,
@@ -1289,12 +1331,12 @@ export function registerSessionRoutes(app: FastifyInstance): void {
       isMain: session.isMain,
       sortOrder: session.sortOrder,
       type: "agent",
-      modeId: session.modeId,
+      modeId: effectiveModeId,
       name: newName,
       ...(prompt ? { nameSource: "auto" as const } : session.nameSource ? { nameSource: session.nameSource } : {}),
       tmuxName: tmuxNameForSession(newId),
-      useTmux: session.useTmux,
-      channel: session.channel,
+      useTmux: newUseTmux,
+      channel: newChannel,
       lifecycle: { state: "not_started", lastTransitionAt: new Date().toISOString() },
       ...(newInitialPrompt ? { initialPrompt: newInitialPrompt } : {}),
       ...(isJsonChannel
@@ -1357,15 +1399,18 @@ export function registerSessionRoutes(app: FastifyInstance): void {
 
     // Spawn the replacement session's runtime through the SAME channel-aware,
     // guarded helper session creation uses (Bug 1/2 fix) — never a raw
-    // unguarded spawnSession/spawnDirectSession call. `mode` was already
-    // resolved and validated to exist above, so `session.modeId` is guaranteed
-    // defined here.
+    // unguarded spawnSession/spawnDirectSession call. `effectiveModeId` was
+    // already resolved and validated to exist above (either the requested
+    // override or the outgoing session's own mode). Using `session.modeId`
+    // here instead would be the exact bug reset-with-mode-switch exists to
+    // avoid: the stored record would show the new mode while the spawned
+    // process still ran the old CLI.
     const daemonPort = (app.server.address() as { port?: number })?.port ?? 7421;
     void spawnNewSessionForChannel({
       project,
       worktree: ctx.kind === "worktree" ? ctx.worktree : undefined,
       session: newSession,
-      modeId: session.modeId,
+      modeId: effectiveModeId,
       prompt: newInitialPrompt,
       daemonPort,
     });


### PR DESCRIPTION
## Summary

`POST /sessions/:id/reset` always copied `modeId`/`channel`/`useTmux` from the outgoing session — there was no way to reset into a different mode. A frequent real case: resetting a session running one CLI (e.g. "agy main") into a different one (e.g. "claude sonnet") required deleting the session and creating a new one from scratch, losing reset's "same tab position" behavior.

## What changed

- `ResetBody` gains an optional `modeId` (accepts a mode id OR name, same convention as session-create's `--mode`, resolved via the existing `resolveModeId` helper) — validated **before** any teardown, so an unknown mode returns 400 without archiving the outgoing session. Absent `modeId` keeps today's behavior exactly.
- If the outgoing session's channel is `"json"` and the new mode's CLI can't do JSON, the new session's channel is silently downgraded to `"tmux"` rather than erroring — switching CLI implies "run it in whatever channel it actually supports."
- `vst session reset <id> --mode <name-or-id>` on the CLI.
- A `reset --mode <name>` argument pattern on the `/vst` in-chat command (combines with the existing `--handoff`/`--handoff-file`/prompt variants), so an agent can switch its own mode on reset too.

## Review

Reviewed by an independent Opus pass — no correctness issues found. Two suggested improvements folded in before this commit:
- The mode-switch regression test now uses a genuinely different **CLI** (not just a different model), so it actually exercises the motivating scenario instead of a same-CLI model change.
- A test's mock restoration moved into a `finally` block so a failed assertion can't leak the mock into later tests in the same file.

## Verification

- `cli`: 63 test files, 606 tests passing, `tsc -b --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)