### PR TITLE
Collapse upstream commits and paginate the VCS tab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,3 +139,27 @@ The lock is scoped to one `WSConnection`. Two browser tabs legitimately hold two
 - **Do not change UI copy back to "JSON chat" / "JSON mode"** to "match" the code — same reasoning in reverse. If you're editing a component and see `"json"` in a prop/variable name right next to `"Rich Chat"` in the JSX it renders, that's correct, not a bug — leave both as they are.
 - **New UI copy for this channel:** use "Rich Chat"; add `(json based)` only where the technical detail is genuinely useful to the reader (a tooltip, an advanced-settings hint), not in every occurrence.
 - **New code identifiers for this channel:** use `json`/`Json`-prefixed names, consistent with the existing files above.
+
+---
+
+## Docker dev sandboxes — two different tools, don't conflate them
+
+**Files:** `docker-compose.dev.yml` · `scripts/dev-sandbox.sh` · `scripts/dev-entrypoint.sh` · `docker-compose.screenshots.yml` · `Dockerfile.screenshots` · `scripts/demo-seed.sh` · `scripts/seed-file-search-demo.sh`
+
+There are two separate docker setups in this repo. They look similar (both boot a daemon + Vite dev server) but exist for different jobs — picking the wrong one silently gives you the wrong environment instead of erroring.
+
+| | `docker-compose.dev.yml` (via `scripts/dev-sandbox.sh`) | `docker-compose.screenshots.yml` |
+|---|---|---|
+| Purpose | Interactive dev/testing sandbox | Frozen, realistic dataset for README screenshots |
+| Source | Bind-mounted (`web-ui/src`) — hot reload on edit | Baked into the image (`COPY . .`) — rebuild to see changes |
+| Seed data | `VST_SEED_MODE=file-search` (default, one lightweight project) or `VST_SEED_MODE=demo` (3 projects / 9 worktrees / 14 sessions, via `scripts/demo-seed.sh`) | Always the same 3-project/9-worktree/14-session dataset |
+| Auth | `VST_NO_AUTH=1` — no login screen | Real token login (printed to container logs) |
+| Instances | Per-worktree (`scripts/dev-sandbox.sh` picks a free port + isolated volumes per worktree checkout) | Single, fixed name/port (`vst-screenshots`, `5174`) — not meant to run more than one at a time |
+
+**Rule of thumb:** if you're testing a UI change and just need *some* worktrees/agent sessions to click into, use `scripts/dev-sandbox.sh up --seed=demo` — you get hot reload, no login, and the realistic dataset in one sandbox. Reach for `docker-compose.screenshots.yml` directly only when you're actually regenerating README screenshots (`scripts/take-screenshots.ts` targets its fixed port/dataset).
+
+### What to watch for
+
+- **Don't assume `scripts/dev-sandbox.sh up` alone gives you worktrees/agents** — its default seed (`file-search`) is intentionally minimal. Pass `--seed=demo` if you need the realistic dataset.
+- **Switching `--seed` mode on an already-seeded volume does NOT cleanly swap datasets — it merges/corrupts them.** The two seed scripts guard themselves independently and asymmetrically, not via a shared "already seeded in mode X" marker: `demo-seed.sh` checks its own `$VST/.seeded` file; `seed-file-search-demo.sh` checks whether `file-search-demo`'s repo dir exists and whether that project is already registered with the daemon. Neither guard knows about the other, so going `file-search` → `demo` on the same worktree-name runs `demo-seed.sh` in full on a volume the daemon already has state for (it `rm -rf`s its own project dirs and overwrites `modes.json`, but doesn't touch the pre-existing `file-search-demo` data or the daemon's already-booted SQLite state — the result is an inconsistent mix, not a clean demo dataset), and going `demo` → `file-search` just registers a 4th project alongside the demo data rather than being a no-op. Use a fresh worktree-name (or `docker volume rm vst-dev-data-<worktree> vst-dev-projects-<worktree>`) whenever you want to actually change an existing sandbox's seed mode.
+- **Don't add demo-dataset seeding to `docker-compose.screenshots.yml`'s job description** or vice versa — `screenshots` intentionally has no hot reload and real auth so it matches what `take-screenshots.ts` expects; don't "fix" that to make it more dev-friendly.

--- a/daemon/src/__tests__/git.commits.test.ts
+++ b/daemon/src/__tests__/git.commits.test.ts
@@ -148,4 +148,54 @@ describe("listCommits", () => {
     expect(mergeCommit!.insertions).toBe(3);
     expect(mergeCommit!.deletions).toBe(0);
   });
+
+  describe("isOnBranch (baseSha-scoped, powers the VCS tab's upstream-commit collapse)", () => {
+    it("Requirement 5 — commits since baseSha are isOnBranch:true, commits at/before it are isOnBranch:false", async () => {
+      await writeFile(join(repoDir, "a.txt"), "a\n");
+      git(["add", "-A"]);
+      git(["commit", "-q", "-m", "base commit 1"]);
+      await writeFile(join(repoDir, "b.txt"), "b\n");
+      git(["add", "-A"]);
+      git(["commit", "-q", "-m", "base commit 2"]);
+      const baseSha = git(["rev-parse", "HEAD"]).trim();
+
+      await writeFile(join(repoDir, "c.txt"), "c\n");
+      git(["add", "-A"]);
+      git(["commit", "-q", "-m", "own commit 1"]);
+      await writeFile(join(repoDir, "d.txt"), "d\n");
+      git(["add", "-A"]);
+      git(["commit", "-q", "-m", "own commit 2"]);
+
+      const commits = await listCommits(repoDir, 200, baseSha);
+      const bySubject = new Map(commits.map((c) => [c.subject, c]));
+      expect(bySubject.get("own commit 2")!.isOnBranch).toBe(true);
+      expect(bySubject.get("own commit 1")!.isOnBranch).toBe(true);
+      expect(bySubject.get("base commit 2")!.isOnBranch).toBe(false);
+      expect(bySubject.get("base commit 1")!.isOnBranch).toBe(false);
+    });
+
+    it("Requirement 6 — no baseSha passed: every commit is conservatively isOnBranch:true", async () => {
+      await writeFile(join(repoDir, "a.txt"), "a\n");
+      git(["add", "-A"]);
+      git(["commit", "-q", "-m", "commit 1"]);
+      await writeFile(join(repoDir, "b.txt"), "b\n");
+      git(["add", "-A"]);
+      git(["commit", "-q", "-m", "commit 2"]);
+
+      const commits = await listCommits(repoDir);
+      expect(commits).toHaveLength(2);
+      expect(commits.every((c) => c.isOnBranch)).toBe(true);
+    });
+
+    it("Requirement 7 — an invalid/unresolvable baseSha fails open: every commit stays isOnBranch:true rather than throwing", async () => {
+      await writeFile(join(repoDir, "a.txt"), "a\n");
+      git(["add", "-A"]);
+      git(["commit", "-q", "-m", "commit 1"]);
+
+      const bogusSha = "0".repeat(40);
+      const commits = await listCommits(repoDir, 200, bogusSha);
+      expect(commits).toHaveLength(1);
+      expect(commits[0]!.isOnBranch).toBe(true);
+    });
+  });
 });

--- a/daemon/src/routes/worktrees.ts
+++ b/daemon/src/routes/worktrees.ts
@@ -1097,10 +1097,11 @@ export function registerWorktreeRoutes(app: FastifyInstance): void {
 
     const project = getAllProjects().find((p) => p.worktrees.some((w) => w.id === wtId));
     if (!project) return reply.status(404).send({ error: `Worktree '${wtId}' not found` });
+    const worktree = project.worktrees.find((w) => w.id === wtId)!;
 
     const wtPath = getWorktreePath(project.id, wtId);
     try {
-      const commits = await listCommits(wtPath, limit);
+      const commits = await listCommits(wtPath, limit, worktree.baseSha);
       return reply.send({ commits });
     } catch (err) {
       return reply.status(500).send({ error: `commits failed: ${String(err)}` });

--- a/daemon/src/services/git.ts
+++ b/daemon/src/services/git.ts
@@ -196,6 +196,21 @@ export interface CommitLogEntry {
   deletions: number;
   /** True if any changed file's diff couldn't be summarized as text (numstat reports "-"). */
   hasBinaryChanges: boolean;
+  /**
+   * True if this commit is reachable from HEAD but not from the worktree's
+   * recorded `baseSha` (`git rev-list HEAD --not <baseSha>`) — i.e. not
+   * reachable from the fork point as recorded at worktree-creation time.
+   * This is a proxy for "unique to this branch", not a guarantee of it: if
+   * the branch was rebased, or the base branch was force-pushed/advanced
+   * past what `baseSha` still points at, a commit that's actually on
+   * today's base branch can still read `true` here (harmless — it just
+   * doesn't get collapsed), and in principle the reverse could happen too.
+   * When `baseSha` isn't available (no worktree record, invalid/deleted
+   * ref), every commit is conservatively marked `true` so nothing is
+   * hidden. Used by the VCS tool tab to collapse base-branch history by
+   * default.
+   */
+  isOnBranch: boolean;
 }
 
 // Record separator (0x1e) delimits commits; unit separator (0x1f) delimits fields
@@ -209,17 +224,24 @@ const US = "\x1f";
 const FULL_SHA_RE = /^[0-9a-f]{40}$/;
 
 /**
- * List commits reachable from HEAD (i.e. the worktree's full branch history,
- * not scoped to commits since the worktree's `baseSha` — same "show
- * everything reachable from here" semantics as a bare `git log`, deliberately
- * not filtered the way `/changed-paths?scope=branch` filters against
- * `baseSha`), most recent first, each annotated with its line-level diffstat
+ * List commits reachable from HEAD (i.e. the worktree's full branch history —
+ * same "show everything reachable from here" semantics as a bare `git log`),
+ * most recent first, each annotated with its line-level diffstat
  * (insertions/deletions) versus its first parent. `--diff-merges=first-parent`
  * ensures merge commits get a real diffstat instead of git's default of
- * suppressing diff output for merges entirely. Used by the VCS tool tab to
- * render a commit timeline for a worktree.
+ * suppressing diff output for merges entirely.
+ *
+ * When `baseSha` is passed, each commit is also annotated with `isOnBranch`
+ * (see `CommitLogEntry`), computed via `git rev-list --not <baseSha> HEAD` —
+ * the same "unique to this branch" semantics `/changed-paths?scope=branch`
+ * uses for `baseSha`-scoped diffs. Used by the VCS tool tab to render a
+ * commit timeline and collapse base-branch history by default.
  */
-export async function listCommits(repoPath: string, limit = 200): Promise<CommitLogEntry[]> {
+export async function listCommits(
+  repoPath: string,
+  limit = 200,
+  baseSha?: string,
+): Promise<CommitLogEntry[]> {
   let stdout: string;
   try {
     stdout = await runGit(
@@ -281,6 +303,8 @@ export async function listCommits(repoPath: string, limit = 200): Promise<Commit
       insertions,
       deletions,
       hasBinaryChanges,
+      // Provisional; overwritten below once the base-branch SHA set is known.
+      isOnBranch: true,
     });
   }
 
@@ -288,7 +312,38 @@ export async function listCommits(repoPath: string, limit = 200): Promise<Commit
     await attachFullBodies(repoPath, commits);
   }
 
+  if (baseSha) {
+    const onBranchShas = await listShasNotIn(repoPath, baseSha);
+    if (onBranchShas) {
+      for (const commit of commits) {
+        commit.isOnBranch = onBranchShas.has(commit.sha);
+      }
+    }
+    // On failure (invalid/deleted baseSha ref), leave every commit's
+    // provisional `isOnBranch: true` in place — fail open rather than hiding
+    // history the user can't get back without knowing to expand it.
+  }
+
   return commits;
+}
+
+/**
+ * Returns the set of full SHAs reachable from `HEAD` but not from `baseSha`
+ * (`git rev-list --not <baseSha> HEAD`), i.e. commits unique to the current
+ * branch. Returns null on failure (e.g. `baseSha` no longer resolves because
+ * the upstream ref was deleted) so callers can fail open.
+ */
+async function listShasNotIn(repoPath: string, baseSha: string): Promise<Set<string> | null> {
+  try {
+    // `--not` negates every ref that follows it, so `baseSha` must come
+    // after `HEAD` — otherwise HEAD itself would be negated too, per
+    // `git rev-list --help`'s "Reverses the meaning ... for all following
+    // revision specifiers" semantics.
+    const stdout = await runGit(["-C", repoPath, "rev-list", "HEAD", "--not", baseSha], repoPath);
+    return new Set(stdout.split("\n").map((l) => l.trim()).filter(Boolean));
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,12 +6,22 @@
 #   Then open: http://localhost:5174
 #
 # Usage (multiple worktrees' sandboxes running concurrently):
-#   scripts/dev-sandbox.sh up [worktree-name] [port]
+#   scripts/dev-sandbox.sh up [worktree-name] [port] [--seed=file-search|demo]
 #   scripts/dev-sandbox.sh down [worktree-name]
 #   See scripts/dev-sandbox.sh — it sets VST_SANDBOX_PORT/DATA_VOLUME/
 #   PROJECTS_VOLUME (below) and a `-p <worktree-name>` compose project name so
 #   each worktree gets its own port + volumes instead of colliding on the
 #   defaults every plain `docker compose ... up` shares.
+#
+# This sandbox always has hot-reload (web-ui/src bind-mounted) and no login
+# (VST_NO_AUTH=1). By default it seeds one lightweight project — pass
+# `--seed=demo` (or set VST_SEED_MODE=demo) for the realistic 3-project/
+# 9-worktree/14-session dataset instead, if you need worktrees/agent sessions
+# to click into rather than an empty tree. If you specifically need to
+# reproduce the frozen, single-instance, real-auth screenshot sandbox itself
+# (e.g. to regenerate README screenshots), use
+# docker-compose.screenshots.yml instead — it bakes source into the image
+# (no hot reload) and keeps auth on, which this file intentionally doesn't.
 #
 # CLI binaries are bind-mounted read-only from the host so that
 # GET /cli-models works inside the container. gemini is installed directly in the image;
@@ -46,6 +56,12 @@ services:
       # mirror these onto a network-exposed production daemon.
       VST_NO_AUTH: "1"
       VITE_DEV_ALLOW_ALL_HOSTS: "1"
+      # "file-search" (default) seeds one lightweight project; "demo" seeds
+      # the same realistic 3-project/9-worktree/14-session dataset
+      # docker-compose.screenshots.yml uses, for testing against actual
+      # worktrees/agents. Set via `scripts/dev-sandbox.sh up --seed=demo` —
+      # see scripts/dev-entrypoint.sh for the branch.
+      VST_SEED_MODE: "${VST_SEED_MODE:-file-search}"
     volumes:
       # Mount CLI binaries read-only so the daemon can shell out to them.
       # Paths use $HOME — override with OPENCODE_BIN, CURSOR_BIN, CLAUDE_BIN if yours differ.

--- a/scripts/dev-entrypoint.sh
+++ b/scripts/dev-entrypoint.sh
@@ -41,12 +41,55 @@ if [ -d /seed/gemini ] && [ ! -f /home/vst/.gemini/.seeded ]; then
   echo 'Seed complete.'
 fi
 
+# VST_SEED_MODE selects what gets seeded into this sandbox:
+#   file-search (default) — one lightweight project, for general UI dev.
+#   demo                  — 3 projects / 9 worktrees / 14 sessions, the same
+#                            realistic dataset docker-compose.screenshots.yml
+#                            uses, for when you need worktrees/agents to
+#                            click into (not just an empty tree).
+# Either way this sandbox keeps hot-reload + VST_NO_AUTH (no login token) —
+# docker-compose.screenshots.yml trades those away for a baked, single-
+# instance image, which is the right tradeoff for screenshot capture but not
+# for interactive testing.
+#
+# The two seed scripts have opposite ordering requirements relative to the
+# daemon, so this can't be one `case` block run at a single point:
+#   - demo-seed.sh (scripts/demo-seed.sh) writes project manifests and tmux
+#     sessions DIRECTLY TO DISK, with no daemon API calls at all — it must
+#     run BEFORE the daemon starts so the daemon picks the manifests up at
+#     boot (this is exactly how Dockerfile.screenshots sequences it). Run it
+#     after boot instead and the daemon never sees the new projects, only
+#     whatever was already registered/persisted in the volume.
+#   - seed-file-search-demo.sh registers its project via live REST calls
+#     (`POST /projects` etc.), so it must run AFTER the daemon is up.
+#
+# `scripts/dev-sandbox.sh` validates VST_SEED_MODE before it ever gets here,
+# but this script is also reachable directly (`docker compose -f
+# docker-compose.dev.yml up`, or a plain `docker run` off this image), so an
+# unrecognized value is called out explicitly rather than silently falling
+# through to the file-search default — a typo like "Demo" or "demos" should
+# be visible in the logs, not produce a quietly-wrong sandbox.
+case "${VST_SEED_MODE:-file-search}" in
+  file-search|demo) ;;
+  *)
+    echo "[seed] WARNING: unrecognized VST_SEED_MODE='${VST_SEED_MODE}' — expected 'file-search' or 'demo'. Falling back to 'file-search'." >&2
+    VST_SEED_MODE=file-search
+    ;;
+esac
+
+if [ "$VST_SEED_MODE" = "demo" ]; then
+  su vst -c 'bash /app/scripts/demo-seed.sh' || echo '[seed] non-fatal seed error — continuing'
+fi
+
 rm -f /home/vst/.vibe-station/.daemon.lock
 su vst -c 'node cli/dist/daemon/main.js' &
 echo 'Waiting for daemon...'
 until curl -sf http://127.0.0.1:7421/health > /dev/null 2>&1; do sleep 0.5; done
 echo 'Daemon ready.'
-su vst -c 'bash /app/scripts/seed-file-search-demo.sh' || echo '[seed] non-fatal seed error — continuing'
+
+if [ "$VST_SEED_MODE" != "demo" ]; then
+  su vst -c 'bash /app/scripts/seed-file-search-demo.sh' || echo '[seed] non-fatal seed error — continuing'
+fi
 
 # --pty: without it, `su` starts a new session and the foreground vite dev
 # server loses the container's tty (stdin_open/tty are set on the compose

--- a/scripts/dev-sandbox.sh
+++ b/scripts/dev-sandbox.sh
@@ -16,7 +16,7 @@
 # isolated everything.
 #
 # Usage:
-#   scripts/dev-sandbox.sh up [worktree-name] [port]
+#   scripts/dev-sandbox.sh up [worktree-name] [port] [--seed=file-search|demo]
 #   scripts/dev-sandbox.sh down [worktree-name]
 #   scripts/dev-sandbox.sh logs [worktree-name]
 #
@@ -25,17 +25,46 @@
 # `vst worktree create` names worktree checkout directories).
 # port defaults to the first free port in 5174-5199 (scanned against
 # currently-running `vst-dev` containers) if omitted on `up`.
+# --seed defaults to "file-search" (one lightweight project). Pass
+# --seed=demo for the realistic 3-project/9-worktree/14-session dataset
+# (scripts/demo-seed.sh) when you need actual worktrees/agent sessions to
+# test against instead of an empty tree — this still keeps hot-reload and
+# VST_NO_AUTH, unlike docker-compose.screenshots.yml.
 
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
+
+# --seed=<mode> can appear anywhere in argv; strip it out first so the
+# remaining positional args (command, worktree-name, port) parse the same as
+# before this flag existed. Defaults to an inherited VST_SEED_MODE (so
+# `VST_SEED_MODE=demo scripts/dev-sandbox.sh up` also works, matching
+# docker-compose.dev.yml's own header comment), falling back to
+# "file-search" — --seed on the command line, when given, wins over both.
+SEED_MODE="${VST_SEED_MODE:-file-search}"
+ARGS=()
+for arg in "$@"; do
+  case "$arg" in
+    --seed=*) SEED_MODE="${arg#--seed=}" ;;
+    *) ARGS+=("$arg") ;;
+  esac
+done
+set -- "${ARGS[@]+"${ARGS[@]}"}"
+
+case "$SEED_MODE" in
+  file-search|demo) ;;
+  *)
+    echo "Unknown --seed mode '$SEED_MODE' — expected 'file-search' or 'demo'." >&2
+    exit 1
+    ;;
+esac
 
 CMD="${1:-}"
 WORKTREE="${2:-$(basename "$PWD")}"
 PORT="${3:-}"
 
 if [ -z "$CMD" ]; then
-  echo "Usage: $0 {up|down|logs} [worktree-name] [port]" >&2
+  echo "Usage: $0 {up|down|logs} [worktree-name] [port] [--seed=file-search|demo]" >&2
   exit 1
 fi
 
@@ -67,8 +96,17 @@ case "$CMD" in
     export VST_SANDBOX_PORT="$PORT"
     export VST_SANDBOX_DATA_VOLUME="vst-dev-data-${WORKTREE}"
     export VST_SANDBOX_PROJECTS_VOLUME="vst-dev-projects-${WORKTREE}"
+    export VST_SEED_MODE="$SEED_MODE"
 
-    echo "Starting sandbox '$WORKTREE' on http://localhost:${PORT} (volumes: ${VST_SANDBOX_DATA_VOLUME}, ${VST_SANDBOX_PROJECTS_VOLUME})"
+    echo "Starting sandbox '$WORKTREE' on http://localhost:${PORT} (volumes: ${VST_SANDBOX_DATA_VOLUME}, ${VST_SANDBOX_PROJECTS_VOLUME}, seed: ${SEED_MODE})"
+    # demo-seed.sh and seed-file-search-demo.sh guard themselves
+    # independently (a $VST/.seeded marker vs. a project-registration check)
+    # — neither knows about the other, so switching --seed on a worktree-name
+    # whose volume was already seeded in the OTHER mode does not cleanly
+    # swap datasets; it merges/corrupts them (see AGENTS.md's "Docker dev
+    # sandboxes" section for specifics). Start with a fresh worktree-name (or
+    # `docker volume rm "$VST_SANDBOX_DATA_VOLUME" "$VST_SANDBOX_PROJECTS_VOLUME"`)
+    # to actually change an existing sandbox's seed mode.
     docker compose -f docker-compose.dev.yml -p "$WORKTREE" up --build -d
     echo "Up: http://localhost:${PORT}"
     ;;

--- a/web-ui/src/api/mock.ts
+++ b/web-ui/src/api/mock.ts
@@ -782,10 +782,19 @@ export function createMockApi() {
       return [];
     },
 
-    async listCommits(worktreeId: string, _limit = 200): Promise<CommitLogEntry[]> {
+    async listCommits(worktreeId: string, limit = 200): Promise<CommitLogEntry[]> {
       if (!worktrees.find((w) => w.id === worktreeId)) throw new ApiError("not found", 404);
       const now = new Date("2026-08-11T12:00:00Z").getTime();
-      const sample: Array<[string, string, number, number, string?]> = [
+      // The first OWN_COMMIT_COUNT entries of `curated` are the worktree's
+      // own commits (`isOnBranch: true` below); everything after — the rest
+      // of `curated`, plus the whole synthetic tail — simulates base-branch
+      // history the worktree forked from, so the VCS tab's collapsed
+      // "commits from upstream" group has something to demonstrate. Kept as
+      // an explicit count rather than arithmetic on `curated.length` so
+      // adding/removing a curated commit above can't silently shift the
+      // own/upstream split.
+      const OWN_COMMIT_COUNT = 3;
+      const curated: Array<[string, string, number, number, string?]> = [
         [
           "Add VCS commit graph skeleton",
           "Ada Lovelace",
@@ -801,9 +810,29 @@ export function createMockApi() {
           3,
           "Web and Emulator sub-tabs now share one live view slot instead of\nmounting/unmounting on switch, avoiding the terminal-remount class of bug.",
         ],
+        // OWN_COMMIT_COUNT above must match: these two, plus everything in
+        // the synthetic tail below, are upstream. The synthetic tail extends
+        // this further so "Load more" also has something to demonstrate,
+        // since 5 curated commits alone never exceed a page.
+        ["Bump lockfile", "Grace Hopper", 4, 4],
         ["Initial worktree scaffold", "Ada Lovelace", 340, 0],
       ];
-      return sample.map(([subject, authorName, insertions, deletions, body], i) => ({
+      const SYNTHETIC_UPSTREAM_COUNT = 120;
+      const authors = ["Grace Hopper", "Ada Lovelace", "Katherine Johnson"];
+      const sample: Array<[string, string, number, number, string?]> = [
+        ...curated,
+        ...Array.from({ length: SYNTHETIC_UPSTREAM_COUNT }, (_, j) => {
+          const n = j + 1;
+          return [
+            `Upstream commit #${n}`,
+            authors[n % authors.length]!,
+            (n % 7) + 1,
+            n % 3,
+          ] as [string, string, number, number, string?];
+        }),
+      ];
+      const page = sample.slice(0, limit);
+      return page.map(([subject, authorName, insertions, deletions, body], i) => ({
         sha: `${worktreeId}-sha-${i}`.padEnd(40, "0"),
         shortSha: `${i}abcdef`.slice(0, 7),
         authorName,
@@ -814,6 +843,7 @@ export function createMockApi() {
         insertions,
         deletions,
         hasBinaryChanges: false,
+        isOnBranch: i < OWN_COMMIT_COUNT,
       }));
     },
 

--- a/web-ui/src/api/types.ts
+++ b/web-ui/src/api/types.ts
@@ -444,6 +444,12 @@ export interface CommitLogEntry {
   insertions: number;
   deletions: number;
   hasBinaryChanges: boolean;
+  /**
+   * True if this commit is unique to the worktree's branch (not already on
+   * the base branch it forked from). False marks upstream/base-branch
+   * history, which the VCS tool tab collapses by default.
+   */
+  isOnBranch: boolean;
 }
 
 export interface PrInfo {

--- a/web-ui/src/components/layout/ToolPanel.tsx
+++ b/web-ui/src/components/layout/ToolPanel.tsx
@@ -15,6 +15,8 @@ interface ToolPanelProps {
   worktreeId: string | null;
   /** Browsing scope. "project" is used by direct sessions (files in the base dir). */
   scope?: FileScope;
+  /** Worktree's base branch (e.g. "main"), for the VCS tab's upstream-commits group label. */
+  baseBranch?: string;
 }
 
 const TABS: { id: ToolTab; label: string }[] = [
@@ -30,7 +32,7 @@ const TABS: { id: ToolTab; label: string }[] = [
  * (web browser + emulators) and Artifacts are placeholders until their backends
  * land.
  */
-export function ToolPanel({ api, worktreeId, scope = "worktree" }: ToolPanelProps) {
+export function ToolPanel({ api, worktreeId, scope = "worktree", baseBranch }: ToolPanelProps) {
   const { toolPanelTab, setToolPanelTab, toggleToolPanel } = useLayout();
 
   return (
@@ -78,7 +80,9 @@ export function ToolPanel({ api, worktreeId, scope = "worktree" }: ToolPanelProp
             ) : null}
             {toolPanelTab === "devices" ? <DevicesPanel /> : null}
             {toolPanelTab === "artifacts" ? <ArtifactsPanel /> : null}
-            {toolPanelTab === "vcs" ? <VcsPanel api={api} worktreeId={worktreeId} /> : null}
+            {toolPanelTab === "vcs" ? (
+              <VcsPanel api={api} worktreeId={worktreeId} baseBranch={baseBranch} />
+            ) : null}
           </>
         )}
       </div>

--- a/web-ui/src/components/tools/VcsPanel.test.tsx
+++ b/web-ui/src/components/tools/VcsPanel.test.tsx
@@ -1,0 +1,229 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { createMockApi } from "@/api/mock";
+import { VcsPanel } from "./VcsPanel";
+import type { CommitLogEntry } from "@/api/types";
+
+/** Builds `count` synthetic commits, newest first, all on-branch unless overridden. */
+function makeCommits(count: number, opts: { isOnBranch?: (i: number) => boolean } = {}): CommitLogEntry[] {
+  const isOnBranch = opts.isOnBranch ?? (() => true);
+  return Array.from({ length: count }, (_, i) => ({
+    // Padded with "x" (never "0") so e.g. index 1 and 10 can't collapse into
+    // the same padded string the way zero-padding after a numeric suffix can.
+    sha: `sha-${i}-`.padEnd(40, "x"),
+    shortSha: `sha-${i}`.slice(0, 7),
+    authorName: "Ada Lovelace",
+    authorEmail: "ada@example.com",
+    date: new Date(2026, 0, 1, 12, 0, 0, -i * 1000).toISOString(),
+    subject: `commit #${i}`,
+    body: `commit #${i}`,
+    insertions: 1,
+    deletions: 0,
+    hasBinaryChanges: false,
+    isOnBranch: isOnBranch(i),
+  }));
+}
+
+/**
+ * A `listCommits` stub backed by a per-worktree commit pool, honoring the
+ * `limit` argument the way the real API does (`.slice(0, limit)`) rather than
+ * returning the whole pool regardless of what was asked for — this is what
+ * makes assertions like "80 total < 101 requested, so there's no more" (the
+ * `limit + 1` lookahead contract `VcsPanel` relies on) actually meaningful.
+ */
+function limitAwareListCommits(pools: Record<string, CommitLogEntry[]>) {
+  return vi.fn(async (worktreeId: string, limit = 200) => (pools[worktreeId] ?? []).slice(0, limit));
+}
+
+/** A promise plus its resolve/reject, for tests that need to control fetch timing. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("VcsPanel", () => {
+  it("Requirement 1 — fewer than a page of commits: no Load more button, header count matches", async () => {
+    const api = createMockApi();
+    vi.spyOn(api, "listCommits").mockImplementation(limitAwareListCommits({ "wt-1": makeCommits(5) }));
+    vi.spyOn(api, "getPr").mockResolvedValue(null);
+
+    render(<VcsPanel api={api} worktreeId="wt-1" />);
+
+    await screen.findByText("Commits (5)");
+    expect(screen.queryByRole("button", { name: /load 50 more/i })).not.toBeInTheDocument();
+  });
+
+  it("Requirement 2 — more than a page of commits: shows exactly PAGE_SIZE (50) and a Load more button", async () => {
+    const api = createMockApi();
+    const spy = vi.spyOn(api, "listCommits").mockImplementation(limitAwareListCommits({ "wt-1": makeCommits(80) }));
+    vi.spyOn(api, "getPr").mockResolvedValue(null);
+
+    render(<VcsPanel api={api} worktreeId="wt-1" />);
+
+    await screen.findByText("Commits (50)");
+    expect(screen.getByRole("button", { name: /load 50 more/i })).toBeInTheDocument();
+    // The initial fetch requests one lookahead commit beyond the page size,
+    // so "exactly 50 vs. more available" is known for certain rather than
+    // guessed from the page being full.
+    expect(spy).toHaveBeenCalledWith("wt-1", 51);
+  });
+
+  it("Requirement 3 — clicking Load more fetches the next page and appends it", async () => {
+    const user = userEvent.setup();
+    const api = createMockApi();
+    const spy = vi.spyOn(api, "listCommits").mockImplementation(limitAwareListCommits({ "wt-1": makeCommits(80) }));
+    vi.spyOn(api, "getPr").mockResolvedValue(null);
+
+    render(<VcsPanel api={api} worktreeId="wt-1" />);
+    await screen.findByText("Commits (50)");
+
+    await user.click(screen.getByRole("button", { name: /load 50 more/i }));
+
+    await screen.findByText("Commits (80)");
+    expect(spy).toHaveBeenLastCalledWith("wt-1", 101);
+    // The pool only has 80, so the 101-commit request genuinely returns
+    // fewer than asked — the lookahead entry never came back, so there's no
+    // more and the button is gone (not just "the mock ran out").
+    expect(screen.queryByRole("button", { name: /load 50 more/i })).not.toBeInTheDocument();
+  });
+
+  it("Requirement 4 — a failed Load more keeps the already-loaded commits on screen and shows an inline error, not a full-panel error", async () => {
+    const user = userEvent.setup();
+    const api = createMockApi();
+    const spy = vi
+      .spyOn(api, "listCommits")
+      .mockImplementationOnce(limitAwareListCommits({ "wt-1": makeCommits(80) }))
+      .mockRejectedValueOnce(new Error("network blip"));
+    vi.spyOn(api, "getPr").mockResolvedValue(null);
+
+    render(<VcsPanel api={api} worktreeId="wt-1" />);
+    await screen.findByText("Commits (50)");
+
+    await user.click(screen.getByRole("button", { name: /load 50 more/i }));
+
+    await screen.findByText(/failed to load more: network blip/i);
+    // The 50 commits already on screen are untouched — this is not the
+    // full-panel "Failed to load commits" error state.
+    expect(screen.getByText("Commits (50)")).toBeInTheDocument();
+    expect(screen.queryByText(/^failed to load commits/i)).not.toBeInTheDocument();
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it("Requirement 4b — a Refresh after a failed Load more clears the stale load-more error", async () => {
+    const user = userEvent.setup();
+    const api = createMockApi();
+    vi.spyOn(api, "listCommits")
+      .mockImplementationOnce(limitAwareListCommits({ "wt-1": makeCommits(80) }))
+      .mockRejectedValueOnce(new Error("network blip"))
+      .mockImplementation(limitAwareListCommits({ "wt-1": makeCommits(80) }));
+    vi.spyOn(api, "getPr").mockResolvedValue(null);
+
+    render(<VcsPanel api={api} worktreeId="wt-1" />);
+    await screen.findByText("Commits (50)");
+    await user.click(screen.getByRole("button", { name: /load 50 more/i }));
+    await screen.findByText(/failed to load more: network blip/i);
+
+    await user.click(screen.getByRole("button", { name: /refresh commits/i }));
+    await waitFor(() => expect(screen.queryByText(/failed to load more/i)).not.toBeInTheDocument());
+    expect(screen.getByText("Commits (50)")).toBeInTheDocument();
+  });
+
+  it("Requirement 5 — own vs. upstream split: own commits render inline, upstream ones start collapsed behind an expand toggle", async () => {
+    const user = userEvent.setup();
+    const api = createMockApi();
+    // 3 own commits (newest), then 4 upstream commits.
+    vi.spyOn(api, "listCommits").mockImplementation(
+      limitAwareListCommits({ "wt-1": makeCommits(7, { isOnBranch: (i) => i < 3 }) }),
+    );
+    vi.spyOn(api, "getPr").mockResolvedValue(null);
+
+    render(<VcsPanel api={api} worktreeId="wt-1" baseBranch="main" />);
+    await screen.findByText("Commits (7)");
+
+    expect(screen.getByText("commit #0")).toBeInTheDocument();
+    expect(screen.getByText("commit #2")).toBeInTheDocument();
+    expect(screen.queryByText("commit #3")).not.toBeInTheDocument();
+
+    const toggle = screen.getByRole("button", { name: /expand commits from main/i });
+    expect(within(toggle).getByText("4")).toBeInTheDocument();
+
+    await user.click(toggle);
+    await waitFor(() => expect(screen.getByText("commit #3")).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: /collapse commits from main/i })).toBeInTheDocument();
+  });
+
+  it("Requirement 6 — switching worktreeId resets pagination back to one page, even after Load more advanced it", async () => {
+    const user = userEvent.setup();
+    const api = createMockApi();
+    const spy = vi.spyOn(api, "listCommits").mockImplementation(
+      limitAwareListCommits({ "wt-1": makeCommits(80), "wt-2": makeCommits(3) }),
+    );
+    vi.spyOn(api, "getPr").mockResolvedValue(null);
+
+    const { rerender } = render(<VcsPanel api={api} worktreeId="wt-1" />);
+    await screen.findByText("Commits (50)");
+    await user.click(screen.getByRole("button", { name: /load 50 more/i }));
+    await screen.findByText("Commits (80)");
+
+    rerender(<VcsPanel api={api} worktreeId="wt-2" />);
+    // Resets to one page (limit 51), not a continuation of wt-1's advanced
+    // pageLimit (which would have requested 101).
+    await waitFor(() => expect(spy).toHaveBeenLastCalledWith("wt-2", 51));
+    await screen.findByText("Commits (3)");
+  });
+
+  it("Requirement 7 — Load more auto-expands an already-collapsed upstream group", async () => {
+    const user = userEvent.setup();
+    const api = createMockApi();
+    // Page 1 (50 commits): all own. Page 2 adds 10 more, all upstream — the
+    // common "everything past page 1 is base-branch history" shape.
+    vi.spyOn(api, "listCommits").mockImplementation(
+      limitAwareListCommits({ "wt-1": makeCommits(60, { isOnBranch: (i) => i < 50 }) }),
+    );
+    vi.spyOn(api, "getPr").mockResolvedValue(null);
+
+    render(<VcsPanel api={api} worktreeId="wt-1" baseBranch="main" />);
+    await screen.findByText("Commits (50)");
+    expect(screen.queryByText("commit #55")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /load 50 more/i }));
+
+    // Without auto-expand, this commit would be loaded but hidden behind a
+    // still-collapsed group — clicking "Load more" would be a no-visible-op.
+    await screen.findByText("commit #55");
+    expect(screen.getByRole("button", { name: /collapse commits from main/i })).toBeInTheDocument();
+  });
+
+  it("Requirement 8 — a stale in-flight Load more for the previous worktree never overwrites the new worktree's state", async () => {
+    const api = createMockApi();
+    const wt1First = deferred<CommitLogEntry[]>();
+    const spy = vi
+      .spyOn(api, "listCommits")
+      .mockImplementationOnce(() => Promise.resolve(makeCommits(80).slice(0, 51))) // wt-1 initial load
+      .mockImplementationOnce(() => wt1First.promise) // wt-1 "Load more" — held open
+      .mockImplementation(limitAwareListCommits({ "wt-2": makeCommits(3) })); // wt-2 initial load
+    vi.spyOn(api, "getPr").mockResolvedValue(null);
+
+    const user = userEvent.setup();
+    const { rerender } = render(<VcsPanel api={api} worktreeId="wt-1" />);
+    await screen.findByText("Commits (50)");
+    await user.click(screen.getByRole("button", { name: /load 50 more/i }));
+    // wt-1's "Load more" is now in flight and held open by `wt1First`.
+
+    rerender(<VcsPanel api={api} worktreeId="wt-2" />);
+    await screen.findByText("Commits (3)");
+
+    // Now let the stale wt-1 response resolve — it must be discarded, not
+    // clobber wt-2's already-rendered state.
+    wt1First.resolve(makeCommits(80).slice(0, 101));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.getByText("Commits (3)")).toBeInTheDocument();
+    expect(spy).toHaveBeenCalledTimes(3);
+  });
+});

--- a/web-ui/src/components/tools/VcsPanel.tsx
+++ b/web-ui/src/components/tools/VcsPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { ChevronRight, ExternalLink, GitCommit, GitMerge, GitPullRequest, GitPullRequestClosed, GitPullRequestDraft, RefreshCw } from "lucide-react";
 import type { ApiInstance } from "@/api";
 import type { CommitLogEntry, PrInfo } from "@/api/types";
@@ -6,6 +6,8 @@ import type { CommitLogEntry, PrInfo } from "@/api/types";
 interface VcsPanelProps {
   api: ApiInstance;
   worktreeId: string;
+  /** Worktree's base branch (e.g. "main"), used to label the collapsed upstream-commits group. */
+  baseBranch?: string;
 }
 
 /** Relative time like "3m ago", "2h ago", "5d ago"; falls back to a date past ~30d. */
@@ -66,24 +68,129 @@ function PrBanner({ pr }: { pr: PrInfo }) {
   );
 }
 
+/** One row of the commit graph — a single commit's card, with expand/collapse for its body. */
+function CommitRow({
+  c,
+  isOpen,
+  onToggle,
+}: {
+  c: CommitLogEntry;
+  isOpen: boolean;
+  onToggle: () => void;
+}) {
+  // Only commits with a body beyond the subject line get the expand
+  // affordance — a bare one-line commit has nothing more to reveal, so
+  // tapping it would just be a no-op toggle.
+  const hasBody = c.body.trim() !== c.subject.trim() && c.body.trim() !== "";
+  return (
+    <li className="vcs-graph__item">
+      <div className="vcs-graph__rail">
+        <span className="vcs-graph__dot">
+          <GitCommit size={11} aria-hidden />
+        </span>
+        <span className="vcs-graph__line" aria-hidden />
+      </div>
+      <div
+        className={`vcs-graph__card${hasBody ? " vcs-graph__card--expandable" : ""}`}
+        role={hasBody ? "button" : undefined}
+        tabIndex={hasBody ? 0 : undefined}
+        aria-expanded={hasBody ? isOpen : undefined}
+        onClick={hasBody ? onToggle : undefined}
+        onKeyDown={
+          hasBody
+            ? (e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  onToggle();
+                }
+              }
+            : undefined
+        }
+      >
+        <div className="vcs-graph__subject-row">
+          <span className="vcs-graph__subject" title={hasBody ? undefined : c.subject}>
+            {c.subject || "(no message)"}
+          </span>
+        </div>
+        {hasBody && isOpen ? <pre className="vcs-graph__body">{c.body}</pre> : null}
+        <div className="vcs-graph__meta">
+          {hasBody ? (
+            <ChevronRight
+              size={12}
+              aria-hidden
+              className={`vcs-graph__chevron${isOpen ? " vcs-graph__chevron--open" : ""}`}
+            />
+          ) : null}
+          <span className="vcs-graph__avatar" title={c.authorName}>
+            {initials(c.authorName)}
+          </span>
+          <span className="vcs-graph__author">{c.authorName}</span>
+          <span className="vcs-graph__dot-sep" aria-hidden>
+            ·
+          </span>
+          <span className="vcs-graph__time" title={c.date}>
+            {relativeTime(c.date)}
+          </span>
+          <span className="vcs-graph__dot-sep" aria-hidden>
+            ·
+          </span>
+          <code className="vcs-graph__sha">{c.shortSha}</code>
+          <span className="vcs-graph__stats">
+            {c.insertions > 0 ? <span className="vcs-graph__add">+{c.insertions}</span> : null}
+            {c.deletions > 0 ? <span className="vcs-graph__del">−{c.deletions}</span> : null}
+            {c.insertions === 0 && c.deletions === 0 ? (
+              <span className="vcs-graph__nochange">no changes</span>
+            ) : null}
+          </span>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+/** Commits fetched and shown per page — an initial load, and each "Load more" click. */
+const PAGE_SIZE = 50;
+
+/** Mirrors the `limit` clamp `GET /worktrees/:id/commits` applies server-side (`daemon/src/routes/worktrees.ts`). */
+const SERVER_MAX_LIMIT = 1000;
+
 /**
  * VCS tool — a vertical commit graph for the current worktree's branch, most
  * recent commit on top, plus a PR banner (linking out to GitHub) when the
  * branch has one. Each commit row shows the subject, author, relative time,
  * short SHA, and a +/- diffstat badge. Fetches `GET /worktrees/:id/commits`
- * and `GET /worktrees/:id/pr` once on mount / worktree change and on manual
- * refresh; no live updates yet (commits/PR state changes aren't
- * push-notified to the UI today).
+ * and `GET /worktrees/:id/pr` on mount / worktree change and on manual
+ * refresh (both reset back to one page of `PAGE_SIZE` commits), plus again
+ * for each additional page on "Load more"; no live updates yet (commits/PR
+ * state changes aren't push-notified to the UI today).
  */
-export function VcsPanel({ api, worktreeId }: VcsPanelProps) {
+export function VcsPanel({ api, worktreeId, baseBranch }: VcsPanelProps) {
+  // `commits` holds at most `pageLimit + 1` entries — the lookahead extra
+  // entry (never rendered) is how `hasMore` is known for certain instead of
+  // guessed from `commits.length === pageLimit`, which can't tell "exactly
+  // that many commits total" apart from "more are available".
   const [commits, setCommits] = useState<CommitLogEntry[] | null>(null);
   const [pr, setPr] = useState<PrInfo | null>(null);
+  // Initial-load/refresh failure — blocks the whole panel, since there's
+  // nothing else to show yet (or the refresh is presumed stale/distrusted).
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  // "Load more" failure — shown inline near the button instead, so a blip
+  // fetching page 2 doesn't blank out the page of commits already on screen.
+  const [loadMoreError, setLoadMoreError] = useState<string | null>(null);
+  // How many commits the user has asked to see (starts at one page, grows by
+  // PAGE_SIZE per "Load more" click). Resets to PAGE_SIZE on worktree change
+  // and on manual refresh — a stale "load more" position from a previous
+  // worktree/session would be confusing carried over.
+  const [pageLimit, setPageLimit] = useState(PAGE_SIZE);
   // Shas whose full message is expanded. A Set rather than a single
   // "expandedSha" so multiple commits can be open at once (mirrors how e.g.
   // GitHub's PR commit list behaves) — tapping a row toggles just that row.
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+  // Collapsed by default — upstream/base-branch history isn't the point of
+  // this view, so it starts hidden behind an explicit expand.
+  const [upstreamOpen, setUpstreamOpen] = useState(false);
 
   const toggleExpanded = (sha: string) => {
     setExpanded((prev) => {
@@ -94,47 +201,127 @@ export function VcsPanel({ api, worktreeId }: VcsPanelProps) {
     });
   };
 
-  useEffect(() => {
+  const hasMore = commits != null && commits.length > pageLimit && pageLimit < SERVER_MAX_LIMIT;
+  // The daemon's `GET /worktrees/:id/commits` clamps `limit` to 1000 (see
+  // `daemon/src/routes/worktrees.ts`) — once a page hits that ceiling with a
+  // full page of commits, "no more available" and "1000+ commits, server
+  // won't return past its clamp" are indistinguishable from the response
+  // alone. Rather than silently hiding "Load more" either way (which reads
+  // as "that's the whole history" even when it isn't), this is surfaced
+  // explicitly below instead.
+  const reachedServerCap = pageLimit >= SERVER_MAX_LIMIT && commits != null && commits.length >= SERVER_MAX_LIMIT;
+  // The page currently on screen — trims off the lookahead entry `hasMore`
+  // uses, so it never gets to leak into the split below or the rendered list.
+  const pageCommits = useMemo(
+    () => (commits == null ? null : commits.slice(0, pageLimit)),
+    [commits, pageLimit],
+  );
+
+  // Commits come back most-recent-first with `isOnBranch` already computed
+  // server-side against the worktree's `baseSha`. In the common case (no
+  // merges back from the base branch mid-history) the branch's own commits
+  // form a contiguous prefix, so splitting at the first `isOnBranch: false`
+  // is enough — everything from there down is base-branch/upstream history
+  // and gets grouped under the collapsed section below. A branch that merged
+  // main back into itself partway through can interleave `isOnBranch: true`
+  // commits after that point; those still get bucketed as upstream here,
+  // which is an acceptable simplification for this view (they're still
+  // visible, just under "from <base>" instead of inline).
+  const { ownCommits, upstreamCommits } = useMemo(() => {
+    if (!pageCommits) return { ownCommits: [], upstreamCommits: [] };
+    const splitIdx = pageCommits.findIndex((c) => !c.isOnBranch);
+    if (splitIdx === -1) return { ownCommits: pageCommits, upstreamCommits: [] };
+    return { ownCommits: pageCommits.slice(0, splitIdx), upstreamCommits: pageCommits.slice(splitIdx) };
+  }, [pageCommits]);
+
+  // The controller for whichever fetch is currently in flight. Centralizing
+  // cancellation here (rather than only aborting on effect cleanup) is what
+  // makes it safe to fire a "Load more" or "Refresh" from an event handler,
+  // not just from the effect: every `load()` call aborts whatever it's
+  // superseding before starting, so a `loadMore` for the *old* worktree that
+  // was still in flight when the user switched worktrees can never resolve
+  // into the new worktree's state — the worktree-change effect's own `load()`
+  // call aborts it as its very first step.
+  const activeLoad = useRef<AbortController | null>(null);
+
+  // Shared loader for the initial fetch, "Load more", and manual refresh —
+  // `limit` is how many commits the caller wants to end up displaying;
+  // `limit + 1` is what's actually requested from the API so `hasMore` above
+  // has a definite answer rather than a guess.
+  const load = (limit: number, mode: "initial" | "more" = "initial") => {
+    activeLoad.current?.abort();
     const controller = new AbortController();
-    setLoading(true);
-    setError(null);
-    Promise.all([
-      api.listCommits(worktreeId),
+    activeLoad.current = controller;
+    const { signal } = controller;
+
+    if (mode === "initial") {
+      setLoading(true);
+      setError(null);
+      // A prior page's "Load more" failure is no longer relevant once we're
+      // re-fetching from scratch (refresh, or a worktree switch) — leaving
+      // it set would show a stale failure next to a button that hasn't
+      // actually failed since this fetch started.
+      setLoadMoreError(null);
+    } else {
+      setLoadingMore(true);
+      setLoadMoreError(null);
+    }
+    return Promise.all([
+      api.listCommits(worktreeId, limit + 1),
       // PR lookup is best-effort — a failure here shouldn't blank out the
-      // commit list, so it's swallowed to null rather than propagated.
-      api.getPr(worktreeId).catch(() => null),
+      // commit list, so it's swallowed to null rather than propagated. Only
+      // refetched on "initial" (mount/worktree-change/refresh) — a "Load
+      // more" page is more commits of the same worktree, so the PR banner
+      // can't have changed as a side effect of it.
+      mode === "initial" ? api.getPr(worktreeId).catch(() => null) : Promise.resolve(undefined),
     ])
       .then(([list, prInfo]) => {
-        if (controller.signal.aborted) return;
+        if (signal.aborted) return;
         setCommits(list);
-        setPr(prInfo);
+        if (prInfo !== undefined) setPr(prInfo);
+        setPageLimit(limit);
       })
       .catch((err: unknown) => {
-        if (controller.signal.aborted) return;
-        setError(err instanceof Error ? err.message : String(err));
+        if (signal.aborted) return;
+        const message = err instanceof Error ? err.message : String(err);
+        // Route the error so a failed "load more" only annotates the button
+        // rather than replacing the page of commits already on screen (see
+        // the `error` vs `loadMoreError` state comments above).
+        if (mode === "initial") setError(message);
+        else setLoadMoreError(message);
       })
       .finally(() => {
-        if (!controller.signal.aborted) setLoading(false);
+        if (signal.aborted) return;
+        if (mode === "initial") setLoading(false);
+        else setLoadingMore(false);
       });
-    return () => controller.abort();
+  };
+
+  useEffect(() => {
+    void load(PAGE_SIZE, "initial");
+    return () => activeLoad.current?.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `load` is redefined every render (reads current api/worktreeId via closure); depending on worktreeId/api alone matches the pre-existing effect's deps.
   }, [api, worktreeId]);
 
   const refresh = () => {
-    setLoading(true);
-    setError(null);
-    Promise.all([api.listCommits(worktreeId), api.getPr(worktreeId).catch(() => null)])
-      .then(([list, prInfo]) => {
-        setCommits(list);
-        setPr(prInfo);
-      })
-      .catch((err: unknown) => setError(err instanceof Error ? err.message : String(err)))
-      .finally(() => setLoading(false));
+    void load(PAGE_SIZE, "initial");
+  };
+
+  const loadMore = () => {
+    // For a typical worktree, page 1 already contains the whole own-commit
+    // prefix — every subsequent page is entirely upstream history. Without
+    // this, clicking "Load more" while the upstream group is still
+    // collapsed would be a no-visible-op (only the collapsed header's count
+    // badge changes). Auto-expanding is a no-op itself when there's nothing
+    // upstream yet (the group doesn't render at all until there is).
+    setUpstreamOpen(true);
+    void load(Math.min(pageLimit + PAGE_SIZE, SERVER_MAX_LIMIT), "more");
   };
 
   return (
     <div className="vcs-panel">
       <div className="vcs-panel__bar">
-        <span className="vcs-panel__title">Commits{commits ? ` (${commits.length})` : ""}</span>
+        <span className="vcs-panel__title">Commits{pageCommits ? ` (${pageCommits.length})` : ""}</span>
         <button
           type="button"
           className="tab tab--icon tool-bar-btn"
@@ -150,88 +337,70 @@ export function VcsPanel({ api, worktreeId }: VcsPanelProps) {
       <div className="vcs-panel__body">
         {error ? (
           <div className="empty-state">Failed to load commits: {error}</div>
-        ) : commits == null ? (
+        ) : pageCommits == null ? (
           <div className="empty-state">Loading commits…</div>
-        ) : commits.length === 0 ? (
+        ) : pageCommits.length === 0 ? (
+          // ownCommits/upstreamCommits partition pageCommits, so this also
+          // covers the "both empty" case — no separate branch needed for it.
           <div className="empty-state">No commits on this branch yet</div>
         ) : (
-          <ol className="vcs-graph">
-            {commits.map((c) => {
-              // Only commits with a body beyond the subject line get the
-              // expand affordance — a bare one-line commit has nothing more
-              // to reveal, so tapping it would just be a no-op toggle.
-              const hasBody = c.body.trim() !== c.subject.trim() && c.body.trim() !== "";
-              const isOpen = expanded.has(c.sha);
-              return (
-                <li key={c.sha} className="vcs-graph__item">
-                  <div className="vcs-graph__rail">
-                    <span className="vcs-graph__dot">
-                      <GitCommit size={11} aria-hidden />
-                    </span>
-                    <span className="vcs-graph__line" aria-hidden />
-                  </div>
-                  <div
-                    className={`vcs-graph__card${hasBody ? " vcs-graph__card--expandable" : ""}`}
-                    role={hasBody ? "button" : undefined}
-                    tabIndex={hasBody ? 0 : undefined}
-                    aria-expanded={hasBody ? isOpen : undefined}
-                    onClick={hasBody ? () => toggleExpanded(c.sha) : undefined}
-                    onKeyDown={
-                      hasBody
-                        ? (e) => {
-                            if (e.key === "Enter" || e.key === " ") {
-                              e.preventDefault();
-                              toggleExpanded(c.sha);
-                            }
-                          }
-                        : undefined
-                    }
-                  >
-                    <div className="vcs-graph__subject-row">
-                      <span className="vcs-graph__subject" title={hasBody ? undefined : c.subject}>
-                        {c.subject || "(no message)"}
-                      </span>
-                    </div>
-                    {hasBody && isOpen ? <pre className="vcs-graph__body">{c.body}</pre> : null}
-                    <div className="vcs-graph__meta">
-                      {hasBody ? (
-                        <ChevronRight
-                          size={12}
-                          aria-hidden
-                          className={`vcs-graph__chevron${isOpen ? " vcs-graph__chevron--open" : ""}`}
-                        />
-                      ) : null}
-                      <span className="vcs-graph__avatar" title={c.authorName}>
-                        {initials(c.authorName)}
-                      </span>
-                      <span className="vcs-graph__author">{c.authorName}</span>
-                      <span className="vcs-graph__dot-sep" aria-hidden>
-                        ·
-                      </span>
-                      <span className="vcs-graph__time" title={c.date}>
-                        {relativeTime(c.date)}
-                      </span>
-                      <span className="vcs-graph__dot-sep" aria-hidden>
-                        ·
-                      </span>
-                      <code className="vcs-graph__sha">{c.shortSha}</code>
-                      <span className="vcs-graph__stats">
-                        {c.insertions > 0 ? (
-                          <span className="vcs-graph__add">+{c.insertions}</span>
-                        ) : null}
-                        {c.deletions > 0 ? (
-                          <span className="vcs-graph__del">−{c.deletions}</span>
-                        ) : null}
-                        {c.insertions === 0 && c.deletions === 0 ? (
-                          <span className="vcs-graph__nochange">no changes</span>
-                        ) : null}
-                      </span>
-                    </div>
-                  </div>
-                </li>
-              );
-            })}
-          </ol>
+          <>
+            {ownCommits.length > 0 ? (
+              <ol className="vcs-graph">
+                {ownCommits.map((c) => (
+                  <CommitRow key={c.sha} c={c} isOpen={expanded.has(c.sha)} onToggle={() => toggleExpanded(c.sha)} />
+                ))}
+              </ol>
+            ) : (
+              <div className="empty-state">No commits on this branch yet</div>
+            )}
+            {upstreamCommits.length > 0 ? (
+              <div className="vcs-upstream-group">
+                <button
+                  type="button"
+                  className="vcs-upstream-group__header"
+                  aria-expanded={upstreamOpen}
+                  onClick={() => setUpstreamOpen((v) => !v)}
+                >
+                  <span className="vcs-upstream-group__chevron" aria-hidden>
+                    {upstreamOpen ? "▼" : "▶"}
+                  </span>
+                  <span className="vcs-upstream-group__label">
+                    {upstreamOpen ? "Collapse" : "Expand"} commits from {baseBranch || "upstream branch"}
+                  </span>
+                  <span className="vcs-upstream-group__count">{upstreamCommits.length}</span>
+                </button>
+                {upstreamOpen ? (
+                  <ol className="vcs-graph vcs-graph--upstream">
+                    {upstreamCommits.map((c) => (
+                      <CommitRow
+                        key={c.sha}
+                        c={c}
+                        isOpen={expanded.has(c.sha)}
+                        onToggle={() => toggleExpanded(c.sha)}
+                      />
+                    ))}
+                  </ol>
+                ) : null}
+              </div>
+            ) : null}
+            {hasMore ? (
+              <div className="vcs-load-more-row">
+                <button type="button" className="vcs-load-more" onClick={loadMore} disabled={loadingMore}>
+                  {loadingMore ? "Loading…" : `Load ${PAGE_SIZE} more`}
+                </button>
+                {loadMoreError ? (
+                  <span className="vcs-load-more-error">Failed to load more: {loadMoreError}</span>
+                ) : null}
+              </div>
+            ) : reachedServerCap ? (
+              <div className="vcs-load-more-row">
+                <span className="vcs-load-more-cap">
+                  Showing the most recent {SERVER_MAX_LIMIT} commits — older history isn't loaded here.
+                </span>
+              </div>
+            ) : null}
+          </>
         )}
       </div>
     </div>

--- a/web-ui/src/routes/Workspace.tsx
+++ b/web-ui/src/routes/Workspace.tsx
@@ -305,7 +305,11 @@ export function Workspace() {
             : {
                 agentPane,
                 toolPanel: (
-                  <ToolPanel api={api} worktreeId={activeWorktreeId} />
+                  <ToolPanel
+                    api={api}
+                    worktreeId={activeWorktreeId}
+                    baseBranch={worktrees.find((w) => w.id === activeWorktreeId)?.baseBranch}
+                  />
                 ),
                 terminalDock,
               })}

--- a/web-ui/src/styles/workspace.css
+++ b/web-ui/src/styles/workspace.css
@@ -3940,6 +3940,95 @@ a.dashboard-card.dashboard-card--session {
   font-style: italic;
 }
 
+.vcs-upstream-group {
+  margin-top: var(--space-2);
+}
+
+.vcs-upstream-group__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-2);
+  border: var(--border-width) dashed var(--border-default);
+  background: transparent;
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-xs);
+  color: var(--fg-muted);
+  text-align: left;
+  cursor: pointer;
+}
+
+.vcs-upstream-group__header:hover {
+  background: var(--bg-hover);
+}
+
+.vcs-upstream-group__chevron {
+  display: inline-flex;
+  width: 14px;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.vcs-upstream-group__label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.vcs-upstream-group__count {
+  flex-shrink: 0;
+  font-size: 10px;
+  font-family: var(--font-mono);
+  color: var(--fg-muted);
+  opacity: 0.85;
+}
+
+.vcs-graph--upstream {
+  margin-top: var(--space-3);
+  opacity: 0.85;
+}
+
+.vcs-load-more-row {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-1);
+  margin-top: var(--space-3);
+}
+
+.vcs-load-more {
+  padding: var(--space-1) var(--space-3);
+  border: var(--border-width) solid var(--border-default);
+  background: transparent;
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-xs);
+  color: var(--fg-secondary);
+  cursor: pointer;
+}
+
+.vcs-load-more:hover:not(:disabled) {
+  background: var(--bg-hover);
+}
+
+.vcs-load-more:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.vcs-load-more-error {
+  font-size: var(--font-size-xs);
+  color: var(--fg-danger, #f85149);
+}
+
+.vcs-load-more-cap {
+  font-size: var(--font-size-xs);
+  color: var(--fg-muted);
+  text-align: center;
+}
+
 .artifacts-panel__badge {
   font-size: var(--font-size-xs);
   text-transform: uppercase;


### PR DESCRIPTION
## Summary
- The VCS tab's commit list now tags each commit `isOnBranch` (server-side, via `git rev-list HEAD --not <baseSha>`) and splits it into the branch's own commits (shown inline) vs. base-branch/upstream history, which starts collapsed behind an "Expand commits from `<base>`" toggle.
- The commit list is now paginated — 50 at a time, with a "Load more" button. Uses a `limit+1` lookahead so "more available" is known for certain, cancels superseded in-flight requests via an active-request ref (fixes a real race where a stale worktree's in-flight "Load more" could clobber a newly-switched worktree's state), keeps a "load more" failure from blanking out already-loaded commits, and surfaces the daemon's 1000-commit clamp explicitly instead of silently hiding the button.
- `scripts/dev-sandbox.sh` (the hot-reload, no-auth dev sandbox) gained a `--seed=file-search|demo` flag so it can optionally seed the same realistic 3-project/9-worktree/14-session dataset `docker-compose.screenshots.yml` uses — useful for testing against real worktrees/agent sessions instead of an empty tree. Required reordering `scripts/dev-entrypoint.sh` since the two seed scripts have opposite ordering requirements relative to the daemon (one writes manifests directly to disk pre-boot, the other registers via live REST calls post-boot) — a real bug caught and fixed live during development (seeding after boot silently produced an empty project list).
- Documented both dev-sandbox setups in `AGENTS.md`, including the two seed scripts' asymmetric idempotency guards.

This changeset was reviewed end-to-end by an independent Opus review pass; the review surfaced (and this PR fixes) two real bugs — the stale in-flight-request race above, and a stale "load more" error message that could survive a successful refresh — plus several quality issues (dead code, a test that didn't test what it claimed, an inaccurate doc claim about seed-script idempotency, a `--seed` flag that could be silently overridden by an inherited env var, and more).

## Test plan
- [x] `pnpm typecheck` (daemon/cli + web-ui) clean
- [x] `pnpm lint` clean on all touched files (pre-existing, unrelated lint errors in `cli/src/__tests__/daemon-client.test.ts` confirmed via `git stash` to predate this branch)
- [x] Full `cli` test suite: 634/634 passing (one pre-existing, unrelated unhandled-rejection warning confirmed via `git stash` to predate this branch)
- [x] Full `web-ui` test suite: 350/350 passing, including a new `VcsPanel.test.tsx` (9 cases: pagination boundaries, load-more fetch/append, load-more-failure isolation, refresh clearing a stale load-more error, own/upstream split + collapse toggle, pagination reset on worktree switch, auto-expand on load-more, and the stale-in-flight-request race) and 3 new backend tests in `git.commits.test.ts` for `isOnBranch` (base vs. own commits, no `baseSha` passed, invalid `baseSha` fails open)
- [x] Manually verified end-to-end in a live docker dev sandbox: seeded real git history on a worktree (own commits + fabricated upstream history), confirmed the API returns the correct `isOnBranch` split and the UI renders/collapses/expands correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)