### PR TITLE
feat: VCS tool tab (commit graph + PR banner)

### DIFF
--- a/.vibekit/feature-plans/wip/vcs-backend/.sdlc-state.yaml
+++ b/.vibekit/feature-plans/wip/vcs-backend/.sdlc-state.yaml
@@ -1,0 +1,19 @@
+feature: vcs-backend
+worktree: /home/gb/.vibe-station/projects/vibe-station/worktrees/vs-37
+master:
+  prd: skipped
+  plan: complete
+current_subfeature: root
+subfeatures:
+  - id: root
+    origin: planned
+    spawned_from: null
+    mode: done
+    last_completed: "4.T2"
+    awaiting_phase: null
+    awaiting_artifact: null
+    phase_chain: [plan, implement]
+    superseded_reason: null
+    parked_reason: null
+    handoff: {next_item: null, returned_at: null, verified_by: null}
+    commit: null

--- a/.vibekit/feature-plans/wip/vcs-backend/plan-vcs-backend.md
+++ b/.vibekit/feature-plans/wip/vcs-backend/plan-vcs-backend.md
@@ -1,0 +1,183 @@
+<!--
+RULES — read before writing or implementing:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. REQUIREMENTS: One crisp line each — no verbose descriptions
+3. CHECKLIST: Mark items [x] as you complete them — this is your persistent todo list
+4. READING TIME: Optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+# Plan: VCS tool tab backend — test coverage + polish
+
+> Close the test-coverage gap on the already-implemented VCS tab backend (commit graph + PR banner). No new behavior — this is a "small" plan per user request.
+
+**Issue:** vcs-backend
+**Branch:** `lot-times-see` (current worktree branch)
+**Status:** Implemented, opus-reviewed, review findings addressed — see Review Findings Addressed below
+**PRD:** none — small, test-only follow-up to already-shipped behavior, skipped per user request (`/sdlc plan-implement`)
+**Parent:** none
+
+**Reference files:**
+- `daemon/src/services/git.ts:180-311` — `CommitLogEntry`, `listCommits()`, `attachFullBodies()` (already implemented, commit `7479886`)
+- `daemon/src/services/github.ts` — `getRemoteUrl()`, `parseGithubRepo()`, `fetchPrForBranch()` (already implemented)
+- `daemon/src/routes/worktrees.ts:1090-1127` — `GET /worktrees/:id/commits`, `GET /worktrees/:id/pr` (already implemented)
+- `daemon/src/__tests__/worktrees.test.ts` — existing route-test conventions to follow; `createWorktree()` helper (line 632) is scoped *inside* the `describe("PATCH /worktrees/:id/pin", ...)` block (line 631), not file-level — new tests add their own local helper (or a top-level `describe("GET /worktrees/:id/commits and /pr", ...)` with its own) rather than importing that one across describe blocks
+- `cli/vitest.config.ts:5` — `preserveSymlinks: true`; `cli/src/daemon` is a symlink to `../../daemon/src`, so vitest resolves daemon test files under `src/daemon/__tests__/`, not `daemon/src/__tests__/`
+
+---
+
+## Problem
+
+- `listCommits()`, `attachFullBodies()`, `getRemoteUrl()`, `parseGithubRepo()`, `fetchPrForBranch()`, and the two new routes have zero automated test coverage
+- Several edge cases were exercised manually during implementation (empty repo, binary diff, multi-line body, real GitHub PR lookup) but aren't codified as tests
+
+## Out of Scope
+
+- Any change to already-implemented, already-committed behavior (`git.ts`, `github.ts`, `worktrees.ts` routes, all of `web-ui/src`) — touch only if a new test surfaces a real bug
+- New markdown docs — `GITHUB_TOKEN`/`GH_TOKEN` already has a one-line mention in `github.ts`'s own JSDoc at the point of use; no dedicated env-var reference doc exists in this repo to extend (checked in Research), so nothing new is added
+- Rate-limit/backoff hardening, GitHub Enterprise / GitLab support, `gh` CLI fallback — none requested
+
+## Concept
+
+- Two new test files, written against the real on-disk location (`daemon/src/__tests__/`, resolved by vitest via the `cli/src/daemon` symlink): `git.commits.test.ts` (unit, real tmp git repos via `execSync`, no server) and `github.test.ts` (unit, mix of a real tmp repo for `getRemoteUrl` + `vi.stubGlobal("fetch", ...)` for `fetchPrForBranch`)
+- Extend `daemon/src/__tests__/worktrees.test.ts` with route-level cases for `/commits` and `/pr`, matching its existing `app.inject` + `createWorktree()` fixture pattern
+- Success state: `pnpm --filter cli test` green, every Requirement below has a corresponding assertion
+
+## Requirements
+
+| # | Requirement |
+|---|-------------|
+| 1 | `listCommits()`: empty repo (no commits) → `[]`, no throw |
+| 2 | `listCommits()`: binary-file commit → `hasBinaryChanges: true`, that file excluded from insertions/deletions sum |
+| 3a | `listCommits()`: a commit **subject** line (the only thing `--numstat`'s parser ever sees per Research) containing an embedded tab and numstat-shaped text does not corrupt parsing of that commit or a following commit's numstat block |
+| 3b | `attachFullBodies()`: a multi-paragraph commit **body** (`%B`, separate `git log` call, no `--numstat` involved) round-trips intact, including embedded newlines |
+| 4 | `listCommits()`: commit with no body → `body === subject` |
+| 5 | `parseGithubRepo()`: accepts `git@github.com:owner/repo.git`, `https://github.com/owner/repo.git`, `https://github.com/owner/repo` (no `.git`); rejects a non-GitHub remote (e.g. GitLab) → `null` |
+| 6 | `getRemoteUrl()`: repo with no `origin` remote → `null`, no throw |
+| 7 | `fetchPrForBranch()`: GitHub API error/non-200/network failure → `null`, no throw (mock `fetch`) |
+| 8 | `fetchPrForBranch()`: successful response with a matching PR → parsed `PrInfo` (number/url/title/state/merged/draft/author) |
+| 9 | `GET /worktrees/:id/commits`: unknown worktree → 404 |
+| 10 | `GET /worktrees/:id/pr`: unknown worktree → 404; known worktree whose **project repo** has no `origin` remote → `200 { pr: null }` |
+| 11 | `GET /worktrees/:id/commits`: worktree with a file committed inside it (beyond the fixture's initial empty commit) → 200, entry with non-zero `insertions` |
+
+---
+
+## Research
+
+### Existing route-test harness
+
+- **File:** `daemon/src/__tests__/worktrees.test.ts:1-95` — `vi.mock("../services/paths.js", ...)` redirects all daemon state under a `mkdtemp` tempDir; `beforeEach` creates a real git repo via `execSync("git init ...")`, boots `buildServer()`, registers a project via `app.inject POST /projects`
+- **File:** `daemon/src/__tests__/worktrees.test.ts:631-638` — existing `createWorktree(branchSuffix)` helper wraps `POST /worktrees`, but is scoped inside the `PATCH /worktrees/:id/pin` describe block; new route tests write their own local equivalent in a new `describe` block rather than reaching across blocks
+- **Risk:** LOW — new route tests append to this file using the same fixture; no new harness needed
+
+### vitest resolves daemon tests through the `cli/src/daemon` symlink, not the `daemon/` dir directly
+
+- **File:** `cli/vitest.config.ts:5` — `preserveSymlinks: true`
+- **Confirmed empirically:** `vitest list --filesOnly src/__tests__/worktrees.test.ts` → no match; `vitest list --filesOnly src/daemon/__tests__/worktrees.test.ts` → matches
+- **Decision:** every `Verify phase N:` command below runs vitest against `src/daemon/__tests__/<file>`, even though the files are edited at their canonical path `daemon/src/__tests__/<file>` (same inode, see Files & Phase Impact)
+
+### No existing git.ts/github.ts unit test file
+
+- **File:** `daemon/src/__tests__/` — grepped for `git.test.ts`/`github.test.ts`, none exist; `git.ts` functions are today only exercised indirectly through route tests
+- **Decision:** new unit test files call `listCommits`/`getRemoteUrl`/`parseGithubRepo`/`fetchPrForBranch` directly against a `mkdtemp` repo (via `execSync`), no Fastify server needed
+
+### `listCommits`'s numstat parser only ever sees the subject line, never the body
+
+- **File:** `daemon/src/services/git.ts:214-221` — the `--numstat` `git log` call formats each commit header with `%s` (subject only), never `%B`/`%b` — so a commit's body text physically cannot reach this parser
+- **File:** `daemon/src/services/git.ts:277-311` — `attachFullBodies()` is a *second*, separate `git log` call (no `--numstat`) that fetches `%B` and splits only on the RS/US bytes, never on `"\n"`
+- **Implication:** Requirement 3's original framing ("a numstat-shaped body line") was untestable — split into 3a (adversarial **subject**, the thing the numstat parser actually processes) and 3b (adversarial **body**, round-tripped by the unrelated second call)
+- **Risk:** LOW — the two-call split already structurally prevents this bug class; 3a/3b are regression guards
+
+## Root Cause
+
+- Feature was implemented interactively during a live session (skeleton → PR banner → expand/collapse), test coverage was deferred to this follow-up pass by design
+
+---
+
+## Architecture Diagram
+
+- Test-only change, no new runtime component — not applicable
+
+## Design Details
+
+- Not applicable — no new API contracts, data model, or CUJs; this plan adds tests for contracts defined in the prior (already-implemented) work
+
+---
+
+## Risks / Open Questions
+
+| # | Question | Notes |
+|---|----------|-------|
+| 1 | Should `fetchPrForBranch`'s 30s in-memory cache be reset between tests? | Module-level `Map`, no test-reset export — mitigated by using a distinct fake `owner/repo` per test case (Phase 2) so no two tests can share a cache key |
+
+---
+
+## Implementation Phases
+
+- Each phase ends with a **`Verify phase N:`** block — the phase is not done until those tests pass
+- Screenshots: none — backend/test-only change
+
+### Phase 1 — `git.ts` unit tests
+
+- [x] **1.1** Create `daemon/src/__tests__/git.commits.test.ts`: `mkdtemp` + `execSync git init`, cover Requirements 1, 2, 4
+- [x] **1.2** Requirement 3a: commit with a **subject** line containing an embedded tab + numstat-shaped text (e.g. `git commit -m $'3\t1\tsomefile.ts'`), assert that commit *and* a subsequent normal commit both parse correctly
+- [x] **1.3** Requirement 3b: commit with a multi-paragraph `-m subject -m body` message, assert `body` returned by `listCommits()` contains the full text with embedded newlines intact
+
+**Verify phase 1:**
+- [x] **1.T1** `pnpm --filter cli exec vitest run src/daemon/__tests__/git.commits.test.ts` — all cases pass (5/5)
+
+### Phase 2 — `github.ts` unit tests
+
+- [x] **2.1** Create `daemon/src/__tests__/github.test.ts`: `mkdtemp` + `execSync git init` fixture for `getRemoteUrl`, cover Requirement 6
+- [x] **2.2** Same file: `global.fetch` stub for `fetchPrForBranch`, cover Requirements 7, 8; `parseGithubRepo` cases (no fixture needed, pure function), cover Requirement 5
+- [x] **2.3** Use a distinct fake `owner/repo` string per `fetchPrForBranch` test case (per Risk #1) so the 30s cache never masks a mock-response change between tests
+
+**Verify phase 2:**
+- [x] **2.T1** `pnpm --filter cli exec vitest run src/daemon/__tests__/github.test.ts` — all cases pass (11/11)
+
+### Phase 3 — Route tests
+
+- [x] **3.1** Extend `daemon/src/__tests__/worktrees.test.ts` with a new top-level `describe("GET /worktrees/:id/commits and /pr", ...)` block (own local worktree-creation helper, following the pattern at line 631-638): Requirement 9 (`GET .../commits` 404), Requirement 10 (`GET .../pr` 404 + no-remote `200 { pr: null }`), Requirement 11 (commit a file inside the created worktree's checkout path, assert non-zero `insertions`)
+
+**Verify phase 3:**
+- [x] **3.T1** `pnpm --filter cli exec vitest run src/daemon/__tests__/worktrees.test.ts` — all cases pass (39/39), no regressions in existing tests in this file
+
+### Phase 4 — Full suite + typecheck
+
+- [x] **4.1** `pnpm typecheck` clean
+- [x] **4.2** Full `cli` package test suite green (no regressions from the new files)
+
+**Verify phase 4:**
+- [x] **4.T1** `pnpm typecheck` — no errors
+- [x] **4.T2** `pnpm --filter cli test` — 65 files / 626 tests pass. One pre-existing `UnhandledRejection` in `sessions.test.ts` ("2.T1e") flips pnpm's exit code even though every assertion is green — reproduced in isolation with none of this plan's new files loaded, confirming it predates this change and isn't a regression from it.
+
+---
+
+## Files & Phase Impact
+
+| File | Status | Phase | Description / Contract Change |
+|------|--------|-------|-------------------------------|
+| `daemon/src/__tests__/git.commits.test.ts` | New | 1 | Unit tests for `listCommits()` — empty repo, binary changes, adversarial subject/body, no-body default, merge commits |
+| `daemon/src/__tests__/gitFixture.ts` | New | 1/2 | Shared mkdtemp+git-init test fixture, deduped out of the two unit test files |
+| `daemon/src/__tests__/github.test.ts` | New | 2 | Unit tests for `getRemoteUrl()`, `parseGithubRepo()`, `fetchPrForBranch()` — incl. request construction + cache TTL/reset |
+| `daemon/src/__tests__/worktrees.test.ts` | Modified | 3 | Route-level cases for `GET /worktrees/:id/commits` and `GET /worktrees/:id/pr`; deduped `createWorktree()` to file scope |
+| `daemon/src/services/git.ts` | Modified | Review fix | `FULL_SHA_RE` guard against RS/US-byte-in-subject corruption; `--diff-merges=first-parent` so merge commits get a real diffstat; doc clarifies full-HEAD-history contract |
+| `daemon/src/services/github.ts` | Modified | Review fix | Adds `_clearPrCacheForTest()` test-reset export |
+
+---
+
+## Review Findings Addressed
+
+Opus code-review pass (via `/code-review high --model=opus`) on the Phase 1-3 diff, run after initial implementation. All 10 findings addressed:
+
+| # | Finding | Fix |
+|---|---------|-----|
+| 1 | **Real bug**: `listCommits` RS/US block-splitting corrupts on a commit subject containing those literal bytes; the "adversarial" test claimed to cover this but only tested a tab | Added `FULL_SHA_RE` guard in `git.ts` (drops fragments whose `sha` field isn't 40 hex chars); rewrote the test to inject actual RS/US bytes via `-F` and assert the guard's real, narrower scope (protects *other* commits, contains — doesn't fully repair — the adversarial one) |
+| 2 | PR route's real GitHub-lookup wiring (owner/repo/branch pass-through) had zero coverage — only the trivial no-remote path was tested | Added a route test with a real git remote + `vi.spyOn(github, "fetchPrForBranch")`, asserting exact call args and response pass-through |
+| 3 | **Real bug**: merge commits get `+0/-0` (git suppresses merge diffs by default without `-m`/`--diff-merges`) | Added `--diff-merges=first-parent` to the `git log` call in `git.ts`; added a merge-commit test |
+| 4 | Binary-diffstat test committed the binary file alone — couldn't catch a `continue`→`break` regression dropping a co-committed text file's stats | Rewrote to commit a binary + text file together, asserting the text file's lines still count |
+| 5 | No test asserted `sha`/`shortSha`/`authorName`/`authorEmail`/`date` — a field-order regression in the positional destructure would go unnoticed | Added assertions on all fields |
+| 6 | 30s PR cache had no reset hook (unlike `_clearStoreForTest` etc. elsewhere) and no TTL/hit-miss test | Added `_clearPrCacheForTest()`; added cache-hit, different-key-different-fetch, and explicit-clear tests |
+| 7 | `/commits` full-HEAD-history vs. `baseSha`-scoped contract was ambiguous | Clarified via doc comment on `listCommits` — full history is the intentional, correct contract (matches how a "commits" tab conventionally shows full branch history, not just the diff-from-base that `/changed-paths` already covers separately); no behavior change |
+| 8 | The no-remote PR test couldn't distinguish "no remote" from "lookup itself is broken" | Superseded by finding #2's new wired-through test, which exercises the non-null path explicitly |
+| 9 | `createWorktree()` helper duplicated verbatim across two describe blocks; `git()` exec wrapper duplicated across two new test files | Hoisted `createWorktree` to file scope (`worktrees.test.ts`); extracted `gitFixture.ts` shared helper |
+| 10 | No-remote PR test round-tripped the full worktree-creation pipeline for a check that only reads `project.absolutePath` | Not changed — the I/O cost is real but small, and consolidating further would reduce test clarity; accepted as-is |

--- a/daemon/src/__tests__/git.commits.test.ts
+++ b/daemon/src/__tests__/git.commits.test.ts
@@ -1,0 +1,151 @@
+/**
+ * `listCommits()` / `attachFullBodies()` — the VCS tool tab's commit-graph data source.
+ *
+ * `listCommits()` parses `git log --numstat` output using a header line built
+ * from `%s` (subject only, never the body) — this test suite is deliberately
+ * adversarial about that boundary: Requirement 3a proves a commit subject
+ * containing the parser's own RS/US delimiter bytes can't corrupt OTHER
+ * commits in the list (git.ts's `FULL_SHA_RE` guard drops any resulting
+ * fragment whose "sha" field isn't actually a valid sha) — it does not claim
+ * to fully recover the adversarial commit's own data, only to contain the
+ * damage to that one commit. Requirement 3b proves a hostile *body* round-trips
+ * through the separate `attachFullBodies()` call untouched.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { listCommits } from "../services/git.js";
+import { createGitFixture, removeGitFixture, type GitFixture } from "./gitFixture.js";
+
+let fixture: GitFixture;
+let repoDir: string;
+let git: GitFixture["git"];
+
+describe("listCommits", () => {
+  beforeEach(async () => {
+    fixture = await createGitFixture("vst-git-commits-test");
+    repoDir = fixture.dir;
+    git = fixture.git;
+  });
+
+  afterEach(async () => {
+    await removeGitFixture(fixture);
+  });
+
+  it("Requirement 1 — empty repo (no commits) returns [] without throwing", async () => {
+    await expect(listCommits(repoDir)).resolves.toEqual([]);
+  });
+
+  it("Requirement 2 — a binary file alongside a text file in the same commit: binary excluded from the diffstat sum, text file's lines still counted", async () => {
+    // Both files in ONE commit — proves the numstat loop's `continue` past a
+    // binary line doesn't also drop the text file's line that follows it
+    // (a `continue` → `break`/early-return regression would fail this).
+    await writeFile(join(repoDir, "text.txt"), "one\ntwo\nthree\n");
+    await writeFile(join(repoDir, "blob.bin"), Buffer.from([0x00, 0x01, 0x02, 0x03]));
+    git(["add", "-A"]);
+    git(["commit", "-q", "-m", "add text file and binary blob together"]);
+
+    const commits = await listCommits(repoDir);
+    expect(commits).toHaveLength(1);
+    const commit = commits[0]!;
+    expect(commit.hasBinaryChanges).toBe(true);
+    expect(commit.insertions).toBe(3); // only text.txt's 3 lines
+    expect(commit.deletions).toBe(0);
+  });
+
+  it("Requirement 3a — a subject containing the parser's own RS/US delimiter bytes doesn't corrupt the commit list (defensive sha-shape guard)", async () => {
+    await writeFile(join(repoDir, "a.txt"), "a\n");
+    git(["add", "-A"]);
+    // %H is always 40 hex chars and can never legitimately contain RS(0x1e)/
+    // US(0x1f) — a commit subject that does is the exact adversarial input
+    // git.ts's `FULL_SHA_RE` guard exists for. Constructed via `-F` (a temp
+    // file OUTSIDE the repo dir, so it never gets picked up by a later
+    // `git add -A`) since these are raw control bytes, not shell-escapable text.
+    const msgFile = join(tmpdir(), `vst-adversarial-msg-${process.pid}-${Date.now()}`);
+    await writeFile(msgFile, `evil\x1esubject\x1fwith-delimiters`);
+    git(["commit", "-q", "-F", msgFile]);
+
+    await writeFile(join(repoDir, "b.txt"), "b\nb2\n");
+    git(["add", "-A"]);
+    git(["commit", "-q", "-m", "normal follow-up commit"]);
+
+    const commits = await listCommits(repoDir);
+    // The real, well-formed follow-up commit parses correctly and isn't
+    // corrupted by the preceding commit's fractured block — this is the
+    // main thing the guard protects: OTHER commits' data staying intact.
+    const followUp = commits.find((c) => c.subject === "normal follow-up commit");
+    expect(followUp).toBeDefined();
+    expect(followUp!.insertions).toBe(2);
+    // Every surviving entry has a well-formed 40-hex sha — the fragment
+    // whose "sha" field was actually leftover subject text ("subject",
+    // not hex) is dropped by the guard rather than rendered as a phantom
+    // row with a garbage id.
+    for (const c of commits) {
+      expect(c.sha).toMatch(/^[0-9a-f]{40}$/);
+    }
+    // What the guard does NOT claim to fix: the adversarial commit's OWN
+    // subject/stats can still end up truncated (data attached to the sha
+    // that appears before the embedded delimiter survives; data attached
+    // to the fragment after it — like this commit's own numstat — does
+    // not). Documented here so a future reader doesn't mistake this for
+    // full recovery of the adversarial commit itself.
+    const adversarial = commits.find((c) => c.subject === "evil");
+    expect(adversarial).toBeDefined();
+    expect(adversarial!.insertions).toBe(0);
+  });
+
+  it("Requirement 3b — a multi-paragraph body round-trips through attachFullBodies with newlines intact", async () => {
+    await writeFile(join(repoDir, "a.txt"), "a\n");
+    git(["add", "-A"]);
+    const body = "First paragraph of the body.\n\nSecond paragraph, with more detail\nspanning two lines.";
+    git(["commit", "-q", "-m", "adversarial body commit", "-m", body]);
+
+    const commits = await listCommits(repoDir);
+    expect(commits).toHaveLength(1);
+    expect(commits[0]!.subject).toBe("adversarial body commit");
+    expect(commits[0]!.body).toBe(`adversarial body commit\n\n${body}`);
+  });
+
+  it("Requirement 4 — a commit with no body has body === subject, and every metadata field is populated correctly", async () => {
+    await writeFile(join(repoDir, "a.txt"), "a\n");
+    git(["add", "-A"]);
+    git(["config", "user.name", "Ada Lovelace"]);
+    git(["config", "user.email", "ada@example.com"]);
+    git(["commit", "-q", "-m", "single line commit"]);
+
+    const commits = await listCommits(repoDir);
+    expect(commits).toHaveLength(1);
+    const c = commits[0]!;
+    expect(c.subject).toBe("single line commit");
+    expect(c.body).toBe("single line commit");
+    // Guards the positional destructure in git.ts (`[sha, shortSha,
+    // authorName, authorEmail, date, subject] = header.split(US)`) against a
+    // silent field-order regression.
+    expect(c.sha).toMatch(/^[0-9a-f]{40}$/);
+    expect(c.shortSha).toBe(c.sha.slice(0, 7));
+    expect(c.authorName).toBe("Ada Lovelace");
+    expect(c.authorEmail).toBe("ada@example.com");
+    expect(c.date).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("merge commits get a real first-parent diffstat, not 0/0", async () => {
+    await writeFile(join(repoDir, "base.txt"), "base\n");
+    git(["add", "-A"]);
+    git(["commit", "-q", "-m", "base commit"]);
+
+    git(["checkout", "-q", "-b", "feature"]);
+    await writeFile(join(repoDir, "feature.txt"), "line one\nline two\nline three\n");
+    git(["add", "-A"]);
+    git(["commit", "-q", "-m", "feature commit"]);
+
+    git(["checkout", "-q", "main"]);
+    git(["merge", "-q", "--no-ff", "-m", "merge feature into main", "feature"]);
+
+    const commits = await listCommits(repoDir);
+    const mergeCommit = commits.find((c) => c.subject === "merge feature into main");
+    expect(mergeCommit).toBeDefined();
+    expect(mergeCommit!.insertions).toBe(3);
+    expect(mergeCommit!.deletions).toBe(0);
+  });
+});

--- a/daemon/src/__tests__/gitFixture.ts
+++ b/daemon/src/__tests__/gitFixture.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared "real temp git repo" test fixture — `mkdtemp` + `git init` + a thin
+ * `execFileSync` wrapper — used by any unit test that needs to run actual
+ * `git` commands against a throwaway repo (as opposed to `worktrees.test.ts`'s
+ * `app.inject`-based route fixture, which spins up the whole Fastify server).
+ * Not itself a `.test.ts` file — vitest's `include` glob only picks up
+ * `*.test.ts`, so this helper is never run as a suite of its own.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+
+export interface GitFixture {
+  dir: string;
+  git(args: string[]): string;
+}
+
+/** Creates a fresh temp git repo (branch `main`, test author/email configured). */
+export async function createGitFixture(prefix: string): Promise<GitFixture> {
+  const dir = await mkdtemp(join(tmpdir(), `${prefix}-`));
+  const git = (args: string[]): string =>
+    execFileSync("git", ["-C", dir, ...args], { encoding: "utf8" });
+
+  git(["init", "-q", "-b", "main"]);
+  git(["config", "user.email", "test@example.com"]);
+  git(["config", "user.name", "Test"]);
+
+  return { dir, git };
+}
+
+/** Removes a fixture's temp directory. Call from `afterEach`. */
+export async function removeGitFixture(fixture: GitFixture): Promise<void> {
+  await rm(fixture.dir, { recursive: true, force: true });
+}

--- a/daemon/src/__tests__/github.test.ts
+++ b/daemon/src/__tests__/github.test.ts
@@ -1,0 +1,204 @@
+/**
+ * GitHub PR lookup (`daemon/src/services/github.ts`) — the VCS tool tab's PR
+ * banner data source. Deliberately doesn't shell out to `gh`; talks to the
+ * GitHub REST API directly, so `fetchPrForBranch` is tested via a stubbed
+ * `global.fetch` rather than a real network call.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  getRemoteUrl,
+  parseGithubRepo,
+  fetchPrForBranch,
+  _clearPrCacheForTest,
+} from "../services/github.js";
+import { createGitFixture, removeGitFixture, type GitFixture } from "./gitFixture.js";
+
+describe("parseGithubRepo", () => {
+  it("Requirement 5 — accepts git@github.com:owner/repo.git", () => {
+    expect(parseGithubRepo("git@github.com:owner/repo.git")).toEqual({
+      owner: "owner",
+      repo: "repo",
+    });
+  });
+
+  it("Requirement 5 — accepts https://github.com/owner/repo.git", () => {
+    expect(parseGithubRepo("https://github.com/owner/repo.git")).toEqual({
+      owner: "owner",
+      repo: "repo",
+    });
+  });
+
+  it("Requirement 5 — accepts https://github.com/owner/repo (no .git suffix)", () => {
+    expect(parseGithubRepo("https://github.com/owner/repo")).toEqual({
+      owner: "owner",
+      repo: "repo",
+    });
+  });
+
+  it("Requirement 5 — rejects a non-GitHub remote", () => {
+    expect(parseGithubRepo("git@gitlab.com:owner/repo.git")).toBeNull();
+  });
+});
+
+describe("getRemoteUrl", () => {
+  let fixture: GitFixture;
+
+  beforeEach(async () => {
+    fixture = await createGitFixture("vst-github-remote-test");
+  });
+
+  afterEach(async () => {
+    await removeGitFixture(fixture);
+  });
+
+  it("Requirement 6 — a repo with no origin remote resolves to null without throwing", async () => {
+    await expect(getRemoteUrl(fixture.dir)).resolves.toBeNull();
+  });
+
+  it("returns the origin URL when one is configured", async () => {
+    fixture.git(["remote", "add", "origin", "git@github.com:owner/repo.git"]);
+    await expect(getRemoteUrl(fixture.dir)).resolves.toBe("git@github.com:owner/repo.git");
+  });
+});
+
+/** Builds a fetch-mock response shaped like `GET /repos/:owner/:repo/pulls`. */
+function mockPrListResponse(prs: unknown[]): typeof fetch {
+  return vi.fn().mockResolvedValue({ ok: true, json: async () => prs }) as unknown as typeof fetch;
+}
+
+function fakePr(overrides: Partial<{
+  number: number;
+  html_url: string;
+  title: string;
+  state: string;
+  draft: boolean;
+  merged_at: string | null;
+  user: { login: string } | null;
+}> = {}) {
+  return {
+    number: 1,
+    html_url: "https://github.com/x/y/pull/1",
+    title: "A PR",
+    state: "open",
+    draft: false,
+    merged_at: null,
+    user: { login: "someone" },
+    ...overrides,
+  };
+}
+
+describe("fetchPrForBranch", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    _clearPrCacheForTest();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+    _clearPrCacheForTest();
+  });
+
+  it("Requirement 7 — a non-OK API response resolves to null without throwing", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 403 }) as unknown as typeof fetch;
+    await expect(fetchPrForBranch("owner-403", "repo-403", "some-branch")).resolves.toBeNull();
+  });
+
+  it("Requirement 7 — a network failure resolves to null without throwing", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("network down")) as unknown as typeof fetch;
+    await expect(fetchPrForBranch("owner-neterr", "repo-neterr", "some-branch")).resolves.toBeNull();
+  });
+
+  it("Requirement 7 — an empty PR list resolves to null", async () => {
+    global.fetch = mockPrListResponse([]);
+    await expect(fetchPrForBranch("owner-empty", "repo-empty", "some-branch")).resolves.toBeNull();
+  });
+
+  it("Requirement 8 — a matching PR is parsed into PrInfo, and the request is built correctly (URL, head filter, headers)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        fakePr({
+          number: 42,
+          html_url: "https://github.com/owner-match/repo-match/pull/42",
+          title: "Add VCS commit graph",
+          user: { login: "octocat" },
+        }),
+      ],
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const pr = await fetchPrForBranch("owner-match", "repo-match", "some-branch");
+    expect(pr).toEqual({
+      number: 42,
+      url: "https://github.com/owner-match/repo-match/pull/42",
+      title: "Add VCS commit graph",
+      state: "open",
+      merged: false,
+      draft: false,
+      author: "octocat",
+    });
+
+    // Guards the request-construction contract, not just the response
+    // parsing: wrong owner/repo in the URL path, or a missing/wrong
+    // `head=owner:branch` filter, would misattribute PRs from the wrong
+    // repo/branch to this worktree while every other assertion still passes.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toContain("/repos/owner-match/repo-match/pulls");
+    expect(url).toContain("head=owner-match:some-branch");
+    expect(url).toContain("state=all");
+    expect((init as { headers: Record<string, string> }).headers.Accept).toBe(
+      "application/vnd.github+json",
+    );
+  });
+
+  it("Requirement 8 — a merged PR sets merged: true and state: closed", async () => {
+    global.fetch = mockPrListResponse([
+      fakePr({
+        number: 7,
+        html_url: "https://github.com/owner-merged/repo-merged/pull/7",
+        title: "Merged feature",
+        state: "closed",
+        merged_at: "2026-01-01T00:00:00Z",
+        user: { login: "hubot" },
+      }),
+    ]);
+
+    const pr = await fetchPrForBranch("owner-merged", "repo-merged", "some-branch");
+    expect(pr).toMatchObject({ number: 7, merged: true, state: "closed" });
+  });
+
+  it("caches a result for repeat calls with the same owner/repo/branch — fetch is called once", async () => {
+    const fetchMock = mockPrListResponse([fakePr({ number: 99 })]);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const first = await fetchPrForBranch("owner-cache", "repo-cache", "branch-cache");
+    const second = await fetchPrForBranch("owner-cache", "repo-cache", "branch-cache");
+
+    expect(first).toEqual(second);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("a different branch (different cache key) triggers a fresh fetch", async () => {
+    const fetchMock = mockPrListResponse([fakePr({ number: 100 })]);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await fetchPrForBranch("owner-cachekey", "repo-cachekey", "branch-a");
+    await fetchPrForBranch("owner-cachekey", "repo-cachekey", "branch-b");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("_clearPrCacheForTest() forces a fresh fetch even for a previously-cached key", async () => {
+    const fetchMock = mockPrListResponse([fakePr({ number: 101 })]);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await fetchPrForBranch("owner-clear", "repo-clear", "branch-clear");
+    _clearPrCacheForTest();
+    await fetchPrForBranch("owner-clear", "repo-clear", "branch-clear");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/daemon/src/__tests__/worktrees.test.ts
+++ b/daemon/src/__tests__/worktrees.test.ts
@@ -96,6 +96,17 @@ describe("Worktree routes", () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
+  /** Shared worktree-creation helper — `prefix` namespaces the branch name per describe block. */
+  async function createWorktree(prefix: string, branchSuffix: string) {
+    const res = await app.inject({
+      method: "POST",
+      url: "/worktrees",
+      payload: { projectId, branch: `${prefix}-${branchSuffix}-${Date.now()}`, modeId: "bug-fix" },
+    });
+    expect(res.statusCode).toBe(201);
+    return res.json<{ id: string; pinnedAt: string | null }>();
+  }
+
   it("GET /worktrees?project=:id returns empty array initially", async () => {
     const res = await app.inject({ method: "GET", url: `/worktrees?project=${projectId}` });
     expect(res.statusCode).toBe(200);
@@ -629,23 +640,13 @@ describe("Worktree routes", () => {
 
   // ─── PATCH /worktrees/:id/pin ───────────────────────────────────────────
   describe("PATCH /worktrees/:id/pin", () => {
-    async function createWorktree(branchSuffix: string) {
-      const res = await app.inject({
-        method: "POST",
-        url: "/worktrees",
-        payload: { projectId, branch: `pin-${branchSuffix}-${Date.now()}`, modeId: "bug-fix" },
-      });
-      expect(res.statusCode).toBe(201);
-      return res.json<{ id: string; pinnedAt: string | null }>();
-    }
-
     it("serializes pinnedAt as null for an unpinned worktree", async () => {
-      const wt = await createWorktree("unpinned");
+      const wt = await createWorktree("pin", "unpinned");
       expect(wt.pinnedAt).toBeNull();
     });
 
     it("PATCH { pinned: true } sets pinnedAt to an ISO timestamp", async () => {
-      const wt = await createWorktree("set");
+      const wt = await createWorktree("pin", "set");
       const res = await app.inject({
         method: "PATCH",
         url: `/worktrees/${wt.id}/pin`,
@@ -659,7 +660,7 @@ describe("Worktree routes", () => {
     });
 
     it("PATCH { pinned: false } clears pinnedAt", async () => {
-      const wt = await createWorktree("clear");
+      const wt = await createWorktree("pin", "clear");
       await app.inject({ method: "PATCH", url: `/worktrees/${wt.id}/pin`, payload: { pinned: true } });
       const res = await app.inject({
         method: "PATCH",
@@ -671,7 +672,7 @@ describe("Worktree routes", () => {
     });
 
     it("is idempotent: pinning twice keeps the original timestamp", async () => {
-      const wt = await createWorktree("idempotent");
+      const wt = await createWorktree("pin", "idempotent");
       const first = await app.inject({
         method: "PATCH",
         url: `/worktrees/${wt.id}/pin`,
@@ -699,7 +700,7 @@ describe("Worktree routes", () => {
     });
 
     it("returns 400 for an invalid body", async () => {
-      const wt = await createWorktree("badbody");
+      const wt = await createWorktree("pin", "badbody");
       const res = await app.inject({
         method: "PATCH",
         url: `/worktrees/${wt.id}/pin`,
@@ -713,7 +714,7 @@ describe("Worktree routes", () => {
       // monkey-patching mutateProject to delete the worktree just before our
       // mutator runs. Without the in-lock re-check, the non-null assertion
       // in the route would throw and Fastify would reply 500.
-      const wt = await createWorktree("toctou");
+      const wt = await createWorktree("pin", "toctou");
       const store = await import("../state/project-store.js");
       const orig = store.mutateProject;
       const spy = vi.spyOn(store, "mutateProject").mockImplementation(async (id, fn) => {
@@ -737,7 +738,7 @@ describe("Worktree routes", () => {
     });
 
     it("GET /worktrees response includes pinnedAt for every record", async () => {
-      const wt = await createWorktree("listshape");
+      const wt = await createWorktree("pin", "listshape");
       await app.inject({
         method: "PATCH",
         url: `/worktrees/${wt.id}/pin`,
@@ -751,6 +752,90 @@ describe("Worktree routes", () => {
       }
       const pinned = items.find((w) => w.id === wt.id);
       expect(pinned?.pinnedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+  });
+
+  // ─── GET /worktrees/:id/commits and /pr ─────────────────────────────────
+  describe("GET /worktrees/:id/commits and /pr", () => {
+    it("Requirement 9 — GET /worktrees/:id/commits 404s for an unknown worktree", async () => {
+      const res = await app.inject({ method: "GET", url: "/worktrees/does-not-exist/commits" });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it("Requirement 10 — GET /worktrees/:id/pr 404s for an unknown worktree", async () => {
+      const res = await app.inject({ method: "GET", url: "/worktrees/does-not-exist/pr" });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it("Requirement 10 — GET /worktrees/:id/pr returns { pr: null } when the project repo has no origin remote", async () => {
+      const wt = await createWorktree("vcs", "no-remote");
+      const res = await app.inject({ method: "GET", url: `/worktrees/${wt.id}/pr` });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ pr: null });
+    });
+
+    it("GET /worktrees/:id/pr wires owner/repo/branch through to fetchPrForBranch correctly and returns its result verbatim", async () => {
+      // Real git remote (getRemoteUrl + parseGithubRepo run for real); only
+      // the actual network call (fetchPrForBranch) is stubbed — this proves
+      // the route's argument pass-through, not just the trivial no-remote
+      // short-circuit that the test above covers.
+      execSync(`git -C "${repoDir}" remote add origin git@github.com:acme/widgets.git`, {
+        stdio: "ignore",
+      });
+      const createRes = await app.inject({
+        method: "POST",
+        url: "/worktrees",
+        payload: { projectId, branch: "wired-branch-name", modeId: "bug-fix" },
+      });
+      expect(createRes.statusCode).toBe(201);
+      const wt = createRes.json<{ id: string }>();
+
+      const github = await import("../services/github.js");
+      const spy = vi.spyOn(github, "fetchPrForBranch").mockResolvedValue({
+        number: 55,
+        url: "https://github.com/acme/widgets/pull/55",
+        title: "Wired-through PR",
+        state: "open",
+        merged: false,
+        draft: false,
+        author: "someone",
+      });
+
+      const res = await app.inject({ method: "GET", url: `/worktrees/${wt.id}/pr` });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({
+        pr: {
+          number: 55,
+          url: "https://github.com/acme/widgets/pull/55",
+          title: "Wired-through PR",
+          state: "open",
+          merged: false,
+          draft: false,
+          author: "someone",
+        },
+      });
+      expect(spy).toHaveBeenCalledWith("acme", "widgets", "wired-branch-name");
+      spy.mockRestore();
+    });
+
+    it("Requirement 11 — GET /worktrees/:id/commits returns a non-zero diffstat for a real commit made in the worktree", async () => {
+      const wt = await createWorktree("vcs", "with-commit");
+      const wtPath = join(tempDir, "projects", projectId, "worktrees", wt.id);
+
+      await writeFile(join(wtPath, "feature.txt"), "line one\nline two\n");
+      execSync(`git -C "${wtPath}" add -A && git -C "${wtPath}" commit -q -m "add feature.txt"`, {
+        stdio: "ignore",
+      });
+
+      const res = await app.inject({ method: "GET", url: `/worktrees/${wt.id}/commits` });
+      expect(res.statusCode).toBe(200);
+      const { commits } = res.json<{
+        commits: Array<{ subject: string; insertions: number; deletions: number }>;
+      }>();
+      expect(commits.length).toBeGreaterThan(0);
+      const top = commits[0]!;
+      expect(top.subject).toBe("add feature.txt");
+      expect(top.insertions).toBe(2);
     });
   });
 });

--- a/daemon/src/routes/worktrees.ts
+++ b/daemon/src/routes/worktrees.ts
@@ -8,7 +8,8 @@ import { getProject, getAllProjects, mutateProject } from "../state/project-stor
 import { validateBranch, branchExistsInRepo } from "../services/branchValidator.js";
 import { reserveNextWorktreeNum, generateSessionId, tmuxNameForSession } from "../services/sessionId.js";
 import { slugifyPrompt } from "../services/naming.js";
-import { worktreeAdd, worktreeRemove, revParse, fetchOrigin, branchExists } from "../services/git.js";
+import { worktreeAdd, worktreeRemove, revParse, fetchOrigin, branchExists, listCommits } from "../services/git.js";
+import { getRemoteUrl, parseGithubRepo, fetchPrForBranch } from "../services/github.js";
 import { rollbackWorktreeCreate } from "../services/rollback.js";
 import { spawnSession } from "../services/spawn.js";
 import { worktreePath as getWorktreePath, cleanupSessionDataDir, sessionDataDir } from "../services/paths.js";
@@ -1084,5 +1085,45 @@ export function registerWorktreeRoutes(app: FastifyInstance): void {
     } catch (err) {
       return reply.status(500).send({ error: `changed-paths failed: ${String(err)}` });
     }
+  });
+
+  // GET /worktrees/:id/commits?limit=<n>
+  // Commit history for the VCS tool tab: most-recent-first, each with a
+  // line-level diffstat (insertions/deletions) versus its first parent.
+  app.get("/worktrees/:id/commits", async (req, reply) => {
+    const { id: wtId } = req.params as { id: string };
+    const { limit: limitRaw } = req.query as { limit?: string };
+    const limit = Math.min(Math.max(Number(limitRaw) || 200, 1), 1000);
+
+    const project = getAllProjects().find((p) => p.worktrees.some((w) => w.id === wtId));
+    if (!project) return reply.status(404).send({ error: `Worktree '${wtId}' not found` });
+
+    const wtPath = getWorktreePath(project.id, wtId);
+    try {
+      const commits = await listCommits(wtPath, limit);
+      return reply.send({ commits });
+    } catch (err) {
+      return reply.status(500).send({ error: `commits failed: ${String(err)}` });
+    }
+  });
+
+  // GET /worktrees/:id/pr
+  // Best-effort GitHub PR lookup for the worktree's branch, for the VCS tool
+  // tab's PR banner. Always 200s with `{ pr: null }` when there's no GitHub
+  // remote, no PR, or the lookup fails — this is an annotation, not a
+  // required resource.
+  app.get("/worktrees/:id/pr", async (req, reply) => {
+    const { id: wtId } = req.params as { id: string };
+
+    const project = getAllProjects().find((p) => p.worktrees.some((w) => w.id === wtId));
+    if (!project) return reply.status(404).send({ error: `Worktree '${wtId}' not found` });
+    const worktree = project.worktrees.find((w) => w.id === wtId)!;
+
+    const remoteUrl = await getRemoteUrl(project.absolutePath);
+    const gh = remoteUrl ? parseGithubRepo(remoteUrl) : null;
+    if (!gh) return reply.send({ pr: null });
+
+    const pr = await fetchPrForBranch(gh.owner, gh.repo, worktree.branch);
+    return reply.send({ pr });
   });
 }

--- a/daemon/src/services/git.ts
+++ b/daemon/src/services/git.ts
@@ -177,6 +177,156 @@ export async function createGitignore(dir: string): Promise<void> {
   await writeFile(join(dir, ".gitignore"), DEFAULT_GITIGNORE, "utf8");
 }
 
+export interface CommitLogEntry {
+  sha: string;
+  shortSha: string;
+  authorName: string;
+  authorEmail: string;
+  /** ISO 8601, author date. */
+  date: string;
+  subject: string;
+  /**
+   * Full raw commit message (subject + body, `git log %B`), untrimmed of
+   * internal newlines. Equal to `subject` for a commit with no body. Used by
+   * the VCS tool tab's expand/collapse — `subject` alone is what's always
+   * shown, `body` is revealed on click when it has more to show.
+   */
+  body: string;
+  insertions: number;
+  deletions: number;
+  /** True if any changed file's diff couldn't be summarized as text (numstat reports "-"). */
+  hasBinaryChanges: boolean;
+}
+
+// Record separator (0x1e) delimits commits; unit separator (0x1f) delimits fields
+// within one commit's header line. Neither appears in normal commit metadata, so
+// this is a safe, allocation-free way to split `git log` output without a
+// per-commit subprocess.
+const RS = "\x1e";
+const US = "\x1f";
+
+/** Full 40-hex-character git SHA. */
+const FULL_SHA_RE = /^[0-9a-f]{40}$/;
+
+/**
+ * List commits reachable from HEAD (i.e. the worktree's full branch history,
+ * not scoped to commits since the worktree's `baseSha` — same "show
+ * everything reachable from here" semantics as a bare `git log`, deliberately
+ * not filtered the way `/changed-paths?scope=branch` filters against
+ * `baseSha`), most recent first, each annotated with its line-level diffstat
+ * (insertions/deletions) versus its first parent. `--diff-merges=first-parent`
+ * ensures merge commits get a real diffstat instead of git's default of
+ * suppressing diff output for merges entirely. Used by the VCS tool tab to
+ * render a commit timeline for a worktree.
+ */
+export async function listCommits(repoPath: string, limit = 200): Promise<CommitLogEntry[]> {
+  let stdout: string;
+  try {
+    stdout = await runGit(
+      [
+        "-C", repoPath,
+        "log",
+        `-n${limit}`,
+        "--diff-merges=first-parent",
+        `--pretty=format:${RS}%H${US}%h${US}%an${US}%ae${US}%aI${US}%s`,
+        "--numstat",
+      ],
+      repoPath,
+    );
+  } catch {
+    // Empty repo (no commits yet) or not a git dir — treat as no history.
+    return [];
+  }
+
+  const blocks = stdout.split(RS).map((b) => b.trim()).filter(Boolean);
+  const commits: CommitLogEntry[] = [];
+
+  for (const block of blocks) {
+    const lines = block.split("\n");
+    const header = lines[0] ?? "";
+    const [sha, shortSha, authorName, authorEmail, date, subject] = header.split(US);
+    // `%H` is always exactly 40 hex chars and can never legitimately contain
+    // the RS/US (0x1e/0x1f) bytes used as delimiters above — so a `sha` that
+    // doesn't match this shape means a commit subject/body contained a
+    // literal RS or US byte and fractured the block/field split. Drop the
+    // resulting phantom entry rather than rendering corrupted data; this is
+    // a defensive guard for adversarial/corrupted input, not an expected
+    // path for normal commit messages.
+    if (!sha || !FULL_SHA_RE.test(sha)) continue;
+
+    let insertions = 0;
+    let deletions = 0;
+    let hasBinaryChanges = false;
+    for (const line of lines.slice(1)) {
+      if (!line.trim()) continue;
+      const [added, removed] = line.split("\t");
+      if (added === "-" || removed === "-") {
+        hasBinaryChanges = true;
+        continue;
+      }
+      const a = Number(added);
+      const r = Number(removed);
+      if (Number.isFinite(a)) insertions += a;
+      if (Number.isFinite(r)) deletions += r;
+    }
+
+    commits.push({
+      sha,
+      shortSha: shortSha ?? sha.slice(0, 7),
+      authorName: authorName ?? "",
+      authorEmail: authorEmail ?? "",
+      date: date ?? "",
+      subject: subject ?? "",
+      body: subject ?? "",
+      insertions,
+      deletions,
+      hasBinaryChanges,
+    });
+  }
+
+  if (commits.length > 0) {
+    await attachFullBodies(repoPath, commits);
+  }
+
+  return commits;
+}
+
+/**
+ * Fills in `body` (full raw commit message, subject + description) for each
+ * entry in `commits`, mutating them in place. A separate `git log` call
+ * (no `--numstat`) keeps this immune to the numstat-line-splitting logic
+ * above — `%B` can contain arbitrary embedded newlines, which would corrupt
+ * the line-based parsing `listCommits` uses for the numstat block if mixed
+ * into the same output. Splitting solely on the RS/US bytes (never on "\n")
+ * sidesteps that entirely. Best-effort: on failure, every commit just keeps
+ * `body === subject` (set by the caller before this runs).
+ */
+async function attachFullBodies(repoPath: string, commits: CommitLogEntry[]): Promise<void> {
+  let stdout: string;
+  try {
+    stdout = await runGit(
+      ["-C", repoPath, "log", `-n${commits.length}`, `--pretty=format:${RS}%H${US}%B`],
+      repoPath,
+    );
+  } catch {
+    return;
+  }
+
+  const bodies = new Map<string, string>();
+  for (const block of stdout.split(RS)) {
+    const sepIdx = block.indexOf(US);
+    if (sepIdx === -1) continue;
+    const sha = block.slice(0, sepIdx);
+    const body = block.slice(sepIdx + 1).trim();
+    if (sha) bodies.set(sha, body);
+  }
+
+  for (const commit of commits) {
+    const body = bodies.get(commit.sha);
+    if (body) commit.body = body;
+  }
+}
+
 /** Check if git is available in PATH. */
 export async function isGitAvailable(): Promise<boolean> {
   try {

--- a/daemon/src/services/github.ts
+++ b/daemon/src/services/github.ts
@@ -1,0 +1,140 @@
+/**
+ * GitHub PR lookup for the VCS tool tab.
+ *
+ * Deliberately does NOT shell out to the `gh` CLI: it isn't provisioned by
+ * dev.Dockerfile or any other environment this daemon runs in (see the
+ * "no PR integration" research that preceded this file — `git.ts`/`tmux.ts`
+ * are the only existing examples of wrapping an external CLI, and both wrap
+ * tools that ARE guaranteed present). Talking to the GitHub REST API
+ * directly needs nothing beyond network access, which the daemon already has
+ * for `fetchOrigin()`.
+ */
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCb);
+
+export interface PrInfo {
+  number: number;
+  url: string;
+  title: string;
+  state: "open" | "closed";
+  merged: boolean;
+  draft: boolean;
+  author: string | null;
+}
+
+/** Returns the `origin` remote URL for a repo, or null if there is none. */
+export async function getRemoteUrl(repoPath: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFile("git", ["-C", repoPath, "remote", "get-url", "origin"], {
+      env: { ...process.env },
+    });
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parses `owner/repo` out of a GitHub remote URL. Handles the common forms:
+ * `git@github.com:owner/repo.git`, `https://github.com/owner/repo.git`,
+ * `https://github.com/owner/repo`, `ssh://git@github.com/owner/repo.git`.
+ * Returns null for non-GitHub remotes (GitHub Enterprise, GitLab, etc. are
+ * out of scope for now).
+ */
+export function parseGithubRepo(remoteUrl: string): { owner: string; repo: string } | null {
+  const patterns = [
+    /^git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/,
+    /^(?:https?|ssh):\/\/(?:git@)?github\.com[/:]([^/]+)\/(.+?)(?:\.git)?$/,
+  ];
+  for (const re of patterns) {
+    const m = remoteUrl.trim().match(re);
+    if (m) return { owner: m[1]!, repo: m[2]!.replace(/\.git$/, "") };
+  }
+  return null;
+}
+
+interface CacheEntry {
+  value: PrInfo | null;
+  expiresAt: number;
+}
+
+// Keyed by `${owner}/${repo}#${branch}`. Unauthenticated GitHub API calls are
+// capped at 60/hr per IP — a short TTL keeps the VCS tab responsive (each
+// manual refresh / worktree switch would otherwise burn a call) without
+// requiring the caller to build its own polling/caching layer.
+const CACHE_TTL_MS = 30_000;
+const cache = new Map<string, CacheEntry>();
+
+/**
+ * Looks up the most relevant open-or-recently-updated PR for `branch` in
+ * `owner/repo` via the GitHub REST API. Returns null if there's no PR, the
+ * repo/branch can't be resolved, or the request fails (rate limit, no
+ * network, private repo without a token, etc.) — this is a "nice to have"
+ * annotation on the commit graph, never a hard failure.
+ */
+export async function fetchPrForBranch(
+  owner: string,
+  repo: string,
+  branch: string,
+): Promise<PrInfo | null> {
+  const key = `${owner}/${repo}#${branch}`;
+  const cached = cache.get(key);
+  if (cached && cached.expiresAt > Date.now()) return cached.value;
+
+  const value = await fetchPrForBranchUncached(owner, repo, branch);
+  cache.set(key, { value, expiresAt: Date.now() + CACHE_TTL_MS });
+  return value;
+}
+
+/** Test-only: clears the module-level PR cache. Matches the `_clearStoreForTest`/
+ * `_resetModesCacheForTest` convention used elsewhere in this codebase for
+ * module-level test state. */
+export function _clearPrCacheForTest(): void {
+  cache.clear();
+}
+
+async function fetchPrForBranchUncached(
+  owner: string,
+  repo: string,
+  branch: string,
+): Promise<PrInfo | null> {
+  const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "vibe-station",
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  try {
+    // `state=all` + head filter: most recent PR for the branch, whether
+    // open, merged, or closed-without-merge — the VCS tab wants to show
+    // "was there ever a PR" state, not just "is one currently open".
+    const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls?head=${encodeURIComponent(owner)}:${encodeURIComponent(branch)}&state=all&per_page=1&sort=created&direction=desc`;
+    const res = await fetch(url, { headers, signal: AbortSignal.timeout(5000) });
+    if (!res.ok) return null;
+    const list = (await res.json()) as Array<{
+      number: number;
+      html_url: string;
+      title: string;
+      state: string;
+      draft: boolean;
+      merged_at: string | null;
+      user: { login: string } | null;
+    }>;
+    const pr = list[0];
+    if (!pr) return null;
+    return {
+      number: pr.number,
+      url: pr.html_url,
+      title: pr.title,
+      state: pr.state === "closed" ? "closed" : "open",
+      merged: pr.merged_at != null,
+      draft: pr.draft,
+      author: pr.user?.login ?? null,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,10 +1,17 @@
 # Dev sandbox: feature branch FE + daemon in isolation.
 # Does NOT touch your running vibe-station instance.
 #
-# Usage:
+# Usage (single sandbox, historical/simple case):
 #   docker compose -f docker-compose.dev.yml up --build
+#   Then open: http://localhost:5174
 #
-# Then open: http://localhost:5174
+# Usage (multiple worktrees' sandboxes running concurrently):
+#   scripts/dev-sandbox.sh up [worktree-name] [port]
+#   scripts/dev-sandbox.sh down [worktree-name]
+#   See scripts/dev-sandbox.sh — it sets VST_SANDBOX_PORT/DATA_VOLUME/
+#   PROJECTS_VOLUME (below) and a `-p <worktree-name>` compose project name so
+#   each worktree gets its own port + volumes instead of colliding on the
+#   defaults every plain `docker compose ... up` shares.
 #
 # CLI binaries are bind-mounted read-only from the host so that
 # GET /cli-models works inside the container. gemini is installed directly in the image;
@@ -26,9 +33,11 @@ services:
       context: .
       dockerfile: dev.Dockerfile
     ports:
-      # Host 5174 → container 5173 (Vite dev server)
-      # Avoids collision with your main vite instance on 5173
-      - "5174:5173"
+      # Host port → container 5173 (Vite dev server). Override via
+      # VST_SANDBOX_PORT (see scripts/dev-sandbox.sh) so concurrent
+      # worktree sandboxes don't fight over the same host port; defaults to
+      # 5174 to match this file's original single-sandbox behavior.
+      - "${VST_SANDBOX_PORT:-5174}:5173"
     environment:
       HOME: /home/vst
       # Vite proxy already points to 127.0.0.1:7421 — no change needed
@@ -79,18 +88,20 @@ services:
     tty: true
 
 volumes:
-  # Explicit global `name:` — every worktree sandbox that uses this base
-  # compose file unmodified mounts these SAME two volumes (see the
-  # "dev-sandbox-volumes-are-shared" memory note: parallel worktree
-  # sandboxes clobber each other's daemon state this way). Known,
-  # intentionally-not-fixed-here limitation: this also means a colleague
-  # still running an OLDER (pre-non-root-daemon) image against these same
-  # volumes will write root-owned files here; the new non-root daemon then
-  # can't read them until this container's next start re-runs the
-  # unconditional chown in scripts/dev-entrypoint.sh. Re-scoping these to
-  # be per-worktree by default is a separate, bigger decision — see
-  # docker-compose.dev.<worktree>.yml for the current workaround.
+  # Explicit `name:`, overridable via VST_SANDBOX_DATA_VOLUME /
+  # VST_SANDBOX_PROJECTS_VOLUME — defaults preserve this file's original
+  # single-shared-sandbox behavior (every plain `docker compose ... up`
+  # mounts the same two volumes), but scripts/dev-sandbox.sh sets these
+  # per-worktree so concurrent sandboxes don't clobber each other's daemon
+  # state (see the "dev-sandbox-volumes-are-shared" memory note — this is
+  # the fix for the "known, intentionally-not-fixed-here limitation" that
+  # note originally described).
+  #
+  # Aside: a colleague still running an OLDER (pre-non-root-daemon) image
+  # against a volume you also use will write root-owned files into it; the
+  # new non-root daemon then can't read them until the next start re-runs
+  # the unconditional chown in scripts/dev-entrypoint.sh.
   vst-dev-data:
-    name: vst-dev-data
+    name: ${VST_SANDBOX_DATA_VOLUME:-vst-dev-data}
   vst-dev-projects:
-    name: vst-dev-projects
+    name: ${VST_SANDBOX_PROJECTS_VOLUME:-vst-dev-projects}

--- a/scripts/dev-sandbox.sh
+++ b/scripts/dev-sandbox.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# dev-sandbox.sh — run docker-compose.dev.yml with a per-worktree compose
+# project name, host port, and volume pair, so multiple worktrees' sandboxes
+# can run concurrently without colliding.
+#
+# Why this exists: docker-compose.dev.yml on its own binds a fixed host port
+# (5174) and two fixed-named volumes (vst-dev-data, vst-dev-projects) — fine
+# for one sandbox, but a second `docker compose ... up` for a different
+# worktree either fails to bind the port or, worse, silently mounts the SAME
+# volumes as the first (deleting its daemon lock file and redirecting a
+# second daemon at the first sandbox's state — see the
+# "dev-sandbox-volumes-are-shared" project memory note). This script sets
+# VST_SANDBOX_PORT / VST_SANDBOX_DATA_VOLUME / VST_SANDBOX_PROJECTS_VOLUME
+# (consumed by docker-compose.dev.yml's `${VAR:-default}` interpolation) plus
+# a `-p <worktree-name>` compose project name, so each worktree gets its own
+# isolated everything.
+#
+# Usage:
+#   scripts/dev-sandbox.sh up [worktree-name] [port]
+#   scripts/dev-sandbox.sh down [worktree-name]
+#   scripts/dev-sandbox.sh logs [worktree-name]
+#
+# worktree-name defaults to the current directory's basename (i.e. run this
+# from inside the worktree checkout you want a sandbox for — matches how
+# `vst worktree create` names worktree checkout directories).
+# port defaults to the first free port in 5174-5199 (scanned against
+# currently-running `vst-dev` containers) if omitted on `up`.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+CMD="${1:-}"
+WORKTREE="${2:-$(basename "$PWD")}"
+PORT="${3:-}"
+
+if [ -z "$CMD" ]; then
+  echo "Usage: $0 {up|down|logs} [worktree-name] [port]" >&2
+  exit 1
+fi
+
+pick_free_port() {
+  local used
+  used="$(docker ps --format '{{.Ports}}' 2>/dev/null | grep -oE '0\.0\.0\.0:[0-9]+->5173' | grep -oE '[0-9]+' | sort -u || true)"
+  for candidate in $(seq 5174 5199); do
+    if ! echo "$used" | grep -qx "$candidate"; then
+      echo "$candidate"
+      return
+    fi
+  done
+  echo "No free port found in 5174-5199 — pass one explicitly: $0 up $WORKTREE <port>" >&2
+  exit 1
+}
+
+case "$CMD" in
+  up)
+    if [ -z "$PORT" ]; then
+      PORT="$(pick_free_port)"
+    fi
+
+    running="$(docker ps --format '{{.Names}}' | grep -- '-vst-dev-1$' || true)"
+    if [ -n "$running" ]; then
+      echo "Other vst-dev sandboxes already running (isolated by this script's per-worktree naming, listed for awareness):"
+      echo "$running" | sed 's/^/  /'
+    fi
+
+    export VST_SANDBOX_PORT="$PORT"
+    export VST_SANDBOX_DATA_VOLUME="vst-dev-data-${WORKTREE}"
+    export VST_SANDBOX_PROJECTS_VOLUME="vst-dev-projects-${WORKTREE}"
+
+    echo "Starting sandbox '$WORKTREE' on http://localhost:${PORT} (volumes: ${VST_SANDBOX_DATA_VOLUME}, ${VST_SANDBOX_PROJECTS_VOLUME})"
+    docker compose -f docker-compose.dev.yml -p "$WORKTREE" up --build -d
+    echo "Up: http://localhost:${PORT}"
+    ;;
+
+  down)
+    # Volume env vars aren't needed to tear down (compose resolves the
+    # already-created project's containers/networks by project name alone),
+    # but are set anyway so a `down` run right after `up` in the same shell
+    # is a no-op diff against the compose config that created them.
+    export VST_SANDBOX_DATA_VOLUME="vst-dev-data-${WORKTREE}"
+    export VST_SANDBOX_PROJECTS_VOLUME="vst-dev-projects-${WORKTREE}"
+    docker compose -f docker-compose.dev.yml -p "$WORKTREE" down
+    echo "Stopped sandbox '$WORKTREE'. Volumes ${VST_SANDBOX_DATA_VOLUME}/${VST_SANDBOX_PROJECTS_VOLUME} were left intact (never 'down -v' — that would delete this worktree's seeded daemon state/projects)."
+    ;;
+
+  logs)
+    docker compose -f docker-compose.dev.yml -p "$WORKTREE" logs -f
+    ;;
+
+  *)
+    echo "Unknown command '$CMD'. Usage: $0 {up|down|logs} [worktree-name] [port]" >&2
+    exit 1
+    ;;
+esac

--- a/web-ui/src/api/client.ts
+++ b/web-ui/src/api/client.ts
@@ -5,6 +5,8 @@ import type {
   ChangedPathEntry,
   Channel,
   CliId,
+  CommitLogEntry,
+  PrInfo,
   CreateDirectSessionBody,
   CreateModeBody,
   CreateProjectBody,
@@ -588,6 +590,25 @@ export function createClientApi() {
         `${root}/worktrees/${encodeURIComponent(worktreeId)}/changed-paths?${q}`,
       );
       return parseJson<ChangedPathEntry[]>(res);
+    },
+
+    /** Commit history for the worktree, most-recent-first, with per-commit diffstat. */
+    async listCommits(worktreeId: string, limit = 200): Promise<CommitLogEntry[]> {
+      const root = baseUrl();
+      const q = new URLSearchParams({ limit: String(limit) });
+      const res = await apiFetch(
+        `${root}/worktrees/${encodeURIComponent(worktreeId)}/commits?${q}`,
+      );
+      const { commits } = await parseJson<{ commits: CommitLogEntry[] }>(res);
+      return commits;
+    },
+
+    /** Best-effort GitHub PR lookup for the worktree's branch; null if there is none. */
+    async getPr(worktreeId: string): Promise<PrInfo | null> {
+      const root = baseUrl();
+      const res = await apiFetch(`${root}/worktrees/${encodeURIComponent(worktreeId)}/pr`);
+      const { pr } = await parseJson<{ pr: PrInfo | null }>(res);
+      return pr;
     },
 
     async listModes(): Promise<Mode[]> {

--- a/web-ui/src/api/mock.ts
+++ b/web-ui/src/api/mock.ts
@@ -6,7 +6,9 @@ import type {
   ChangedPathEntry,
   Channel,
   CliId,
+  CommitLogEntry,
   NormalizedEvent,
+  PrInfo,
   CreateDirectSessionBody,
   CreateModeBody,
   CreateProjectBody,
@@ -778,6 +780,57 @@ export function createMockApi() {
         return Object.keys(unifiedDiffs).map((path) => ({ path, status: "M" as const }));
       }
       return [];
+    },
+
+    async listCommits(worktreeId: string, _limit = 200): Promise<CommitLogEntry[]> {
+      if (!worktrees.find((w) => w.id === worktreeId)) throw new ApiError("not found", 404);
+      const now = new Date("2026-08-11T12:00:00Z").getTime();
+      const sample: Array<[string, string, number, number, string?]> = [
+        [
+          "Add VCS commit graph skeleton",
+          "Ada Lovelace",
+          128,
+          4,
+          "Adds the vertical commit graph tool tab: most-recent-first, per-commit\ndiffstat badges, and a GitHub PR banner when the branch has one.\n\nBacked by a new GET /worktrees/:id/commits endpoint that shells out to\n`git log --numstat` and sums insertions/deletions per commit.",
+        ],
+        ["Fix double input after fullscreen toggle", "Grace Hopper", 22, 9],
+        [
+          "Wire up devices panel sub-tabs",
+          "Grace Hopper",
+          61,
+          3,
+          "Web and Emulator sub-tabs now share one live view slot instead of\nmounting/unmounting on switch, avoiding the terminal-remount class of bug.",
+        ],
+        ["Initial worktree scaffold", "Ada Lovelace", 340, 0],
+      ];
+      return sample.map(([subject, authorName, insertions, deletions, body], i) => ({
+        sha: `${worktreeId}-sha-${i}`.padEnd(40, "0"),
+        shortSha: `${i}abcdef`.slice(0, 7),
+        authorName,
+        authorEmail: `${authorName.toLowerCase().replace(/\s+/g, ".")}@example.com`,
+        date: new Date(now - i * 3 * 60 * 60 * 1000).toISOString(),
+        subject,
+        body: body ? `${subject}\n\n${body}` : subject,
+        insertions,
+        deletions,
+        hasBinaryChanges: false,
+      }));
+    },
+
+    async getPr(worktreeId: string): Promise<PrInfo | null> {
+      if (!worktrees.find((w) => w.id === worktreeId)) throw new ApiError("not found", 404);
+      if (worktreeId === "wt-1") {
+        return {
+          number: 42,
+          url: "https://github.com/example/example/pull/42",
+          title: "Add VCS commit graph skeleton",
+          state: "open",
+          merged: false,
+          draft: false,
+          author: "ada-lovelace",
+        };
+      }
+      return null;
     },
 
     async listModes(): Promise<Mode[]> {

--- a/web-ui/src/api/types.ts
+++ b/web-ui/src/api/types.ts
@@ -431,6 +431,31 @@ export interface ChangedPathEntry {
   status: GitStatusChar;
 }
 
+export interface CommitLogEntry {
+  sha: string;
+  shortSha: string;
+  authorName: string;
+  authorEmail: string;
+  /** ISO 8601, author date. */
+  date: string;
+  subject: string;
+  /** Full raw commit message (subject + body). Equal to `subject` when there's no body. */
+  body: string;
+  insertions: number;
+  deletions: number;
+  hasBinaryChanges: boolean;
+}
+
+export interface PrInfo {
+  number: number;
+  url: string;
+  title: string;
+  state: "open" | "closed";
+  merged: boolean;
+  draft: boolean;
+  author: string | null;
+}
+
 export interface ProjectBranchesResponse {
   branches: string[];
   /** Null for a non-git project (the daemon sends null in that case). */

--- a/web-ui/src/components/layout/ToolPanel.tsx
+++ b/web-ui/src/components/layout/ToolPanel.tsx
@@ -6,6 +6,7 @@ import { useLayout } from "@/hooks/useLayout";
 import { FilesPanel } from "@/components/tools/FilesPanel";
 import { DevicesPanel } from "@/components/tools/DevicesPanel";
 import { ArtifactsPanel } from "@/components/tools/ArtifactsPanel";
+import { VcsPanel } from "@/components/tools/VcsPanel";
 import { ToolFullscreenButton } from "@/components/tools/ToolFullscreenButton";
 
 interface ToolPanelProps {
@@ -20,6 +21,7 @@ const TABS: { id: ToolTab; label: string }[] = [
   { id: "files", label: "Files" },
   { id: "devices", label: "Devices" },
   { id: "artifacts", label: "Artifacts" },
+  { id: "vcs", label: "VCS" },
 ];
 
 /**
@@ -76,6 +78,7 @@ export function ToolPanel({ api, worktreeId, scope = "worktree" }: ToolPanelProp
             ) : null}
             {toolPanelTab === "devices" ? <DevicesPanel /> : null}
             {toolPanelTab === "artifacts" ? <ArtifactsPanel /> : null}
+            {toolPanelTab === "vcs" ? <VcsPanel api={api} worktreeId={worktreeId} /> : null}
           </>
         )}
       </div>

--- a/web-ui/src/components/tools/VcsPanel.tsx
+++ b/web-ui/src/components/tools/VcsPanel.tsx
@@ -1,0 +1,239 @@
+import { useEffect, useState } from "react";
+import { ChevronRight, ExternalLink, GitCommit, GitMerge, GitPullRequest, GitPullRequestClosed, GitPullRequestDraft, RefreshCw } from "lucide-react";
+import type { ApiInstance } from "@/api";
+import type { CommitLogEntry, PrInfo } from "@/api/types";
+
+interface VcsPanelProps {
+  api: ApiInstance;
+  worktreeId: string;
+}
+
+/** Relative time like "3m ago", "2h ago", "5d ago"; falls back to a date past ~30d. */
+function relativeTime(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return iso;
+  const diffMs = Date.now() - then;
+  const mins = Math.floor(diffMs / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+function initials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0]!.slice(0, 2).toUpperCase();
+  return `${parts[0]![0]}${parts[parts.length - 1]![0]}`.toUpperCase();
+}
+
+/** Icon + label + modifier class for a PR's current status. */
+function prStatus(pr: PrInfo): { Icon: typeof GitPullRequest; label: string; modifier: string } {
+  if (pr.merged) return { Icon: GitMerge, label: "Merged", modifier: "merged" };
+  if (pr.state === "closed") return { Icon: GitPullRequestClosed, label: "Closed", modifier: "closed" };
+  if (pr.draft) return { Icon: GitPullRequestDraft, label: "Draft", modifier: "draft" };
+  return { Icon: GitPullRequest, label: "Open", modifier: "open" };
+}
+
+/**
+ * PR banner shown above the commit list when the worktree's branch has a
+ * GitHub pull request (any state — open/draft/merged/closed). Renders
+ * nothing while loading or when there's no PR/no GitHub remote, so it never
+ * shows a "no PR" placeholder — the commit list is the primary content.
+ */
+function PrBanner({ pr }: { pr: PrInfo }) {
+  const { Icon, label, modifier } = prStatus(pr);
+  return (
+    <a
+      className={`vcs-pr vcs-pr--${modifier}`}
+      href={pr.url}
+      target="_blank"
+      rel="noreferrer noopener"
+      title={`Open PR #${pr.number} on GitHub`}
+    >
+      <Icon size={14} aria-hidden className="vcs-pr__icon" />
+      <span className="vcs-pr__title" title={pr.title}>
+        {pr.title}
+      </span>
+      <span className="vcs-pr__number">#{pr.number}</span>
+      <span className={`vcs-pr__badge vcs-pr__badge--${modifier}`}>{label}</span>
+      {pr.author ? <span className="vcs-pr__author">by {pr.author}</span> : null}
+      <ExternalLink size={12} aria-hidden className="vcs-pr__external" />
+    </a>
+  );
+}
+
+/**
+ * VCS tool — a vertical commit graph for the current worktree's branch, most
+ * recent commit on top, plus a PR banner (linking out to GitHub) when the
+ * branch has one. Each commit row shows the subject, author, relative time,
+ * short SHA, and a +/- diffstat badge. Fetches `GET /worktrees/:id/commits`
+ * and `GET /worktrees/:id/pr` once on mount / worktree change and on manual
+ * refresh; no live updates yet (commits/PR state changes aren't
+ * push-notified to the UI today).
+ */
+export function VcsPanel({ api, worktreeId }: VcsPanelProps) {
+  const [commits, setCommits] = useState<CommitLogEntry[] | null>(null);
+  const [pr, setPr] = useState<PrInfo | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  // Shas whose full message is expanded. A Set rather than a single
+  // "expandedSha" so multiple commits can be open at once (mirrors how e.g.
+  // GitHub's PR commit list behaves) — tapping a row toggles just that row.
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+
+  const toggleExpanded = (sha: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(sha)) next.delete(sha);
+      else next.add(sha);
+      return next;
+    });
+  };
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+    Promise.all([
+      api.listCommits(worktreeId),
+      // PR lookup is best-effort — a failure here shouldn't blank out the
+      // commit list, so it's swallowed to null rather than propagated.
+      api.getPr(worktreeId).catch(() => null),
+    ])
+      .then(([list, prInfo]) => {
+        if (controller.signal.aborted) return;
+        setCommits(list);
+        setPr(prInfo);
+      })
+      .catch((err: unknown) => {
+        if (controller.signal.aborted) return;
+        setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+    return () => controller.abort();
+  }, [api, worktreeId]);
+
+  const refresh = () => {
+    setLoading(true);
+    setError(null);
+    Promise.all([api.listCommits(worktreeId), api.getPr(worktreeId).catch(() => null)])
+      .then(([list, prInfo]) => {
+        setCommits(list);
+        setPr(prInfo);
+      })
+      .catch((err: unknown) => setError(err instanceof Error ? err.message : String(err)))
+      .finally(() => setLoading(false));
+  };
+
+  return (
+    <div className="vcs-panel">
+      <div className="vcs-panel__bar">
+        <span className="vcs-panel__title">Commits{commits ? ` (${commits.length})` : ""}</span>
+        <button
+          type="button"
+          className="tab tab--icon tool-bar-btn"
+          aria-label="Refresh commits"
+          title="Refresh commits"
+          onClick={refresh}
+          disabled={loading}
+        >
+          <RefreshCw size={13} className={loading ? "vcs-panel__spin" : undefined} />
+        </button>
+      </div>
+      {pr ? <PrBanner pr={pr} /> : null}
+      <div className="vcs-panel__body">
+        {error ? (
+          <div className="empty-state">Failed to load commits: {error}</div>
+        ) : commits == null ? (
+          <div className="empty-state">Loading commits…</div>
+        ) : commits.length === 0 ? (
+          <div className="empty-state">No commits on this branch yet</div>
+        ) : (
+          <ol className="vcs-graph">
+            {commits.map((c) => {
+              // Only commits with a body beyond the subject line get the
+              // expand affordance — a bare one-line commit has nothing more
+              // to reveal, so tapping it would just be a no-op toggle.
+              const hasBody = c.body.trim() !== c.subject.trim() && c.body.trim() !== "";
+              const isOpen = expanded.has(c.sha);
+              return (
+                <li key={c.sha} className="vcs-graph__item">
+                  <div className="vcs-graph__rail">
+                    <span className="vcs-graph__dot">
+                      <GitCommit size={11} aria-hidden />
+                    </span>
+                    <span className="vcs-graph__line" aria-hidden />
+                  </div>
+                  <div
+                    className={`vcs-graph__card${hasBody ? " vcs-graph__card--expandable" : ""}`}
+                    role={hasBody ? "button" : undefined}
+                    tabIndex={hasBody ? 0 : undefined}
+                    aria-expanded={hasBody ? isOpen : undefined}
+                    onClick={hasBody ? () => toggleExpanded(c.sha) : undefined}
+                    onKeyDown={
+                      hasBody
+                        ? (e) => {
+                            if (e.key === "Enter" || e.key === " ") {
+                              e.preventDefault();
+                              toggleExpanded(c.sha);
+                            }
+                          }
+                        : undefined
+                    }
+                  >
+                    <div className="vcs-graph__subject-row">
+                      <span className="vcs-graph__subject" title={hasBody ? undefined : c.subject}>
+                        {c.subject || "(no message)"}
+                      </span>
+                    </div>
+                    {hasBody && isOpen ? <pre className="vcs-graph__body">{c.body}</pre> : null}
+                    <div className="vcs-graph__meta">
+                      {hasBody ? (
+                        <ChevronRight
+                          size={12}
+                          aria-hidden
+                          className={`vcs-graph__chevron${isOpen ? " vcs-graph__chevron--open" : ""}`}
+                        />
+                      ) : null}
+                      <span className="vcs-graph__avatar" title={c.authorName}>
+                        {initials(c.authorName)}
+                      </span>
+                      <span className="vcs-graph__author">{c.authorName}</span>
+                      <span className="vcs-graph__dot-sep" aria-hidden>
+                        ·
+                      </span>
+                      <span className="vcs-graph__time" title={c.date}>
+                        {relativeTime(c.date)}
+                      </span>
+                      <span className="vcs-graph__dot-sep" aria-hidden>
+                        ·
+                      </span>
+                      <code className="vcs-graph__sha">{c.shortSha}</code>
+                      <span className="vcs-graph__stats">
+                        {c.insertions > 0 ? (
+                          <span className="vcs-graph__add">+{c.insertions}</span>
+                        ) : null}
+                        {c.deletions > 0 ? (
+                          <span className="vcs-graph__del">−{c.deletions}</span>
+                        ) : null}
+                        {c.insertions === 0 && c.deletions === 0 ? (
+                          <span className="vcs-graph__nochange">no changes</span>
+                        ) : null}
+                      </span>
+                    </div>
+                  </div>
+                </li>
+              );
+            })}
+          </ol>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web-ui/src/hooks/useStore.ts
+++ b/web-ui/src/hooks/useStore.ts
@@ -3,9 +3,9 @@ import { persist } from "zustand/middleware";
 import type { DiffScope, Session, SessionState } from "@/api/types";
 
 /** Tools hosted by the right-side tool panel (one visible at a time). */
-export type ToolTab = "files" | "devices" | "artifacts";
+export type ToolTab = "files" | "devices" | "artifacts" | "vcs";
 
-export const TOOL_TABS: ToolTab[] = ["files", "devices", "artifacts"];
+export const TOOL_TABS: ToolTab[] = ["files", "devices", "artifacts", "vcs"];
 
 /**
  * Per-worktree workspace layout.

--- a/web-ui/src/styles/workspace.css
+++ b/web-ui/src/styles/workspace.css
@@ -3647,6 +3647,299 @@ a.dashboard-card.dashboard-card--session {
   flex-shrink: 0;
 }
 
+/* ── VCS tool: vertical commit graph, most-recent first ─────────────────────── */
+.vcs-panel {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-primary);
+}
+
+.vcs-panel__bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-bottom: var(--border-width) solid var(--border-default);
+  flex-shrink: 0;
+}
+
+.vcs-panel__title {
+  font-size: var(--font-size-sm);
+  color: var(--fg-secondary);
+}
+
+.vcs-panel__spin {
+  animation: vcs-spin 0.8s linear infinite;
+}
+
+@keyframes vcs-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.vcs-pr {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-bottom: var(--border-width) solid var(--border-default);
+  background: var(--bg-secondary);
+  text-decoration: none;
+  color: inherit;
+  flex-shrink: 0;
+  min-width: 0;
+}
+
+.vcs-pr:hover {
+  background: var(--bg-tertiary);
+}
+
+.vcs-pr__icon {
+  flex-shrink: 0;
+}
+
+.vcs-pr--open .vcs-pr__icon {
+  color: #4ade80;
+}
+
+.vcs-pr--merged .vcs-pr__icon {
+  color: #a78bfa;
+}
+
+.vcs-pr--closed .vcs-pr__icon {
+  color: #f87171;
+}
+
+.vcs-pr--draft .vcs-pr__icon {
+  color: var(--fg-muted);
+}
+
+.vcs-pr__title {
+  font-size: var(--font-size-sm);
+  color: var(--fg-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.vcs-pr__number {
+  font-size: var(--font-size-xs);
+  color: var(--fg-muted);
+  flex-shrink: 0;
+}
+
+.vcs-pr__badge {
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 1px var(--space-2);
+  border-radius: var(--radius-full);
+  flex-shrink: 0;
+}
+
+.vcs-pr__badge--open {
+  color: #4ade80;
+  background: rgba(74, 222, 128, 0.12);
+}
+
+.vcs-pr__badge--merged {
+  color: #a78bfa;
+  background: rgba(167, 139, 250, 0.12);
+}
+
+.vcs-pr__badge--closed {
+  color: #f87171;
+  background: rgba(248, 113, 113, 0.12);
+}
+
+.vcs-pr__badge--draft {
+  color: var(--fg-muted);
+  background: var(--bg-tertiary);
+}
+
+.vcs-pr__author {
+  font-size: var(--font-size-xs);
+  color: var(--fg-muted);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.vcs-pr__external {
+  color: var(--fg-muted);
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+.vcs-panel__body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--space-2) var(--space-3);
+}
+
+.vcs-graph {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.vcs-graph__item {
+  display: flex;
+  gap: var(--space-3);
+}
+
+.vcs-graph__rail {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 20px;
+  flex-shrink: 0;
+}
+
+.vcs-graph__dot {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: var(--radius-full);
+  border: var(--border-width) solid var(--border-default);
+  background: var(--bg-secondary);
+  color: var(--fg-secondary);
+  flex-shrink: 0;
+}
+
+.vcs-graph__line {
+  flex: 1;
+  width: 1px;
+  min-height: var(--space-3);
+  background: var(--border-default);
+}
+
+.vcs-graph__item:last-child .vcs-graph__line {
+  display: none;
+}
+
+.vcs-graph__card {
+  flex: 1;
+  min-width: 0;
+  padding-bottom: var(--space-4);
+}
+
+.vcs-graph__card--expandable {
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  margin: calc(var(--space-1) * -1) calc(var(--space-2) * -1) 0;
+  padding: var(--space-1) var(--space-2) 0;
+}
+
+.vcs-graph__card--expandable:hover {
+  background: var(--bg-secondary);
+}
+
+.vcs-graph__subject-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-width: 0;
+}
+
+.vcs-graph__chevron {
+  flex-shrink: 0;
+  color: var(--fg-muted);
+  transition: transform 0.12s ease;
+}
+
+.vcs-graph__chevron--open {
+  transform: rotate(90deg);
+}
+
+.vcs-graph__subject {
+  flex: 1;
+  font-size: var(--font-size-sm);
+  color: var(--fg-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.vcs-graph__body {
+  margin: var(--space-2) 0 0;
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-secondary);
+  border: var(--border-width) solid var(--border-default);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--fg-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.vcs-graph__meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: var(--space-1);
+  font-size: var(--font-size-xs);
+  color: var(--fg-muted);
+  flex-wrap: wrap;
+}
+
+.vcs-graph__avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: var(--radius-full);
+  background: var(--bg-tertiary);
+  color: var(--fg-secondary);
+  font-size: 9px;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.vcs-graph__dot-sep {
+  color: var(--fg-muted);
+}
+
+.vcs-graph__sha {
+  font-family: var(--font-mono, monospace);
+  background: var(--bg-secondary);
+  border: var(--border-width) solid var(--border-default);
+  border-radius: var(--radius-sm);
+  padding: 0 var(--space-1);
+}
+
+.vcs-graph__stats {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-family: var(--font-mono, monospace);
+}
+
+.vcs-graph__add {
+  color: #4ade80;
+}
+
+.vcs-graph__del {
+  color: #f87171;
+}
+
+.vcs-graph__nochange {
+  font-style: italic;
+}
+
 .artifacts-panel__badge {
   font-size: var(--font-size-xs);
   text-transform: uppercase;


### PR DESCRIPTION
## Summary
- New **VCS** tool tab (next to Files/Devices/Artifacts): a vertical commit graph for the current worktree's branch, most-recent commit on top, each with a `+N/−N` diffstat badge and an expandable full commit message.
- GitHub PR banner above the graph when the branch has an associated PR (open/draft/merged/closed), linking out to GitHub — best-effort, no `gh` CLI dependency, works without a remote/PR (renders nothing).
- Backend: `daemon/src/services/git.ts` (`listCommits()`, `attachFullBodies()`), `daemon/src/services/github.ts` (`getRemoteUrl()`, `parseGithubRepo()`, `fetchPrForBranch()`), new routes `GET /worktrees/:id/commits` and `GET /worktrees/:id/pr`.
- Full test coverage for the backend (unit + route tests), added after an opus code-review pass caught two real bugs in the initial implementation:
  - A commit subject containing the parser's own RS/US delimiter bytes could corrupt the commit list — fixed with a defensive sha-shape guard.
  - Merge commits always showed a `0/0` diffstat (git suppresses merge diffs by default) — fixed with `--diff-merges=first-parent`.
- Bonus: `docker-compose.dev.yml` + new `scripts/dev-sandbox.sh` make the dev sandbox (used to build/tweak this feature's UI live) safe to run per-worktree instead of every worktree's sandbox colliding on the same port/volumes.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm --filter cli test` — 65 files / 631 tests pass (one pre-existing, unrelated `UnhandledRejection` in `sessions.test.ts` flips pnpm's exit code even though every assertion is green — reproduced in isolation, predates this branch)
- [x] Manually verified in a live dev sandbox: VCS tab renders real commit history + diffstats for multiple demo projects/worktrees, PR banner renders correctly for a worktree pointed at a real GitHub repo with a merged PR, commit-message expand/collapse works
- [x] `daemon/src/__tests__/git.commits.test.ts`, `github.test.ts`, and the new block in `worktrees.test.ts` cover empty repos, binary diffs, merge commits, adversarial commit messages, GitHub API failure modes, and PR-cache TTL/reset behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)