### PR TITLE
fix(daemon): resolve VCS tab fork point live instead of caching it

### DIFF
--- a/daemon/src/__tests__/git.resolveBaseSha.test.ts
+++ b/daemon/src/__tests__/git.resolveBaseSha.test.ts
@@ -1,0 +1,89 @@
+/**
+ * `resolveBaseSha()` — recomputes a worktree's current fork point against
+ * `baseBranch` live (`git merge-base HEAD <baseBranch>`) instead of trusting
+ * a `baseSha` value cached at worktree-creation time. See git.ts's doc
+ * comment for why a cached value goes stale: a long-running branch that gets
+ * synced/rebased onto an advancing base branch moves its true fork point
+ * forward, but a cached `baseSha` doesn't follow — every commit the base
+ * branch picked up since caching then misreads as "unique to this branch"
+ * wherever the stale value is used.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { resolveBaseSha } from "../services/git.js";
+import { createGitFixture, removeGitFixture, type GitFixture } from "./gitFixture.js";
+
+let fixture: GitFixture;
+let repoDir: string;
+let git: GitFixture["git"];
+
+describe("resolveBaseSha", () => {
+  beforeEach(async () => {
+    fixture = await createGitFixture("vst-git-resolve-base-test");
+    repoDir = fixture.dir;
+    git = fixture.git;
+  });
+
+  afterEach(async () => {
+    await removeGitFixture(fixture);
+  });
+
+  it("returns the live merge-base with baseBranch, not a stale cached value", async () => {
+    // Original fork point.
+    await writeFile(join(repoDir, "a.txt"), "a\n");
+    git(["add", "-A"]);
+    git(["commit", "-q", "-m", "commit 1"]);
+    const staleBaseSha = git(["rev-parse", "HEAD"]).trim();
+
+    // Branch off, add the branch's own commit.
+    git(["checkout", "-q", "-b", "feature"]);
+    await writeFile(join(repoDir, "b.txt"), "b\n");
+    git(["add", "-A"]);
+    git(["commit", "-q", "-m", "own commit"]);
+
+    // main advances after the branch was cut, and the branch syncs with it
+    // (merges main forward) — simulating a long-running branch workflow.
+    git(["checkout", "-q", "main"]);
+    await writeFile(join(repoDir, "c.txt"), "c\n");
+    git(["add", "-A"]);
+    git(["commit", "-q", "-m", "main advances"]);
+    const newMainTip = git(["rev-parse", "HEAD"]).trim();
+
+    git(["checkout", "-q", "feature"]);
+    git(["merge", "-q", "-m", "sync with main", "main"]);
+
+    // The stale cached baseSha still resolves, but it's no longer the true
+    // fork point — merge-base with current main has moved to newMainTip.
+    const resolved = await resolveBaseSha(repoDir, "main", staleBaseSha);
+    expect(resolved).toBe(newMainTip);
+    expect(resolved).not.toBe(staleBaseSha);
+  });
+
+  it("falls back to the stored baseSha when baseBranch doesn't resolve", async () => {
+    await writeFile(join(repoDir, "a.txt"), "a\n");
+    git(["add", "-A"]);
+    git(["commit", "-q", "-m", "commit 1"]);
+    const baseSha = git(["rev-parse", "HEAD"]).trim();
+
+    const resolved = await resolveBaseSha(repoDir, "does-not-exist-branch", baseSha);
+    expect(resolved).toBe(baseSha);
+  });
+
+  it("returns null when neither baseBranch nor the fallback resolves", async () => {
+    await writeFile(join(repoDir, "a.txt"), "a\n");
+    git(["add", "-A"]);
+    git(["commit", "-q", "-m", "commit 1"]);
+
+    // A well-formed but nonexistent SHA (not the all-zero null oid, which
+    // `git rev-parse --verify` treats as a special case and resolves without
+    // error rather than failing like a genuinely absent object would).
+    const resolved = await resolveBaseSha(repoDir, "does-not-exist-branch", "f".repeat(40));
+    expect(resolved).toBeNull();
+  });
+
+  it("returns null when baseBranch is absent and no fallback is given", async () => {
+    const resolved = await resolveBaseSha(repoDir, null, null);
+    expect(resolved).toBeNull();
+  });
+});

--- a/daemon/src/routes/worktrees.ts
+++ b/daemon/src/routes/worktrees.ts
@@ -8,7 +8,15 @@ import { getProject, getAllProjects, mutateProject } from "../state/project-stor
 import { validateBranch, branchExistsInRepo } from "../services/branchValidator.js";
 import { reserveNextWorktreeNum, generateSessionId, tmuxNameForSession } from "../services/sessionId.js";
 import { slugifyPrompt } from "../services/naming.js";
-import { worktreeAdd, worktreeRemove, revParse, fetchOrigin, branchExists, listCommits } from "../services/git.js";
+import {
+  worktreeAdd,
+  worktreeRemove,
+  revParse,
+  fetchOrigin,
+  branchExists,
+  listCommits,
+  resolveBaseSha,
+} from "../services/git.js";
 import { getRemoteUrl, parseGithubRepo, fetchPrForBranch } from "../services/github.js";
 import { rollbackWorktreeCreate } from "../services/rollback.js";
 import { spawnSession } from "../services/spawn.js";
@@ -953,6 +961,14 @@ export function registerWorktreeRoutes(app: FastifyInstance): void {
     const worktree = project.worktrees.find((w) => w.id === wtId)!;
     const wtPath = getWorktreePath(project.id, wtId);
 
+    const baseSha =
+      scope === "branch"
+        ? await resolveBaseSha(wtPath, worktree.baseBranch, worktree.baseSha)
+        : null;
+    if (scope === "branch" && !baseSha) {
+      return reply.status(422).send({ error: "Could not resolve base branch fork point" });
+    }
+
     const gitArgs =
       scope === "branch"
         ? ([
@@ -961,7 +977,7 @@ export function registerWorktreeRoutes(app: FastifyInstance): void {
             "-c",
             "core.quotepath=false",
             "diff",
-            worktree.baseSha,
+            baseSha!,
             "--",
             filePath,
           ] as const)
@@ -1042,9 +1058,13 @@ export function registerWorktreeRoutes(app: FastifyInstance): void {
 
     try {
       if (scope === "branch") {
+        const branchBaseSha = await resolveBaseSha(wtPath, worktree.baseBranch, worktree.baseSha);
+        if (!branchBaseSha) {
+          return reply.status(422).send({ error: "Could not resolve base branch fork point" });
+        }
         const ns = spawnSync(
           "git",
-          ["-c", "core.quotepath=false", "diff", "-z", "--name-status", worktree.baseSha],
+          ["-c", "core.quotepath=false", "diff", "-z", "--name-status", branchBaseSha],
           {
             cwd: wtPath,
             encoding: "utf-8",
@@ -1101,7 +1121,8 @@ export function registerWorktreeRoutes(app: FastifyInstance): void {
 
     const wtPath = getWorktreePath(project.id, wtId);
     try {
-      const commits = await listCommits(wtPath, limit, worktree.baseSha);
+      const baseSha = await resolveBaseSha(wtPath, worktree.baseBranch, worktree.baseSha);
+      const commits = await listCommits(wtPath, limit, baseSha ?? undefined);
       return reply.send({ commits });
     } catch (err) {
       return reply.status(500).send({ error: `commits failed: ${String(err)}` });

--- a/daemon/src/services/git.ts
+++ b/daemon/src/services/git.ts
@@ -130,6 +130,47 @@ export async function revParse(repoPath: string, ref: string): Promise<string> {
   return runGit(["-C", repoPath, "rev-parse", ref]);
 }
 
+/**
+ * Resolves the *current* fork point between `HEAD` and `baseBranch` in the
+ * given worktree (`git merge-base HEAD <baseBranch>`), falling back to
+ * `fallbackBaseSha` (the worktree's stored, creation-time `baseSha`) if
+ * `baseBranch` doesn't resolve — e.g. it was deleted/renamed upstream.
+ *
+ * A worktree's stored `baseSha` is captured once, at creation time, and
+ * never updated. If the branch is later synced/rebased onto an advancing
+ * base branch (a normal, expected workflow for long-running branches), the
+ * true fork point moves forward but the stored value doesn't — every commit
+ * the base branch picked up since creation then reads as "unique to this
+ * branch" wherever `baseSha` is used for branch-scoped diffs/commit lists.
+ * Recomputing the merge-base live avoids that drift. Returns null if neither
+ * `baseBranch` nor the fallback resolves (e.g. a corrupted/pruned repo).
+ */
+export async function resolveBaseSha(
+  repoPath: string,
+  baseBranch: string | null | undefined,
+  fallbackBaseSha?: string | null,
+): Promise<string | null> {
+  if (baseBranch) {
+    try {
+      return await runGit(["-C", repoPath, "merge-base", "HEAD", baseBranch], repoPath);
+    } catch {
+      // baseBranch ref doesn't resolve (deleted/renamed) — fall through.
+    }
+  }
+  if (fallbackBaseSha) {
+    try {
+      // `cat-file -e` checks the object actually exists in the odb — unlike
+      // `rev-parse --verify`, which accepts any syntactically well-formed
+      // 40-hex string as a "valid" revision even if no such object exists.
+      await runGit(["-C", repoPath, "cat-file", "-e", fallbackBaseSha], repoPath);
+      return fallbackBaseSha;
+    } catch {
+      // stored SHA no longer resolves either (pruned) — give up.
+    }
+  }
+  return null;
+}
+
 /** Add a git worktree with a new branch. */
 export async function worktreeAdd(
   repoPath: string,
@@ -197,18 +238,20 @@ export interface CommitLogEntry {
   /** True if any changed file's diff couldn't be summarized as text (numstat reports "-"). */
   hasBinaryChanges: boolean;
   /**
-   * True if this commit is reachable from HEAD but not from the worktree's
-   * recorded `baseSha` (`git rev-list HEAD --not <baseSha>`) — i.e. not
-   * reachable from the fork point as recorded at worktree-creation time.
-   * This is a proxy for "unique to this branch", not a guarantee of it: if
-   * the branch was rebased, or the base branch was force-pushed/advanced
-   * past what `baseSha` still points at, a commit that's actually on
-   * today's base branch can still read `true` here (harmless — it just
-   * doesn't get collapsed), and in principle the reverse could happen too.
-   * When `baseSha` isn't available (no worktree record, invalid/deleted
-   * ref), every commit is conservatively marked `true` so nothing is
-   * hidden. Used by the VCS tool tab to collapse base-branch history by
-   * default.
+   * True if this commit is reachable from HEAD but not from the `baseSha`
+   * passed to `listCommits` (`git rev-list HEAD --not <baseSha>`). Callers
+   * are expected to pass a freshly resolved fork point (see
+   * `resolveBaseSha`, `git merge-base HEAD <baseBranch>`), not a value
+   * cached from worktree-creation time — a cached value goes stale as soon
+   * as the branch is synced/rebased onto an advancing base branch, at which
+   * point every commit the base branch picked up since caching would
+   * misread as "unique to this branch" here. Even with a freshly resolved
+   * `baseSha` this is a proxy, not a guarantee: a force-pushed/rewritten
+   * base branch can still produce a mismatch (harmless — it just doesn't
+   * get collapsed). When `baseSha` isn't available at all (no worktree
+   * record, base branch and stored fallback both unresolvable), every
+   * commit is conservatively marked `true` so nothing is hidden. Used by
+   * the VCS tool tab to collapse base-branch history by default.
    */
   isOnBranch: boolean;
 }


### PR DESCRIPTION
## Summary
- `worktree.baseSha` was captured once at worktree-creation time and never refreshed. When a long-running branch is later synced/rebased onto an advancing base branch (normal workflow), the true fork point moves forward but the cached `baseSha` doesn't — so every base-branch commit picked up since creation gets misclassified as "unique to this branch" wherever `baseSha` was used. This is why the VCS tab could show dozens of commits for a branch with e.g. just 1 real commit.
- Add `resolveBaseSha()` in `daemon/src/services/git.ts`, which recomputes the fork point live via `git merge-base HEAD <baseBranch>`, falling back to the stored `baseSha` only if `baseBranch` no longer resolves (deleted/renamed) — and to `null` if neither resolves.
- Wire it into the three route handlers in `daemon/src/routes/worktrees.ts` that previously read `worktree.baseSha` directly: `GET /worktrees/:id/commits`, `GET /worktrees/:id/diff/*` (scope=branch), and `GET /worktrees/:id/changed-paths` (scope=branch).

## Test plan
- [x] `pnpm --filter @vibestation/cli typecheck` — clean
- [x] Added `daemon/src/__tests__/git.resolveBaseSha.test.ts` covering: live merge-base recompute after a branch syncs with an advanced base, fallback to stored `baseSha` when `baseBranch` doesn't resolve, `null` when neither resolves, `null` when both are absent
- [x] `pnpm --filter @vibestation/cli test` — 638/638 passing (one pre-existing unhandled-rejection flake in `sessions.test.ts` unrelated to this change, confirmed present on `main` too)
- [x] `pnpm --filter @vibestation/cli lint` — no new issues (pre-existing unused-import errors in `daemon-client.test.ts`, confirmed present on `main` too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)