### PR TITLE
Workspace canvas tiling, saved-workspace detachment, and canvas-mode top bar

### DIFF
--- a/.vibekit/feature-plans/wip/agent-interaction-workspaces/.sdlc-state.yaml
+++ b/.vibekit/feature-plans/wip/agent-interaction-workspaces/.sdlc-state.yaml
@@ -4,7 +4,7 @@ created: 2026-08-11T00:00:00Z
 master:
   prd: complete
   plan: complete
-current_subfeature: 03-interaction-states
+current_subfeature: 04-workspaces
 
 # v4 restructure note (2026-08-12): docs-only restructure per user feedback on v3 —
 # "I don't understand the 2 part split... 1st introducing the new agent states and
@@ -97,12 +97,96 @@ subfeatures:
   - id: 04-workspaces
     origin: planned
     spawned_from: null
-    mode: implementing
-    last_completed: "2.4"
+    mode: verifying
+    last_completed: "4c.T3"
     awaiting_phase: null
     awaiting_artifact: null
     phase_chain: [plan]
     superseded_reason: null
     parked_reason: null
+    handoff: {next_item: "3a.T3", returned_at: null, verified_by: null}
+    commit: null
+    # v7 implement note (2026-08-13): user asked to implement this plan next,
+    # after 03-interaction-states was committed (c41d680). Implemented Phase 3
+    # (workspace detachment: contextKey demoted to provenance-only, persist
+    # v14->v15 migration clearing stale activeWorkspaceId pointers, new
+    # /workspaces/:workspaceId route, LeftSidebar's Workspaces section made
+    # global) and Phase 4 (spawnedFrom: daemon column + REST/WS + CLI
+    # --source-agent flag + client-side auto-insert on session:created).
+    #
+    # Decision 4/6 (detachment + global sidebar) treated as ALREADY confirmed
+    # by the user's own earlier explicit instruction ("A saved workspace
+    # should be detached from the worktree... back to unsaved won't make
+    # sense anymore") rather than re-asked — a per-worktree-filtered sidebar
+    # list is incompatible with "detached" by construction, so global listing
+    # is the only coherent reading, not an open design question. Risk #9/#10
+    # (multi-workspace fan-out) genuinely left unconfirmed per the plan's own
+    # instruction — implemented single-match only, multi-match logs+skips.
+    #
+    # Notable implementation deviation from the plan's literal phrasing:
+    # Decision 8 ("reuse the existing Add tile insert function") couldn't
+    # call into the live WorkspaceCanvas component instance (a session:created
+    # WS event can fire while that workspace isn't even mounted) — instead
+    # extracted the algorithm into a new pure function
+    # (insertTileIntoCanvas, useStore.ts) that BOTH the manual "Add tile" flow
+    # AND the new auto-insert path call, which is a stronger form of "one
+    # implementation" than the plan anticipated (same function object, not
+    # just same behavior).
+    #
+    # Verified: full daemon+cli suite 663/663 passing (was 610 before this
+    # phase — 53 new: lifecycle/jsonAgent tests already counted under
+    # 03-interaction-states, this phase added worktrees/sessions/protocol/cli
+    # sourceAgent tests), full web-ui suite 364/364 passing (was 347), tsc
+    # clean both sides, eslint clean (only pre-existing untouched errors in
+    # cli/src/__tests__/daemon-client.test.ts remain). Live-verified against
+    # the real docker sandbox (not just test doubles): POST /worktrees ->
+    # POST /sessions {sourceAgentId} -> GET confirms spawnedFrom persisted
+    # and round-tripped through sqlite. The client-side route/sidebar/canvas
+    # wiring (Phase 3) and the browser-side auto-insert (Phase 4c) were NOT
+    # re-verified in a live browser this session (no Workspace.tsx test
+    # harness exists in this codebase, and building one was out of scope) —
+    # see 3a.T3/3c.T1-T3's individual notes for what's covered by other means
+    # vs. genuinely deferred. Nothing committed — all changes left
+    # uncommitted per orchestrator ownership of commits (user commits when
+    # ready, same as the prior 03-interaction-states round).
+
+  - id: 05-workspace-persistence
+    origin: planned
+    spawned_from: null
+    mode: planning
+    last_completed: null
+    awaiting_phase: plan
+    awaiting_artifact: ".vibekit/feature-plans/wip/agent-interaction-workspaces/05-workspace-persistence/plan-05-agent-interaction-workspaces-workspace-persistence.md"
+    phase_chain: [prd, plan]
+    superseded_reason: null
+    parked_reason: null
     handoff: {next_item: null, returned_at: null, verified_by: null}
     commit: null
+    # v1 (2026-08-14): new sub-feature — move SAVED WorkspaceDoc persistence from
+    # client-only localStorage to the daemon's sqlite DB, synced live across
+    # clients over WS. Chosen as a numbered sub-feature under this existing
+    # feature dir (not a new top-level feature) because it shares the same
+    # domain model (WorkspaceDoc, CanvasGeometry) and directly builds on
+    # 04-workspaces' shipped client data model + already-existing
+    # `/workspaces/:workspaceId` route — same .sdlc-state.yaml, same reasoning
+    # the sdlc skill uses for "shares the same domain model" sub-features.
+    # Ran the prd+plan chain only, per instruction — did NOT implement.
+    # PRD written first (storage/sync/concurrency/migration requirements +
+    # options + resolved questions), reviewed by one reviewer subagent pass
+    # (gate: llm, default config — no .vibekit/config.yaml present), two
+    # issues fixed (R11/Open-Q1 contradiction, R1 redundant field list) plus
+    # one added open question (migration id identity) before the plan was
+    # written. Technical plan covers: new top-level `workspaces` daemon table
+    # (Decision 1: no project-store.ts-style graph cache, unneeded at this
+    # entity's scale), REST CRUD + WS broadcast (Decision 2: last-write-wins,
+    # no merge/op-log), client sync via a new `useWorkspaceServerStore`
+    # mirroring the existing `useServerStore`/`useServerSync` shape exactly
+    # (Decision 3, per explicit PRD instruction to reuse that pattern), a
+    # local-optimistic-drag-then-flush-on-gesture-end design for
+    # WorkspaceCanvas.tsx's per-mousemove `patchCanvas` calls (Decision 4 —
+    # confirmed via code read that all three drag/resize/divider handlers
+    # write on every mousemove today, not just on release), and a one-time
+    # client-generated-id-based migration upload (Decision 5). Explicitly did
+    # NOT touch scratchCanvas (stays client-only) or any canvas UX. Did not
+    # edit any source code — docs/plan files only, per orchestrator
+    # instruction; did not commit.

--- a/.vibekit/feature-plans/wip/agent-interaction-workspaces/.sdlc-state.yaml
+++ b/.vibekit/feature-plans/wip/agent-interaction-workspaces/.sdlc-state.yaml
@@ -1,0 +1,108 @@
+feature: agent-interaction-workspaces
+worktree: /home/gb/.vibe-station/projects/vibe-station/worktrees/vs-39
+created: 2026-08-11T00:00:00Z
+master:
+  prd: complete
+  plan: complete
+current_subfeature: 03-interaction-states
+
+# v4 restructure note (2026-08-12): docs-only restructure per user feedback on v3 —
+# "I don't understand the 2 part split... 1st introducing the new agent states and
+# ensuring state machine is correct. The 2nd would be the workspace feature." Root
+# plan's former Phase 1+1b+2 (interaction states) relocated verbatim into new
+# `03-interaction-states`. Root plan's former Phase 3 (stale POC checklist) +
+# Phase 4 (cursor/border fixes) relocated into new `04-workspaces`, replacing the
+# stale POC phase with a real `[x]`-marked "shipped implementation" phase (confirmed
+# against actual web-ui/ code this session) and marking Phase 4 (cursor grab, direct-
+# session borders) `[x]` complete (also confirmed via code read: workspace-canvas.css:332
+# has cursor:grab, AgentPaneSlot.tsx has the border class + shared sessionStatus()
+# helper). The two pre-existing sub-plans (`01-workspace-detachment`,
+# `02-source-agent-spawn`) keep their NN/directory/files unchanged — only
+# `spawned_from` changed (root -> 04-workspaces) to nest them under the Workspaces
+# sub-feature conceptually, matching the plan's own file-naming convention (which
+# doesn't support 3-level-deep directory nesting; the grouping is expressed via
+# 04-workspaces' Sub-Plan Breakdown table instead — see PHASES/SECTIONS.md).
+# Root plan is now a thin master (no own checklist, Files & Phase Impact replaced
+# with a pointer to Sub-Plan Breakdown per the master/root exception rule) so its
+# own last_completed/awaiting_phase are cleared (nulled) below — nothing to resume
+# there anymore, all real work lives on 03-interaction-states / 04-workspaces.
+# Also discovered (not assumed): `daemon/src/types.ts:8` LifecycleState still does
+# NOT include waiting_for_human/needs_review (confirmed) — 03-interaction-states'
+# daemon-side Phase 1/1b stay fully unimplemented. Web-ui-side Phase 2 of that same
+# plan, by contrast, is ALREADY present in code (worktreeStatus.ts, StatusDot.tsx,
+# LeftSidebar.tsx) but only as dev-simulation scaffolding (SessionState's own doc
+# comment confirms real values are "not yet wired up"), so those items are marked
+# [x] with an explicit "functionally inert until Phase 1/1b" note rather than left
+# unchecked or silently treated as done — this is new ground truth found this
+# session, not something the prior state file or plan revision claimed.
+#
+# v5 restructure note (2026-08-12): user feedback on v4 — "Why do we still have 1
+# and 2. I clearly said let's just have 2 plans. We don't need 4." `01-workspace-
+# detachment` and `02-source-agent-spawn` are merged verbatim into `04-workspaces`
+# as Phase 3 (sub-phases 3a/3b/3c) and Phase 4 (sub-phases 4a/4b/4c) respectively —
+# all Requirements rows, Research, Architecture Diagrams, CUJs, Data Model rows,
+# API Contracts, Key Decisions, Risks, checklist items, and Files & Phase Impact
+# rows relocated (renumbered to fit 04-workspaces' own numbering, not rewritten).
+# Both subfeature entries below are removed — there is nothing left to plan/
+# implement/track separately for `01`/`02`; their directories are deleted. No
+# change to `04-workspaces`' own `last_completed` ("2.4") — Phase 3/Phase 4 are new,
+# unstarted work (mode stays `implementing`, no `next_item` set since neither 3a.1
+# nor 4a.1 has been started this session).
+
+subfeatures:
+  - id: root
+    origin: planned
+    spawned_from: null
+    mode: implementing
+    last_completed: null
+    awaiting_phase: null
+    awaiting_artifact: null
+    phase_chain: [prd, plan]
+    superseded_reason: null
+    parked_reason: null
+    handoff: {next_item: null, returned_at: null, verified_by: null}
+    commit: null
+
+  - id: 03-interaction-states
+    origin: planned
+    spawned_from: null
+    mode: verifying
+    last_completed: "2.T2"
+    awaiting_phase: null
+    awaiting_artifact: null
+    phase_chain: [plan]
+    superseded_reason: null
+    parked_reason: null
+    handoff: {next_item: "1.T9", returned_at: null, verified_by: null}
+    commit: null
+    # v6 implement note (2026-08-13): user asked to drop R2 (empirically found
+    # dead/harmful for all 4 CLIs — see plan's "R2 dropped: empirical evidence"
+    # section) and implement ONLY 03-interaction-states (explicitly not
+    # 04-workspaces). Implemented R3-only "waiting_for_human" via an `everWorked`
+    # flag on both the TTY poller (lifecycle.ts) and the JSON channel
+    # (jsonAgent.ts's drain()). The flag's semantics went through 3 revisions
+    # this session (resume-only -> observed-hash-change -> unconditional-true),
+    # the last two ruled out by live-testing against the real docker daemon, not
+    # speculation — see plan item 1.5's revision note. Final state: full daemon
+    # suite 610/610 passing, typecheck clean, lint clean (pre-existing unrelated
+    # jsonAgent.ts:1064 `_drop` lint error untouched), live end-to-end daemon
+    # verification confirms not_started -> working -> waiting_for_human on a
+    # real spawn (1.T8), and worktreeStatus.test.ts gained 3 new rollup-precedence
+    # tests (2.T1/2.T2, 9/9 passing) covering the color/border-driving rollup
+    # logic. Only 1.T9 (needs_review live-PR click-through) remains open —
+    # deferred, out of scope for this pass; needs_review already has full unit
+    # coverage (prPoller.test.ts) and CSS in place. Nothing committed — all
+    # changes left uncommitted per orchestrator ownership of commits.
+
+  - id: 04-workspaces
+    origin: planned
+    spawned_from: null
+    mode: implementing
+    last_completed: "2.4"
+    awaiting_phase: null
+    awaiting_artifact: null
+    phase_chain: [plan]
+    superseded_reason: null
+    parked_reason: null
+    handoff: {next_item: null, returned_at: null, verified_by: null}
+    commit: null

--- a/.vibekit/feature-plans/wip/agent-interaction-workspaces/03-interaction-states/plan-03-agent-interaction-workspaces-interaction-states.md
+++ b/.vibekit/feature-plans/wip/agent-interaction-workspaces/03-interaction-states/plan-03-agent-interaction-workspaces-interaction-states.md
@@ -1,0 +1,435 @@
+---
+PRD: ../prd-agent-interaction-workspaces.md
+Status: WIP
+---
+
+<!--
+RULES — read before writing or implementing:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. REQUIREMENTS: One crisp line each — no verbose descriptions
+3. CHECKLIST: Mark items [x] as you complete them — this is your persistent todo list
+4. READING TIME: Optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+# Plan: Interaction States (03, sub-feature of Agent Interaction State + Workspaces)
+
+> Extend `LifecycleState` with `waiting_for_human` (JSON-channel human-gate tools + universal "idle after ever working" rule) and `needs_review` (daemon PR poller), and surface both through the existing rollup + `StatusDot` infrastructure. **Relocated verbatim from the root plan's former Phase 1 + Phase 1b + Phase 2** — no content changes, only extraction into its own sub-feature so it stops sharing a checklist with the unrelated Workspaces feature (see [`04-workspaces`](../04-workspaces/plan-04-agent-interaction-workspaces-workspaces.md)).
+
+**Issue:** agent-interaction-workspaces / 03-interaction-states
+**Branch:** `introducing-new-state` (current)
+**Status:** WIP — daemon side (Phase 1, Phase 1b) not started; web-ui side (Phase 2) already exists as dev-simulation scaffolding, functionally inert until Phase 1/1b ship (see Phase 2 note)
+**PRD:** `.vibekit/feature-plans/wip/agent-interaction-workspaces/prd-agent-interaction-workspaces.md` §1 (R1-R9)
+**Spawned from:** root plan (restructure — see root plan's Revision note; this is a relocation of already-planned, not-yet-implemented work, not a new requirement)
+
+**Reference files:**
+- Data / schema: `daemon/src/types.ts:8` (`LifecycleState`) — confirmed current value: `"not_started" | "working" | "idle" | "done" | "exited"`, does **not** yet include `waiting_for_human`/`needs_review`.
+- Core logic: `daemon/src/services/lifecycle.ts`, `daemon/src/services/jsonAgent.ts`, `daemon/src/services/github.ts`
+- UI / entrypoint: `web-ui/src/lib/worktreeStatus.ts`, `web-ui/src/components/layout/StatusDot.tsx`, `web-ui/src/components/layout/LeftSidebar.tsx`
+- Dev-only scaffolding (confirmed present, not real wiring): `web-ui/src/components/dev/DevStatePanel.tsx`, `web-ui/src/api/types.ts:66-77` (`SessionState` doc comment reads: "real daemon-side detection... is planned but not yet wired up... these values are only ever set by the dev-only state-simulation panel")
+- Wiring: `daemon/src/ws/protocol.ts` (`SessionStateEvent`), `daemon/src/routes/worktrees.ts:1110-1127` (existing PR route)
+
+---
+
+## Problem
+
+- See [prd-agent-interaction-workspaces.md](../prd-agent-interaction-workspaces.md) §Problem, §1 — no way to tell "idle" from "blocked on a human" or "PR ready for review" today.
+
+## Out of Scope
+
+- Any change to `--dangerously-skip-permissions` spawn behavior.
+- Hook-based PR-creation fast-path (PRD Non-goals, Resolved Q2) — poll-based only this round.
+- Everything Workspaces-shaped (canvas, tiling, tile chrome, direct-session borders, detachment, spawn affinity) — see [`04-workspaces`](../04-workspaces/plan-04-agent-interaction-workspaces-workspaces.md).
+
+## Concept
+
+- See [prd-agent-interaction-workspaces.md](../prd-agent-interaction-workspaces.md) §1 for full behavior + state machine + color mapping.
+- **One shippable slice, not two: `waiting_for_human` is R3-only.** R2 (immediate JSON-channel tool_use detection) is **dropped entirely** — see Research §R2 dropped: empirical evidence below. Plus `needs_review` (PR poller, unaffected by this change).
+- **R3 (idle after ever having worked) is the sole `waiting_for_human` entry path, for all four CLIs, with no exceptions.** This is a real simplification, not a workaround: R3 needed zero CLI-specific work to begin with (pane-output stability, channel-agnostic), so dropping R2 removes an entire axis of per-CLI complexity (the `HUMAN_GATE_TOOLS` map, the `toolName` threading through `updateTurnState`, the optional opencode hook) without losing any real coverage — see the empirical evidence below for why.
+
+## Requirements
+
+| # | PRD ID | Requirement |
+|---|--------|-------------|
+| 1 | R1 | `LifecycleState` gains `waiting_for_human` AND `needs_review`; every exhaustive switch/map over the type is updated (compiler-enforced). |
+| 2 | ~~R2~~ | **DROPPED (see Research §R2 dropped).** Empirically, every headless invocation across all four CLIs (claude, cursor, opencode, agy) auto-skips/auto-rejects any human-gate tool and always terminates in a `result` event — so R3 always fires and R2 provides zero additional correctness value. For cursor specifically, implementing R2 as originally speced would be **actively wrong**: `askQuestionToolCall` only appears in the stream *after* the question has already been auto-rejected, so keying off it would flag a session as blocked when it's actually already unblocked and finishing. PRD R2 itself is stale pending an update to match (not edited here — PRD is a different file, flag for follow-up). |
+| 3 | R3, R3a | A session that has reached `working` at least once transitions `idle → waiting_for_human` instead of staying `idle`; a session that never reached `working` stays `idle` as today. **This is now the ONLY `waiting_for_human` entry path — universal, no CLI ever needs anything more.** |
+| 4 | R4 | A human response (new user turn) transitions `waiting_for_human` → `working` at the same point turns already do today. |
+| 5 | R5 | `waiting_for_human`/`needs_review` are absorbed into `done`/`exited` like every other non-terminal state — no special-case guard needed, `persistLifecycleState` already treats those as unconditional terminal writes. |
+| 6 | R6, R7 | A new daemon poller finds an open non-draft PR for a worktree's branch (via existing `fetchPrForBranch`) → `needs_review`; PR merged/closed/gone → exits back to `working`/`idle`. |
+| 7 | R8 | `worktreeRolledUpStatus` ranks `waiting_for_human` above `needs_review` above `working`. |
+| 8 | R9 | `StatusDot` renders distinct glyphs/colors for `waiting_for_human` (red) and `needs_review` (violet), delivered over the existing `session:state` broadcast. |
+
+---
+
+## Research
+
+> Relocated verbatim from root plan's Research section (Lifecycle/JSON/PR/rollup/protocol subsections only) — no re-derivation.
+
+### Lifecycle state today
+- **File:** `daemon/src/types.ts:8` — `LifecycleState = "not_started" | "working" | "idle" | "done" | "exited"`.
+- **File:** `daemon/src/services/lifecycle.ts:72-97` — `persistLifecycleState()` broadcasts `session:state` + single-row DB update; unchanged signature, only the `newState` value set grows.
+- **File:** `daemon/src/services/lifecycle.ts:118-121` — JSON-channel sessions are skipped by the tmux-hash poller; their lifecycle is driven by `JsonAgentSession` itself.
+- **File:** `daemon/src/services/lifecycle.ts:163-164, 216-217` — this is exactly the "idle" transition point R3 hooks into: instead of unconditionally flipping to `"idle"`, check whether the session has ever reached `"working"` and flip to `"waiting_for_human"` instead.
+
+### JSON channel turn/tool events
+- **File:** `daemon/src/services/jsonAgent.ts:986-1004` — `updateTurnState(kind)` maps `NormalizedEventKind` → `TurnState`; `tool_use` currently always maps to `"tool"` with no distinction by tool name.
+- **File:** `daemon/src/services/jsonAgent.ts:776-782` — `persistLifecycle(state: LifecycleState)`, the JSON-channel's own lifecycle setter — call site to extend for R2.
+- **File:** `daemon/src/services/jsonAgentChat.ts:264` — lifecycle set to `"working"` on new-turn start; natural exit point back from `waiting_for_human`.
+
+### Per-CLI human-gate capability (resolves Risk #1 — researched, not assumed)
+
+- All four plugins return `supportsJson(): true` (`claude.ts:461`, `cursor.ts:314`, `opencode.ts:273`, `agy.ts:405`) — so R2's mechanism is *reachable* from all four and had to be answered per CLI, not for Claude alone.
+- **`toolName` is 100% plugin-defined** — each plugin's own line-parser decides the string; there is no shared normalization table. The four derivations:
+
+| CLI | Where `toolName` is set | Derivation |
+|-----|------------------------|------------|
+| claude | `daemon/src/agent-plugins/claude.ts:92-100` | `toolName: block.name` — Anthropic tool names passed through **verbatim** (`Bash`, `Read`, `AskUserQuestion`, …) |
+| cursor | `daemon/src/agent-plugins/cursor.ts:119-137` | `keys.find((k) => k.endsWith("ToolCall")) ?? keys[0]` — the **proto payload key**, e.g. `shellToolCall`, `readToolCall` (asserted in `daemon/src/__tests__/jsonPlugins.test.ts:54,156`). Second, rarer path at `cursor.ts:93-101` uses `block.name` (never observed live). |
+| opencode | `daemon/src/agent-plugins/opencode.ts:136-157` | `toolName: part.tool` — opencode's own lowercase tool ids (`bash`, `read`, `edit`, `webfetch`, `todowrite`, `task`, …; test asserts `"bash"` at `jsonPlugins.test.ts:218`) |
+| agy | `daemon/src/agent-plugins/agy.ts:90-166` | **none — `parseAgyResultLine` never emits a `tool_use` event at all.** Plugin doc comment `agy.ts:44-46`: *"Unlike claude/cursor/opencode, agy does NOT stream per-event NDJSON — there are no live thinking/tool_use/tool_result events in print JSON."* |
+
+**Per-CLI capability table (R2 answer):**
+
+| CLI | JSON channel | Human-gate tool exists? | Real normalized `toolName` | R2 mechanism | Confidence |
+|-----|--------------|-------------------------|----------------------------|--------------|------------|
+| **claude** | ✅ `supportsJson` (`claude.ts:461`) | ✅ ask + plan-exit | `AskUserQuestion`, `ExitPlanMode` | **(a)** `HUMAN_GATE_TOOLS.claude` toolName set | **High** — both strings present in the shipped `claude` binary (v2.1.229); `block.name` is passed through unmodified |
+| **cursor** | ✅ (`cursor.ts:314`) | ✅ ask + plan-approval | `askQuestionToolCall`, `createPlanToolCall` | **(a)** `HUMAN_GATE_TOOLS.cursor` toolName set | **Medium** — key names extracted from the shipped `cursor-agent` bundle (`2026.07.16-899851b`, `189.index.js`/`1931.index.js`): `askQuestionToolCall` carries `{title, questions}` and maps to display tool `askQuestion`; `createPlanToolCall` renders `pending/accepted/rejected` (a plan-approval gate). **Not live-verified** that headless `cursor-agent -p … --output-format stream-json -f` (`cursor.ts:340`) still emits them rather than auto-answering under `-f` |
+| **opencode** | ✅ (`opencode.ts:273`) | ❌ no such tool | n/a — tool surface is `bash/read/edit/write/grep/glob/list/patch/todowrite/todoread/webfetch/task`; "plan" is an **agent**, switched by the user, not a tool call | **(b)** new `permission.ask` plugin hook — see Phase 1c; **(c)** R3-only if 1c is skipped | **Medium** — tool ids read from the shipped `opencode` 1.18.12 binary; hook surface verified in `@opencode-ai/plugin@1.4.3` `dist/index.d.ts` |
+| **agy** | ✅ (`agy.ts:405`) | Irrelevant — signal cannot reach us | n/a — **zero `tool_use` events emitted** (`agy.ts:44-46`, `parseAgyResultLine`) | **(c)** N/A — `waiting_for_human` via R3 only | **High** on the negative (structural: one final envelope at `agy.ts:435-440`); **Low** on any workaround |
+
+- **opencode's real hook surface** (`~/.config/opencode/node_modules/@opencode-ai/plugin/dist/index.d.ts`, v1.4.3) — the plugin `Hooks` interface includes a genuine blocked-on-human hook:
+  ```ts
+  "permission.ask"?: (input: Permission, output: { status: "ask" | "deny" | "allow" }) => Promise<void>;
+  ```
+  plus SDK events `EventPermissionUpdated { type: "permission.updated" }` / `EventPermissionReplied { type: "permission.replied" }` and `EventSessionIdle` (`@opencode-ai/sdk/dist/gen/types.gen.d.ts:384-418`). The daemon **already ships an opencode plugin file** (`opencode.ts:360-390` writes `.opencode/plugins/vst-recorder.ts` with a `session.created` handler), so adding a `permission.ask` handler is a same-file, same-pattern extension — this is why opencode is (b) and not (c).
+- **claude's hook surface** — `setupWorkspaceHooks` (`claude.ts:291-443`) already merges `SessionStart` + `UserPromptSubmit` command hooks into `.claude/settings.json`. The binary also exposes `Notification`, `PreToolUse`, `PostToolUse`, `Stop`, `SubagentStop`, `PreCompact`, `SessionEnd` (verified via `strings` on the shipped `claude` 2.1.229). A `PreToolUse` matcher on `AskUserQuestion|ExitPlanMode` would be *possible* but is **strictly worse than (a)**: same event, extra file, extra process spawn, and it does not work on the JSON channel headless path that R2 targets.
+- **cursor's hook surface** — `setupWorkspaceHooks` (`cursor.ts:394-469`) writes only a `.cursor/commands/vst.md` slash command; no hook/plugin event API was found. (a) is the only option for cursor.
+- **agy's hook surface** — plugin has **no `setupWorkspaceHooks` at all** (`agy.ts:299-511`). The binary does contain a JSON-hook subsystem (`jsonhook.JSONHookSpec`, `GetJSONHookPaths`, `enableJsonHooks`, and the strings `PreToolUse`/`PostToolUse`/`SessionStart`) and supports `--mode plan` + `--output-format stream-json` per `agy --help`. **Explicitly low confidence:** agy is a ~199 MB stripped Go binary with no public hook docs; none of this was live-verified, and the plugin would need a `setupWorkspaceHooks` built from scratch. Not planned. A cheaper future route, if agy ever needs R2, is migrating `agy.ts:435-440` from `--output-format json` to `stream-json` (the binary carries `tool_use` type strings) — out of scope here.
+- **Bottom line on "do we need hooks?"** — no, not to ship R2. claude + cursor are covered by per-CLI `toolName` sets (zero new CLI-side machinery); agy is structurally out of R2 and gets `waiting_for_human` from R3, which is CLI-agnostic (pane-output stability, `lifecycle.ts:163-164, 216-217`); opencode is the **only** CLI where a hook buys anything, and it's an optional enhancement (Phase 1c), not a prerequisite.
+
+### R2 dropped: empirical evidence (supersedes the table above — kept for its per-CLI toolName research value, but its "R2 mechanism" column no longer reflects the decision)
+
+All four CLIs were **actually invoked** headless (exactly as this daemon spawns them) with prompts engineered to trigger their respective human-gate tool, and the raw stream-json output captured:
+
+- **claude**: `AskUserQuestion`/`ExitPlanMode` **do not appear in the tool list the headless CLI reports at all** (`system/init`'s 30-tool list has neither). The model notices mid-turn — *"there is no such tool called 'AskUserQuestion' in my toolset"* — and answers in prose instead. Every run ends in a normal `result` event. R2's claude tool names are unreachable dead code in this daemon's actual invocation shape.
+- **cursor**: `askQuestionToolCall` genuinely fires — but headless mode (`-f`) auto-rejects the question ~1.5s **before** the `tool_call started` event is even emitted (`{"type":"interaction_query","subtype":"response",...,"result":{"rejected":{"reason":"Questions skipped by the user, continue with the information you already have"}}}`). By the time `askQuestionToolCall` appears in the stream, the block is already over. Detecting it would be a false positive, not just redundant.
+- **opencode**: no ask/plan-exit tool exists, confirmed again live. Separately: any permission request in headless `run` mode is **auto-rejected regardless of the `--auto` flag** (`! permission requested: external_directory (/tmp/*); auto-rejecting`) — so the `permission.ask` hook considered for Phase 1c would fire on an already-decided outcome, exactly like cursor's tool. Phase 1c has no value.
+- **agy**: correction to the original per-CLI table — it *does* have `ask_question`/`ask_permission` tools (`init.tools` lists them), and *does* emit tool step events, but only under `--output-format stream-json`, which this daemon doesn't use (`agy.ts:436-440` uses plain `json`). Even under `stream-json`, a question is auto-skipped and surfaces as an anonymous `"step_type":"unknown"` event with **no `tool_name` at all** — nothing to key detection on regardless. A hard 5-minute `--print-timeout` ceiling exists independent of any of this.
+
+**Every headless invocation, across all four CLIs, terminates in a `result` event.** The failure mode R2 was built to catch — a pending human-gate `tool_use` that never gets a `result`, so R3's idle trigger never fires — does not occur in practice for any of them. R3 alone catches every real case, with equal reliability to R2 and, for cursor, *better* correctness (no false-positive window).
+
+**Decision (supersedes Decision 1/1b below, kept for their research value but no longer the operative plan): drop R2 and Phase 1c entirely. Ship R3 only.**
+
+### R3's "ever worked" tracking
+- No existing field tracks "has this session ever reached working" — `SessionLifecycle` (`types.ts:10-14`) only holds the *current* state + `lastTransitionAt`. Needs a new boolean, either persisted (`SessionLifecycle.everWorked?: boolean`) or derived in-memory in the poller's `idleTracking` map (`lifecycle.ts:36`) — **in-memory is simpler and sufficient**: it only needs to survive for the life of one idle-tracking entry, and a daemon restart naturally resets to "unknown" which is safe (worst case: one session briefly doesn't get the R3 upgrade until its next working→idle cycle).
+
+### PR detection (existing, reused for `needs_review`)
+- **File:** `daemon/src/services/github.ts:17-23` — `PrInfo { number, state: "open"|"closed", merged: boolean, draft: boolean, ... }`.
+- **File:** `daemon/src/services/github.ts:77-95` — `fetchPrForBranch(owner, repo, branch)`, direct GitHub REST API (not `gh` CLI), 30s module-level cache.
+- **File:** `daemon/src/services/github.ts:28-45` — `getRemoteUrl`/`parseGithubRepo` — github.com only, resolves owner/repo from the worktree's git remote.
+- **File:** `daemon/src/routes/worktrees.ts:1110-1127` — existing `GET /worktrees/:id/pr` route, pull-only, consumed by `web-ui/src/components/tools/VcsPanel.tsx:78-131` on mount + manual refresh; **no poller, no push today** — this is the gap `needs_review` fills.
+- **Risk:** MEDIUM — unauthenticated GitHub API is 60 req/hr per IP; a poller across many worktrees will exhaust that fast without `GITHUB_TOKEN`/`GH_TOKEN` configured. Not a blocker for the POC (mocked), but the real implementer must account for it (see Risks table).
+
+### Worktree rollup + status UI
+- **File:** `web-ui/src/lib/worktreeStatus.ts:3-18` — `WorktreeRolledUpStatus` union + `rank` map; `waiting_for_human` and `needs_review` both slot in above `working`, with `waiting_for_human` highest. **Note (confirmed at restructure time):** the live file today already has `waiting_for_human`/`needs_review` in the `WorktreeRolledUpStatus` type/rank map — that's the *client-side display* type used by both Interaction States (this plan) and Workspaces (see `04-workspaces`), which the shipped `WorkspaceCanvas`/`AgentPaneSlot` chrome (04) already consumes for tile coloring. This plan's R1 is about the **daemon's** `LifecycleState` (`daemon/src/types.ts:8`), which is a separate, still-unwidened type — confirmed absent of `waiting_for_human`/`needs_review` as of this restructure. The client type existing ahead of the daemon type is not a contradiction: the client union was sized for the full color-mapping design up front; nothing upstream (daemon) emits those values yet, so `worktreeRolledUpStatus`'s per-session mapping for them is presently unreachable dead code until this plan's Phase 1/1b ship.
+- **File:** `web-ui/src/components/layout/StatusDot.tsx:3-10` — `GLYPH` record keyed by `WorktreeRolledUpStatus`; add both new entries + CSS classes in `web-ui/src/styles/workspace.css` (existing `.status-dot--*` convention starts at `workspace.css:2000`).
+- **File:** `web-ui/src/components/layout/LeftSidebar.tsx:141` — `sessionStateToStatus()` maps raw `SessionState` → `WorktreeRolledUpStatus`; add both passthrough cases.
+
+### Protocol
+- **File:** `daemon/src/ws/protocol.ts:227-233` — `SessionStateEvent` carries `{ sessionId, state }`; **`state`'s type is NOT derived from `LifecycleState`** — it's a hardcoded literal zod enum, duplicated three times: `:209` (a session-list-snapshot schema's `state`), `:210` (`lifecycleState` on the same schema), `:230` (`SessionStateEvent.state` itself), each `z.enum(["not_started", "working", "idle", "done", "exited"])`. Widening `daemon/src/types.ts:8`'s `LifecycleState` union does **not** widen these — TypeScript exhaustiveness checks don't cover zod value-literal enums, so this is a real, separate edit, not a corollary of R1's "compiler-enforced" safety net. All three must be updated or the daemon will emit states its own protocol schema rejects.
+
+---
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    subgraph Daemon
+        LC[lifecycle.ts poller<br/>+ JSON channel's own idle signal] -- "idle AND everWorked<br/>(R3, sole entry path — R2 dropped)" --> PLh["persistLifecycle('waiting_for_human')"]
+        PRP[new: PR poller,<br/>mirrors lifecycle.ts pollAll] -- "fetchPrForBranch → open PR" --> PLr["persistLifecycleState('needs_review')"]
+        GH["github.ts fetchPrForBranch<br/>(existing)"] --> PRP
+        PLh -- "session:state" --> WS[WSConnection broadcast]
+        PLr -- "session:state" --> WS
+    end
+    subgraph WebUI
+        WS --> Store[useStore session map]
+        Store --> Rollup[worktreeRolledUpStatus]
+        Store --> Dot[StatusDot]
+        Rollup --> Dot
+        Dot -- "red / violet border" --> TabsStrip
+        Dot -- "red / violet border" --> LeftSidebar
+    end
+```
+
+### Lifecycle state machine (R2 dropped — R3 is the sole `waiting_for_human` entry path, all CLIs)
+
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> not_started
+    not_started --> working: first turn / first pane output
+
+    working --> idle: R3a — output stable, never worked
+    working --> waiting_for_human: R3 · UNIVERSAL, ALL CLIs
+    idle --> waiting_for_human: R3 · UNIVERSAL, ALL CLIs
+    waiting_for_human --> working: R4 — new user turn
+
+    working --> needs_review: R6 · UNIVERSAL (PR poller)
+    idle --> needs_review: R6 · UNIVERSAL (PR poller)
+    needs_review --> working: R6 — PR merged/closed
+    needs_review --> idle: R6 — PR merged/closed
+
+    working --> done: turn/session complete
+    idle --> done
+    waiting_for_human --> done
+    needs_review --> done
+    working --> exited: process death (markSessionExited)
+    idle --> exited
+    waiting_for_human --> exited
+    needs_review --> exited
+    done --> [*]
+    exited --> [*]
+
+    note right of waiting_for_human
+      LEGEND — entry paths (post R2-drop)
+      R3 UNIVERSAL (any CLI, any channel, no exceptions):
+        idle-after-ever-working, from pane-output stability
+        (TTY: lifecycle.ts poller hash-stability; JSON: same
+         rule applied to the channel's own idle/turn-end signal)
+        -> the ONLY waiting_for_human path for claude, cursor,
+           opencode, AND agy. R2 (tool_use toolName detection)
+           was evaluated and dropped — every headless CLI
+           invocation auto-resolves its own human-gate tool and
+           always emits a terminating event, so R3 always fires
+           and a separate immediate-detection path adds no real
+           coverage (and for cursor, would have produced a false
+           positive). See Research §R2 dropped for the evidence.
+      R6 UNIVERSAL: PR poller, CLI-independent by construction
+    end note
+```
+
+---
+
+## Design Details
+
+### System Boundaries
+
+| Boundary | Fields + types | Errors | Source of truth |
+|----------|----------------|--------|-----------------|
+| Daemon ↔ Web-UI (WS) | `SessionStateEvent { sessionId: string, state: LifecycleState }` — `LifecycleState` widened to include `"waiting_for_human"` \| `"needs_review"` | none new (existing WS error handling unchanged) | Daemon (`JsonAgentSession.persistLifecycle`, `lifecycle.ts` poller, new PR poller) |
+| Module ↔ Module (in-process, daemon) | `JsonAgentSession.updateTurnState(kind, toolName?)` → may call `persistLifecycle("waiting_for_human")` | n/a | `JsonAgentSession` owns its own lifecycle field |
+| Module ↔ Module (in-process, daemon) | new `prPoller.ts`: `pollAllPrs(): Promise<void>` reads `getAllProjects()`, calls `fetchPrForBranch` per worktree, calls `persistLifecycleState(..., "needs_review" \| fallback)` | n/a | `github.ts` remains the sole PR-truth source; poller only reacts to it |
+
+### Critical User Journeys (CUJs)
+
+#### CUJ 1 — Agent asks a question via Rich Chat (happy path, R2)
+```
+User is running an agent on the JSON channel
+  → Agent calls AskUserQuestion tool
+  → JsonAgentSession sees tool_use with toolName in human-gate set
+  → persistLifecycle("waiting_for_human") fires immediately (not at turn end)
+  → session:state broadcast → StatusDot/TabsStrip/LeftSidebar flip to red
+  → User answers the question (sends next turn)
+  → persistLifecycle("working") fires on turn start (existing code path, jsonAgentChat.ts:264)
+  → border returns to blue/working
+```
+- **Edge case:** agent exits/crashes while `waiting_for_human` — existing exit-detection path (`markSessionExited`) still fires and overrides to `exited`.
+- **Edge case:** two human-gate tool_use events back-to-back before a response — state stays `waiting_for_human` (idempotent set).
+
+#### CUJ 2 — TTY session goes idle after working (happy path, R3)
+```
+Agent (any channel) is "working"
+  → Output stabilizes for IDLE_THRESHOLD_MS
+  → lifecycle.ts poller checks: has this session's idleTracking entry ever seen "working"? Yes.
+  → persistLifecycleState(..., "waiting_for_human") instead of "idle"
+  → border flips to red
+  → User sends new input → pane output changes → poller flips back to "working"
+```
+- **Edge case:** a session's very first idle (never reached working, R3a) — stays `"idle"`, gray, as today.
+- **Edge case:** JSON-channel sessions are skipped by this poller entirely (lifecycle.ts:118-121 unchanged) — R3 for JSON channel is instead the natural consequence of R2 plus JSON's own turn-result → `working`→`idle` path in `jsonAgent.ts`; **verify during Phase 1 whether JSON-channel idle needs its own "everWorked" check or whether R2 already covers the realistic cases** (open risk, see Risks table).
+
+#### CUJ 3 — PR opened while agent is idle (happy path, R6)
+```
+Agent finishes work, session goes "idle"
+  → Human (or the agent via `gh pr create` in a terminal) opens a PR
+  → New PR poller's next tick calls fetchPrForBranch for this worktree
+  → PrInfo.state === "open" && !draft
+  → persistLifecycleState(..., "needs_review")
+  → border flips to violet
+  → PR is merged
+  → Next poll tick: fetchPrForBranch returns merged: true (or no longer "open")
+  → persistLifecycleState(..., "idle") — lands back on idle/working per current activity
+```
+- **Edge case:** no `GITHUB_TOKEN` configured — `fetchPrForBranch` still works but rate-limits fast across many worktrees; poller should log once, not spam (see Risks).
+- **Edge case:** non-GitHub remote (`parseGithubRepo` returns null) — poller skips that worktree silently, same as the existing route's behavior.
+
+### Data Model
+
+- No persisted schema change beyond the existing `lifecycle.state` column already storing a string enum — `waiting_for_human`/`needs_review` are new valid values, no migration needed unless a CHECK constraint exists (confirm via `daemon/src/state/project-store.ts` before implementing).
+- New **in-memory-only** tracking: `everWorked: Set<sessionId>` (or a boolean on the existing `idleTracking` entry, `lifecycle.ts:35-36`) — not persisted, reset on daemon restart (acceptable per Research above).
+
+### API Contracts
+
+- `SessionStateEvent` (`daemon/src/ws/protocol.ts:227-233`) — existing contract, only its `state` field's value set grows. No request/response shape change — but the zod schema backing that value set is 3 separate hardcoded enums (`:209,210,230`), each needing its own edit (1.7); this is a schema-widening change, not a free consequence of widening the TS type.
+- `GET /worktrees/:id/pr` (`daemon/src/routes/worktrees.ts:1110-1127`) — existing contract, unchanged; the new poller calls the same underlying `fetchPrForBranch` service function directly (not the HTTP route) to avoid a daemon-internal HTTP round-trip.
+
+### Key Decisions
+
+#### Decision 0: R2 dropped entirely; R3 is the sole `waiting_for_human` entry path (supersedes Decisions 1 and 1b below)
+- **Decision:** do not implement R2 (per-CLI `tool_use` toolName detection) or Phase 1c (opencode's `permission.ask` hook) at all. `waiting_for_human` is reached exclusively via R3.
+- **Rationale:** empirical evidence (Research §R2 dropped) — every headless invocation of all 4 CLIs auto-resolves its own human-gate tool and always emits a terminating event, so R3's idle-after-working rule always fires; R2 would add zero additional correctness coverage, extra per-CLI maintenance surface (`HUMAN_GATE_TOOLS`, `toolName` threading through `updateTurnState`), and for cursor specifically would be actively wrong (flags an already-resolved session as still blocked).
+- **Where:** this removes the need for `jsonAgent.ts:986`/`:954` changes (Decision 1's snippet, kept below for historical/research value only) and the entire opencode Phase 1c. The only daemon changes that remain are `types.ts` (R1, widen the enum), `lifecycle.ts` (R3's `everWorked` flag, Decision 2), `protocol.ts` (widen the 3 hardcoded enums), and the new PR poller (R6/R7, Decision 3/3b) — a materially smaller Phase 1 than originally speced.
+- **Follow-up (not done here):** the PRD's own R2 wording (`prd-agent-interaction-workspaces.md`) still describes R2 as a real CLI-dependent mechanism — it should be updated to reflect this drop. Flagged for a separate PRD edit, out of scope for this plan-only pass.
+
+#### Decision 1 (historical — research value only, no longer implemented): Human-gate tool set is a hardcoded allowlist — **keyed per CLI, not one flat global set**
+- **Decision:** `waiting_for_human` (R2 path) triggers only on `tool_use` events whose `toolName` exactly matches the allowlist **for that session's CLI**. Tool names do not overlap across CLIs (see Research: Per-CLI human-gate capability), so a flat global set would be a name-collision hazard for zero benefit.
+- **Rationale:** deterministic, no false positives; matches PRD R2's "immediate, authoritative" requirement. Per-CLI keying also makes the "this CLI has no R2 signal" cases (`opencode`, `agy`) explicit and self-documenting in code rather than silently absent.
+- **Lookup key:** the plugin's own `name` (`AgentPlugin.name`, `spawn.ts:95` — `"claude" | "cursor" | "opencode" | "agy"`), which equals the `provider` stamped on every `NormalizedEvent` by each plugin's event factory (`claude.ts:36`, `cursor.ts:40`, `opencode.ts:46`, `agy.ts:76`) — so the CLI is already available on the event itself; no new plumbing.
+- **Where:** `daemon/src/services/jsonAgent.ts:986` (`updateTurnState`) — add a branch checking `toolName` before falling through to the existing `"tool"` turn-state case.
+
+```ts
+// Per-CLI, NOT one flat Set. Empty set = "this CLI has no R2 signal; R3 only".
+const HUMAN_GATE_TOOLS: Record<string, ReadonlySet<string>> = {
+  // claude.ts:92-100 passes Anthropic tool names through verbatim.
+  claude: new Set(["AskUserQuestion", "ExitPlanMode"]),
+  // cursor.ts:127 uses the proto payload key (`<name>ToolCall`), NOT a display name.
+  cursor: new Set(["askQuestionToolCall", "createPlanToolCall"]),
+  // opencode has no ask/plan-exit tool (opencode.ts:140 -> part.tool, lowercase ids).
+  // Populate only if Phase 1c's permission.ask hook ships — and that hook signals
+  // out-of-band, so it likely never populates this map at all.
+  opencode: new Set<string>(),
+  // agy emits NO tool_use events whatsoever (agy.ts:44-46) — unreachable by design.
+  agy: new Set<string>(),
+};
+
+// updateTurnState is `private updateTurnState(kind: NormalizedEventKind): void`
+// (jsonAgent.ts:986), called only from jsonAgent.ts:954 as
+// `this.updateTurnState(ev.kind)`. Both the signature and the call site must
+// change together — toolName isn't in scope today.
+//
+//   private updateTurnState(kind: NormalizedEventKind, toolName?: string): void {
+//     ...
+//       case "tool_use":
+//         if (toolName && HUMAN_GATE_TOOLS[this.pluginName]?.has(toolName)) {
+//           void this.persistLifecycle("waiting_for_human"); // fire-and-forget, see below
+//         }
+//         this.setTurnState("tool");
+//         break;
+//     ...
+//   }
+//
+// Call site (jsonAgent.ts:954):
+//   this.updateTurnState(ev.kind, ev.toolName);
+// (`this.pluginName` — resolve from the session's plugin/mode, or read `ev.provider`,
+//  which every plugin stamps on every event; pick whichever is already in scope at :954.)
+```
+
+#### Decision 1b (historical — superseded by Decision 0, R2 dropped entirely rather than "shipped without hooks"): No new CLI hook is required to ship R2
+- **Decision:** ship R2 with per-CLI `toolName` sets only. No hook work for claude (already has `setupWorkspaceHooks`, `claude.ts:291-443`, but a `PreToolUse` hook would be strictly worse — same signal, extra process, and inert on the headless JSON path R2 targets), none for cursor (no hook API found, `cursor.ts:394-469` is slash-command only), none for agy (no `setupWorkspaceHooks`; JSON channel emits no tool events at all).
+- **Rationale:** every CLI reaches `waiting_for_human` today — via R2 (claude, cursor) or via R3, which is universal and needs zero per-CLI work. A CLI with no R2 signal is a *legitimate outcome*, not a gap.
+- **Exception:** opencode is the one CLI with a real, strictly-better hook available (`permission.ask`) and an existing plugin file to hang it on — captured as **optional Phase 1c**, sequenced after Phase 1 and not blocking it.
+
+#### Decision 2: R3's "idle after ever working" replaces the v1 TTY text heuristic entirely
+- **Decision:** the poller's `idle` transition (`lifecycle.ts:163-164` and `:216-217`) checks an in-memory "has this session ever been working" flag; if true, persist `waiting_for_human` instead of `idle`.
+- **Rationale:** deterministic, zero content inspection, applies uniformly — the user's own framing ("whenever it's idle after it got to working at least once") is simpler and more robust than the v1 approach of pattern-matching pane text for question-shaped prompts.
+- **Where:** `daemon/src/services/lifecycle.ts:163-164, 216-217` (both the direct-pty and tmux idle-transition sites) — read/set the new `everWorked` flag alongside the existing `idleTracking` map entry (`lifecycle.ts:35-36`).
+
+#### Decision 3: `needs_review` is poll-based, reusing `github.ts`, not a per-CLI hook
+- **Decision:** a new poller (shape mirrors `lifecycle.ts`'s `pollAll`/`startLifecyclePoller`) calls `fetchPrForBranch` per worktree on an interval and calls `persistLifecycleState(..., "needs_review")` on open-PR, `"working"/"idle"` on merge/close.
+- **Rationale:** the detection service already exists and is CLI-independent; only polling can also observe the *exit* condition (PR merged/closed) or catch a human/web-created PR — a hook-based fast path would need per-CLI implementations (Claude Code only proven today) and would still require the poller for the exit edge, making it pure duplication for entry alone. See PRD Resolved Q2/Q3.
+- **Where:** new file `daemon/src/services/prPoller.ts`, started alongside `startLifecyclePoller()` (likely from the same daemon bootstrap site — locate via `grep -rn startLifecyclePoller daemon/src` during Phase 1, not yet located).
+
+#### Decision 3b: `PR_POLL_INTERVAL_MS = 60_000` (60s), not left as a vague "on an interval"
+- **Decision:** the poller ticks once every **60 seconds** across all worktrees (one `pollAllPrs()` sweep per tick, mirroring `lifecycle.ts`'s single-tick-covers-everything shape — NOT one `setInterval` per worktree). This was previously undecided — the PRD's "~60-120s" (`prd-…:202`) was only ever a rough tradeoff estimate in an options table, never an actual constant; this decision pins it down.
+- **Rationale:**
+  - **Floor:** must be `>= github.ts`'s own `CACHE_TTL_MS = 30_000` (`github.ts:67`) — polling faster than the cache's own TTL wastes ticks re-reading a cached value with no new GitHub API call, so anything under 30s is pure churn.
+  - **Ceiling:** GitHub's unauthenticated rate limit is 60 req/hr (`github.ts` module header) — at N worktrees polled every tick, sustainable request rate is `N req / interval`. At 60s, N worktrees costs `N * 60 req/hr` — **already at the unauthenticated ceiling with just 1 worktree** polled continuously, before any other daemon traffic. This is exactly why 1b.4 requires the `GITHUB_TOKEN`/`GH_TOKEN` warning (Risk #4) — 60s is only sustainable multi-worktree with a token (5000 req/hr authenticated, i.e. up to ~83 worktrees polled every 60s before hitting the ceiling).
+  - **Latency:** 60s matches the low end of the PRD's original estimate and the existing lifecycle poller's philosophy (fast enough to feel "live," not so fast it's wasteful) — a human going to check on a PR review request has no expectation of sub-minute notification the way `waiting_for_human` (R2/R3, seconds-scale) does; PR review is inherently a slower-paced signal.
+  - Not made configurable this round — a fixed constant, like `lifecycle.ts`'s `POLL_INTERVAL_MS = 1000` (`lifecycle.ts:27`), is simpler and matches the existing poller's own precedent; revisit only if real usage shows the rate-limit ceiling is actually being hit (ties into the existing Resolved Q re: hook fast-path, PRD:365).
+- **Where:** `daemon/src/services/prPoller.ts`, a new `export const PR_POLL_INTERVAL_MS = 60_000;` constant analogous to `lifecycle.ts:27`'s `POLL_INTERVAL_MS`, consumed by `startPrPoller()`'s `setInterval` call.
+
+---
+
+## Risks / Open Questions
+
+| # | Question | Notes |
+|---|----------|-------|
+| 1 | ~~**Exact normalized `toolName` for AskUserQuestion/ExitPlanMode across CLIs?**~~ **RESOLVED, then SUPERSEDED** | Answered per CLI against real plugin code + shipped CLI binaries (Research §Per-CLI human-gate capability), then the whole R2 mechanism this risk was about was **dropped** after live-testing all 4 CLIs (Research §R2 dropped) — see Decision 0. No longer applicable; R3 is the sole entry path. |
+| 2 | **Does the `lifecycle.state` DB column have a CHECK constraint?** | If yes, needs a migration in `daemon/src/state/project-store.ts`; if free-text, no migration needed. |
+| 3 | **Does JSON-channel idle need its own R3 "everWorked" check, separate from the tmux poller's?** | `lifecycle.ts` skips JSON-channel sessions entirely (`:118-121`); JSON's own idle transition lives in `jsonAgent.ts`/`jsonAgentChat.ts` and isn't researched at the line level here — a Phase-1 implementer must locate JSON's own working→idle transition and apply the same "everWorked" rule there, or confirm R2 already covers it in practice. |
+| 4 | **GitHub API rate limit (60 req/hr unauthenticated) vs. poller frequency × worktree count.** | Needs a `GITHUB_TOKEN` check + backoff/skip-and-warn when unauthenticated and worktree count is high; not modeled in the POC (PRD open question). |
+| 5 | **Where does `startLifecyclePoller()` get called from daemon bootstrap?** | Not yet located — needed to know where to start the new PR poller alongside it. |
+| 6 | ~~**Does cursor's headless JSON path actually emit `askQuestionToolCall`/`createPlanToolCall`?**~~ **RESOLVED, negative** | Live-tested: it fires, but *after* the question is already auto-rejected (`-f` resolves it ~1.5s before `tool_call started`). Confirms R2 would be actively wrong for cursor, not just unverified — see Research §R2 dropped. |
+| 7 | ~~**Does `opencode run` (headless) even fire `permission.ask`?**~~ **RESOLVED, negative** | Live-tested: permission requests are auto-rejected in headless `run` mode regardless of `--auto`. Phase 1c dropped — see Decision 0. |
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Daemon: `waiting_for_human` (R3 only — R2 and Phase 1c dropped, see Decision 0)
+
+- [x] **1.1** Add `"waiting_for_human"` and `"needs_review"` to `LifecycleState` in `daemon/src/types.ts:8` (both added together since every exhaustiveness check needs updating once regardless).
+- [x] **1.5** Add an in-memory `everWorked` flag to the `idleTracking` entry shape (`lifecycle.ts`), seeded `true` unconditionally the moment the poller starts tracking any session; in both idle-transition sites (tmux and direct-pty branches) persist `"waiting_for_human"` instead of `"idle"` once idle-stable. Also apply the same rule to the **JSON channel** — `drain()`'s `finally` block (`jsonAgent.ts`) now ALWAYS persists `"waiting_for_human"` on queue-drain, since R2 is dropped and R3 is the JSON channel's only path to `waiting_for_human` too. **Revision note (post-empirical-testing):** the flag was originally seeded `false`-until-first-observed-resume (matching a stricter reading of R3a), then briefly refined to "true only after an OBSERVED hash change" to guard a hypothetical blank-session false-positive — **both were empirically wrong**, live-verified against the real docker daemon: a fast-completing turn's whole response prints and stabilizes between two 1s poll ticks, so no hash delta is ever observed and the stricter rules left sessions stuck at `"idle"` forever, never reaching `"waiting_for_human"`. Final rule: `everWorked` seeds `true` unconditionally, because a session only reaches this poller's tracking code after `"not_started"` is filtered out and its ready signal has already printed visible content — "genuinely blank, nothing has happened yet" is structurally unachievable here, so R3a's carve-out has no live manifestation on this poller. The JSON channel's `everWorked` field was removed entirely (not just seeded true) since reaching `drain()`'s finally block always means a real turn was processed.
+- [x] **1.6** Check `daemon/src/state/project-store.ts` for a CHECK constraint on `lifecycle.state`; add migration only if one exists. **Confirmed no constraint** — the `sessions` table's `state TEXT NOT NULL` column (`daemon/src/services/dbSchema.ts:65`, the actual schema-defining file — `project-store.ts` itself has no `CREATE TABLE`) has no `CHECK`, unlike sibling columns (`type`, `nameSource`) that do. No migration needed.
+- [x] **1.7** Widen all three hardcoded `z.enum([...])` state lists in `daemon/src/ws/protocol.ts:209,210,230` to include `"waiting_for_human"`, `"needs_review"` — NOT covered by widening the `LifecycleState` TS type alone (see Research: WS protocol).
+
+**Verify phase 1:**
+- [x] **1.T3** Unit — `lifecycle.test.ts`: a session that reaches `"working"` then goes idle-stable transitions to `"waiting_for_human"`, INCLUDING on its first-ever idle-stable tick (R3a's "never worked" carve-out is structurally vacuous on this poller — see 1.5's revision note). Cover BOTH the TTY poller path (`lifecycle.ts`) and the JSON-channel path (`jsonAgent.ts`). **Implemented as (final revision):** TTY-path tests in `lifecycle.test.ts` re-verified against the final unconditional-`everWorked` semantic — first-ever idle-stable tick now asserts `"waiting_for_human"` (not `"idle"`), a resume-then-idle-again cycle asserts `"waiting_for_human"` again, and R4 (`waiting_for_human`→`working` on pane change) is unaffected. JSON-channel test in `jsonAgent.test.ts` renamed to assert `"waiting_for_human"` on EVERY drain, including the first.
+- [x] **1.T4** Regression — existing `jsonChannelToggle.test.ts` and `lifecycle.test.ts` assertions (`"working"`/`"exited"`, and non-R3 `"idle"` cases like `clearIdleTracking` teardown avoiding a flip and the R3a-truly-vacuous `stableSince`-reset tests) still pass. Full daemon suite (`cd cli && npx vitest run src/daemon`) re-run after the final semantic revert: **610/610 tests pass**, 59 files.
+- [x] **1.T5** Unit/integration — `protocol.test.ts` (or wherever WS schemas are tested): a `session:state` broadcast with `state: "waiting_for_human"` (and separately `"needs_review"`) parses successfully against `SessionStateEvent`'s zod schema — regression guard for 1.7. **New file:** `daemon/src/__tests__/protocol.test.ts` (none existed for `ws/protocol.ts` before) — 4 tests via `ServerMessage.parse()`.
+- [x] **1.T8** End-to-end (manual, real daemon) — with 1.1/1.5/1.6/1.7 shipped, actually drive a real JSON-channel session to `waiting_for_human` and confirm the daemon broadcasts the new state. **Verified:** rebuilt the docker dev sandbox (`scripts/dev-sandbox.sh up vs-39`), created a fresh worktree (`fsd-3`, project `file-search-demo`) with a real Claude spawn ("Say hello in one short sentence, then stop."), polled `GET /sessions/:id` every 3s — observed `not_started → working → waiting_for_human` within ~18s (well inside `IDLE_THRESHOLD_MS`), confirming R3 fires correctly end-to-end on a real running daemon, not just in unit tests. Worktree deleted after verification. The color/border CSS consumers of this state (`StatusDot.tsx`'s `!` glyph, `.agent-pane-slot--waiting_for_human`, `.workspace-canvas__tile--waiting_for_human`) were confirmed present in source (`web-ui/src/styles/chat.css:21`, `web-ui/src/styles/workspace-canvas.css:289`, `web-ui/src/styles/workspace.css:2011`) but this pass did not re-open a browser to click through them — that visual pass was already done via the opus-subagent browser check earlier in this feature's work, before this session's state-machine simplification; the state value they key off (`waiting_for_human`) is unchanged, so that verification still holds.
+- [ ] **1.T9** Same as 1.T8, for `needs_review` (violet) once a worktree with a real open GitHub PR is available to drive the PR poller — deferred; not required for this pass since the user scoped this implementation round to plan-1's R3/color-border work, and `needs_review`'s poller (Phase 1b) already has unit coverage (`prPoller.test.ts`, 10 tests) plus its CSS is already in place (`workspace.css:2015`, `workspace-canvas.css:293`, `chat.css:25`) — only the live-PR end-to-end click-through remains open.
+
+---
+
+### Phase 1b — Daemon: `needs_review` PR poller (R6, R7)
+
+- [x] **1b.1** Locate `startLifecyclePoller()`'s call site in daemon bootstrap (open Risk #5) to determine where to start the new poller alongside it. **Found:** `daemon/src/main.ts:172` (inside the daemon's HTTP-listen setup, right after `buildServer`); `stopLifecyclePoller()` is called from the `shutdown()` handler at `main.ts:177`. `startPrPoller()`/`stopPrPoller()` added at the same two call sites.
+- [x] **1b.2** Create `daemon/src/services/prPoller.ts` mirroring `lifecycle.ts`'s `pollAll`/`startLifecyclePoller`/`stopLifecyclePoller` shape (`lifecycle.ts:269-325`): iterate `getAllProjects()` worktrees, resolve owner/repo via `getRemoteUrl`/`parseGithubRepo` (`github.ts:28-45`), call `fetchPrForBranch` (`github.ts:77-95`). Export `PR_POLL_INTERVAL_MS = 60_000` (Decision 3b) and use it in the `setInterval` call — one sweep per tick covers every worktree, not one timer per worktree. **Attribution note (not explicit in the plan, but required to be well-defined):** `needs_review` is a per-SESSION `LifecycleState`, not a worktree-level field (confirmed via `web-ui/src/lib/worktreeStatus.ts`'s rollup, which reads `SessionState` per agent session) — the poller attributes it to the worktree's MAIN agent session (`SessionRecord.isMain === true`), the same session `GET /worktrees/:id/mainSessionId` already treats as canonical (`routes/worktrees.ts:137`). A worktree with no main agent session is skipped.
+- [x] **1b.3** On `PrInfo.state === "open" && !draft` → `persistLifecycleState(..., "needs_review")`; on merged/closed/no-PR while currently `"needs_review"` → `persistLifecycleState(..., "working"` or `"idle"` per current turn/idle activity)`. **Implementation note:** `needs_review` is deliberately excluded from `lifecycle.ts`'s 1Hz idle/working membership guard (same treatment as `done`/`exited`) so nothing else touches it while it's set — this poller is its sole owner for both entry and exit, matching R5's "no special-case guard needed" framing. The exit fallback (`working` vs `idle`) checks whether the session is a live JSON agent with an in-flight turn (`jsonAgentRegistry` + `getMeta().turnState !== "idle"`); everything else falls back to `"idle"`, matching plan CUJ 3's own worked example.
+- [x] **1b.4** Add a once-per-daemon-lifetime warning log when `GITHUB_TOKEN`/`GH_TOKEN` is unset and the poller is about to run against >1 worktree (Risk #4).
+- [x] **1b.5** Skip (not error) worktrees where `parseGithubRepo` returns null (non-GitHub remote) — matches existing route behavior.
+
+**Verify phase 1b:**
+- [x] **1b.T1** Unit — `prPoller.test.ts`: a worktree whose branch has an open non-draft PR transitions to `"needs_review"`.
+- [x] **1b.T2** Unit — same suite: a worktree whose PR becomes merged transitions out of `"needs_review"`.
+- [x] **1b.T3** Unit — a worktree with `parseGithubRepo` returning null is skipped without throwing. **New file:** `daemon/src/__tests__/prPoller.test.ts`, 10 tests total (draft-PR non-trigger, closed-without-merge, no-PR, done-session immunity, no-remote-at-all, no-main-session — beyond the 3 named cases — all passing).
+
+---
+
+### Phase 2 — Web-UI: rollup + StatusDot
+
+> **Ground-truth correction (found during this restructure, not assumed from the original root plan):** all five implementation items below are **already present in code** — `WorktreeRolledUpStatus`/`sessionStatus()`/`worktreeRolledUpStatus()` (`worktreeStatus.ts`), `sessionStateToStatus()` (`LeftSidebar.tsx:141-144`), the `StatusDot` `GLYPH` map (`StatusDot.tsx:3-10`), and the `.status-dot--waiting_for_human`/`.status-dot--needs_review` CSS rules (`workspace.css:2011,2015`) all handle these two values today. This was built as **scaffolding for the dev-only state-simulation panel** (`DevStatePanel.tsx`) ahead of real daemon wiring — `SessionState`'s own doc comment (`web-ui/src/api/types.ts:66-71`) says as much: these values are "only ever set by the dev-only state-simulation panel, never by a real `session:state` event," because Phase 1/1b (daemon) haven't shipped. Marked `[x]` below since the code demonstrably exists; **functionally inert** (unreachable via real sessions) until Phase 1/1b land — this phase has no daemon dependency to re-verify, only to activate.
+
+- [x] **2.1** `WorktreeRolledUpStatus` in `web-ui/src/lib/worktreeStatus.ts:3-11` already includes `"waiting_for_human"`/`"needs_review"`, ranked highest/second-highest (`worktreeStatus.ts:17-26`) — confirmed matches R8.
+- [x] **2.2** Both mapping cases already present in `worktreeRolledUpStatus`'s per-session `if/else` chain (`worktreeStatus.ts:78-79`).
+- [x] **2.3** Both passthrough cases already present in `sessionStateToStatus()` (`web-ui/src/components/layout/LeftSidebar.tsx:141-144`) — it maps every `SessionState` value straight through except `not_started` → `spawning`.
+- [x] **2.4** `waiting_for_human`/`needs_review` glyph entries already present in `StatusDot.tsx:3-10` `GLYPH` map (`"!"` and `"◆"` respectively).
+- [x] **2.5** `.status-dot--waiting_for_human` / `.status-dot--needs_review` rules already present in `web-ui/src/styles/workspace.css:2011,2015`.
+
+**Verify phase 2:**
+- [x] **2.T1** Unit — `worktreeStatus.test.ts`: added 3 new tests — `waiting_for_human` outranks `working`; `needs_review` outranks `working`; `waiting_for_human` outranks `needs_review` when both present (R8 precedence). All pass.
+- [x] **2.T2** Regression — existing `worktreeStatus.test.ts` cases (`working`/`idle`/`done`/`exited`/`none` precedence) still pass unmodified. Full file: **9/9 tests pass** (6 pre-existing + 3 new).
+
+---
+
+## Files & Phase Impact
+
+| File | Status | Phase | Description / Contract Change |
+|------|--------|-------|-------------------------------|
+| `daemon/src/types.ts` | **Modified** | 1.1 | Widen `LifecycleState` union with `"waiting_for_human"`, `"needs_review"` |
+| `daemon/src/services/jsonAgent.ts` / `jsonAgentChat.ts` | **Modified** | 1.5 | R3's `everWorked` check applied to the JSON channel's own idle/turn-end transition (`case "result"` → idle), so R3 is JSON's only `waiting_for_human` path too — NOT a toolName branch (R2 dropped, no `HUMAN_GATE_TOOLS`, no `jsonAgent.ts:986/954` signature change). |
+| `daemon/src/agent-plugins/opencode.ts` | **Unmodified** | — | Phase 1c (opencode `permission.ask` hook) dropped — see Decision 0, Risk #7 resolved negative. No change to claude.ts / cursor.ts / opencode.ts / agy.ts. |
+| `daemon/src/services/lifecycle.ts` | **Modified** | 1.5 | `idleTracking` entries gain `everWorked` flag; both idle-transition sites branch on it |
+| `daemon/src/state/project-store.ts` | **Modified (conditional)** | 1.6 | Only if a CHECK constraint on `lifecycle.state` exists |
+| `daemon/src/ws/protocol.ts` | **Modified** | 1.7 | Widen 3 hardcoded `z.enum([...])` state lists (`:209,210,230`) — NOT covered by the `LifecycleState` TS type change alone |
+| `daemon/src/services/prPoller.ts` | **New** | 1b.2–1b.5 | Contract: `pollAllPrs(): Promise<void>`, `startPrPoller()`, `stopPrPoller()` — mirrors `lifecycle.ts` poller shape · Owns: nothing new (reads `github.ts`, writes via `persistLifecycleState`) |
+| `web-ui/src/lib/worktreeStatus.ts` | **Shipped (scaffolding, inert until Phase 1/1b)** | 2.1, 2.2 | `WorktreeRolledUpStatus` already includes `"waiting_for_human"`, `"needs_review"`, ranked accordingly. **Shared file, split ownership:** this plan owns the `WorktreeRolledUpStatus` union + `rank` map + `worktreeRolledUpStatus()`; `04-workspaces` owns the `sessionStatus()` helper in the same file — see that plan's Files & Phase Impact. |
+| `web-ui/src/components/layout/LeftSidebar.tsx` | **Shipped (scaffolding, inert until Phase 1/1b)** | 2.3 | `sessionStateToStatus()` passthrough cases already present |
+| `web-ui/src/components/layout/StatusDot.tsx` | **Shipped (scaffolding, inert until Phase 1/1b)** | 2.4 | Glyph entries already present |
+| `web-ui/src/styles/workspace.css` | **Shipped (scaffolding, inert until Phase 1/1b)** | 2.5 | `.status-dot--waiting_for_human` / `.status-dot--needs_review` rules already present |
+| `web-ui/src/components/layout/WorkspaceCanvas.tsx`, `AgentPaneSlot.tsx`, `web-ui/src/styles/workspace-canvas.css`, `chat.css` | **Verified end-to-end, not modified here** | 1.T8, 1.T9 | Colored-border chrome (`.workspace-canvas__tile--*` / `.agent-pane-slot--*`) already shipped by `04-workspaces` Phase 2 — this plan's 1.T8/1.T9 are the real end-to-end proof that a genuine daemon-emitted `waiting_for_human`/`needs_review` event actually lights up BOTH the dot (this plan's Phase 2) and the border (04-workspaces' Phase 2), not just the dev-simulation panel. No file changes expected; this row exists so the checklist doesn't silently skip verifying the cross-plan dependency. |
+| `daemon/src/__tests__/jsonAgent*.test.ts` | **Modified** | 1.T3 | JSON-channel `everWorked` → `waiting_for_human` assertions (R3, not R2) |
+| `daemon/src/__tests__/lifecycle.test.ts` | **Modified** | 1.T3, 1.T4 | New `everWorked` assertions |
+| `daemon/src/__tests__/prPoller.test.ts` | **New** | 1b.T1–1b.T3 | New poller unit tests |
+| `web-ui/src/lib/worktreeStatus.test.ts` | **Modified** | 2.T1 | New rollup precedence cases |

--- a/.vibekit/feature-plans/wip/agent-interaction-workspaces/04-workspaces/plan-04-agent-interaction-workspaces-workspaces.md
+++ b/.vibekit/feature-plans/wip/agent-interaction-workspaces/04-workspaces/plan-04-agent-interaction-workspaces-workspaces.md
@@ -438,40 +438,40 @@ User opens "New Agent" dialog, fills it out normally, submits
 
 #### Phase 3a — Data model: demote `contextKey`, add view-state route param
 
-- [ ] **3a.1** Update `WorkspaceDoc.contextKey` doc comment (`useStore.ts:100-101`) to reflect "provenance only," confirm no other code path treats it as an ownership gate besides `LeftSidebar.tsx:518` and the toolbar's `isSaved`/`worktreeId` binding in `WorkspaceCanvas.tsx`.
-- [ ] **3a.2** Bump `persist` `version` to `15` (`useStore.ts:579`) and add a `// v14 → v15: workspace detachment` migration branch (`useStore.ts:580` area) — no-op on `contextKey` itself (kept as-is), clears any `layoutByWorktree[*].activeWorkspaceId` that still points at a saved doc (Risk #7), per the established migration-branch pattern (`useStore.ts:583-732`).
-- [ ] **3a.3** Add the new route `web-ui/src/App.tsx:56-64` — `<Route path="/workspaces/:workspaceId" element={<Workspace />} />` (reuses the existing `Workspace` route element, following the same pattern as `/worktree/:wtId` and `/session/:directSessionId`).
-- [ ] **3a.4** In `web-ui/src/routes/Workspace.tsx`, add a `useParams<{ workspaceId?: string }>()` read (mirrors the existing `directSessionId` pattern at `Workspace.tsx:30`) and a `isWorkspaceView`/`viewedWorkspace` derivation (`workspaceDocs[workspaceId]`), analogous to `isDirectSession`/`directSession` (`Workspace.tsx:33, 65-68`).
+- [x] **3a.1** Updated `WorkspaceDoc.contextKey` doc comment (`useStore.ts`) to "provenance only"; confirmed the only remaining reads were `LeftSidebar.tsx`'s filter (removed in 3b.1) and `WorkspaceCanvas.tsx`'s toolbar `isSaved`/`worktreeId` binding (handled by the new `detachedWorkspaceId` prop in 3c).
+- [x] **3a.2** Bumped `persist` `version` to `15`; added the `v14 → v15` migration branch clearing `layoutByWorktree[*].activeWorkspaceId` when it pointed at a doc present in `workspaceDocs` (Risk #7) — `contextKey` itself untouched.
+- [x] **3a.3** Added `<Route path="/workspaces/:workspaceId" element={<Workspace />} />` to `App.tsx`, right beside the existing (unrelated, singular) `/workspace` redirect.
+- [x] **3a.4** Added `params.workspaceId` + `isWorkspaceView`/`viewedWorkspace` derivation to `Workspace.tsx`, mirroring the `directSessionId`/`directSession` pattern. Also wired: mutual-exclusion clear of `activeWorktreeId`/`activeSessionId` on entry, a dedicated `detachedWorkspacePaneKeys`/`detachedWorkspacePaneHostLayer` (the classic `worktreePaneKeys` derivation is gated on `activeWorktreeId`, which is null in this view, so it needed its own pane-key derivation reusing the same `renderWorktreePane`), rendering via `Layout`'s `dashboardPane` slot (full-bleed, since the classic 3-pane `agentPane`/`toolPanel`/`terminalDock` machinery is keyed to a single owning worktree that doesn't exist here), and a `TopBar` `layoutMode: "workspace-view"` breadcrumb showing the doc's name.
 
 **Verify phase 3a:**
-- [ ] **3a.T1** Unit — `useStore.test.ts` (or equivalent): a persisted v14 store with a saved `WorkspaceDoc` migrates to v15 without data loss (doc still present, same `id`/`tiles`/`tree`).
-- [ ] **3a.T2** Unit — a persisted v14 store whose `layoutByWorktree[wtId].activeWorkspaceId` pointed at a saved doc has that pointer cleared post-migration (Risk #7 resolution — confirm the chosen behavior once decided).
-- [ ] **3a.T3** Integration — navigating to `/workspaces/<validId>` resolves `viewedWorkspace` to the correct `WorkspaceDoc`; `/workspaces/<invalidId>` resolves to `null`/not-found state.
+- [x] **3a.T1** Unit — `useStore.test.ts`: a persisted v14 store with a saved `WorkspaceDoc` migrates to v15 with the doc unchanged (`toEqual`). Passing.
+- [x] **3a.T2** Unit — same suite: `layoutByWorktree[wtId].activeWorkspaceId` pointing at a saved doc is cleared post-migration, everything else on the entry preserved; a no-op case (null/dangling pointer) also covered. Passing.
+- [ ] **3a.T3** Integration — deferred: no `Workspace.tsx` test harness exists in this codebase (it's a large, deeply-integrated route component with no prior test file) and building one from scratch was out of scope for this pass. The `viewedWorkspace` derivation itself is a one-line pure memo (`workspaceDocs[params.workspaceId] ?? null`) exercised implicitly by 3a.T1/3a.T2's store-shape tests, and the not-found redirect mirrors the pre-existing, already-tested `directSession` redirect pattern 1:1 (same file, same shape). Live end-to-end (not-found → real redirect, valid id → real canvas render) not re-verified this session — recommended before next touching this route.
 
 ---
 
 #### Phase 3b — Sidebar: global Workspaces section — **blocked on user confirmation (Risk #5)**
 
-- [ ] **3b.1** *(after confirmation)* Remove the `contextKey === activeWorktreeId` filter in `workspacesForActiveWorktree` (`LeftSidebar.tsx:516-519`) — rename to `allWorkspaces` (or similar), list `Object.values(workspaceDocs)` unfiltered.
-- [ ] **3b.2** Move the "Workspaces" `<section>` (`LeftSidebar.tsx:1124-1167`) out of any per-worktree nesting so it renders exactly once, sibling to the worktree/project tree (confirm current nesting at implementation time — Research above didn't fully resolve whether it's already top-level or nested; the `workspacesOpen` collapse state, `:501-512`, is already a single boolean, not per-worktree, which suggests the section may already be structurally top-level and only the *data* filter needs to change).
-- [ ] **3b.3** Update the click handler (`LeftSidebar.tsx:352`, `store.setActiveWorkspace(worktreeId, id)`) to `navigate(`/workspaces/${id}`)` instead (Decision 4).
+- [x] **3b.1** Removed the `contextKey === activeWorktreeId` filter; renamed to `allWorkspaces = Object.values(workspaceDocs)`, unfiltered (Decision 6). **Confirmation note:** treated as already-confirmed by the user's own earlier explicit instruction ("A saved workspace should be detached from the worktree" / "back to unsaved won't make sense anymore") — a per-worktree-filtered sidebar list would contradict "detached" (you'd only ever see a workspace again from the worktree that happened to create it), so global listing is the only coherent reading of that instruction, not a fresh open design question.
+- [x] **3b.2** Confirmed the section was ALREADY structurally top-level (gated only by `!collapsed && activeWorktreeId`, not nested in any per-worktree loop — Research's own speculation was correct). Only the gate changed: `!collapsed && activeWorktreeId` → `!collapsed` (renders regardless of active worktree, including the dashboard).
+- [x] **3b.3** Click/keydown handlers now `navigate(\`/workspaces/${ws.id}\`)` instead of `setActiveWorkspace(activeWorktreeId, ws.id)` + `setLayoutMode(activeWorktreeId, "workspace")`. Row highlighting (`isActive`) switched from the old `activeWorkspaceId === ws.id && activeLayoutMode === "workspace"` check to a route match (`location.pathname` against `/workspaces/:id`).
 
 **Verify phase 3b:**
-- [ ] **3b.T1** Unit — `LeftSidebar.test.tsx`: with two saved workspaces created under different worktrees, both appear in the Workspaces section regardless of which worktree (or none) is active.
-- [ ] **3b.T2** Integration — clicking a workspace row navigates to `/workspaces/<id>` and does not mutate `activeWorktreeId`.
+- [x] **3b.T1** Unit — `LeftSidebar.test.tsx`: two docs (different `contextKey`s, one with an empty-string `contextKey` simulating "created with nothing active") both appear regardless of active worktree, AND with no active worktree at all (dashboard). Passing.
+- [x] **3b.T2** Integration — clicking a workspace row navigates to `/workspaces/<id>` (verified via a sibling `useLocation()` probe inside the same `MemoryRouter`, since `navigate()` mutates router-internal history with no other observable signal) without mutating `activeWorktreeId`. Passing.
 
 ---
 
 #### Phase 3c — Canvas: remove "Back to unsaved" for the detached case, wire route-driven view
 
-- [ ] **3c.1** `WorkspaceCanvas.tsx:688-707` — when rendering via the new `/workspaces/:workspaceId` route (Phase 3a.4), always take the `isSaved` branch (`:689-701`) but **omit** the "Back to unsaved" button (`:693-700`) — there is no unsaved canvas to go back to in this view.
-- [ ] **3c.2** Confirm the existing per-worktree canvas flow (`/worktree/:wtId`, viewing *that worktree's* scratch canvas or a saved workspace via the old `activeWorkspaceId` mechanism) still works for the transient case — this phase must not regress D2 (scratch canvas untouched).
-- [ ] **3c.3** Decide + implement the "workspace not found" state for a stale/deleted `WorkspaceDoc.id` in the URL (Risk #8) — redirect to `/` after showing a brief message, mirroring `Workspace.tsx:105-109`'s pattern for a missing direct session.
+- [x] **3c.1** Added a `detachedWorkspaceId?: string` prop to `WorkspaceCanvas` — when set, `savedDoc`/`isSaved`/`canvas` bind directly to `workspaceDocs[detachedWorkspaceId]` (bypassing `layoutByWorktree`), the scratch-canvas seeding effect is skipped entirely (no scratch concept in this view), and the "Back to unsaved" button is omitted (still shows the doc name).
+- [x] **3c.2** Unaffected by construction: `detachedWorkspaceId` is a new, additive, opt-in prop — every existing call site (`Workspace.tsx`'s per-worktree `workspaceCanvas`) omits it, so `isDetachedView` is `false` and every branch touched in 3c.1 falls through to the pre-existing behavior unchanged. Confirmed via full regression suite (664 daemon+cli / 364 web-ui tests, all passing) rather than a fresh manual click-through.
+- [x] **3c.3** `viewedWorkspace === null` (doc deleted or invalid id) → `navigate("/", { replace: true })`, mirroring the existing `directSession`-not-found effect in the same file.
 
 **Verify phase 3c:**
-- [ ] **3c.T1** Manual — open a saved workspace via `/workspaces/:id`: no "Back to unsaved" button present.
-- [ ] **3c.T2** Manual — open a worktree's *unsaved* scratch canvas via `/worktree/:wtId` (never saved): behaves exactly as before this phase (D2 regression check).
-- [ ] **3c.T3** Manual — navigate to `/workspaces/<deleted-id>`: redirected to `/`, no crash.
+- [ ] **3c.T1** Manual — deferred (no browser click-through this session; the button's conditional render was verified by code read only — `{!isDetachedView ? <button>Back to unsaved</button> : null}`).
+- [ ] **3c.T2** Manual — deferred; see 3c.2's regression-suite note above for the argument this is low-risk (additive-only change).
+- [ ] **3c.T3** Manual — deferred; the redirect effect itself is code-identical in shape to the already-verified `directSession` redirect, but not re-clicked through in a live browser this session.
 
 ---
 
@@ -481,41 +481,41 @@ User opens "New Agent" dialog, fills it out normally, submits
 
 #### Phase 4a — Daemon: `spawnedFrom` field + persistence
 
-- [ ] **4a.1** Locate the session-record schema/insert path (Risk #11) — likely `daemon/src/state/project-store.ts` alongside the `lifecycle.state` column referenced in `03-interaction-states`.
-- [ ] **4a.2** Add `sourceAgentId: z.string().optional()` to `CreateWorktreeBody` (`daemon/src/routes/worktrees.ts:141-156`) and to both `WorktreeSessionBody`/`DirectSessionBody` (`daemon/src/routes/sessions.ts:52-72`).
-- [ ] **4a.3** Thread `sourceAgentId` from the validated body through to the session-record insert (Phase 4a.1's location) as `spawnedFrom`, defaulting to `null` when absent.
-- [ ] **4a.4** Add a migration if the session table's schema requires one (conditional on 4a.1's finding).
+- [x] **4a.1** Located: `daemon/src/services/dbSchema.ts` (schema + `addColumnIfMissing` backfill pattern), `daemon/src/state/sqliteRowMappers.ts` (`SessionRow`/`rowToSession`/`sessionToRow`), `daemon/src/state/project-store.ts` (the actual `INSERT INTO sessions` statement — a full-replace-on-every-mutation strategy, not per-field UPDATE), `daemon/src/types.ts` (`SessionRecord`). Risk #11 resolved: no CHECK constraint issue (same finding as `03-interaction-states`'s analogous `lifecycle.state` investigation) — `spawnedFrom TEXT` needed only the existing `addColumnIfMissing` backfill, no data migration.
+- [x] **4a.2** Added `sourceAgentId: z.string().optional()` to `CreateWorktreeBody`, `WorktreeSessionBody`, and `DirectSessionBody`.
+- [x] **4a.3** Threaded through all three session-record construction sites (`worktrees.ts`'s main-session build, and both branches of `sessions.ts`'s `POST /sessions`) as `spawnedFrom: data.sourceAgentId ?? null` / `result.data.sourceAgentId ?? null`. Also added `spawnedFrom` to `serializeSession()` (the `GET /sessions` response shape) — the plan didn't call this out explicitly but it's necessary for the field to be readable via REST at all, not just via the WS event.
+- [x] **4a.4** Migration: `addColumnIfMissing(db, "sessions", "spawnedFrom", "TEXT")` in `dbSchema.ts`, matching the existing `branchIsPlaceholder` precedent exactly.
 
 **Verify phase 4a:**
-- [ ] **4a.T1** Unit — `worktrees.test.ts`/`sessions.test.ts`: `POST /worktrees`/`POST /sessions` with `sourceAgentId` set persists it as `spawnedFrom` on the new record.
-- [ ] **4a.T2** Regression — omitting `sourceAgentId` still creates a session with `spawnedFrom: null`, identical to pre-change behavior otherwise.
+- [x] **4a.T1** Unit — 2 new tests each in `worktrees.test.ts`/`sessions.test.ts`: `sourceAgentId` set → GET confirms `spawnedFrom` matches, round-tripped through the DB (not just the create response). Passing. **Also live-verified against the real running docker sandbox** (not a test double): `POST /worktrees`, then `POST /sessions {sourceAgentId}`, then `GET /sessions/:id` — `spawnedFrom` correctly persisted and survived the round trip.
+- [x] **4a.T2** Regression — same 2 files: omitting `sourceAgentId` → `spawnedFrom: null`. Passing.
 
 ---
 
 #### Phase 4b — Daemon: WS event + CLI flag
 
-- [ ] **4b.1** Add `spawnedFrom: z.string().nullable().optional()` to `SessionCreatedEvent` (`daemon/src/ws/protocol.ts:218-225`); populate it from the new session record when broadcasting.
-- [ ] **4b.2** Add `--source-agent <sessionId>` option to `cli/src/commands/worktree/create.ts`, threaded into the `daemonPost("/worktrees", { ... sourceAgentId })` call; default via `opts.sourceAgent ?? process.env.VST_SESSION`.
-- [ ] **4b.3** Add the same `--source-agent <sessionId>` option to `cli/src/commands/session/create.ts`, same defaulting rule.
+- [x] **4b.1** Added `spawnedFrom: z.string().nullable().optional()` to `SessionCreatedEvent`; populated at all 3 real create-flow broadcast sites (`worktrees.ts`'s main-session broadcast, both branches of `sessions.ts`'s `POST /sessions` broadcast) as `spawnedFrom: <record>.spawnedFrom ?? null`. Left the 3 non-create broadcast sites (manifest-import/legacy paths in `projects.ts`, a reset-replacement path in `sessions.ts`) omitting the field — correct behavior (optional in the schema), not a gap, since those aren't genuine "spawned from a source" creations. Also added `spawnedFrom` to web-ui's `WSEvent` TS type (`api/types.ts`) so the client can actually read it.
+- [x] **4b.2** Added `--source-agent <sessionId>` to `worktree/create.ts`; defaults via `opts.sourceAgent ?? process.env.VST_SESSION ?? undefined`, sent only when truthy (`...(sourceAgentId ? { sourceAgentId } : {})`) so an old daemon build sees no new field at all rather than an explicit `undefined`.
+- [x] **4b.3** Same for `session/create.ts`.
 
 **Verify phase 4b:**
-- [ ] **4b.T1** Unit — CLI test: `vst worktree create` invoked with `VST_SESSION=abc` in env and no explicit `--source-agent` sends `sourceAgentId: "abc"` in the POST body.
-- [ ] **4b.T2** Unit — CLI test: explicit `--source-agent xyz` overrides `$VST_SESSION` when both are present.
-- [ ] **4b.T3** Unit — `session:created` WS payload includes `spawnedFrom` matching what was persisted in Phase 4a.
+- [x] **4b.T1** Unit — new `cli/src/commands/sourceAgent.test.ts` (no CLI-command test harness existed in this codebase before this file — built one: mock `daemon-client.js`/`preflight.js`, drive the real registered commander action via a minimal parent `Command` tree matching `program.ts`'s own wiring). Covers both `worktree create` and `session create`: `$VST_SESSION` env defaulting, with and without an explicit flag. 8/8 passing.
+- [x] **4b.T2** Unit — same file: explicit `--source-agent` overrides `$VST_SESSION` when both present, for both commands. Passing. Also covers the "neither present → field omitted entirely, not sent as undefined" case (S5).
+- [x] **4b.T3** Unit — new `protocol.test.ts` cases: `SessionCreatedEvent` parses with `spawnedFrom` as a string, as `null`, and absent entirely (pre-upgrade-daemon compat). Passing. The "matches what was persisted" half of this item is covered by 4a.T1's REST-level assertions (same request, same underlying record).
 
 ---
 
 #### Phase 4c — Web-UI: auto-insert on `session:created` — **Risk #9/#10 gate scope of multi-workspace fan-out**
 
-- [ ] **4c.1** Add a `session:created` handler (or extend the existing one) that reads `spawnedFrom`; if null, no-op (CUJ 6 regression guard).
-- [ ] **4c.2** Implement `findWorkspacesTilingSession(sessionId): WorkspaceDoc[]` scanning `workspaceDocs` (Research, System Boundaries).
-- [ ] **4c.3** Locate and reuse the existing "Add tile" insert function (Decision 8, Risk #13) — call it programmatically with the source tile as split target.
-- [ ] **4c.4** *(pending Risk #9/#10 confirmation)* Insert into all matching workspaces vs. only the active one — implement per whichever answer is confirmed; until then, implement for the single-match case only (uncontroversial) and stub/log the multi-match case rather than guessing.
+- [x] **4c.1** Extended the existing `session:created` handler in `useServerSync.ts` — `if (ev.spawnedFrom) { ...scan... }`, falsy (null/absent) → no-op, zero behavior change from before Phase 4 (CUJ 6).
+- [x] **4c.2** Implemented `findWorkspacesTilingSession(sessionId, workspaceDocs)` in `useStore.ts`, exported, unit-tested directly.
+- [x] **4c.3** Resolved Risk #13 (exact function): `WorkspaceCanvas.tsx`'s `addTile(kind, sessionId?, tileWorktreeId?)`. Rather than calling into the live component instance (impossible — the WS event can fire while that workspace isn't even mounted), **extracted its core algorithm** into a new pure function `insertTileIntoCanvas(canvas, kind, sessionId?, tileWorktreeId?, sameWorktreeId?)` in `useStore.ts`, operating on a plain `CanvasGeometry` instead of component state. `WorkspaceCanvas.tsx`'s `addTile` now CALLS this same function (refactored, not duplicated) via `patchCanvas`; a new store action `insertTileIntoWorkspaceDoc(docId, ...)` calls it directly against `workspaceDocs`. Single implementation, satisfies Decision 8 more strongly than the plan's original phrasing implied (not just "behaves identically" — is literally the same code). Also moved `findLeafId` from a `WorkspaceCanvas.tsx`-local function to an exported `lib/tiling.ts` function (needed by the now-headless insert path) and fixed `tiling.ts`'s stale "DEV-ONLY POC" file-header comment (Risk #2, flagged as a drive-by cleanup opportunity — done while already touching the file).
+- [x] **4c.4** Implemented exactly as scoped: single-match case auto-inserts; multi-match (Risk #9/#10, still unconfirmed) logs a `console.warn` and skips both, rather than guessing "all" vs. "active" vs. "none".
 
 **Verify phase 4c:**
-- [ ] **4c.T1** Integration — a `session:created` event with `spawnedFrom` matching a tile in exactly one workspace auto-inserts a new tile there, split from the source tile.
-- [ ] **4c.T2** Integration — a `session:created` event with `spawnedFrom` matching no tile anywhere results in no tile insert, no error (S5).
-- [ ] **4c.T3** Regression — a `session:created` event with `spawnedFrom: null` (or absent, old-daemon compat) behaves identically to pre-change (no scan attempted).
+- [x] **4c.T1** Integration — new `useServerSync.test.ts` cases (real hook, real store, `api.__test.emit`): single-match auto-inserts a new tile, doc's tile count goes 1→2. Passing.
+- [x] **4c.T2** Integration — same file: no-match → no insert, no error, tile count stays 1. Passing.
+- [x] **4c.T3** Regression — same file: `spawnedFrom` absent entirely → no scan, tile count unchanged (CUJ 6). Also added (beyond the plan's 3 items): a multi-match case asserting BOTH docs are left untouched and a warning is logged (4c.4's stub behavior). Plus direct unit tests for `insertTileIntoCanvas`/`findWorkspacesTilingSession` in `useStore.test.ts` (free/tiled mode, cross-context worktreeId stamping, immutability, multi-doc matching). All passing.
 
 ---
 

--- a/.vibekit/feature-plans/wip/agent-interaction-workspaces/04-workspaces/plan-04-agent-interaction-workspaces-workspaces.md
+++ b/.vibekit/feature-plans/wip/agent-interaction-workspaces/04-workspaces/plan-04-agent-interaction-workspaces-workspaces.md
@@ -1,0 +1,547 @@
+---
+PRD: ../prd-agent-interaction-workspaces.md
+Status: WIP
+---
+
+<!--
+RULES — read before writing or implementing:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. REQUIREMENTS: One crisp line each — no verbose descriptions
+3. CHECKLIST: Mark items [x] as you complete them — this is your persistent todo list
+4. READING TIME: Optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+# Plan: Workspaces (04, sub-feature of Agent Interaction State + Workspaces)
+
+> A canvas of **live** agent chat/terminal panes and panel panes (any worktree), tileable either free-form or in a window-manager-style split layout, each carrying a state-colored indicator. This plan is the single home for **everything workspace-shaped**: the already-shipped real implementation (Phase 1), the already-shipped v3 cursor/border fixes (Phase 2), workspace detachment (Phase 3), and source-agent spawn affinity (Phase 4) — one coherent plan, not split by "when the requirement was gathered."
+
+**Issue:** agent-interaction-workspaces / 04-workspaces
+**Branch:** `introducing-new-state` (current)
+**Status:** WIP — Phase 1 implementation complete (shipped) with 2 of 3 verify items outstanding (1.T2/1.T3, not re-run this session — see Phase 1's Verify block); Phase 2 fully complete including verify. Phase 3 (detachment) and Phase 4 (spawn affinity) are planned, not yet implemented — Phase 3b is blocked on user confirmation (Risk #5).
+**PRD:** `.vibekit/feature-plans/wip/agent-interaction-workspaces/prd-agent-interaction-workspaces.md` §2, §3, §4, §5 (W1-W12, L1-L8, D1-D8, S1-S6)
+**Spawned from:** root plan (restructure — see root plan's Revision note; absorbs the root plan's former Phase 3/Phase 4 content plus the two former sub-plans `01-workspace-detachment`/`02-source-agent-spawn`, merged in as Phase 3/Phase 4 of this single plan per user feedback: "Why do we still have 1 and 2. I clearly said let's just have 2 plans. We don't need 4.")
+
+**Reference files:**
+- Live implementation: `web-ui/src/components/layout/WorkspaceCanvas.tsx`, `web-ui/src/lib/tiling.ts`, `web-ui/src/components/layout/PaneHostLayer.tsx`, `web-ui/src/components/layout/paneOutlets.tsx`, `web-ui/src/components/layout/LeftSidebar.tsx` (Workspaces section, ~line 1124-1167), `web-ui/src/hooks/useStore.ts:97-102` (`WorkspaceDoc`)
+- Direct-session + shared status helper: `web-ui/src/components/layout/AgentPaneSlot.tsx`, `web-ui/src/lib/worktreeStatus.ts` (`sessionStatus()`)
+- Styling: `web-ui/src/styles/workspace-canvas.css`
+- Detachment — data model: `web-ui/src/hooks/useStore.ts:97-102` (`WorkspaceDoc`), `:115-220` (`WorkspaceState` incl. `layoutByWorktree`, `activeWorkspaceId`, `setActiveWorkspace`), `:577-580` (`persist` middleware, `name: "vibestation:workspace"`, `version: 14`, `migrate`)
+- Detachment — sidebar: `web-ui/src/components/layout/LeftSidebar.tsx:514-526` (`workspacesForActiveWorktree` filter, `orderedWorkspaces`), `:1124-1167` (render block), `:352` (`store.setActiveWorkspace(worktreeId, id)` on click)
+- Detachment — canvas top bar: `web-ui/src/components/layout/WorkspaceCanvas.tsx:688-707` (saved/unsaved toolbar incl. "Back to unsaved" button, line 697-699), `:130` (`setActiveWorkspace` hook usage), `:352` (click handler)
+- Detachment — routing: `web-ui/src/App.tsx:56-64` — existing routes; `/workspace` (singular, no id) already exists and redirects to `/worktree` (`App.tsx:63`) — a new detached-view route must not collide with this path.
+- Spawn affinity — CLI: `cli/src/commands/worktree/create.ts` (full file, `vst worktree create`), `cli/src/commands/session/create.ts` (full file, `vst session create`), `cli/src/lib/daemon-client.ts` (`daemonPost`)
+- Spawn affinity — daemon routes: `daemon/src/routes/worktrees.ts:141-156` (`CreateWorktreeBody` zod schema), `:305-325` (`POST /worktrees` handler); `daemon/src/routes/sessions.ts:52-72` (`WorktreeSessionBody`/`DirectSessionBody`/`CreateSessionBody` union), `:448-473` (`POST /sessions` handler)
+- Spawn affinity — env injection: `daemon/src/routes/sessions.ts:1079-1082, 1753-1755` (`VST_SESSION`, `VST_WORKTREE` injected into every spawned agent's environment)
+- Spawn affinity — existing `/vst` slash command + hooks: `daemon/src/agent-plugins/claude.ts:291-343` (`setupWorkspaceHooks` — writes a `/vst` custom slash command into `.claude/commands/vst.md` that expands to `vst` CLI invocations using `$VST_SESSION`/`$VST_WORKTREE`)
+- Spawn affinity — WS protocol: `daemon/src/ws/protocol.ts:218-225` (`SessionCreatedEvent` — `session:created`), `:339-342` (`WorktreeCreatedEvent` — `worktree:created`)
+- Spawn affinity — confirmed absence: `grep -rn "spawnedFrom" daemon/src web-ui/src cli/src` returns no hits (pre-implementation) — no existing field/mechanism to build on.
+
+---
+
+## Superseded
+
+> Relocated verbatim from root plan.
+
+| Prior approach | Why it failed | Superseded on |
+|-----------------|---------------|---------------|
+| v1: single `waiting_review` state; TTY entry via a text-pattern heuristic; tiles showed static mock text; free-form-only canvas | User feedback: replace the fragile TTY heuristic; add independent `needs_review`; tiles must show live, replyable content; layout must support tiling as well as free-form | superseded by v2 |
+| v2: Workspaces shipped as a standalone `.scratch/workspaces-poc.html` Artifact (mock/simulated data, no daemon wiring) | Superseded by reality, not by user feedback: the feature was subsequently built for real in `web-ui/` (`WorkspaceCanvas.tsx`, `useStore.ts`'s `WorkspaceDoc`, `tiling.ts`) | superseded by real implementation, noted at v3; documented here as Phase 1 (below), not left as a stale unchecked POC phase |
+| v3/v4-interim: detachment (`D1-D8`) and spawn affinity (`S1-S6`) tracked as two separate sub-plan files (`01-workspace-detachment/`, `02-source-agent-spawn/`), each with its own directory | User feedback: "Why do we still have 1 and 2. I clearly said let's just have 2 plans. We don't need 4." | superseded by this restructure — both merged into this plan as Phase 3/Phase 4; the two directories are deleted, no content lost (see Files & Phase Impact) |
+
+## Problem
+
+- See [prd-agent-interaction-workspaces.md](../prd-agent-interaction-workspaces.md) §Problem, §2, §3, §4, §5 — the current layout is a fixed single-agent-pane split with no way to see or interact with multiple agents (possibly from different worktrees) side by side; once a workspace is saved it's still wrongly modeled as owned by one worktree; and spawning a related agent has no way to auto-join the workspace(s) tiling its source.
+
+## Out of Scope
+
+- Multi-user / permissions on workspaces (single local user only, same as today's app).
+- Tabbed/stacked tiling container layouts — split-only (row/column) this round (PRD Non-goals).
+- Direct sessions becoming full workspace-tileable (addable as a tile) — only the colored-border indicator ships; see Risks below and PRD Resolved Q9.
+- Everything Interaction-States-shaped (the `waiting_for_human`/`needs_review` daemon lifecycle machine itself) — see [`03-interaction-states`](../03-interaction-states/plan-03-agent-interaction-workspaces-interaction-states.md); this plan only *consumes* that state (via `sessionStatus()`) for tile/pane coloring, it does not produce it.
+- *(Phase 3, detachment)* Any change to the per-worktree **transient** scratch canvas (`WorktreeLayout.scratchCanvas` per `useStore.ts:38-42`) — it stays worktree-owned exactly as today (PRD D2).
+- *(Phase 3, detachment)* A dedicated "Workspaces library" management page (rename/duplicate/delete beyond what already exists) — PRD Non-goal.
+- *(Phase 3, detachment)* Server-side persistence of `WorkspaceDoc` — it remains client-only (zustand `persist` → localStorage, `useStore.ts:577-580`); detachment is a client-side modeling change, not a new sync layer.
+- *(Phase 3, detachment)* Multi-workspace tile sharing semantics — tracked in Phase 4's open questions, not decided in Phase 3.
+- *(Phase 4, spawn affinity)* Changing the in-app "New Agent"/"Direct Agent" dialogs' UI to expose a source-agent picker to the *human* — PRD S2 requires the capability to exist on the request path, not that every dialog must surface a picker widget this round (propose: dialogs pass `spawnedFrom` only when programmatically known, e.g. a future "spawn related agent" action; a manual picker UI is a follow-on, not blocking this phase — flagged as an open question).
+- *(Phase 4, spawn affinity)* Auto-tiling into workspaces that don't yet exist / creating a new workspace on the fly — S4 only inserts into workspaces that **already** contain a tile for the source session.
+- *(Phase 4, spawn affinity)* Cross-CLI hook parity (Cursor/OpenCode equivalents of `setupWorkspaceHooks`) — Claude Code only, matching the existing hook infrastructure's scope (PRD Resolved Q2, unrelated non-goal carried over).
+
+## Concept
+
+- See [prd-agent-interaction-workspaces.md](../prd-agent-interaction-workspaces.md) §2-§5 for full behavior + layout model + detachment + spawn affinity.
+- Four parts, all owned by this one plan: (1) the shipped canvas/tiling/tile-chrome implementation (Phase 1 — complete); (2) the shipped v3 cursor fix + direct-session color borders (Phase 2 — complete); (3) workspace detachment — decouple a saved workspace from its creating worktree, redesign the sidebar's "Workspaces" section as a global list, add a dedicated workspace-view route, remove "Back to unsaved" for the detached case (Phase 3 — planned); (4) source-agent spawn affinity — a new agent session can record which existing session it was spawned from (dialogs or the `vst` CLI), and the client auto-inserts the new session as a tile into whichever workspace(s) currently tile the source session (Phase 4 — planned).
+- Phase 4 benefits from Phase 3 (a global, non-per-worktree `workspaceDocs` scan is simpler once workspaces aren't filtered by worktree) but does not require Phase 3 to land first — the scan works over `workspaceDocs` either way (already a flat global map, see Research).
+
+## Requirements
+
+| # | PRD ID | Requirement |
+|---|--------|-------------|
+| 1 | W1–W9, L1–L8 | Workspaces canvas: tiles (agent or panel pane), live chat/terminal content + working composer, mixed worktrees, state-colored indicator, free-form and window-manager-style tiling layout modes with split/resize/remove/switch semantics. **Shipped for real** — see Phase 1. |
+| 2 | W10 | Tile-header drag handle shows `cursor: grab`, not `cursor: move`. **Shipped** — see Phase 2. |
+| 3 | W11 | Workspace-mode tiles keep rendering a state-colored border AND `StatusDot` glyph in the tile header (regression guard on both). **Shipped, verified still true** — see Phase 2. |
+| 4 | W12 | Direct-session single-pane chrome also renders a state-colored border (same treatment as W11's tile border, via the shared `sessionStatus()` helper). **Shipped** — see Phase 2. |
+| 5 | D1 | Saving a workspace detaches it — `contextKey` no longer gates sidebar visibility or "which worktree can view this." **Planned** — see Phase 3a. |
+| 6 | D2 | Transient scratch canvas (unsaved) stays worktree-scoped, unchanged. **Planned** — see Phase 3c. |
+| 7 | D3 | "Back to unsaved" is removed from the canvas toolbar when viewing a detached (saved) workspace. **Planned** — see Phase 3c. |
+| 8 | D4 | Sidebar shows one global "Workspaces" list, not nested under any worktree. **Planned** — see Phase 3b. |
+| 9 | D5, D6 | A detached workspace is viewable from the global list regardless of active worktree, without first navigating into a worktree. **Planned** — see Phase 3a/3b. |
+| 10 | D7 | Tile behavior inside a detached workspace (live panes, any worktree, add/remove) is unchanged. **Planned** — see Phase 3c. |
+| 11 | D8 | Pre-v3 saved `WorkspaceDoc`s (with a meaningful `contextKey`) migrate cleanly, no data loss, no manual re-save. **Planned** — see Phase 3a. |
+| 12 | S1 | Session creation accepts an optional source-agent session reference. **Planned** — see Phase 4a. |
+| 13 | S2 | Available both from in-app dialogs (request-path support) and from a running agent's shell via the CLI. **Planned** — see Phase 4a/4b. |
+| 14 | S3 | CLI defaults the source agent to `$VST_SESSION` when invoked from inside a running agent's shell and no explicit value is given. **Planned** — see Phase 4b. |
+| 15 | S4 | New session auto-appears as a tile in every workspace currently tiling the source session. **Planned** — see Phase 4c. |
+| 16 | S5 | Source agent not tiled anywhere → new session created normally, no auto-tiling side effect. **Planned** — see Phase 4c. |
+| 17 | S6 | Auto-inserted tile placement is deterministic (default: split the source agent's own tile). **Planned** — see Phase 4c. |
+
+> **Ground-truth correction (carried from PRD, v4):** an earlier v3 pass claimed workspace tiles had no state-colored border (`StatusDot` glyph only) and flagged W12's border-vs-dot choice as an open question. Both claims are now stale — a colored `border-color` per session state exists on BOTH surfaces (`workspace-canvas.css`'s `.workspace-canvas__tile--*` rules and `chat.css`'s `.agent-pane-slot--*` rules), sharing one `sessionStatus()` helper (`web-ui/src/lib/worktreeStatus.ts`). Workspace tiles additionally keep the `StatusDot` glyph. No visual inconsistency between the two surfaces, no open question to resolve. See PRD §2's own corrected note.
+
+---
+
+## Research
+
+### Workspace tile chrome + color mapping — real implementation (Phase 1/2)
+- **File:** `web-ui/src/lib/worktreeStatus.ts:34-53` — `sessionStatus(state: SessionState): WorktreeRolledUpStatus`, maps a raw session state to the rollup status used for coloring. **Shared helper** — imported by both `WorkspaceCanvas.tsx` (tile chrome) and `AgentPaneSlot.tsx` (direct-session chrome), per its own doc comment ("so both surfaces use one source of truth").
+- **File:** `web-ui/src/components/layout/WorkspaceCanvas.tsx:548` — `const status = tile.kind !== "tools" && session ? sessionStatus(session.state) : null;` — computed per tile, feeds `<StatusDot status={status} />` in the tile header when non-null.
+- **File:** `web-ui/src/components/layout/WorkspaceCanvas.tsx:1-26` — imports `buildBalancedTree`, `insertPane`, `removePane`, `resizeSplit`, `swapPanes`, `LayoutNode`, `Side`, `SplitNode` from `@/lib/tiling` — confirms the tiling engine described in the original POC design (Decision 1 below) is the one actually driving the shipped canvas, not a separate reimplementation.
+- **Stale comment (minor, non-blocking cleanup):** `web-ui/src/lib/tiling.ts:1-8`'s file-header doc comment still reads "DEV-ONLY POC code (`web-ui/workspaces-demo.html`), not wired into the real app" — **confirmed stale**: `tiling.ts` is imported and actively used by `WorkspaceCanvas.tsx` (previous bullet), which is mounted by the real `/workspace` route (`web-ui/src/routes/Workspace.tsx:16,291`). Flagged as a doc-comment cleanup opportunity, not a functional gap — no behavior depends on it.
+
+### Direct-session pane chrome — real implementation (v3, W12)
+- **File:** `web-ui/src/components/layout/AgentPaneSlot.tsx:7` (import), `:49` (computed) — `sessionStatus()` imported from `@/lib/worktreeStatus`; computed as `const status = session ? sessionStatus(session.lifecycleState) : null;` and rendered as `className={\`agent-pane-slot${status ? \` agent-pane-slot--${status}\` : ""}\`}` on the component's root `<div>` — an actual CSS class driving a border color, confirmed by the component's own inline comment: "Same colored-rectangle treatment as a workspace tile... a border is the only 'colored rectangle' surface available here."
+- **File:** `web-ui/src/routes/Workspace.tsx:307-319` — `directAgentPane` passes `session={directSession}` into `AgentPaneSlot`, which is all W12 needed — no additional wiring required at the call site.
+
+### Tile-header cursor (v3, W10)
+- **File:** `web-ui/src/styles/workspace-canvas.css:332` — confirmed: `cursor: grab;` (and `:337` `cursor: grabbing;` for the active-drag state) on the tile-header drag-handle rule. The `cursor: move` variant described in the original v3 research pass is **no longer present** — already fixed.
+
+### Workspace data model (shipped)
+- **File:** `web-ui/src/hooks/useStore.ts:97-102` — `WorkspaceDoc extends CanvasGeometry { id, name, contextKey }`; `contextKey` today still means "owning worktree" — this is exactly what Phase 3 (detachment) changes.
+- **File:** `web-ui/src/hooks/useStore.ts:280` — `workspaceDocs: Record<string, WorkspaceDoc>` — flat, global map (relevant to Phase 3's finding that detachment is smaller than it looks).
+
+### Sidebar Workspaces section (shipped)
+- **File:** `web-ui/src/components/layout/LeftSidebar.tsx:501-512` — `workspacesOpen` collapse state (single boolean, not per-worktree).
+- **File:** `web-ui/src/components/layout/LeftSidebar.tsx:1124-1167` — renders the `<section className="workspaces-section">`. Whether this section is currently scoped per-worktree or already structurally global is the open question Phase 3b resolves at the line level.
+
+### `WorkspaceDoc` today — worktree-owned (Phase 3, detachment)
+- **File:** `web-ui/src/hooks/useStore.ts:96-102` — `WorkspaceDoc extends CanvasGeometry { id, name, contextKey }`; `contextKey` doc comment: "worktreeId this workspace was created in (drives the sidebar's per-worktree list)."
+- **File:** `web-ui/src/hooks/useStore.ts:117` — `layoutByWorktree: Record<string, WorktreeLayout>`; each `WorktreeLayout` entry carries its own `activeWorkspaceId` (set via `setActiveWorkspace`, `useStore.ts:533-541`) — viewing a saved workspace today means "this worktree's layout entry points at workspace X," not a standalone view state.
+- **File:** `web-ui/src/hooks/useStore.ts:280` — `workspaceDocs: Record<string, WorkspaceDoc>` — already a flat, global map keyed by doc id; nothing about the storage shape itself is worktree-scoped, only the sidebar's *filter* and the *entry mechanism* (`activeWorkspaceId` living inside a per-worktree layout entry) are. This means D1 is a smaller change than it first looks: **the data already lives in a global map** — detachment is about removing the filter/ownership semantics layered on top, not restructuring storage.
+
+### Sidebar filter to remove (Phase 3, detachment)
+- **File:** `web-ui/src/components/layout/LeftSidebar.tsx:514-519` — `workspacesForActiveWorktree` (comment: "this section is worktree-scoped, per the spec") filters `Object.values(workspaceDocs)` by `d.contextKey === activeWorktreeId`; returns `[]` when `!activeWorktreeId`.
+- **File:** `web-ui/src/components/layout/LeftSidebar.tsx:1124-1167` — renders the "Workspaces" `<section>` using `orderedWorkspaces` (derived from the filtered list, `:521-526`), nested inside the same sidebar tree as worktrees/projects.
+- **File:** `web-ui/src/components/layout/LeftSidebar.tsx:352` — `store.setActiveWorkspace(worktreeId, id)` on clicking a workspace row — ties the click to "the currently active worktree," which breaks once a workspace can be opened while no worktree (or a *different* worktree) is active.
+
+### "Back to unsaved" to remove for the detached case (Phase 3, detachment)
+- **File:** `web-ui/src/components/layout/WorkspaceCanvas.tsx:688-707` — `isSaved` branch renders `savedDoc.name` + a "Back to unsaved" button (`:693-700`) calling `setActiveWorkspace(worktreeId, null)` (`:697`); the unsaved branch (`:702-706`) renders "Unsaved canvas" with no button. This toolbar is keyed off `worktreeId` (component prop), which assumes "the workspace being viewed belongs to this worktree" — no longer true post-detachment.
+
+### Routing — new view entry point (Phase 3, detachment)
+- **File:** `web-ui/src/App.tsx:56-64` — current routes: `/`, `/settings`, `/worktree`, `/worktree/:wtId`, `/worktree/:wtId/:sessionId`, `/session/:directSessionId`; `/workspace` (**singular**, no param) already exists and is a bare redirect to `/worktree` (`:63`) — likely a stale/placeholder route from before workspaces existed as a real feature. A new detached-workspace-view route must use a **different** path (proposed: `/workspaces/:workspaceId`, plural) to avoid colliding with or having to repurpose that existing redirect.
+
+### Persistence / migration precedent (Phase 3, detachment)
+- **File:** `web-ui/src/hooks/useStore.ts:577-580` — zustand `persist` middleware, `name: "vibestation:workspace"`, `version: 14`, `migrate(persisted, version)`. Storage is **client-only** (localStorage) — no daemon-side `WorkspaceDoc` table exists (confirmed no `grep -rn WorkspaceDoc daemon/src` hits during root-plan research), so D8's "migration" is a version bump + `migrate()` branch, not a DB migration.
+- **File:** `web-ui/src/hooks/useStore.ts:583-732` — existing `migrate()` shows the established pattern: version-gated `if` blocks that reshape `persisted` in place, each documented with a `// vN → vM: ...` comment. D8 follows this same pattern at `version: 15`.
+
+### No existing spawn-affinity mechanism (confirmed absent, Phase 4)
+- `grep -rn "spawnedFrom\|sourceAgentId\|source_agent" daemon/src web-ui/src cli/src` — zero hits. This is a new field end-to-end, not an extension of something partially built.
+
+### CLI commands to extend (Phase 4)
+- **File:** `cli/src/commands/worktree/create.ts` (full file, 80 lines) — `vst worktree create <projectId>` registers options `--mode`, `--name`, `--base`, `--branch`, `--prompt`, `--prompt-file`, `--json`; posts to `POST /worktrees` with `{ projectId, modeId, name, baseBranch, branch, prompt, channel? }`. A new `--source-agent <sessionId>` option slots in alongside the existing `Option`/`option()` calls the same way.
+- **File:** `cli/src/commands/session/create.ts` (full file, 65 lines) — `vst session create <worktreeId>` registers `--type`, `--mode`, `--prompt`, `--prompt-file`, `--json`; posts to `POST /sessions` with `{ worktreeId, type, modeId, prompt, channel? }`. Same pattern for `--source-agent`.
+- **Defaulting rule (S3):** neither command today reads `process.env.VST_SESSION` for anything — this needs a new lookup: `opts.sourceAgent ?? process.env.VST_SESSION ?? undefined`. `VST_SESSION` is only set when the CLI happens to be invoked from inside an already-running agent's own shell (`daemon/src/routes/sessions.ts:1079, 1753` inject it into every spawned agent's process env) — from a human's own terminal (not inside an agent), `VST_SESSION` is unset, so the field is simply omitted, matching S5's "no side effect" default.
+
+### Daemon request bodies to extend (Phase 4)
+- **File:** `daemon/src/routes/worktrees.ts:141-156` — `CreateWorktreeBody` zod object; add `sourceAgentId: z.string().optional()`.
+- **File:** `daemon/src/routes/sessions.ts:52-72` — `WorktreeSessionBody`/`DirectSessionBody` (unioned into `CreateSessionBody`); add `sourceAgentId: z.string().optional()` to both variants (a direct session can also be spawned from an existing agent, e.g. a worktree agent spawning a direct-session helper — no PRD language restricts S1 to worktree sessions only).
+- **Persistence:** the field needs a home on the session record itself (wherever `SessionRecord`/equivalent is defined and written on creation — not yet located at the line level; locate via the same file that handles `POST /sessions`' insert, likely `daemon/src/state/project-store.ts` alongside the `lifecycle.state` column referenced in `03-interaction-states`'s Risk #2). Store as `spawnedFrom: string | null`, nullable, no FK enforcement needed (a deleted source session leaving a dangling id is harmless — the client-side tile scan simply won't find a match).
+
+### WS event to extend (Phase 4)
+- **File:** `daemon/src/ws/protocol.ts:218-225` — `SessionCreatedEvent`: `{ type: "session:created", sessionId, worktreeId, projectId?, sessionType, mode?, snapshot? }`. Add `spawnedFrom: z.string().nullable().optional()`.
+- No equivalent change needed on `session:state` (`protocol.ts:227-233`) — `spawnedFrom` is a creation-time-only fact, not a live-changing one.
+
+### Client-side auto-insert target (Phase 4)
+- **File:** `web-ui/src/hooks/useStore.ts:280` — `workspaceDocs: Record<string, WorkspaceDoc>`; each `WorkspaceDoc.tiles: TileSpec[]` (via `CanvasGeometry`, `useStore.ts:89`) carries `sessionId` per tile (confirmed via `WorkspaceCanvas.tsx:560`, `tile.sessionId ? sessionById.get(tile.sessionId) : undefined`). The scan is: on `session:created` with `spawnedFrom` set, `Object.values(workspaceDocs).filter(doc => doc.tiles.some(t => t.sessionId === spawnedFrom))` → for each match, insert a new tile via the same tile-insert path `WorkspaceCanvas`'s "Add tile" (W8) already uses (splitting the source tile per S6/L4's split-target mechanism — reuse, don't reinvent).
+- This scan is **already workspace-agnostic** (`workspaceDocs` is a flat global map regardless of Phase 3's status) — confirms Phase 4's "benefits from, not blocked by" relationship to Phase 3.
+
+### Existing `/vst` hook infrastructure (context, not directly reused, Phase 4)
+- **File:** `daemon/src/agent-plugins/claude.ts:291-343` — `setupWorkspaceHooks` writes a `/vst` custom Claude Code slash command that expands into `vst` CLI invocations using `$VST_SESSION`/`$VST_WORKTREE`. This is the existing precedent for "agent-invocable vst CLI usage" (S2) — the new `--source-agent` flag rides the same `vst` binary already on every agent's `PATH`, no new plumbing needed for "agent can invoke it," only the flag itself is new. Whether the `/vst` slash-command doc (`vstCommand` template, `claude.ts:302+`) needs a line documenting the new flag is a documentation nicety, not a functional requirement — add if convenient during implementation.
+
+---
+
+## Architecture Diagram
+
+- Phase 1/Phase 2: single-module (web-ui client) feature — no new service/DB boundary. The only cross-boundary input is the `session:state`/session-object `state`/`lifecycleState` field, already covered by [`03-interaction-states`](../03-interaction-states/plan-03-agent-interaction-workspaces-interaction-states.md)'s Architecture Diagram; this plan only *consumes* it via `sessionStatus()`.
+
+### Phase 3 — Detachment (client routing)
+
+```mermaid
+flowchart LR
+    subgraph Sidebar["LeftSidebar.tsx"]
+        Filter["workspacesForActiveWorktree\n(filter: contextKey === activeWorktreeId)"] -.->|removed| Global["global workspace list\n(no filter — all of workspaceDocs)"]
+    end
+    subgraph Store["useStore.ts"]
+        Docs[("workspaceDocs\n(already global, unchanged)")]
+        Layout["layoutByWorktree[wtId].activeWorkspaceId\n(worktree-scoped view pointer)"]
+        NewView["new: standalone view state\n(not per-worktree)"]
+        Layout -.->|removed for detached case| NewView
+    end
+    subgraph Routing["App.tsx"]
+        NewRoute["new: /workspaces/:workspaceId"]
+    end
+    Global --> Docs
+    Global --> NewRoute
+    NewRoute --> NewView
+    NewView --> Canvas["WorkspaceCanvas.tsx\n(minus 'Back to unsaved' for this case)"]
+```
+
+### Phase 4 — Source-agent spawn affinity (daemon-CLI-client)
+
+```mermaid
+flowchart LR
+    subgraph Agent["Running agent shell"]
+        VstCli["vst session create <wtId> --source-agent $VST_SESSION"]
+    end
+    subgraph CLI["cli/src"]
+        SC["session/create.ts\n(new --source-agent flag,\ndefaults to $VST_SESSION)"]
+    end
+    subgraph Daemon
+        Route["POST /sessions\n(sessions.ts:448)\nsourceAgentId in body"]
+        Store[("SessionRecord.spawnedFrom\n(new column)")]
+        WS["session:created\n(spawnedFrom added)"]
+    end
+    subgraph WebUI
+        Listener["WS listener"] --> Scan["scan workspaceDocs for\ntiles[].sessionId === spawnedFrom"]
+        Scan --> Insert["insert new tile\n(split source tile, S6)"]
+    end
+    VstCli --> SC --> Route --> Store
+    Route --> WS --> Listener
+```
+
+---
+
+## Design Details
+
+### Critical User Journeys (CUJs)
+
+#### CUJ 1 — User adds a tile and reads/replies from inside it (happy path, W3/W4/W8)
+```
+User is viewing a workspace canvas (some tiles already present)
+  → Clicks "Add tile", picks an existing agent session or the panel pane (W8)
+  → New tile renders that session's live chat/terminal content (W3), scrollable
+  → User types a reply into the tile's composer / keystrokes into its terminal (W4)
+  → Reply/keystrokes go to the real session — same underlying pane as the single-agent view
+```
+- **Edge case (W9):** removing a tile does not close/kill its underlying session — the session keeps running, just un-tiled.
+- **Edge case (W6a):** a panel-pane tile (no session) never shows a state color — fixed "unset" chrome.
+
+#### CUJ 2 — User switches a workspace between free-form and tiling layout (happy path, L1/L6/L7)
+```
+User has a free-form workspace with several overlapping/arranged tiles
+  → Toggles layout mode to "Tiling"
+  → Tiles auto-arrange into a balanced split tree in reading order (L6) — buildBalancedTree()
+  → User drags a divider between two tiles — both resize (zero-sum), clamped to a minimum (L3)
+  → User toggles back to "Free-form"
+  → Each tile lands at its last-rendered tiled rect (L7, lossless)
+```
+- **Edge case (L4):** adding a tile while in tiling mode splits a chosen target tile (side: left/right/top/bottom) instead of dropping at an arbitrary point.
+- **Edge case (L5):** removing a tile in tiling mode collapses its slot into its sibling(s) — never leaves a blank gap.
+
+#### CUJ 3 — User opens a detached workspace from the sidebar (happy path, D4/D5/D6)
+```
+User is looking at worktree A (or the dashboard, or nothing active)
+  → Sidebar's global "Workspaces" section lists every saved WorkspaceDoc
+  → User clicks "Review Sprint" (created originally in worktree B)
+  → Router navigates to /workspaces/<id>
+  → WorkspaceCanvas mounts bound to that WorkspaceDoc.id directly (not via layoutByWorktree[wtId].activeWorkspaceId)
+  → Tiles render (mixed worktrees, exactly as before) — no "Back to unsaved" in the toolbar
+```
+- **Edge case:** the `WorkspaceDoc.id` in the URL no longer exists (deleted) — canvas shows an empty/"workspace not found" state, does not crash; redirect to `/` after a beat (mirrors existing not-found handling at `App.tsx`-level `useEffect`s, e.g. `Workspace.tsx:105-109`'s pattern for a missing direct session).
+- **Edge case:** user is mid-edit on worktree A's *unsaved* scratch canvas, then opens a detached workspace — worktree A's scratch canvas state is untouched (D2), navigating away and back preserves it exactly as `layoutByWorktree` already does today.
+
+#### CUJ 4 — Pre-v3 saved workspace on first load post-upgrade (happy path, D8)
+```
+User upgrades to a build with this change
+  → zustand persist sees stored version 14 < current version 15
+  → migrate() runs the new v14→v15 branch: no field is dropped, contextKey is kept
+    as provenance only (no longer read for filtering/ownership)
+  → Sidebar's global Workspaces section immediately shows this doc, unfiltered
+  → No user action required, no re-save needed
+```
+- **Edge case:** two pre-v3 docs from different worktrees happen to have colliding names — no dedup needed, sidebar just lists both (names were never guaranteed unique even in the per-worktree model).
+
+#### CUJ 5 — Agent spawns a helper agent from its own shell (happy path, S2/S3/S4/S6)
+```
+Agent "auth-flow" is running, tiled in workspace "Review Sprint"
+  → Inside its shell, agent runs: vst worktree create myproj --mode ... --source-agent $VST_SESSION
+    (or omits --source-agent entirely — CLI defaults it to $VST_SESSION automatically, S3)
+  → CLI posts { ..., sourceAgentId: "<auth-flow's own session id>" } to POST /worktrees
+  → Daemon creates the new worktree + session, stores spawnedFrom on the new session record
+  → Daemon broadcasts session:created { sessionId: "<new>", spawnedFrom: "<auth-flow id>", ... }
+  → Web-UI listener: scans workspaceDocs, finds "Review Sprint" has a tile with sessionId === auth-flow id
+  → Auto-inserts a new tile for the new session, splitting auth-flow's own tile (S6)
+  → User sees the new agent appear as a sibling tile without touching "Add tile"
+```
+- **Edge case (S5):** auth-flow isn't tiled in any workspace — new session is created identically, no tile insert happens anywhere, no error surfaced.
+- **Edge case:** auth-flow is tiled in *two* workspaces simultaneously (allowed per PRD's proposed answer under §5 Open questions, pending confirmation) — new tile is inserted into **both** (S4's literal "workspace(s)," plural) — **this default is flagged as needing user confirmation in the PRD, not a locked behavior**.
+
+#### CUJ 6 — Human creates an agent via the in-app dialog with no source (regression, S1 optional)
+```
+User opens "New Agent" dialog, fills it out normally, submits
+  → No sourceAgentId is sent (dialog doesn't set it — Out of Scope: no picker UI this round)
+  → Daemon stores spawnedFrom: null, broadcasts session:created with spawnedFrom: null
+  → Web-UI listener: spawnedFrom is null → skip the workspace scan entirely
+  → Behavior identical to today, zero regression
+```
+
+### System Boundaries (Phase 4, spawn affinity)
+
+| Boundary | Fields + types | Errors | Source of truth |
+|----------|----------------|--------|-----------------|
+| CLI ↔ Daemon (HTTP) | `POST /worktrees` body gains `sourceAgentId?: string`; `POST /sessions` body gains `sourceAgentId?: string` on both `WorktreeSessionBody`/`DirectSessionBody` variants | Existing 400 "Validation error" path (zod) covers a malformed value; an unknown/nonexistent `sourceAgentId` is **not** an error — silently stored as-is (S5's "no side effect if not tiled" already covers the harmless-dangling-id case) | Daemon — CLI never resolves/validates the id itself |
+| Daemon ↔ Web-UI (WS) | `SessionCreatedEvent` (`protocol.ts:218`) gains `spawnedFrom: string \| null` | none new | Daemon (set at session-creation time, immutable after) |
+| Module ↔ Module (in-process, web-ui) | new: `findWorkspacesTilingSession(sessionId: string): WorkspaceDoc[]` reads `workspaceDocs` | n/a | `useStore.ts`'s `workspaceDocs` map remains sole source of truth; this is a pure read + derived insert, no new persisted state |
+
+### Data Model
+
+| Entity | Field | Type | Constraint | Migration |
+|--------|-------|------|------------|-----------|
+| `WorkspaceDoc` (`useStore.ts:97`) | `id, name, contextKey` + `CanvasGeometry` fields | — | Shipped, unchanged by Phase 1/2 | N (Phase 1/2) |
+| Tiling tree (`web-ui/src/lib/tiling.ts`) | `SplitNode { id, type:'split', axis, children, sizes }` / `LeafNode { id, type:'leaf', tileId }` | `LayoutNode = SplitNode \| LeafNode` | `sizes` sums to ~1, normalized after every mutation | N — shipped as designed in the original POC decision (Decision 1), lifted directly into the real implementation |
+| `WorkspaceDoc` (`useStore.ts:97`) | `contextKey` | `string` | **Repurposed** (Phase 3): was "owning worktree," becomes "worktree this doc was created in" (provenance/display only, e.g. for a future "created in ‹name›" hint) — no longer read by any filter/gate | N — same field, semantics-only change, no shape change |
+| `WorktreeLayout` (`useStore.ts`, exact fields TBD at implementation — locate via `layoutByWorktree`'s value type) | `activeWorkspaceId` | `string \| null` | Stops being the mechanism for "viewing a saved workspace" (Phase 3) — a detached workspace's view state moves to the new route-driven state instead; this field's remaining purpose (if any, e.g. "last workspace this worktree was tiled into") is an implementation decision, not a requirement | Y — `persist` `version: 15`, `migrate()` branch (D8, Phase 3a) |
+| `SessionRecord` (exact file/line TBD — locate the session-record insert path during Phase 4a) | `spawnedFrom` | `string \| null` | Nullable, no FK enforcement (dangling id is harmless, S5) | Y — new column (Phase 4a); confirm whether the daemon's session table uses a schema requiring an explicit migration file (mirrors `03-interaction-states`'s open Risk #2 re: `lifecycle.state` CHECK constraints — same investigation needed here) |
+
+```ts
+// Tiling-mode data model — as shipped in web-ui/src/lib/tiling.ts (confirmed
+// identical in shape to the original POC design, see Key Decision below):
+// type Axis = 'row' | 'column'
+// type SplitNode = { id, type:'split', axis, children: LayoutNode[], sizes: number[] }
+// type LeafNode  = { id, type:'leaf', tileId: string }
+// type LayoutNode = SplitNode | LeafNode
+// Operations: insertPane, removePane, resizeSplit, swapPanes, buildBalancedTree
+```
+
+### API Contracts
+
+- No new daemon/backend contract for Phase 1/2 — entirely client-side, consuming the existing session object's `state`/`lifecycleState` field (contract owned by [`03-interaction-states`](../03-interaction-states/plan-03-agent-interaction-workspaces-interaction-states.md)).
+- *(Phase 3, detachment)* No daemon/backend contract changes — entirely client-side (`web-ui/`), confirmed no server-side `WorkspaceDoc` persistence exists today (Research above).
+- *(Phase 3, detachment)* New client route: `GET /workspaces/:workspaceId` (React Router path, not an HTTP endpoint) — resolves `workspaceDocs[workspaceId]` from the existing zustand store; 404-equivalent (doc not found) → redirect to `/`.
+- *(Phase 4, spawn affinity)* `POST /worktrees` (`daemon/src/routes/worktrees.ts:305`) — existing contract; body gains optional `sourceAgentId: string`. Response shape (`WorktreeCreateResponse` client-side, `{ id, branch, projectId }`) is **unchanged** — `spawnedFrom` is not round-tripped in the synchronous POST response, only via the async `session:created`/`worktree:created` WS events (matches how the daemon already prefers WS for session-state fan-out over response-body round-trips).
+- *(Phase 4, spawn affinity)* `POST /sessions` (`daemon/src/routes/sessions.ts:448`) — same treatment; body gains optional `sourceAgentId: string` on both union variants.
+- *(Phase 4, spawn affinity)* `session:created` WS event (`daemon/src/ws/protocol.ts:218-225`) — gains `spawnedFrom: string | null` (present, not omitted, even when null — client relies on its presence to know the field is populated vs. an older daemon build that doesn't send it at all; treat `undefined` the same as `null` client-side for backward compat with pre-upgrade daemons).
+
+### Key Decisions
+
+#### Decision 1 (historical): Workspaces POC shipped first as a standalone artifact with live-styled panes
+- **Decision:** the tiling/chrome design was first validated as a self-contained HTML artifact (scripted transcripts, locally-functional input) before being ported into `web-ui/`.
+- **Rationale:** validated both the interaction model and the n-ary split-tree layout model without risking `Layout.tsx`'s TerminalPane-remount invariant or requiring a real WS connection.
+- **Where (historical):** `.scratch/workspaces-poc.html` (gitignored scratch dir) — **superseded**; the real implementation now lives at the Reference files listed above. Kept for history per the Superseded table.
+- **Status today:** superseded by the real implementation (Phase 1) — the POC's data model (tiling tree shape) was lifted directly, confirmed identical in Research above.
+
+#### Decision 2: shared `sessionStatus()` helper hoisted to `web-ui/src/lib/worktreeStatus.ts`
+- **Decision:** both `WorkspaceCanvas.tsx` (tile chrome) and `AgentPaneSlot.tsx` (direct-session chrome, incl. workspace agent-pane tiles that route through it) compute their state color via one shared function, `sessionStatus(state: SessionState): WorktreeRolledUpStatus`, rather than two independent implementations.
+- **Rationale:** guarantees the two surfaces' color mappings can never drift apart — exactly the risk W11's regression guard exists to catch.
+- **Where:** `web-ui/src/lib/worktreeStatus.ts:34-53` (definition), `WorkspaceCanvas.tsx:24` + `AgentPaneSlot.tsx:7,49` (both call sites).
+
+#### Decision 3: W12's direct-session indicator is a border, not a `StatusDot` dot
+- **Decision:** `AgentPaneSlot`'s wrapper renders an `agent-pane-slot--<status>` border-color class instead of embedding a `<StatusDot>` glyph.
+- **Rationale:** the pane has no tile-header element to host a dot (unlike a workspace tile) — a border is the only "colored rectangle" surface available on that chrome, per the component's own inline comment.
+- **Where:** `web-ui/src/components/layout/AgentPaneSlot.tsx:49` (status computed), `:51` (className applied).
+
+#### Decision 4: Detached-workspace view state is route-driven, not stored in any worktree's `layoutByWorktree` entry
+- **Decision:** viewing a saved workspace becomes "the URL is `/workspaces/:id`," full stop — no longer routed through `layoutByWorktree[activeWorktreeId].activeWorkspaceId`.
+- **Rationale:** the old mechanism inherently required an active worktree to hang the pointer off of; a detached workspace has no single owning worktree to hang it off of either, so the pointer has to move somewhere that isn't per-worktree — the URL is the natural place (bookmarkable, matches how `/worktree/:wtId` already works).
+- **Where:** `web-ui/src/App.tsx:56-64` (new route), `web-ui/src/components/layout/WorkspaceCanvas.tsx` (accept a workspace-id-driven mode alongside its existing worktree-driven mode), `web-ui/src/components/layout/LeftSidebar.tsx:352` (click handler navigates instead of calling `setActiveWorkspace`).
+
+#### Decision 5: `contextKey` is kept, not removed, but demoted to provenance
+- **Decision:** do not delete `WorkspaceDoc.contextKey` or bump a breaking schema change — keep the field, stop using it as a filter/ownership key.
+- **Rationale:** cheapest, lowest-risk migration (D8) — every existing stored doc already has a valid `contextKey` value; repurposing it as display-only provenance ("created in ‹worktree name›") costs nothing and avoids a field-removal migration that would need to backfill or drop data.
+- **Where:** `web-ui/src/hooks/useStore.ts:100-101` (doc comment update), `LeftSidebar.tsx:514-519` (remove the filter, optionally use `contextKey` only for a "created in X" label).
+
+#### Decision 6: Sidebar section placement — global, sibling to the worktree tree
+- **Decision:** the "Workspaces" section becomes a single top-level section in `LeftSidebar.tsx`, rendered once, not per-worktree.
+- **Rationale:** matches PRD D4 directly; **flagged in the PRD as needing user confirmation** — this decision is provisional pending that sign-off, not a closed design question.
+- **Where:** `web-ui/src/components/layout/LeftSidebar.tsx:1124-1167` (existing render block moves out of any per-worktree loop, if it's currently inside one — confirm exact nesting at implementation time) — **needs user confirmation before implementation starts** (PRD Open questions).
+
+#### Decision 7: `spawnedFrom` is set once at creation, never updated
+- **Decision:** the field is write-once (set during `POST /worktrees`/`POST /sessions`, never mutated after).
+- **Rationale:** "spawned from" is an immutable fact about how a session came to exist — there's no product requirement to ever change it post-creation, keeping it simple avoids a whole class of "what if it changes mid-life" edge cases.
+- **Where:** daemon session-record insert path (Phase 4a, file TBD).
+
+#### Decision 8: Auto-insert reuses the existing tile-insert/split mechanism, not a new code path
+- **Decision:** the client's auto-insert (S4/S6) calls the same underlying tile-insert function `WorkspaceCanvas`'s manual "Add tile" (W8) flow already uses, passing the source tile as the split target (matching L4's split-target+side model) rather than writing a second, parallel insert implementation.
+- **Rationale:** avoids two divergent code paths for "how a tile gets added to a workspace"; guarantees the auto-inserted tile behaves identically (resizable, removable, etc.) to a manually-added one.
+- **Where:** `web-ui/src/components/layout/WorkspaceCanvas.tsx` (locate the exact "Add tile" handler function during implementation — not yet pinpointed at the line level in this research pass) — new WS listener calls into it programmatically instead of via the "Add tile" picker's UI submit.
+
+---
+
+## Risks / Open Questions
+
+| # | Question | Notes |
+|---|----------|-------|
+| 1 | **Should direct sessions become fully workspace-tileable, beyond just a colored border?** | Explicitly deferred — PRD Non-goals + Resolved Q9; only the border ships. Still open as a future ask, not scheduled. |
+| 2 | **`tiling.ts`'s stale "DEV-ONLY POC" file-header comment** | Non-blocking; confirmed the file is actively used by the real `WorkspaceCanvas.tsx` (Research above) — propose a one-line doc-comment fix whenever the file is next touched, not worth a dedicated phase. |
+| 3 | **Multi-workspace tile sharing + auto-insert-into-which-workspace(s) on spawn** | See Risk #9/#10 below (Phase 4). |
+| 4 | **Sidebar global Workspaces section + dedicated workspace-view route** | See Risk #5 below (Phase 3). |
+| 5 | **Exact sidebar placement + a dedicated workspace-view route** — carried from PRD | Both flagged as needing user confirmation before Phase 3 starts implementation (PRD §4 Open questions). Do not implement Decision 4/6 until confirmed. |
+| 6 | **Does `/workspaces/:workspaceId` need its own top-bar affordance (back button, breadcrumb to "last worktree")?** | Not specified by the PRD; propose: a simple "← Back" that returns to whatever route was active before navigating in (browser history back), no new state needed. |
+| 7 | **What happens to `layoutByWorktree[wtId].activeWorkspaceId` for entries that already point at a since-detached doc?** | Proposed: ignored/cleared during the v15 migration (D8) since the pointer's meaning is gone; verify no other code path still reads it for anything besides "is a saved workspace currently shown in this worktree's canvas" (the toolbar's `isSaved` check, `WorkspaceCanvas.tsx:688`) — that check likely needs to move to the new route-driven state too. |
+| 8 | **Can a `WorkspaceDoc` be deleted while its `/workspaces/:id` route is open in another tab?** | Not a new problem (same class of issue as a worktree being deleted while open) — reuse whatever pattern the codebase already has for that, confirm during implementation. |
+| 9 | **If the source agent's tile appears in multiple workspaces, auto-add to all, the active one, or none?** | PRD proposes "all" — **needs user confirmation**, carried verbatim from PRD §5 Open questions. Do not implement S4's multi-workspace fan-out until confirmed; implement single-workspace case first regardless (uncontroversial). |
+| 10 | **Can one session appear as a tile in more than one saved `WorkspaceDoc` at once — is that even allowed today?** | Nothing in the current code prevents it (tiles just reference a `sessionId`), but it's never been an explicit product decision. PRD proposes "allow it." **Needs user confirmation** — blocks Risk #9's answer from being meaningful either way. |
+| 11 | **Exact file/line for the daemon's session-record insert + whether a schema migration is required.** | Not located at the line level in this research pass — same class of investigation as `03-interaction-states`'s open Risk #2 (`lifecycle.state` CHECK constraint); a Phase 4a implementer must locate `daemon/src/state/project-store.ts`'s session-insert path before writing the migration. |
+| 12 | **Should the in-app "New Agent"/"Direct Agent" dialogs eventually expose a source-agent picker to the human (not just the CLI/agent-invoked path)?** | Out of Scope this round (S2 only requires the *capability* to exist on the request path) — flagged as a natural follow-on, not decided here. |
+| 13 | **Exact "Add tile"/tile-insert function name + line in `WorkspaceCanvas.tsx` for Decision 8's reuse.** | Not pinpointed in this research pass — locate during Phase 4c implementation (search for the W8 "Add tile" picker's submit handler). |
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Workspaces canvas: live tiles, free-form + tiling layout (SHIPPED)
+
+> Real implementation, confirmed present in code (Research above) — not the original stale/superseded `.scratch/workspaces-poc.html` POC checklist. Marked complete because the code satisfies every requirement in the row below; no further action needed unless a regression is found.
+
+- [x] **1.1** Tile chrome renders live, scrollable chat/terminal content per tile (W3) — `WorkspaceCanvas.tsx` + `PaneOutlet` (`paneOutlets.tsx`).
+- [x] **1.2** Working composer/keystroke-forwarding input inside each agent tile (W4) — same live pane, not a preview.
+- [x] **1.3** Mixed-worktree tiles coexist in one workspace (W5).
+- [x] **1.4** Every agent-pane tile renders a state-colored border AND a `StatusDot` glyph, both driven by `sessionStatus()` (W6/W7, see Ground-truth correction); panel-pane tiles render no state color (W6a) — `WorkspaceCanvas.tsx:548-...`, `workspace-canvas.css`'s `.workspace-canvas__tile--*` rules.
+- [x] **1.5** Add/remove tile without killing the underlying session (W8/W9).
+- [x] **1.6** n-ary split-tree tiling engine: `SplitNode`/`LeafNode`, `insertPane`/`removePane`/`resizeSplit`/`swapPanes`/`buildBalancedTree` (L2, L3, L5) — `web-ui/src/lib/tiling.ts`.
+- [x] **1.7** Per-workspace free-form/tiling layout-mode toggle (L1, L8); switching free-form → tiling auto-arranges via `buildBalancedTree` (L6); switching back is lossless (L7) — `WorkspaceCanvas.tsx` (exact toggle UI confirmed present, not re-verified line-by-line here since Research already located the underlying tiling calls).
+- [x] **1.8** Tiling-mode "Add tile" picks a split target + side (L4).
+
+**Verify phase 1:**
+- [x] **1.T1** Manual (confirmed via code read, not a fresh run) — `sessionStatus()` maps every `SessionState` value including `waiting_for_human`/`needs_review` to a distinct `WorktreeRolledUpStatus` (`worktreeStatus.ts:34-53`), so all 7 interaction states are representable as distinct tile colors once `03-interaction-states` ships the daemon side.
+- [ ] **1.T2** Manual — not re-run this session: type a reply into a tile's composer, confirm it reaches the live session (regression spot-check recommended before the next release touching `WorkspaceCanvas.tsx`).
+- [ ] **1.T3** Manual — not re-run this session: toggle free-form ↔ tiling and confirm lossless round-trip (L7) end-to-end in the running app.
+
+---
+
+### Phase 2 — Cursor fix + direct-session color borders (SHIPPED, v3)
+
+> Confirmed via direct code read during this restructure (not assumed from the earlier plan revision) — both items are done.
+
+- [x] **2.1** `web-ui/src/styles/workspace-canvas.css:332` — tile-header drag handle uses `cursor: grab;` (and `:337` `cursor: grabbing;` while dragging), not `cursor: move` (W10). Confirmed present.
+- [x] **2.2** `web-ui/src/components/layout/AgentPaneSlot.tsx:49` (computes `sessionStatus(session.lifecycleState)`), `:51` (renders `agent-pane-slot--<status>` as a real border-color class, W12). Confirmed present.
+- [x] **2.3** `web-ui/src/routes/Workspace.tsx:307-319` — `directAgentPane` already passes `session={directSession}` into `AgentPaneSlot`; no additional wiring was needed. Confirmed present.
+- [x] **2.4** `sessionStatus()` hoisted to the shared `web-ui/src/lib/worktreeStatus.ts` (Decision 2) rather than duplicated — both `WorkspaceCanvas.tsx` and `AgentPaneSlot.tsx` import the same function. Confirmed present.
+
+**Verify phase 2:**
+- [x] **2.T1** Manual (confirmed via code read) — tile-header CSS rule is `grab`/`grabbing`, not a 4-way move cursor.
+- [x] **2.T2** Manual (confirmed via code read) — `AgentPaneSlot`'s status class naming (`agent-pane-slot--waiting_for_human`, etc.) matches the `.status-dot--*` state-name convention used by workspace tiles (same `WorktreeRolledUpStatus` union feeds both), satisfying "colors match" — not visually screenshotted this session, but the class-name/token wiring is provably shared, not duplicated/hardcoded.
+- [x] **2.T3** Regression — `WorkspaceCanvas.tsx` still imports and calls `sessionStatus()` from the shared helper (not a local copy) post-hoist — confirmed via Research above; workspace tiles' `StatusDot` rendering path is unchanged by the `AgentPaneSlot` work (different component, same helper).
+
+---
+
+### Phase 3 — Workspace detachment
+
+> Decouple a saved `WorkspaceDoc` from its creating worktree: drop the per-worktree ownership model, redesign the sidebar's "Workspaces" section as a single global list, add a dedicated workspace-view entry point independent of the worktree route, and remove "Back to unsaved" for the now-detached case. The per-worktree transient scratch canvas is unaffected (D2). Split into three sub-phases (3a data model, 3b sidebar, 3c canvas) matching the natural layer boundaries.
+
+#### Phase 3a — Data model: demote `contextKey`, add view-state route param
+
+- [ ] **3a.1** Update `WorkspaceDoc.contextKey` doc comment (`useStore.ts:100-101`) to reflect "provenance only," confirm no other code path treats it as an ownership gate besides `LeftSidebar.tsx:518` and the toolbar's `isSaved`/`worktreeId` binding in `WorkspaceCanvas.tsx`.
+- [ ] **3a.2** Bump `persist` `version` to `15` (`useStore.ts:579`) and add a `// v14 → v15: workspace detachment` migration branch (`useStore.ts:580` area) — no-op on `contextKey` itself (kept as-is), clears any `layoutByWorktree[*].activeWorkspaceId` that still points at a saved doc (Risk #7), per the established migration-branch pattern (`useStore.ts:583-732`).
+- [ ] **3a.3** Add the new route `web-ui/src/App.tsx:56-64` — `<Route path="/workspaces/:workspaceId" element={<Workspace />} />` (reuses the existing `Workspace` route element, following the same pattern as `/worktree/:wtId` and `/session/:directSessionId`).
+- [ ] **3a.4** In `web-ui/src/routes/Workspace.tsx`, add a `useParams<{ workspaceId?: string }>()` read (mirrors the existing `directSessionId` pattern at `Workspace.tsx:30`) and a `isWorkspaceView`/`viewedWorkspace` derivation (`workspaceDocs[workspaceId]`), analogous to `isDirectSession`/`directSession` (`Workspace.tsx:33, 65-68`).
+
+**Verify phase 3a:**
+- [ ] **3a.T1** Unit — `useStore.test.ts` (or equivalent): a persisted v14 store with a saved `WorkspaceDoc` migrates to v15 without data loss (doc still present, same `id`/`tiles`/`tree`).
+- [ ] **3a.T2** Unit — a persisted v14 store whose `layoutByWorktree[wtId].activeWorkspaceId` pointed at a saved doc has that pointer cleared post-migration (Risk #7 resolution — confirm the chosen behavior once decided).
+- [ ] **3a.T3** Integration — navigating to `/workspaces/<validId>` resolves `viewedWorkspace` to the correct `WorkspaceDoc`; `/workspaces/<invalidId>` resolves to `null`/not-found state.
+
+---
+
+#### Phase 3b — Sidebar: global Workspaces section — **blocked on user confirmation (Risk #5)**
+
+- [ ] **3b.1** *(after confirmation)* Remove the `contextKey === activeWorktreeId` filter in `workspacesForActiveWorktree` (`LeftSidebar.tsx:516-519`) — rename to `allWorkspaces` (or similar), list `Object.values(workspaceDocs)` unfiltered.
+- [ ] **3b.2** Move the "Workspaces" `<section>` (`LeftSidebar.tsx:1124-1167`) out of any per-worktree nesting so it renders exactly once, sibling to the worktree/project tree (confirm current nesting at implementation time — Research above didn't fully resolve whether it's already top-level or nested; the `workspacesOpen` collapse state, `:501-512`, is already a single boolean, not per-worktree, which suggests the section may already be structurally top-level and only the *data* filter needs to change).
+- [ ] **3b.3** Update the click handler (`LeftSidebar.tsx:352`, `store.setActiveWorkspace(worktreeId, id)`) to `navigate(`/workspaces/${id}`)` instead (Decision 4).
+
+**Verify phase 3b:**
+- [ ] **3b.T1** Unit — `LeftSidebar.test.tsx`: with two saved workspaces created under different worktrees, both appear in the Workspaces section regardless of which worktree (or none) is active.
+- [ ] **3b.T2** Integration — clicking a workspace row navigates to `/workspaces/<id>` and does not mutate `activeWorktreeId`.
+
+---
+
+#### Phase 3c — Canvas: remove "Back to unsaved" for the detached case, wire route-driven view
+
+- [ ] **3c.1** `WorkspaceCanvas.tsx:688-707` — when rendering via the new `/workspaces/:workspaceId` route (Phase 3a.4), always take the `isSaved` branch (`:689-701`) but **omit** the "Back to unsaved" button (`:693-700`) — there is no unsaved canvas to go back to in this view.
+- [ ] **3c.2** Confirm the existing per-worktree canvas flow (`/worktree/:wtId`, viewing *that worktree's* scratch canvas or a saved workspace via the old `activeWorkspaceId` mechanism) still works for the transient case — this phase must not regress D2 (scratch canvas untouched).
+- [ ] **3c.3** Decide + implement the "workspace not found" state for a stale/deleted `WorkspaceDoc.id` in the URL (Risk #8) — redirect to `/` after showing a brief message, mirroring `Workspace.tsx:105-109`'s pattern for a missing direct session.
+
+**Verify phase 3c:**
+- [ ] **3c.T1** Manual — open a saved workspace via `/workspaces/:id`: no "Back to unsaved" button present.
+- [ ] **3c.T2** Manual — open a worktree's *unsaved* scratch canvas via `/worktree/:wtId` (never saved): behaves exactly as before this phase (D2 regression check).
+- [ ] **3c.T3** Manual — navigate to `/workspaces/<deleted-id>`: redirected to `/`, no crash.
+
+---
+
+### Phase 4 — Source-agent spawn affinity
+
+> A new agent session can record which existing session it was spawned from — from the in-app dialogs or from a running agent's own shell via the `vst` CLI — and the client auto-inserts the new session as a tile into whichever workspace(s) currently tile the source session. Split into three sub-phases (4a daemon persistence, 4b WS event + CLI, 4c client auto-insert) matching the natural layer boundaries.
+
+#### Phase 4a — Daemon: `spawnedFrom` field + persistence
+
+- [ ] **4a.1** Locate the session-record schema/insert path (Risk #11) — likely `daemon/src/state/project-store.ts` alongside the `lifecycle.state` column referenced in `03-interaction-states`.
+- [ ] **4a.2** Add `sourceAgentId: z.string().optional()` to `CreateWorktreeBody` (`daemon/src/routes/worktrees.ts:141-156`) and to both `WorktreeSessionBody`/`DirectSessionBody` (`daemon/src/routes/sessions.ts:52-72`).
+- [ ] **4a.3** Thread `sourceAgentId` from the validated body through to the session-record insert (Phase 4a.1's location) as `spawnedFrom`, defaulting to `null` when absent.
+- [ ] **4a.4** Add a migration if the session table's schema requires one (conditional on 4a.1's finding).
+
+**Verify phase 4a:**
+- [ ] **4a.T1** Unit — `worktrees.test.ts`/`sessions.test.ts`: `POST /worktrees`/`POST /sessions` with `sourceAgentId` set persists it as `spawnedFrom` on the new record.
+- [ ] **4a.T2** Regression — omitting `sourceAgentId` still creates a session with `spawnedFrom: null`, identical to pre-change behavior otherwise.
+
+---
+
+#### Phase 4b — Daemon: WS event + CLI flag
+
+- [ ] **4b.1** Add `spawnedFrom: z.string().nullable().optional()` to `SessionCreatedEvent` (`daemon/src/ws/protocol.ts:218-225`); populate it from the new session record when broadcasting.
+- [ ] **4b.2** Add `--source-agent <sessionId>` option to `cli/src/commands/worktree/create.ts`, threaded into the `daemonPost("/worktrees", { ... sourceAgentId })` call; default via `opts.sourceAgent ?? process.env.VST_SESSION`.
+- [ ] **4b.3** Add the same `--source-agent <sessionId>` option to `cli/src/commands/session/create.ts`, same defaulting rule.
+
+**Verify phase 4b:**
+- [ ] **4b.T1** Unit — CLI test: `vst worktree create` invoked with `VST_SESSION=abc` in env and no explicit `--source-agent` sends `sourceAgentId: "abc"` in the POST body.
+- [ ] **4b.T2** Unit — CLI test: explicit `--source-agent xyz` overrides `$VST_SESSION` when both are present.
+- [ ] **4b.T3** Unit — `session:created` WS payload includes `spawnedFrom` matching what was persisted in Phase 4a.
+
+---
+
+#### Phase 4c — Web-UI: auto-insert on `session:created` — **Risk #9/#10 gate scope of multi-workspace fan-out**
+
+- [ ] **4c.1** Add a `session:created` handler (or extend the existing one) that reads `spawnedFrom`; if null, no-op (CUJ 6 regression guard).
+- [ ] **4c.2** Implement `findWorkspacesTilingSession(sessionId): WorkspaceDoc[]` scanning `workspaceDocs` (Research, System Boundaries).
+- [ ] **4c.3** Locate and reuse the existing "Add tile" insert function (Decision 8, Risk #13) — call it programmatically with the source tile as split target.
+- [ ] **4c.4** *(pending Risk #9/#10 confirmation)* Insert into all matching workspaces vs. only the active one — implement per whichever answer is confirmed; until then, implement for the single-match case only (uncontroversial) and stub/log the multi-match case rather than guessing.
+
+**Verify phase 4c:**
+- [ ] **4c.T1** Integration — a `session:created` event with `spawnedFrom` matching a tile in exactly one workspace auto-inserts a new tile there, split from the source tile.
+- [ ] **4c.T2** Integration — a `session:created` event with `spawnedFrom` matching no tile anywhere results in no tile insert, no error (S5).
+- [ ] **4c.T3** Regression — a `session:created` event with `spawnedFrom: null` (or absent, old-daemon compat) behaves identically to pre-change (no scan attempted).
+
+---
+
+## Files & Phase Impact
+
+| File | Status | Phase | Description / Contract Change |
+|------|--------|-------|-------------------------------|
+| `web-ui/src/components/layout/WorkspaceCanvas.tsx` | **Shipped / Modified** | 1.1–1.8, 3c.1-3c.3, 4c.3 | Live workspace tiling, chrome, color mapping, layout-mode toggle (shipped); detached-view toolbar + programmatic tile-insert reuse (planned) |
+| `web-ui/src/lib/tiling.ts` | **Shipped** | 1.6, 1.7 | Contract: `SplitNode`/`LeafNode`/`LayoutNode`, `insertPane`/`removePane`/`resizeSplit`/`swapPanes`/`buildBalancedTree` — file-header comment is stale (Risk #2), functionality is not |
+| `web-ui/src/components/layout/PaneHostLayer.tsx` | **Shipped** | 1.1 | Live pane mounting/visibility for tiled panes |
+| `web-ui/src/components/layout/paneOutlets.tsx` | **Shipped** | 1.1 | `PaneOutlet` — renders the actual live chat/terminal content inside a tile |
+| `web-ui/src/components/layout/LeftSidebar.tsx` (Workspaces section, ~1124-1167) | **Shipped / Modified** | 1.5, 3b.1-3b.3 | Sidebar entry point (shipped); global unfiltered list + navigate-on-click (planned) |
+| `web-ui/src/hooks/useStore.ts` | **Shipped / Modified** | 1.1–1.8, 3a.1-3a.2 | `WorkspaceDoc`, `CanvasGeometry`, tile CRUD — data model backing the canvas (shipped); `persist` version 14→15, new migration branch; `WorkspaceDoc.contextKey` doc comment updated, no shape change (planned) |
+| `web-ui/src/styles/workspace-canvas.css` | **Shipped** | 1.4, 2.1 | Tile chrome incl. state-color border rules for tiles, `cursor: grab` fix |
+| `web-ui/src/components/layout/AgentPaneSlot.tsx` | **Shipped** | 2.2 | Contract: computes `status` via `sessionStatus()` at `:49`, renders `agent-pane-slot--<status>` border class at `:51` |
+| `web-ui/src/styles/chat.css` | **Shipped** | 2.2 | `.agent-pane-slot--*` border-color rules (`:21-48`), the CSS half of W12 |
+| `web-ui/src/lib/worktreeStatus.ts` | **Shipped** | 2.4 | Contract: `sessionStatus(state): WorktreeRolledUpStatus` — shared by `WorkspaceCanvas.tsx` and `AgentPaneSlot.tsx`. **Shared file, split ownership:** this plan owns `sessionStatus()`; `03-interaction-states` owns the `WorktreeRolledUpStatus` union/rank map/`worktreeRolledUpStatus()` in the same file — see that plan's Files & Phase Impact. If `03` later adds a new state, both this row and that plan's Phase 2 need updating. |
+| `web-ui/src/App.tsx` | **Modified** | 3a.3 | New route `/workspaces/:workspaceId` → existing `Workspace` element |
+| `web-ui/src/routes/Workspace.tsx` | **Modified** | 3a.4, 3c.1-3c.3 | New `workspaceId` param handling, "not found" redirect |
+| `web-ui/src/hooks/useStore.test.ts` (or wherever store tests live) | **Modified** | 3a.T1, 3a.T2, 4c.T1-4c.T3 | New migration test cases; new auto-insert assertions |
+| `web-ui/src/components/layout/LeftSidebar.test.tsx` | **Modified** | 3b.T1 | New global-list assertions |
+| `daemon/src/state/project-store.ts` (or wherever located, Phase 4a.1) | **Modified** | 4a.1, 4a.3, 4a.4 | New `spawnedFrom` column/field on the session record |
+| `daemon/src/routes/worktrees.ts` | **Modified** | 4a.2 | `CreateWorktreeBody` gains `sourceAgentId?: string` |
+| `daemon/src/routes/sessions.ts` | **Modified** | 4a.2 | `WorktreeSessionBody`/`DirectSessionBody` gain `sourceAgentId?: string` |
+| `daemon/src/ws/protocol.ts` | **Modified** | 4b.1 | Contract: `SessionCreatedEvent` gains `spawnedFrom: string \| null` |
+| `cli/src/commands/worktree/create.ts` | **Modified** | 4b.2 | New `--source-agent` option, `$VST_SESSION` default |
+| `cli/src/commands/session/create.ts` | **Modified** | 4b.3 | New `--source-agent` option, `$VST_SESSION` default |
+| `daemon/src/__tests__/worktrees.test.ts` / `sessions.test.ts` | **Modified** | 4a.T1, 4a.T2 | New `spawnedFrom` persistence assertions |
+| `cli/src/__tests__/*.test.ts` | **New/Modified** | 4b.T1, 4b.T2 | New `--source-agent` + `$VST_SESSION` default assertions |

--- a/.vibekit/feature-plans/wip/agent-interaction-workspaces/05-workspace-persistence/plan-05-agent-interaction-workspaces-workspace-persistence.md
+++ b/.vibekit/feature-plans/wip/agent-interaction-workspaces/05-workspace-persistence/plan-05-agent-interaction-workspaces-workspace-persistence.md
@@ -1,0 +1,401 @@
+<!--
+RULES — read before writing or implementing:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. REQUIREMENTS: One crisp line each — no verbose descriptions
+3. CHECKLIST: Mark items [x] as you complete them — this is your persistent todo list
+4. READING TIME: Optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+# Plan: Workspace Persistence (05, sub-feature of Agent Interaction State + Workspaces)
+
+> Move SAVED `WorkspaceDoc`s from client-only `localStorage` into a new top-level `workspaces` table in the daemon's `vibe-station.db`, with live cross-client sync over the existing WS broadcast mechanism. The transient per-worktree scratch canvas is untouched.
+
+**Issue:** agent-interaction-workspaces / 05-workspace-persistence
+**Branch:** `introducing-new-state` (current)
+**Status:** Pending — planning only, not yet implemented
+**PRD:** `.vibekit/feature-plans/wip/agent-interaction-workspaces/05-workspace-persistence/prd-05-agent-interaction-workspaces-workspace-persistence.md`
+**Parent:** `.vibekit/feature-plans/wip/agent-interaction-workspaces/plan-agent-interaction-workspaces.md` (master; this is a new sub-feature, sibling to `04-workspaces`)
+
+**Reference files:**
+- Client data model (today, client-only): `web-ui/src/hooks/useStore.ts:97-110` (`WorkspaceDoc`), `:87-94` (`CanvasGeometry`), `:226-252` (`workspaceDocs`/CRUD actions), `:277-302` (`insertTileIntoCanvas`), `:311-316` (`findWorkspacesTilingSession`), `:671-901` (`persist` middleware, `version: 15`, `migrate`)
+- Client canvas component (writer of layout edits): `web-ui/src/components/layout/WorkspaceCanvas.tsx:163-175` (`readCanvas`/`patchCanvas`), `:315-357` (`addTile`/`removeTile`/`saveAsWorkspace`), `:362-463` (drag/resize/divider handlers — call `patchCanvas` on every `mousemove`)
+- Server-truth store precedent (client): `web-ui/src/hooks/useServerStore.ts` (full file — `ServerData` shape + `applyXCreated/Updated/Deleted` reducers), `web-ui/src/hooks/useServerSync.ts` (full file — initial fetch + `ws:open` refetch + WS reducer wiring)
+- Daemon schema: `daemon/src/services/dbSchema.ts` (full file — `ensureSchema`, `addColumnIfMissing` migration pattern)
+- Daemon top-level-entity precedent: `daemon/src/routes/projects.ts:126` (`registerProjectRoutes`), `:303-317` (`POST /projects` — validate, persist, `broadcastAll`), `:858` (`POST.../DELETE` → `broadcastAll({ type: "project:deleted", projectId })`)
+- Daemon route registration: `daemon/src/server.ts:8-16` (`register*Routes` calls)
+- Daemon store cache pattern (NOT reused as-is — see Decision 1): `daemon/src/state/project-store.ts` (full file — `mutateProject`, `writeProjectFull`, in-memory cache tied to `Database` handle identity)
+- WS protocol: `daemon/src/ws/protocol.ts:354-398` (`ProjectCreatedEvent`/`ProjectUpdatedEvent`/`ProjectDeletedEvent`/`WorktreeCreatedEvent`/etc. — the event-shape precedent this plan's new events follow), `daemon/src/broadcaster.ts` (full file — `broadcastAll`)
+- WS broadcast fan-out (client side): `web-ui/src/api/index.ts:5` (`api` singleton), `web-ui/src/api/client.ts:227-278` (`listProjects`/`listWorktrees` REST call shape — the pattern new `listWorkspaces`/`createWorkspace`/etc. calls follow), `web-ui/src/api/mock.ts:305-483` (mock counterpart — every real API method needs a mock twin)
+- Client types: `web-ui/src/api/types.ts:9-45` (`Project`/`Worktree` — shape precedent for a new `WorkspaceDoc` API type)
+- Routing (already shipped, unaffected): `web-ui/src/App.tsx:65` (`/workspaces/:workspaceId` route — already exists from 04-workspaces Phase 3, consumes whatever `workspaceDocs[id]` resolves to; this plan changes where that map's data comes from, not the route)
+- Sibling plan (data model + canvas UX, already shipped): `.vibekit/feature-plans/wip/agent-interaction-workspaces/04-workspaces/plan-04-agent-interaction-workspaces-workspaces.md`
+
+---
+
+## Problem
+
+- See [prd-05-...md](./prd-05-agent-interaction-workspaces-workspace-persistence.md) §Problem — `WorkspaceDoc` lives only in the browser's `localStorage` (`useStore.ts:671`, `name: "vibestation:workspace"`); no daemon-side storage exists at all (confirmed: `grep -rn WorkspaceDoc daemon/src` returns zero hits). Two tabs/devices on the same daemon never converge; a cleared browser profile loses saved workspaces permanently.
+
+## Out of Scope
+
+- `WorktreeLayout.scratchCanvas` (`useStore.ts:44`) — stays exactly as-is, client-only, untouched (PRD Non-goals).
+- Any change to the canvas tiling/free-form editing UX, tile chrome, or state-coloring (04-workspaces, shipped) — this plan only relocates persistence.
+- Multi-user permissions/ownership.
+- Operation-based/CRDT conflict merge — last-write-wins only (PRD Options, Decision 2 below).
+- A dedicated Workspaces management page.
+- Presence indicators ("who's editing this workspace").
+
+## Concept
+
+- See [prd-05-...md](./prd-05-agent-interaction-workspaces-workspace-persistence.md) §Goals/§1-§5 for full behavior.
+- Three parts: (1) daemon-side storage — new top-level `workspaces` table + REST CRUD; (2) live sync — new WS events broadcast on every mutation, new client-side `useWorkspaceServerStore` (mirroring `useServerStore`) fetched/patched the same way `useServerSync` already does for projects/worktrees/sessions; (3) client migration — one-time upload of any `localStorage`-only `WorkspaceDoc`s into the daemon on first successful connect post-upgrade.
+- `useWorkspaceStore`'s `workspaceDocs` map (`useStore.ts:226`) stops being a `persist`-backed source of truth for saved docs and becomes a **read-through cache of server data** — `WorkspaceCanvas.tsx`'s `readCanvas`/`patchCanvas` (`WorkspaceCanvas.tsx:163-175`) keep working against local state for drag/resize responsiveness, but every layout write is flushed to the daemon on gesture-end (Decision 4) instead of only ever living in `localStorage`.
+
+## Requirements
+
+| # | PRD ID | Requirement |
+|---|--------|-------------|
+| 1 | R1-R4 | New top-level daemon `workspaces` table stores id/name/geometry (`mode`, `tiles`, `tree`, `freeRects`); REST CRUD (list/create/rename/update-layout/delete). |
+| 2 | R5-R9 | Every mutation broadcasts a WS event (`broadcastAll`); client refetches on `ws:open` reconnect, same pattern as `useServerSync`. |
+| 3 | R10-R11 | Last-write-wins on concurrent layout edits; in-flight local drag/resize gestures are not interrupted by an incoming remote patch until gesture end. |
+| 4 | R12-R14 | One-time, automatic, idempotent upload of pre-existing `localStorage` `WorkspaceDoc`s on first successful connect; local copies survive an unreachable daemon and retry later. |
+| 5 | R15-R16 | `scratchCanvas` and the canvas editing UX are functionally and visually unchanged. |
+
+---
+
+## Research
+
+### Client: `WorkspaceDoc` today is `persist`-backed, not server data
+
+- **File:** `web-ui/src/hooks/useStore.ts:226` — `workspaceDocs: Record<string, WorkspaceDoc>` lives inside `useWorkspaceStore`, whose `persist` middleware (`:671-901`) writes the whole map to `localStorage` under `partialize` (`:899` includes `workspaceDocs`/`workspaceOrder`).
+- **File:** `web-ui/src/hooks/useStore.ts:574-622` — `createWorkspace`/`renameWorkspace`/`deleteWorkspace`/`updateWorkspaceDoc`/`insertTileIntoWorkspaceDoc` are synchronous local `set()` calls, no network I/O anywhere in this file today.
+- **Risk:** HIGH — every one of these five actions, plus every `WorkspaceCanvas.tsx` call site that invokes them, needs to become (or trigger) a network write. Getting the local-optimistic-vs-server-confirmed split wrong will either lag the UI (waiting on round-trips for a drag) or silently drop concurrent edits.
+
+### Client: layout writes happen on every `mousemove`, not on gesture end
+
+- **File:** `web-ui/src/components/layout/WorkspaceCanvas.tsx:377-391` (`startDrag`'s `onMove`), `:412-421` (`startResize`'s `onMove`), `:449-455` (`startDividerDrag`'s `onMove`) — each calls `patchCanvas(...)` on every `mousemove` event during a drag, which today is a cheap in-memory `set()`.
+- **Risk:** HIGH if unaddressed — naively wiring `patchCanvas` straight to a `PUT /workspaces/:id` call would fire dozens of HTTP requests per second during a single drag. Confirmed no existing debounce anywhere in these three handlers today.
+- **Mitigating precedent:** `startDrag`'s `onUp` (`:392-396`) and `startResize`'s `onUp` (`:423-426`) already exist as the natural "gesture ended" hook — used today only to remove the window listeners.
+
+### Server-truth client store precedent — reuse the shape, don't invent a third one
+
+- **File:** `web-ui/src/hooks/useServerStore.ts:1-114` (full file) — `ServerData` = flat arrays (`projects`/`worktrees`/`sessions`) + `loaded` flag + `replaceAll` (bulk) + per-entity `applyXCreated/Updated/Deleted` reducers (targeted WS patches). Explicitly documented as "NOT persisted... server truth — always fetch on load" (`:13`).
+- **File:** `web-ui/src/hooks/useServerSync.ts:36-82` — one `useEffect` does: initial fetch (`Promise.all` of `listProjects`/`listWorktrees`/`listSessions`) + refetch on every `ws:open` (dedup'd via a module-level `inFlightRefresh` guard, `:19`, `:55-75`) — reconnect-safe by construction.
+- **File:** `web-ui/src/hooks/useServerSync.ts:86-189` — second `useEffect` wires one `api.on(eventName, handler)` per WS event type, each calling the matching `useServerStore` reducer.
+- **Decision (Decision 3 below):** the same two-file shape (`useWorkspaceServerStore.ts` + wiring folded into `useServerSync.ts`) is the least-novel design — it is the one thing this plan should NOT invent freshly.
+
+### Daemon: top-level-entity CRUD + broadcast precedent (`projects`)
+
+- **File:** `daemon/src/routes/projects.ts:126` (`registerProjectRoutes`), `:277-317` (`POST /projects` — zod-validate body, `addProject`, `broadcastAll({ type: "project:created", project })`), `:858` (`DELETE` → `broadcastAll({ type: "project:deleted", projectId: id })`).
+- **File:** `daemon/src/server.ts:9,16` — `registerProjectRoutes(app)` called alongside five sibling `register*Routes` calls; a new `registerWorkspaceRoutes(app)` slots in the same way.
+- **Confirmed absent:** `grep -rn "workspace" daemon/src` (case-sensitive `Workspace`/`workspaceDocs`) returns zero hits — no existing daemon-side concept to collide with or extend.
+
+### Daemon: `project-store.ts`'s cache pattern is NOT a fit here (see Decision 1)
+
+- **File:** `daemon/src/state/project-store.ts:1-47` (module doc) — the cache is deliberately keyed to a project's full worktree/session object graph (`writeProjectFull` deletes+reinserts every child row per write, `:228-272`) because that graph is the daemon's single hottest read path (per-keystroke `findSessionRecord`, `:11-21`).
+- **Contrast:** a `workspaces` table has no such graph — one row per workspace, no FK-owned children in another table (tiles/tree/freeRects are serialized JSON columns on the row itself, see Data Model). A `mutateProject`-style "clone, mutate, delete-and-reinsert-children, refresh" apparatus is unneeded complexity for a single-row upsert.
+- **Decision:** simple direct `better-sqlite3` prepared statements (list/get/insert/update/delete), no bespoke in-memory graph cache — see Decision 1.
+
+### WS event shape precedent
+
+- **File:** `daemon/src/ws/protocol.ts:354-398` — every existing top-level-entity event pairs a `created`/`updated` event carrying the full serialized record (`z.record(z.string(), z.unknown())`) with a `deleted` event carrying only the id. New `workspace:created`/`workspace:updated`/`workspace:deleted` events follow this exact shape (see API Contracts).
+- **File:** `daemon/src/broadcaster.ts:30-35` — `broadcastAll(msg: ServerMessage)` is the one function every route already uses; no session-scoped variant needed since a workspace isn't tied to a session's subscriber list (unlike `sendToSession`, `broadcaster.ts:37+`).
+
+### Migration source data — what's already in `localStorage` today
+
+- **File:** `web-ui/src/hooks/useStore.ts:846-874` — the existing `v14 → v15` migration is the most recent precedent for a `workspaceDocs`-adjacent migration branch; this plan's client migration (R12-R14) is NOT a `persist` `version` bump (the shape of `WorkspaceDoc` itself doesn't change) — it's a one-time upload side effect, triggered once server sync is live, not a `migrate()` function change. See Decision 5.
+
+---
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    subgraph ClientA["Browser tab A"]
+        CanvasA["WorkspaceCanvas.tsx\n(local drag state,\nflush on gesture-end)"]
+        WSStoreA["useWorkspaceServerStore\n(new — mirrors useServerStore)"]
+        CanvasA <--> WSStoreA
+    end
+    subgraph ClientB["Browser tab B / device 2"]
+        CanvasB["WorkspaceCanvas.tsx"]
+        WSStoreB["useWorkspaceServerStore"]
+        CanvasB <--> WSStoreB
+    end
+    subgraph Daemon
+        Routes["routes/workspaces.ts\n(new)\nGET/POST/PATCH/DELETE /workspaces"]
+        Store[("workspaces table\nvibe-station.db")]
+        WSOut["broadcastAll\nworkspace:created/updated/deleted"]
+        Routes --> Store
+        Routes --> WSOut
+    end
+    WSStoreA -- "REST: list/create/rename/\nupdate-layout/delete" --> Routes
+    WSOut -- "WS broadcast" --> WSStoreA
+    WSOut -- "WS broadcast" --> WSStoreB
+```
+
+---
+
+## Design Details
+
+### Critical User Journeys (CUJs)
+
+#### CUJ 1 — User saves a workspace, sees it live on a second tab (happy path, R1/R5)
+
+```
+User A clicks "Save as workspace" on WorkspaceCanvas (worktree context)
+  → Client POSTs /workspaces { name, contextKey, mode, tiles, tree, freeRects }
+  → Daemon inserts row, broadcasts workspace:created { workspace: <full row> }
+  → User A's client applies the create locally (already has it via the POST response,
+    reducer is idempotent — same as applySessionCreated's existing-id check)
+  → User B's (second tab) WS listener receives workspace:created, useWorkspaceServerStore
+    inserts it, sidebar's global Workspaces list updates with no reload
+```
+- **Edge case:** two clients call "Save as workspace" simultaneously with the same name — both succeed, two distinct ids, no uniqueness constraint on `name` (matches today's client-only behavior, PRD CUJ "no dedup needed").
+
+#### CUJ 2 — User drags a tile; the write lands once, on release (happy path, R7, R10)
+
+```
+User A starts dragging a tile in a saved workspace
+  → Each mousemove updates LOCAL state only (readCanvas/patchCanvas keep writing to
+    an in-memory "pending edit" buffer, not the network — see Decision 4)
+  → mouseup (gesture end) fires: client sends ONE
+    PATCH /workspaces/:id/layout { mode, tiles, tree, freeRects }
+  → Daemon overwrites the row's geometry columns, broadcasts workspace:updated
+  → User B (viewing the same workspace) receives workspace:updated, tile jumps
+    to the new position — acceptable per PRD R11 (not mid-gesture, since B wasn't dragging)
+```
+- **Edge case (R11):** User B is ALSO mid-drag on a different tile of the same workspace when A's `workspace:updated` arrives — B's local pending-edit buffer is not overwritten; the incoming patch is merged into B's base geometry for every field except the tile B is actively moving, then B's own gesture-end write follows normally. (Simplification for this round, flagged in Risks: a genuinely simultaneous multi-user drag on the SAME tile is not specially handled — last-write-wins at the HTTP layer, per PRD Decision.)
+- **Edge case:** WS disconnects mid-drag — local drag still works (pure client state until gesture-end); the gesture-end PATCH is retried on reconnect if it failed, same retry posture as any other REST call's existing error handling (toast + no silent loss — confirm exact UX at implementation time against how other PATCH failures surface today).
+
+#### CUJ 3 — Workspace deleted by another client while open (R8, PRD Resolved Q4)
+
+```
+User B has /workspaces/<id> open
+  → User A deletes that workspace
+  → Daemon broadcasts workspace:deleted { workspaceId }
+  → User B's useWorkspaceServerStore removes it from workspaceDocs
+  → Workspace.tsx's existing "doc not found" effect (mirrors the missing-direct-session
+    pattern already used elsewhere, per 04-workspaces plan's CUJ 3 edge case) fires and
+    redirects User B to "/"
+```
+- **Edge case:** User B was mid-drag when the delete lands — the eventual gesture-end PATCH targets a since-deleted id; daemon responds 404, client discards the pending write silently (nothing to converge to) rather than erroring loudly.
+
+#### CUJ 4 — First load post-upgrade: local-only workspaces migrate (happy path, R12-R14)
+
+```
+User upgrades to a build with this change, opens the app
+  → useWorkspaceServerStore's initial sync fetches GET /workspaces (server list, likely empty
+    for this user on first upgrade)
+  → Migration effect compares local persist()-stored workspaceDocs (still present in
+    localStorage, untouched by any persist version bump — see Decision 5) against the
+    server list by id
+  → Every local id NOT present server-side is POSTed to /workspaces with a client-supplied id
+    (idempotency key — see Decision 5) so a retried/duplicate migration attempt never
+    double-creates
+  → On confirmed success per doc, that doc's local-only flag is cleared (see Data Model,
+    client-side sentinel) — it's now server-backed like any other
+  → workspaceDocs stops being read from persist() for anything not yet uploaded
+```
+- **Edge case (R13):** daemon unreachable during migration — upload attempts fail, local docs stay in `localStorage` untouched (nothing deleted pre-confirmation), `useWorkspaceServerStore` shows what it has (possibly empty) while local docs still render via the not-yet-migrated fallback path (Decision 5) — retried on next `ws:open`.
+- **Edge case (R14):** the SAME local doc was already migrated from a different browser under a different server-side id (no shared identity across browsers pre-migration) — out of scope for automatic de-dup (PRD doesn't require cross-browser content-based dedup); this migration only prevents re-uploading from the SAME browser twice.
+
+### System Boundaries
+
+| Boundary | Fields + types | Errors | Source of truth |
+|----------|----------------|--------|-----------------|
+| Client ↔ Daemon (REST) | See API Contracts below | `400 VALIDATION_ERROR` (zod), `404 NOT_FOUND` (unknown id), `409 CONFLICT` (create with a client-supplied id that already exists — migration idempotency) | Daemon |
+| Daemon ↔ Client (WS) | `workspace:created { workspace }`, `workspace:updated { workspace }`, `workspace:deleted { workspaceId }` — full-row payloads, same shape as `project:created`/`worktree:created` | none new (WS delivery is best-effort; reconnect refetch is the correctness backstop, R9) | Daemon (set at write time, broadcast is fire-and-forget) |
+| Client ↔ DB (daemon-local) | `workspaces` table — see Data Model | SQLite constraint violations surface as 500s (mirrors existing route error handling elsewhere in `routes/projects.ts`) | `vibe-station.db`, daemon-exclusive writer (same invariant `project-store.ts:23-28` documents) |
+| Module ↔ Module (web-ui, in-process) | `useWorkspaceServerStore` (new) ↔ `WorkspaceCanvas.tsx` — canvas reads/writes through the SAME `readCanvas`/`patchCanvas` function signatures it uses today (Decision 4); only what's behind those functions changes | n/a | `useWorkspaceServerStore` for saved docs; `useWorkspaceStore.layoutByWorktree[...].scratchCanvas` unchanged for transient |
+
+### Data Model
+
+| Entity | Field | Type | Constraints | Notes |
+|--------|-------|------|-------------|-------|
+| `workspaces` (new table) | `id` | `TEXT` | PK | Client-supplied on create (existing `randomId()` client-side convention, `useStore.ts:575`) — enables migration idempotency (Decision 5), matches how `sessions`/`worktrees` ids already work (`project-store.ts` inserts client/daemon-generated ids, never `AUTOINCREMENT`) |
+| `workspaces` | `name` | `TEXT NOT NULL` | — | |
+| `workspaces` | `contextKey` | `TEXT NOT NULL` | — | Provenance only (04-workspaces Decision 5) — carried over unchanged in meaning |
+| `workspaces` | `mode` | `TEXT NOT NULL` | `CHECK (mode IN ('tiled','free'))` | |
+| `workspaces` | `tiles` | `TEXT NOT NULL` | — | JSON-serialized `TileSpec[]` (`useStore.ts:59-72`) — no relational tile table; matches the "small local daemon, not a distributed system" scale this app already operates at (see `project-store.ts`'s own module doc for the precedent of choosing simplicity at this scale) |
+| `workspaces` | `tree` | `TEXT` | nullable | JSON-serialized `LayoutNode \| null` (`lib/tiling.ts`) |
+| `workspaces` | `freeRects` | `TEXT NOT NULL` | — | JSON-serialized `Record<string, FreeRect>` |
+| `workspaces` | `createdAt` | `TEXT NOT NULL` | ISO8601 | |
+| `workspaces` | `updatedAt` | `TEXT NOT NULL` | ISO8601 | Bumped on every PATCH — used for R10's "clients converge shortly after" (a client that just wrote can ignore a same-or-older `updatedAt` broadcast echo of its own write, avoiding a redundant re-render/loop) |
+| Client-side only: `WorkspaceDoc` (`useStore.ts:97`) | *(unchanged shape)* | — | — | Becomes the client-side type returned by `useWorkspaceServerStore`, not a `persist`-backed record; `contextKey` kept for compat with existing consumers (sidebar "created in X" hint, if any) |
+| Client-side only: migration sentinel | `localOnlyWorkspaceIds: string[]` (or equivalent) | — | — | Transient/persisted client flag tracking which locally-originated ids still need upload — see Decision 5; lives in `useWorkspaceStore`'s existing `persist` blob (small, scalar-ish addition, not a new table) |
+
+- **Migration (daemon):** `addColumnIfMissing`-style `CREATE TABLE IF NOT EXISTS workspaces (...)` added to `dbSchema.ts`'s `ensureSchema` — brand-new table, no backfill needed (nothing existed server-side before).
+- **Migration (client):** NOT a `persist` `version` bump (`WorkspaceDoc`'s shape is unchanged) — a one-time upload side effect wired into the new sync hook, see Decision 5.
+
+### API Contracts
+
+```
+GET /workspaces
+  Request:  —
+  Response: 200 WorkspaceDoc[]  (full rows, geometry fields parsed from JSON columns)
+  Errors:   —
+
+POST /workspaces
+  Request:  { id: string, name: string, contextKey: string, mode: "tiled"|"free",
+              tiles: TileSpec[], tree: LayoutNode|null, freeRects: Record<string,FreeRect> }
+  Response: 201 WorkspaceDoc
+  Errors:   400 VALIDATION_ERROR (zod), 409 CONFLICT (id already exists — migration replay)
+  Broadcast: workspace:created { workspace: WorkspaceDoc }
+
+PATCH /workspaces/:id
+  Request:  { name?: string }               -- rename
+  Response: 200 WorkspaceDoc
+  Errors:   400 VALIDATION_ERROR, 404 NOT_FOUND
+  Broadcast: workspace:updated { workspace: WorkspaceDoc }
+
+PATCH /workspaces/:id/layout
+  Request:  { mode: "tiled"|"free", tiles: TileSpec[], tree: LayoutNode|null,
+              freeRects: Record<string,FreeRect> }   -- full-geometry replace, gesture-end only
+  Response: 200 WorkspaceDoc
+  Errors:   400 VALIDATION_ERROR, 404 NOT_FOUND
+  Broadcast: workspace:updated { workspace: WorkspaceDoc }
+
+DELETE /workspaces/:id
+  Request:  —
+  Response: 200 { ok: true }
+  Errors:   404 NOT_FOUND
+  Broadcast: workspace:deleted { workspaceId: string }
+```
+
+- Rename and layout-update are separate endpoints (not one generic `PATCH /workspaces/:id` with optional fields for everything) — keeps the high-frequency gesture-end write's request body small and its intent unambiguous in server logs/tests; both broadcast the same `workspace:updated` event shape so the client doesn't need to distinguish.
+- `WorkspaceDoc` wire shape = the existing client type (`useStore.ts:97-110`) verbatim, so `web-ui/src/api/types.ts` can alias/import it rather than redefine it.
+
+### Key Decisions
+
+#### Decision 1: Direct prepared statements for `workspaces`, no `project-store.ts`-style graph cache
+
+- **Decision:** implement `daemon/src/state/workspace-store.ts` (new) with plain `db.prepare(...)` list/get/insert/update/delete — no per-handle in-memory `Map` cache, no clone-mutate-refresh apparatus.
+- **Rationale:** `project-store.ts`'s cache exists because the project/worktree/session graph is reassembled from 3 joined tables on every read and sits on a per-keystroke hot path (module doc, `project-store.ts:1-21`); `workspaces` is one flat table with no child rows and no comparable read frequency (opened rarely — on saving, listing in a sidebar, or loading a workspace view). Adding the cache pattern here is complexity with no measured problem to solve.
+- **Where:** `daemon/src/state/workspace-store.ts` (new file).
+
+#### Decision 2: Last-write-wins, no per-field merge, no op log
+
+- **Decision:** `PATCH /workspaces/:id/layout` fully replaces `mode`/`tiles`/`tree`/`freeRects`; the server does not attempt to merge concurrent writes.
+- **Rationale:** matches PRD's chosen option (no operation-based merge) and every other entity's mutation model in this codebase (`writeProjectFull` is itself a full delete-and-reinsert, not a diff — `project-store.ts:220-227`'s own comment: "Simple full-replace strategy... rather than a diff — correct and easy to reason about at the scale a local per-user daemon operates at").
+- **Where:** `daemon/src/routes/workspaces.ts` (new), the `PATCH /:id/layout` handler.
+
+#### Decision 3: Client sync reuses the `useServerStore`/`useServerSync` shape exactly
+
+- **Decision:** new `web-ui/src/hooks/useWorkspaceServerStore.ts` (mirrors `useServerStore.ts`'s `ServerData` shape: flat array + `loaded` + `applyCreated/Updated/Deleted` reducers) and fold its fetch/WS-wiring into the existing `useServerSync.ts` (one more `Promise.all` entry, one more set of `api.on(...)` handlers) rather than writing a parallel sync mechanism.
+- **Rationale:** PRD explicitly calls this out (§Client architecture change) — `useServerSync`'s reconnect-safe refetch-on-`ws:open` + in-flight-dedup guard (`useServerSync.ts:19-82`) is exactly the correctness property R9 needs; reimplementing it for workspaces risks a subtly different (and untested) reconnect story.
+- **Where:** `web-ui/src/hooks/useWorkspaceServerStore.ts` (new), `web-ui/src/hooks/useServerSync.ts` (modified — add workspace fetch + 3 new `api.on` handlers alongside the existing ones).
+
+#### Decision 4: `WorkspaceCanvas.tsx` keeps its local-optimistic drag path; only the flush target changes
+
+- **Decision:** `readCanvas`/`patchCanvas` (`WorkspaceCanvas.tsx:163-175`) continue to exist with the same signatures. For a saved doc, `patchCanvas` during an active drag writes to a **local pending-geometry buffer** (component-local `useState`/`useRef`, not the server store) exactly as fast as today; a new `flushLayout()` call — wired into the existing `onUp` handlers (`:392-396`, `:423-426`) and `startDividerDrag`'s `onUp` (`:457-460`) — sends the ONE `PATCH /workspaces/:id/layout` request per completed gesture.
+- **Rationale:** preserves drag responsiveness (zero network latency per frame, unchanged from today) while bounding write frequency to "once per user gesture" — directly answers PRD Open Question 4 (proposed: gesture-end only) and avoids flooding the WS/DB.
+- **Where:** `web-ui/src/components/layout/WorkspaceCanvas.tsx:163-175` (modify `readCanvas`/`patchCanvas` dispatch), `:392-396`, `:423-426`, `:457-460` (add `flushLayout()` calls in each `onUp`).
+
+```ts
+// Sketch — the shape that matters is "every onMove stays purely local; only
+// onUp crosses the network," not the exact buffer implementation.
+function patchCanvas(patch: Partial<CanvasGeometry>) {
+  if (savedDocId) {
+    pendingGeometryRef.current = { ...readCanvas(), ...patch }; // local only
+    forceRerender(); // whatever the component already uses to reflect local state
+  } else {
+    store.updateScratchCanvas(worktreeId, patch); // unchanged — scratch stays local-only
+  }
+}
+function flushLayout() {
+  if (!savedDocId || !pendingGeometryRef.current) return;
+  const g = pendingGeometryRef.current;
+  pendingGeometryRef.current = null;
+  api.updateWorkspaceLayout(savedDocId, g); // fire PATCH .../layout — see API Contracts
+}
+```
+
+#### Decision 5: Migration is a one-time upload side effect, not a `persist` version bump; client-supplied ids give idempotency
+
+- **Decision:** `WorkspaceDoc`'s stored shape does not change, so no `useStore.ts` `migrate()` branch is added for this. Instead, a new effect (co-located with the sync wiring, Decision 3) runs once per app load: after the first successful `GET /workspaces`, diff local `persist()`-stored `workspaceDocs` ids against the server list; for every id not present server-side, POST it using that SAME id as the new row's PK.
+- **Rationale:** reusing the existing client-generated id as the server row's PK means a retried migration attempt (app reloaded before the first attempt's response was confirmed, or two tabs racing the same migration) is a harmless `409 CONFLICT` on the second attempt rather than a duplicate — no separate idempotency-key mechanism needed.
+- **Where:** `web-ui/src/hooks/useServerSync.ts` (new migration effect, gated on `useWorkspaceServerStore`'s `loaded` flag going true), `daemon/src/routes/workspaces.ts` (`POST /workspaces` honors a client-supplied `id`, 409s on collision — see API Contracts).
+
+---
+
+## Risks / Open Questions
+
+| # | Question | Notes |
+|---|----------|-------|
+| 1 | **Exact UX when a gesture-end `PATCH /workspaces/:id/layout` fails (network drop, 404 on a since-deleted doc)** | PRD Open Question 1/CUJ 2 edge case propose: silent discard on 404 (nothing to converge to), toast + no data loss on network failure (local pending buffer is NOT cleared until a confirmed 200, so nothing is lost — just re-flushed on the next gesture or an explicit retry). Confirm the exact toast/retry UX against existing PATCH-failure conventions elsewhere in the app before implementing Phase 2. |
+| 2 | **Should `updatedAt`-based echo suppression (Data Model note) be implemented this round, or is a harmless extra re-render acceptable?** | Proposed: skip it initially — an extra re-render from a client receiving its own broadcast echo is a minor inefficiency, not a correctness bug (per `applySessionUpdated`'s existing "just overwrite" reducer style, no existing echo-suppression precedent found in `useServerStore.ts`). Revisit only if it's visibly janky. |
+| 3 | **Multi-tile-drag collision (CUJ 2's "User B is ALSO mid-drag" edge case) — is the proposed partial-merge worth building, or is a flat last-write-wins (B's gesture-end write simply clobbers whatever A sent) acceptable?** | PRD's chosen option is flat last-write-wins with no merge (Options table) — CUJ 2's "merge every field except the actively-dragged tile" is arguably scope creep beyond that decision. **Propose simplifying to flat last-write-wins even in this edge case** (no special-casing) unless the reviewer disagrees — flag for plan-review resolution before implementation starts. |
+| 4 | **Does `PATCH /workspaces/:id` (rename) also need gesture-end-style write-suppression, or is it low-frequency enough to fire immediately?** | Rename is a discrete user action (type a name, hit enter/blur), not a continuous gesture — propose: fire immediately, no buffering needed, unlike layout PATCH. |
+| 5 | **`contextKey` on the new table — required at create time from every caller, or does the server default it?** | `createWorkspace(contextKey, name, mode)` (`useStore.ts:229`, `574`) already always passes it client-side today — propose keeping it required in the POST body, no server-side default needed. Confirm no call site exists that omits it. |
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Daemon storage + REST CRUD
+
+- [ ] **1.1** Add `workspaces` table to `daemon/src/services/dbSchema.ts`'s `ensureSchema` (`CREATE TABLE IF NOT EXISTS workspaces (id TEXT PRIMARY KEY, name TEXT NOT NULL, contextKey TEXT NOT NULL, mode TEXT NOT NULL CHECK (mode IN ('tiled','free')), tiles TEXT NOT NULL, tree TEXT, freeRects TEXT NOT NULL, createdAt TEXT NOT NULL, updatedAt TEXT NOT NULL)`)
+- [ ] **1.2** New `daemon/src/state/workspace-store.ts` — `listWorkspaces()`, `getWorkspace(id)`, `addWorkspace(record)`, `updateWorkspace(id, patch)`, `updateWorkspaceLayout(id, geometry)`, `deleteWorkspace(id)` — direct prepared statements per Decision 1, JSON-serialize `tiles`/`tree`/`freeRects` on write, parse on read
+- [ ] **1.3** New `daemon/src/routes/workspaces.ts` — `registerWorkspaceRoutes(app)`: `GET /workspaces`, `POST /workspaces` (zod body, 409 on id collision), `PATCH /workspaces/:id` (rename), `PATCH /workspaces/:id/layout`, `DELETE /workspaces/:id` — each mutating route calls `broadcastAll(...)` per API Contracts
+- [ ] **1.4** Register in `daemon/src/server.ts` — `import { registerWorkspaceRoutes } from "./routes/workspaces.js"` + call alongside the other five `register*Routes` calls
+- [ ] **1.5** Add `WorkspaceCreatedEvent`/`WorkspaceUpdatedEvent`/`WorkspaceDeletedEvent` to `daemon/src/ws/protocol.ts` (same shape as `ProjectCreatedEvent` et al., `protocol.ts:354-398`) and add them to the `ServerMessage` union
+
+**Verify phase 1:**
+- [ ] **1.T1** Unit — `workspace-store.test.ts`: create → get round-trips `tiles`/`tree`/`freeRects` byte-identical after JSON round-trip (including `tree: null` and an empty `freeRects: {}`)
+- [ ] **1.T2** Integration — `routes/workspaces.test.ts`: `POST /workspaces` with a duplicate `id` returns `409`; `PATCH /workspaces/:id/layout` on an unknown id returns `404`
+- [ ] **1.T3** Integration — `routes/workspaces.test.ts`: every mutating route asserts `broadcastAll` was called with the expected event `type` and payload shape (mirrors existing `projects.test.ts` broadcast-assertion style)
+
+---
+
+### Phase 2 — Client sync wiring
+
+- [ ] **2.1** New `web-ui/src/hooks/useWorkspaceServerStore.ts` — `WorkspaceServerData` (flat `workspaces: WorkspaceDoc[]`, `loaded: boolean`, `replaceAll`, `applyWorkspaceCreated/Updated/Deleted`), mirroring `useServerStore.ts:17-114` exactly
+- [ ] **2.2** Add `WorkspaceDoc` REST methods to `web-ui/src/api/client.ts` (`listWorkspaces`, `createWorkspace`, `renameWorkspace`, `updateWorkspaceLayout`, `deleteWorkspace`) following the `listProjects`/`addProject` shape (`client.ts:227-241`); mirror each in `web-ui/src/api/mock.ts`
+- [ ] **2.3** Extend `web-ui/src/hooks/useServerSync.ts`'s initial-fetch `Promise.all` (`:59-63`) with `api.listWorkspaces()`, feed into `useWorkspaceServerStore`'s `replaceAll`; add `workspace:created`/`workspace:updated`/`workspace:deleted` handlers to the second `useEffect` (`:86-189`) calling the matching `applyWorkspace*` reducer
+- [ ] **2.4** Rewire `useWorkspaceStore`'s `workspaceDocs`-touching actions (`createWorkspace`/`renameWorkspace`/`deleteWorkspace`/`updateWorkspaceDoc`/`insertTileIntoWorkspaceDoc`, `useStore.ts:574-622`) to call the new API methods instead of local `set()`, OR (implementer's call, confirm against how deeply `WorkspaceCanvas.tsx` and `LeftSidebar.tsx` already couple to these exact action names) replace their call sites to read from `useWorkspaceServerStore` directly — pick whichever keeps `WorkspaceCanvas.tsx`'s existing call sites (`saveAsWorkspace`, `addTile`, etc.) working with the smallest diff
+- [ ] **2.5** Implement Decision 4's local-pending-geometry buffer + `flushLayout()` in `WorkspaceCanvas.tsx`, wired into the three `onUp` handlers (`:392-396`, `:423-426`, `:457-460`)
+- [ ] **2.6** Drop `workspaceDocs`/`workspaceOrder` from `useWorkspaceStore`'s `persist` `partialize` (`useStore.ts:899-900`) once Phase 2/3 both land — keep them in the in-memory state shape (still used as the local migration source, Decision 5) but stop writing them to `localStorage` going forward (bump `persist` `version` to 16 with a `migrate()` no-op-for-shape branch that just leaves old persisted `workspaceDocs` alone so Phase 3's migration effect can still read them once)
+
+**Verify phase 2:**
+- [ ] **2.T1** Unit — `useWorkspaceServerStore.test.ts`: `applyWorkspaceUpdated` on an unknown id is a no-op (mirrors `applyWorktreeUpdated`'s existing "drop silently" behavior, `useServerStore.ts:87-96`)
+- [ ] **2.T2** Integration — `useServerSync.test.ts`: a `workspace:created` WS event inserts into `useWorkspaceServerStore`; a `workspace:deleted` event removes it
+- [ ] **2.T3** Regression — `WorkspaceCanvas.test.tsx` (or equivalent): dragging a tile does NOT fire a network call on every `mousemove`, fires exactly one `updateWorkspaceLayout` call on `mouseup`
+- [ ] **2.T4** Regression — scratch canvas (`updateScratchCanvas`/`clearScratchCanvas`) behavior and its existing tests are unaffected by this phase
+
+---
+
+### Phase 3 — Client migration
+
+- [ ] **3.1** Add a `localOnlyWorkspaceIds`-style client-side migration-pending tracker (Data Model) — seeded once from whatever `workspaceDocs` still exist in the OLD `persist` storage at the moment `useWorkspaceServerStore` first loads
+- [ ] **3.2** Migration effect (Decision 5) in `useServerSync.ts` (or a new co-located hook): on `useWorkspaceServerStore`'s `loaded` transitioning true, for every locally-known id not in the server list, `POST /workspaces` with that id; on `200`/`201` clear it from the pending tracker; on `409` (already migrated elsewhere) also clear it (already server-known, nothing to do); on any other failure, leave it pending for the next `ws:open`
+- [ ] **3.3** Confirm/implement the "unreachable daemon" degraded read path (R13) — while `useWorkspaceServerStore.loaded` is false AND local pending ids are non-empty, the sidebar/canvas fall back to rendering from the OLD `persist`-stored `workspaceDocs` rather than an empty list (exact fallback wiring is an implementation-time call — confirm against how `useServerStore`'s `loaded` flag is already consumed elsewhere, e.g. `DashboardPanel`/`LeftSidebar`'s loading-state handling)
+
+**Verify phase 3:**
+- [ ] **3.T1** Integration — `migration.test.ts` (or folded into `useServerSync.test.ts`): seed `localStorage` with 2 pre-existing `WorkspaceDoc`s, mount, assert both get `POST`ed exactly once and the pending tracker empties
+- [ ] **3.T2** Integration — re-mounting after a successful migration does NOT re-POST the same ids (idempotency, R14)
+- [ ] **3.T3** Integration — `POST /workspaces` failing (simulated daemon-unreachable) leaves the pending tracker non-empty and local docs still render (R13)
+- [ ] **3.T4** Regression — full daemon + web-ui suites pass (`npm test` or repo's existing per-package test commands — confirm exact commands from `package.json`/CI config at implementation time, not guessed here)
+
+---
+
+## Files & Phase Impact
+
+| File | Status | Phase | Description / Contract Change |
+|------|--------|-------|-------------------------------|
+| `daemon/src/services/dbSchema.ts` | **Modified** | 1.1 | New `workspaces` table |
+| `daemon/src/state/workspace-store.ts` | **New** | 1.2 | Contract: `listWorkspaces(): WorkspaceRow[]`, `addWorkspace`, `updateWorkspace`, `updateWorkspaceLayout`, `deleteWorkspace` · Owns: nothing (stateless, direct DB reads/writes, Decision 1) |
+| `daemon/src/routes/workspaces.ts` | **New** | 1.3 | Contract: `registerWorkspaceRoutes(app: FastifyInstance): void` — 5 REST endpoints, see API Contracts |
+| `daemon/src/server.ts` | **Modified** | 1.4 | Register new route module |
+| `daemon/src/ws/protocol.ts` | **Modified** | 1.5 | 3 new event schemas + `ServerMessage` union entries |
+| `daemon/src/state/workspace-store.test.ts` | **New** | 1.T1 | Unit tests |
+| `daemon/src/routes/workspaces.test.ts` | **New** | 1.T2, 1.T3 | Integration tests incl. broadcast assertions |
+| `web-ui/src/hooks/useWorkspaceServerStore.ts` | **New** | 2.1 | Contract: `WorkspaceServerData` store, mirrors `useServerStore.ts` shape |
+| `web-ui/src/api/client.ts` | **Modified** | 2.2 | 5 new methods on `ApiInstance` |
+| `web-ui/src/api/mock.ts` | **Modified** | 2.2 | Mock counterparts of the 5 new methods |
+| `web-ui/src/api/types.ts` | **Modified** | 2.2 | `WorkspaceDoc` type (or re-export from `useStore.ts`) |
+| `web-ui/src/hooks/useServerSync.ts` | **Modified** | 2.3, 3.2 | Extended fetch + WS reducer wiring; migration effect |
+| `web-ui/src/hooks/useStore.ts` | **Modified** | 2.4, 2.6, 3.1 | `workspaceDocs` actions call the API; `persist` `partialize`/`version` change; migration-pending tracker field |
+| `web-ui/src/components/layout/WorkspaceCanvas.tsx` | **Modified** | 2.5 | `patchCanvas`/`readCanvas` dispatch change; new `flushLayout()` wired into 3 `onUp` handlers |
+| `web-ui/src/hooks/useWorkspaceServerStore.test.ts` | **New** | 2.T1 | Unit tests |
+| `web-ui/src/hooks/useServerSync.test.ts` | **Modified** | 2.T2, 3.T1, 3.T2, 3.T3 | New WS-reducer + migration test cases |
+| `web-ui/src/components/layout/WorkspaceCanvas.test.tsx` | **Modified/New** | 2.T3 | Drag-flush-frequency regression test (confirm existing test file name/presence at implementation time) |

--- a/.vibekit/feature-plans/wip/agent-interaction-workspaces/05-workspace-persistence/prd-05-agent-interaction-workspaces-workspace-persistence.md
+++ b/.vibekit/feature-plans/wip/agent-interaction-workspaces/05-workspace-persistence/prd-05-agent-interaction-workspaces-workspace-persistence.md
@@ -1,0 +1,140 @@
+<!--
+RULES — read before writing or implementing:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. REQUIREMENTS: One crisp line each — no verbose descriptions
+3. CHECKLIST: Mark items [x] as you complete them — this is your persistent todo list
+4. READING TIME: Optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+# PRD: Workspace Persistence (05, sub-feature of Agent Interaction State + Workspaces)
+
+> Move SAVED workspace layouts (`WorkspaceDoc`) off client-only `localStorage` and into the daemon's `vibe-station.db`, synced live across every connected client over WS — so a saved workspace is a durable, shared record instead of a browser-local one.
+
+**Status:** Draft
+**Technical plan:** `.vibekit/feature-plans/wip/agent-interaction-workspaces/05-workspace-persistence/plan-05-agent-interaction-workspaces-workspace-persistence.md`
+**Parent feature:** `.vibekit/feature-plans/wip/agent-interaction-workspaces/prd-agent-interaction-workspaces.md` (Workspaces canvas, §2-§5) — this sub-feature only changes *where a saved WorkspaceDoc lives*, not the canvas/tiling UX itself (04-workspaces, shipped) or the daemon interaction-state machine (03-interaction-states).
+
+---
+
+## Problem
+
+- A saved workspace (`WorkspaceDoc` — name + tile layout) exists only in the browser profile that saved it (`localStorage`, zustand `persist`) — clearing browser data, switching browsers/machines, or opening vibe-station from a second device loses or fails to show it.
+- Two browser tabs (or two devices) open on the same daemon today see **independent** copies of a saved workspace — renaming/retiling/deleting in one tab has no effect on the other until that tab happens to re-save over it, and normally never converges at all.
+- Every other durable entity in the app (projects, worktrees, sessions) already lives in the daemon's `vibe-station.db` and syncs live over WS (`useServerStore`/`useServerSync`); `WorkspaceDoc` is the one exception, which is surprising and a real data-loss risk (a user who reinstalls a browser has genuinely lost work today).
+
+## Goals
+
+- A saved workspace is durable server-side truth: created once, visible identically from any browser/device pointed at the same daemon.
+- Save / rename / delete / tile-layout-edit on one connected client appears live on every other connected client — no reload needed — matching the existing behavior for sessions/worktrees/projects.
+- Existing users' `localStorage`-only workspaces are not lost on upgrade — they migrate to the daemon automatically.
+- No change to the workspace canvas UX itself (tiling/free-form editing, tile chrome, state coloring) — this is a storage-layer move, not a feature redesign.
+
+## Non-goals
+
+- Any change to `WorktreeLayout.scratchCanvas` (the transient, unsaved, per-worktree canvas) — it stays exactly as-is, client-only `localStorage`, untouched by this work.
+- Any change to the workspace canvas's tiling/free-form editing UX, tile chrome, or state-coloring behavior (04-workspaces, shipped) — this sub-feature only relocates *storage*.
+- Multi-user permissions/ownership on a workspace — same single-local-user model as the rest of the app; "synced across clients" means every client pointed at one daemon, not multi-account sharing.
+- Offline editing / conflict-free merge (CRDT-style) — see §4 Resolved design questions for the concurrency model chosen instead.
+- A dedicated "Workspaces library" management page beyond what already exists (carried over as a non-goal from 04-workspaces).
+- Real-time cursor/presence indicators ("who's editing this workspace right now") — out of scope; see Open questions for whether a simpler "someone else is editing" toast is worth a follow-on.
+
+---
+
+## 1. Server-side storage
+
+| ID | Requirement |
+|----|-------------|
+| R1 | A saved workspace (name + its full tile layout, per Resolved Design Question 2) persists in the daemon's database, not the browser. |
+| R2 | A workspace is a top-level record, not owned by or nested under any single project/worktree — it can reference tiles from multiple projects/worktrees at once. |
+| R3 | Restarting the daemon, or connecting from a browser that has never loaded the app before, shows every previously saved workspace exactly as last saved. |
+| R4 | Deleting a workspace removes it for every client; it does not delete or affect any underlying agent/terminal session referenced by its tiles. |
+
+## 2. Live cross-client sync
+
+| ID | Requirement |
+|----|-------------|
+| R5 | Creating a workspace on client A makes it appear in client B's workspace list within the same latency budget as a new worktree/session appearing today (WS push, no polling). |
+| R6 | Renaming a workspace on client A updates its displayed name on client B live. |
+| R7 | Editing a workspace's tile layout (add/remove/move/resize a tile, switch tiled↔free-form) on client A updates client B's view of that workspace live, if client B is currently viewing it. |
+| R8 | Deleting a workspace on client A removes it from client B's list live, and if client B currently has that workspace open, client B is taken to a graceful "workspace no longer exists" state (matching existing deleted-entity handling elsewhere in the app), not a crash. |
+| R9 | A client that was offline (tab backgrounded, laptop asleep, WS dropped) reconciles to current server truth on reconnect — same refetch-on-`ws:open` pattern already used for projects/worktrees/sessions. |
+
+## 3. Concurrent-edit behavior
+
+| ID | Requirement |
+|----|-------------|
+| R10 | Two clients editing the same workspace's tile layout at the same time do not corrupt the stored layout — the last write applied by the server wins, and both clients converge to that same state shortly after. |
+| R11 | A client actively mid-edit (e.g. mid-drag-resize) does not visibly jump or stutter because of an incoming remote update — exact mechanism (defer vs. apply-through) is an open question, not yet decided. |
+
+## 4. Client migration
+
+| ID | Requirement |
+|----|-------------|
+| R12 | On first load after upgrading to this version, every workspace currently sitting only in that browser's `localStorage` is uploaded to the daemon automatically, with no user action required. |
+| R13 | If the daemon is unreachable at that moment, the local copies are not deleted — migration retries on the next successful connection, and the user sees their local workspaces in the meantime (degraded, read/edit-locally-only) rather than an empty list. |
+| R14 | A workspace that has already been migrated is never re-uploaded as a duplicate on a subsequent load (from the same browser, or a second browser migrating the same locally-originated doc after it's already server-known elsewhere). |
+
+## 5. Scope boundary (regression guards)
+
+| ID | Requirement |
+|----|-------------|
+| R15 | The transient per-worktree scratch canvas continues to behave identically to today — worktree-scoped, client-only, not visible to other clients, not part of this sync. |
+| R16 | Everything about how a workspace canvas is edited today (tiling, free-form drag, add/remove tile, state-colored tile borders) is visually and behaviorally unchanged — only the persistence/sync layer underneath changes. |
+
+---
+
+## Options considered
+
+### Where does a saved workspace live server-side?
+
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| A — New top-level `workspaces` table in `vibe-station.db`, independent of `projects`/`worktrees`/`sessions` | Matches the data model (a workspace already spans multiple projects/worktrees, per the existing `workspaceDocs` flat map); no FK-cascade surprises when a referenced project/worktree/session is deleted | Yet another top-level table to maintain | ✅ chosen |
+| B — Nest workspace rows under whichever project "owns" the workspace (mirroring `mutateProject`'s per-project blob pattern) | Reuses an existing, proven read/write path | Forces a false single-owner model onto a cross-project entity — exactly the ownership model 04-workspaces' detachment phase already rejected for the client-side `contextKey` field | ❌ rejected |
+
+### Conflict resolution for concurrent tile-layout edits
+
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| A — Last-write-wins (server accepts the newest full-layout write it receives, broadcasts it, no merge) | Simple, matches every other entity's mutation model in this app (sessions/worktrees/projects have no merge logic either); workspace editing is a low-frequency, mostly-single-editor-at-a-time action | A genuinely simultaneous edit from two clients can silently drop one side's change | ✅ chosen |
+| B — Operation-based merge (each tile add/move/remove is its own op, server serializes and replays) | No silent drop of concurrent edits | Real complexity (op log, replay, conflict rules) for a scenario (two humans actively retiling the same saved workspace at the same instant) that's rare for a single-local-user tool | ❌ deferred — revisit only if last-write-wins proves painful in practice |
+
+### Client migration trigger
+
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| A — Automatic, silent upload on first successful daemon connection post-upgrade, no prompt | Zero friction, matches "it just works" bar of the rest of the app; workspaces are low-stakes (recreatable) so a silent background action is low-risk | User isn't asked before their local data leaves the browser (mitigated: it's the user's own daemon, not a third party) | ✅ chosen |
+| B — Prompt the user ("Upload N local workspaces to the daemon?") before migrating | Explicit consent | Adds a modal for something that should just work, inconsistent with how every other piece of local UI state (sort orders, font scale) is already silently daemon-agnostic vs. not | ❌ rejected |
+
+---
+
+## Resolved design questions
+
+1. **Is a `WorkspaceDoc` scoped to a project/worktree the way sessions are?** — **No, it's a top-level entity.** A saved workspace can tile sessions from multiple projects/worktrees at once (already true client-side today); forcing single-project ownership would contradict the existing cross-context tile picker.
+2. **What counts as "the layout" that must round-trip through the DB?** — **Everything in `CanvasGeometry`:** `mode`, `tiles[]` (including cross-context `worktreeId` per tile), `tree` (tiled-mode split structure — axis/children/sizes), and `freeRects` (free-mode per-tile x/y/w/h). Tile membership alone is not sufficient — positioning must persist too.
+3. **Does the transient scratch canvas move server-side too?** — **No, explicitly out of scope.** Only named/saved `WorkspaceDoc`s move; `WorktreeLayout.scratchCanvas` remains exactly as today.
+4. **What happens to a client actively viewing/editing a workspace when it's deleted by another client?** — **Graceful "no longer exists" state**, same class of handling the app already needs for a worktree deleted while open elsewhere (04-workspaces flagged the equivalent question for its own detached-view route; this sub-feature answers it the same way, reusing whatever pattern that lands on).
+5. **Conflict resolution for simultaneous edits** — **Last-write-wins**, matching every other entity in the app. See Options above.
+6. **How does migration behave when the daemon is unreachable** — **Local copies are never deleted before a confirmed successful upload; retried on next connect.** A user is never worse off than today (client-only) during an outage.
+
+---
+
+## Priority & sequencing
+
+| Order | Sub-part | Depends on | Can ship independently? |
+|-------|----------|------------|--------------------------|
+| 1 | Server-side storage + REST CRUD (R1-R4) | — | Yes (daemon-only change, no client behavior change yet) |
+| 2 | WS broadcast + client sync wiring (R5-R11) | 1 | No — needs server storage to exist first |
+| 3 | Client migration (R12-R14) | 1, 2 | No — migration uploads into the storage/sync layer built in 1-2 |
+
+---
+
+## Open questions
+
+| # | Question | Proposed answer / owner |
+|---|----------|--------------------------|
+| 1 | **Exact mechanism for R11 (remote update lands mid-local-gesture)** — defer the incoming patch, or apply-and-let-the-drag-jump? | Proposed: buffer/defer any remote patch to a workspace the local client is actively drag/resizing, apply immediately after gesture end (mouseup/touchend) — avoids a visible jump under the user's cursor. This is the plan's proposed answer, not yet locked — confirm at plan-review time. |
+| 2 | **Should a "someone else is editing this workspace" indicator exist?** | Proposed: not this round — last-write-wins is silent by design (Options above); revisit only if real usage shows it's confusing. |
+| 3 | **Does workspace deletion need a confirmation dialog, given it's now a shared/durable action affecting other clients too?** | Not decided — today's client-only delete may already have no confirmation; if so, propose keeping that (deletion is cheap — layouts are recreatable, no underlying sessions are destroyed per R4). Confirm current behavior at plan time. |
+| 4 | **Rate limits / debounce on tile-layout-edit writes (R7)** — every drag-resize frame, or on gesture end only? | Proposed: write on gesture end only (mirrors how `sortOrder` drag-reorder likely already debounces) — avoids flooding the WS/DB with per-frame writes. Confirm at plan time against actual `WorkspaceCanvas.tsx` drag-handler granularity. |
+| 5 | **Migration identity (R12-R14): does a locally-originated workspace keep its client-generated id as the server's canonical id, or does the server mint a new one?** | Proposed: keep the client-generated id as the canonical server id — simplest, and lets a retried/duplicate upload attempt from the same browser be recognized by id rather than needing a separate dedup key. Does not resolve cross-browser dedup (two browsers independently "created" what a human considers the same workspace get two distinct server rows — acceptable, not attempted this round). Confirm at plan time. |

--- a/.vibekit/feature-plans/wip/agent-interaction-workspaces/plan-agent-interaction-workspaces.md
+++ b/.vibekit/feature-plans/wip/agent-interaction-workspaces/plan-agent-interaction-workspaces.md
@@ -1,0 +1,73 @@
+---
+PRD: prd-agent-interaction-workspaces.md
+Status: WIP
+---
+
+<!--
+RULES — read before writing or implementing:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. REQUIREMENTS: One crisp line each — no verbose descriptions
+3. CHECKLIST: Mark items [x] as you complete them — this is your persistent todo list
+4. READING TIME: Optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+# Plan: Agent Interaction State + Workspaces (v5 — thin master)
+
+> Exactly two sub-feature plans, split along the boundary the user actually asked for: **(1) interaction states** — the `waiting_for_human`/`needs_review` daemon lifecycle-state machine and everything that surfaces it — and **(2) Workspaces** — the entire tiled-canvas feature (shipped implementation, shipped cursor/border fixes, in-flight detachment, in-flight spawn-affinity), all as phases of one coherent plan. This root plan carries no implementation checklist of its own — see Sub-Plan Breakdown.
+
+**Issue:** agent-interaction-workspaces
+**Branch:** `introducing-new-state` (current)
+**Status:** WIP
+**PRD:** `.vibekit/feature-plans/wip/agent-interaction-workspaces/prd-agent-interaction-workspaces.md`
+
+---
+
+## Revision note (v5 — this restructure)
+
+- **Why:** user feedback on v4 — *"Why do we still have 1 and 2. I clearly said let's just have 2 plans. We don't need 4."*
+- **What changed:** v4 still carried 4 sub-feature plan files (`01-workspace-detachment`, `02-source-agent-spawn`, `03-interaction-states`, `04-workspaces`) even though `04-workspaces` already pointed at `01`/`02` via a Sub-Plan Breakdown table. This revision **merges `01-workspace-detachment` and `02-source-agent-spawn` directly into `04-workspaces`** as new phases (Phase 3 — workspace detachment, Phase 4 — source-agent spawn affinity), deletes both directories, and removes `04-workspaces`'s Sub-Plan Breakdown table (no sub-plans left to index). The feature is now exactly **two** sub-feature plans:
+  - [`03-interaction-states`](./03-interaction-states/plan-03-agent-interaction-workspaces-interaction-states.md) — unchanged, still the `waiting_for_human`/`needs_review` daemon lifecycle-state machine.
+  - [`04-workspaces`](./04-workspaces/plan-04-agent-interaction-workspaces-workspaces.md) — now a single plan covering all of Workspaces: shipped canvas/tiling (Phase 1), shipped cursor/border fixes (Phase 2), workspace detachment (Phase 3, absorbs former `01-workspace-detachment`), source-agent spawn affinity (Phase 4, absorbs former `02-source-agent-spawn`).
+- **Numbering:** `01-workspace-detachment`/`02-source-agent-spawn` directories are deleted outright, not kept as empty/stub dirs — their content lives on as `04-workspaces`'s Phase 3/Phase 4 (sub-phases 3a/3b/3c and 4a/4b/4c). No new `NN` is assigned to anything by this revision.
+- **No content lost:** every requirement ID (R1-R9/R3a, W1-W12, L1-L8, D1-D8, S1-S6), every CUJ, every Key Decision, every Risk/Open Question, every Files & Phase Impact row from the two deleted sub-plans is now inside `04-workspaces` — verified by ID-traceability grep across the two remaining sub-feature plans.
+- **v4 / v3 / v2 / v1 history:** see the prior revision notes preserved in the PRD (`prd-agent-interaction-workspaces.md` §Revision note) — not repeated here to avoid re-deriving content that already has a canonical home.
+
+---
+
+## Problem
+
+- See [prd-agent-interaction-workspaces.md](./prd-agent-interaction-workspaces.md) §Problem — no way to tell "idle" from "blocked on a human" or "PR ready for review" today, and the layout can't show multiple agents at once.
+
+## Concept
+
+- See [prd-agent-interaction-workspaces.md](./prd-agent-interaction-workspaces.md) §1-§5 for full behavior + state machine + color mapping + tiling model + detachment + spawn affinity.
+- This root plan makes no implementation decisions of its own — every requirement is owned by exactly one of the two sub-feature plans below (or their own nested sub-plans).
+
+---
+
+## Priority & sequencing
+
+| Order | Sub-feature | Depends on |
+|-------|-------------|------------|
+| 1 | [`03-interaction-states`](./03-interaction-states/plan-03-agent-interaction-workspaces-interaction-states.md) — `waiting_for_human` + `needs_review` state machine (daemon `LifecycleState`, JSON-channel detection, PR poller, WS broadcast, rollup/`StatusDot`) | none |
+| 2 | [`04-workspaces`](./04-workspaces/plan-04-agent-interaction-workspaces-workspaces.md) — live-pane tiles, free-form + tiling layout modes, color mapping (Phase 1, shipped); cursor/border fixes (Phase 2, shipped); workspace detachment (Phase 3, in-flight); source-agent spawn affinity (Phase 4, in-flight) | Consumes `03-interaction-states`'s color mapping for tile/pane coloring, but is not blocked by it — the canvas already renders correctly for the 5 states that exist today; `waiting_for_human`/`needs_review` colors activate automatically once `03` ships (shared `sessionStatus()` helper, no Workspaces-side change needed) |
+
+- Within `04-workspaces`: Phase 3 (detachment) should land before/alongside Phase 4 (spawn affinity) since spawn-affinity's workspace-scan logic is simpler once workspaces are a flat global list — see `04-workspaces`'s own Concept section.
+
+---
+
+## Sub-Plan Breakdown
+
+| Sub-plan | Origin | Scope |
+|----------|--------|-------|
+| [`03-interaction-states`](./03-interaction-states/plan-03-agent-interaction-workspaces-interaction-states.md) | planned (relocated from this plan's former Phase 1/1b/2, v4 restructure) | `waiting_for_human`/`needs_review` daemon lifecycle-state machine + rollup/`StatusDot` surfacing. PRD §1 (R1-R9). Not yet implemented on the daemon side. |
+| [`04-workspaces`](./04-workspaces/plan-04-agent-interaction-workspaces-workspaces.md) | planned (relocated from this plan's former Phase 3/4, v4 restructure; absorbed former `01-workspace-detachment`/`02-source-agent-spawn` as Phase 3/4, v5 restructure) | Entire Workspaces feature as one plan: shipped canvas/tiling/chrome implementation (Phase 1), shipped cursor+border fixes (Phase 2), workspace detachment (Phase 3, PRD §4 D1-D8), source-agent spawn affinity (Phase 4, PRD §5 S1-S6). |
+
+- `NN` (`03`, `04`) assigned once, never renumbered. `01`/`02` (formerly `01-workspace-detachment`/`02-source-agent-spawn`) were deleted in the v5 restructure — their content lives on inside `04-workspaces`'s Phase 3/Phase 4, not as separate `NN` directories.
+- **Master/root exception:** this plan replaces its own Files & Phase Impact table with this Sub-Plan Breakdown table per the planning skill's convention for a root plan with a populated breakdown — see `SECTIONS.md` "Master/root exception." No file is modified directly by this root plan; every file touched by this feature is owned by one of the two sub-feature plans above (or their nested sub-plans).
+
+---
+
+## Files & Phase Impact
+
+See Sub-Plan Breakdown above — this root plan has no checklist or files of its own.

--- a/.vibekit/feature-plans/wip/agent-interaction-workspaces/prd-agent-interaction-workspaces.md
+++ b/.vibekit/feature-plans/wip/agent-interaction-workspaces/prd-agent-interaction-workspaces.md
@@ -1,0 +1,374 @@
+---
+Status: WIP
+plan: plan-agent-interaction-workspaces.md
+---
+
+# Agent Interaction State + Workspaces
+
+Adds two semantic lifecycle states — "waiting for human" and "needs review" (PR-triggered) — replacing today's dumb pane-idle heuristic, and introduces **Workspaces**: a canvas of live agent chat/terminal panes and panel panes (any worktree), tileable either free-form or in a window-manager-style split layout, each bordered by its live interaction state.
+
+<!--
+RULES — read before writing or implementing:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. REQUIREMENTS: One crisp line each — no verbose descriptions
+3. CHECKLIST: Mark items [x] as you complete them — this is your persistent todo list
+4. READING TIME: Optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+## Revision note
+
+- **v5** (this revision, docs-accuracy pass — no behavior change): rewrote the Workspaces screen layouts / requirements to describe the **actual shipped UX** instead of earlier speculative/POC-era prose, verified line-by-line against `WorkspaceCanvas.tsx`, `tiling.ts`, `useStore.ts`, `AgentPaneSlot.tsx`, `worktreeStatus.ts`, and `LeftSidebar.tsx`. New: W13-W15 (transient scratch canvas + explicit "Save as workspace" flow + saved-only cross-context picker), L9 (drag-to-tile 5-zone drop overlay — edge = split, center = swap). Resolved design question added for worktree-selection/workspace-viewing independence (folds in and closes the prior open question on "how does a user enter a detached workspace's view"). Sidebar-placement open question narrowed accordingly (exact widget placement still unconfirmed; the navigation-independence *principle* is no longer in question). No existing requirement IDs were renumbered or dropped.
+- **v4** (docs restructure only — no new requirements, no behavior change): reorganized the plan-side sub-feature split per user feedback (the v3 split by "when the requirement was gathered" was confusing). See `plan-agent-interaction-workspaces.md`'s own Revision note and the updated Priority & sequencing table below for the full old→new mapping. No PRD requirement IDs changed, moved out of this document, or were dropped.
+- **v3**: the feature described by v2 has since been **largely implemented** (real `WorkspaceDoc`/`WorkspaceCanvas`/tiling code exists in `web-ui/`, not just a POC artifact). This revision documents 4 new requirements gathered after the user exercised the shipped feature: (1) a saved workspace must be **detached** from its owning worktree — `WorkspaceDoc.contextKey` as currently modeled is wrong post-save, and "Back to unsaved" must be reworked; (2) the tile-header drag cursor should read as "grab", not "move"; (3) state-colored tile borders must keep working for workspace tiles (regression guard) **and** extend to direct-session single-pane chrome, which has none today; (4) a new agent created from inside a running agent's shell should be able to land as a tile in whichever workspace(s) the source agent is currently tiled in. See new `## 4. Workspace detachment` and `## 5. New-agent workspace affinity` sections, and amendments to `## 2. Workspaces`. Two sub-features were spun off for the larger items — see Priority & sequencing.
+- **v2**: renamed `waiting_review` → `waiting_for_human`; replaced the fragile TTY text-heuristic (old R3) with a simpler, universal, high-confidence rule (idle after ever reaching `working` ⇒ `waiting_for_human`); added a second, independent `needs_review` state driven by PR detection; upgraded tiles from static mock content to embedded live chat/terminal panes; added a configurable per-workspace layout mode (free-form vs. window-manager-style tiling). Superseded content from v1 is removed, not kept side-by-side — see git history for v1 if needed.
+
+## Problem
+
+- Today's `LifecycleState` (`not_started|working|idle|done|exited`) is derived purely from pane-output stability (4s of unchanged tmux/pty bytes = "idle") — it cannot tell "agent finished and is truly idle" apart from "agent is blocked waiting on the human."
+- A user with many worktrees/agents open has no way to see, at a glance, which tabs actually need their attention right now vs. which are just quietly idle or still working.
+- Once an agent opens a PR, nothing in the product surfaces "a human should go review this" — the existing VCS/PR panel is pull-only (manual refresh), not pushed into any session state.
+- The current layout is a fixed single-agent-pane + single-tool-panel + single-terminal-dock split (`Layout.tsx`) — there's no way to see multiple agents (possibly from different worktrees) side by side, and no way to actually interact with more than one at a time.
+
+## Goals
+
+- Introduce `waiting_for_human`, a red-bordered state meaning "this session needs you right now," with a simple, high-confidence, channel-agnostic entry rule.
+- Introduce `needs_review`, a distinct state meaning "this worktree has an open PR," driven by the existing PR-detection service, not by agent self-reporting.
+- Introduce **Workspaces**: a canvas of **live, interactive** agent panes (real chat/terminal content, not a preview) and panel panes, any worktree, each bordered by its state.
+- Make workspace tile placement a first-class configurable property: **free-form** (drag anywhere, may overlap) or **tiling** (window-manager-style split layout, never overlaps, always fills the canvas).
+- Ship a working POC demonstrating all of the above.
+
+## Non-goals
+
+- Wiring Workspaces or the interaction states into the real daemon/`Layout.tsx` in this PRD — POC only; the POC's "live" panes are locally-simulated content (scripted transcripts + a working local input box), not a real WS connection to a real daemon session. *(Superseded by reality as of v3 — real wiring shipped; kept for history.)*
+- Hook-based PR-creation signaling (`PostToolUse` shelling out to notify the daemon) — the recommended mechanism is poll-based (see Resolved design questions); a hook fast-path is an explicit fast-follow, not built this round.
+- Multi-user / permissions on workspaces (single local user only, same as today's app).
+- Tabbed/stacked tiling layouts (i3-style `tabbed`/`stacked` containers) — tiling ships split-only (row/column); container `layout` values for tabs are a future extension, not built this round.
+- **(v3)** Direct sessions becoming full workspace-tileable (i.e. addable as a tile alongside worktree agents) — the new ask is narrowly "give the direct-session pane a state-colored border," not "make direct sessions participate in Workspaces." See Open questions.
+- **(v3)** A shared/multi-workspace session model — whether one session can appear as a tile in more than one saved workspace at once is explicitly unresolved, not assumed. See Open questions under §5.
+- **(v3)** Any UI for browsing/managing detached workspaces beyond a renamed sidebar section (e.g. no dedicated "Workspaces library" page) — out of scope this round.
+
+---
+
+## Requirements
+
+### 1. Interaction states
+
+| ID | Requirement |
+|----|-------------|
+| R1 | A session's state model gains two new values: `waiting_for_human` and `needs_review`, alongside `not_started\|working\|idle\|done\|exited`. |
+| R2 | **CLI-dependent** — for CLIs with a real human-gate tool (Claude Code's `AskUserQuestion`/`ExitPlanMode`, Cursor's `askQuestionToolCall`/`createPlanToolCall`), a session enters `waiting_for_human` the instant the agent emits that `tool_use` on the JSON (Rich Chat) channel — immediate, not after the turn completes. OpenCode and agy have no equivalent tool and reach `waiting_for_human` only via R3's universal rule (see `03-interaction-states`'s per-CLI capability research). |
+| R3 | A session enters `waiting_for_human` when it goes idle (pane-output-stable on TTY, or turn-result on JSON) **and it has reached `working` at least once before** — replaces v1's TTY text-pattern heuristic with one universal, deterministic rule that needs no content inspection and applies to both channels equally. |
+| R3a | A session that has **never** reached `working` (still `not_started`) does not qualify for R3 — going idle pre-first-work has no meaning to escalate. |
+| R4 | A session exits `waiting_for_human` back to `working` the moment the human responds (sends a chat message, answers the question, submits terminal input that produces new output). |
+| R5 | A session exits `waiting_for_human` to `exited`/`done` if the process dies or is marked done while waiting — terminal states always win. |
+| R6 | A session enters `needs_review` when the daemon's PR poller finds an **open, non-draft** PR for the worktree's branch — independent of and orthogonal to `waiting_for_human` (a session can theoretically be in only one lifecycle state; see Decision on precedence below). |
+| R7 | A session exits `needs_review` when the poller finds the PR merged, closed, or no longer present. |
+| R8 | Rollup precedence (highest wins): `waiting_for_human` > `needs_review` > `working` > `idle` > `done` > `exited` > `not_started`. |
+| R9 | The daemon broadcasts every state transition over the existing `session:state` WS event (extended enum, not a new event type). |
+
+### State machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> not_started
+    not_started --> working: spawn / ready signal
+
+    working --> idle: pane output stable<br/>or turn result event
+    idle --> working: pane output changes<br/>or new turn starts
+
+    working --> waiting_for_human: tool_use = human-gate tool (immediate)
+    idle --> waiting_for_human: idle AND session has worked before (R3)
+
+    waiting_for_human --> working: human responds
+
+    working --> needs_review: PR poller finds an open PR (R6)
+    idle --> needs_review: PR poller finds an open PR (R6)
+    needs_review --> working: PR merged/closed AND agent resumes work
+    needs_review --> idle: PR merged/closed, agent stays idle
+
+    working --> done: user marks done
+    idle --> done: user marks done
+    waiting_for_human --> done: user marks done
+    needs_review --> done: user marks done
+
+    working --> exited: process exits
+    idle --> exited: process exits
+    waiting_for_human --> exited: process exits
+    needs_review --> exited: process exits
+
+    done --> [*]
+    exited --> [*]
+```
+
+**Entry points (3):**
+1. JSON channel: `tool_use` for a human-gate tool name → `waiting_for_human`, deterministic, immediate (R2).
+2. Any channel: idle + previously reached `working` → `waiting_for_human` (R3) — this single rule replaces v1's separate, fragile per-channel heuristics.
+3. Daemon PR poller: open non-draft PR found for the worktree's branch → `needs_review` (R6), independent of channel or turn state.
+
+**Exit points (3):**
+1. *Returns to `working`:* human responds while `waiting_for_human` (R4).
+2. *Returns to `working`/`idle`:* PR poller finds the PR merged/closed while `needs_review` (R7) — lands on whichever of `working`/`idle` the session's turn activity actually reflects at that moment.
+3. *Absorbed into a terminal state:* `done` (user action) or `exited` (process death) from any non-terminal state — does NOT return to `working`.
+
+---
+
+### 2. Workspaces — live panes
+
+| ID | Requirement |
+|----|-------------|
+| W1 | A Workspace is a canvas containing zero or more **tiles**; placement mode is a per-workspace property (§3). |
+| W2 | A tile wraps exactly one pane: either an agent pane (any session, any worktree) or a panel pane (the existing right-side tool panel, made independently placeable). |
+| W3 | An agent-pane tile renders that session's **actual chat/terminal content** — scrollable transcript (Rich Chat message list, or raw terminal output) filling the tile — not a static text preview. |
+| W4 | An agent-pane tile includes a working input control (composer box for Rich Chat sessions, keystroke-forwarding for terminal sessions) so the user can reply from inside the tile. |
+| W5 | Tiles from different worktrees can coexist in the same workspace. |
+| W6 | Every agent-pane tile renders a border colored by its session's interaction state, per the Color mapping table below. In the real (non-POC) product this state is live/pushed via `session:state`; the POC supplies mock/simulated state and scripted transcript content (see Non-goals). |
+| W6a | Panel-pane tiles (no underlying session) render the fixed **unset** border style — never a state color. |
+| W7 | `waiting_for_human` is always **red** — the one non-negotiable color mapping (per explicit ask). |
+| W8 | A new tile can be added to a workspace by picking any existing agent session or the panel pane. |
+| W9 | A tile can be removed from a workspace without closing/killing its underlying session. |
+| W10 *(v3)* | A tile's drag handle shows a "grab" cursor (open hand), not a 4-way "move" cursor — the handle only ever drags the tile itself, never pans/moves the canvas, so "grab" reads correctly and "move" is misleading. |
+| W11 *(v3, regression guard)* | Workspace-mode tiles keep rendering a state-colored indicator (W6/W7) going forward — already implemented as a colored `StatusDot` glyph in the tile header (see correction below), not a full tile border; this is a standing requirement so future changes don't silently regress it. |
+| W12 *(v3)* | A **direct session's** single-pane chrome (outside Workspaces — its own dedicated view) also renders an interaction-state color indicator, using the same color mapping as workspace tiles — today it renders no state indicator at all. This does **not** make direct sessions workspace-tileable (see Non-goals). |
+| W13 *(v5, shipped)* | Toggling into Workspace mode for a worktree does not auto-create a saved workspace — it opens a **transient, unsaved "scratch canvas"** scoped to that one worktree, seeded from whatever panes are already open. |
+| W14 *(v5, shipped)* | An explicit **"Save as workspace"** action (inline named-input form, not a browser `prompt()`) promotes the current scratch-canvas arrangement into a real, named, detached `WorkspaceDoc` — only then does it appear in the sidebar's Workspaces list. |
+| W15 *(v5, shipped)* | Cross-worktree/cross-project tile picking (the Add-tile picker grouping by Project → Worktree) is offered **only** once a workspace is saved — the transient/unsaved scratch canvas's picker stays scoped to sessions in its own worktree. |
+
+> **Ground-truth correction (v4, supersedes the v3 note below):** the v3 note claimed workspace tiles only rendered a `StatusDot` glyph, with no border. That was true when v3 was written but is **no longer accurate** — a colored `border-color` per session state was added to `.workspace-canvas__tile--*` (`web-ui/src/styles/workspace-canvas.css`) in the same round that shipped W12's direct-session border, using one shared `sessionStatus()` helper (`web-ui/src/lib/worktreeStatus.ts`) consumed by both `WorkspaceCanvas.tsx` and `AgentPaneSlot.tsx`. **Both surfaces now render an actual colored border; workspace tiles additionally keep the `StatusDot` glyph in the tile header** (belt-and-suspenders, not a fallback). W11 guards both the border and the dot. There is no visual inconsistency between the two surfaces — see 04-workspaces's Phase 2 for the shipped implementation.
+
+### Color mapping
+
+| State | Color | Rationale |
+|-------|-------|-----------|
+| `waiting_for_human` | 🔴 Red | Explicit requirement — needs human now, most urgent |
+| `needs_review` | 🟣 Violet | Distinct from red — informational/lower-urgency ("something's ready"), not blocking |
+| `working` | 🔵 Blue (pulsing/animated) | Active, no action needed |
+| `idle` | ⚪ Gray | Quiet, no action needed (only reachable pre-first-work under R3a) |
+| `done` | 🟢 Green | Completed successfully |
+| `exited` | 🟠 Amber/dim | Process gone, may need attention but not urgent |
+| `not_started` | ⚫ Dim outline | Spawning |
+| panel pane (no session) | — **unset** border (default chrome, no state color at all) | Not session-driven |
+
+---
+
+### 3. Workspace layout modes
+
+| ID | Requirement |
+|----|-------------|
+| L1 | Each workspace has a `layout mode`: **free-form** (tiles have independent x/y/w/h, draggable anywhere, may overlap) or **tiling** (tiles occupy non-overlapping slots that always fill 100% of the canvas). |
+| L2 | Tiling mode uses an n-ary split-tree layout (i3-style): each internal node is a row-or-column split with an ordered list of children and a size ratio per child; leaves hold one tile each. |
+| L3 | In tiling mode, dragging the border between two sibling tiles resizes both (zero-sum ratio adjustment), clamped so neither shrinks below a minimum usable size. |
+| L4 | In tiling mode, adding a tile splits a chosen existing tile (pick a target tile + edge: left/right/top/bottom) rather than dropping at an arbitrary point. |
+| L5 | In tiling mode, removing a tile collapses its slot — the space is absorbed by its sibling(s), never left blank. |
+| L6 | Switching a workspace from free-form → tiling auto-arranges existing tiles into a balanced split tree, preserving reading order (top-to-bottom, left-to-right) rather than attempting to reconstruct exact (possibly overlapping) prior geometry. |
+| L7 | Switching tiling → free-form is exact and lossless: each leaf's current rendered rect becomes that tile's new x/y/w/h. |
+| L8 | The layout-mode toggle is per-workspace, not global — different workspaces can use different modes. |
+| L9 *(v5, shipped)* | In tiling mode, dragging a tile's header over another tile shows a 5-zone drop overlay (4 edges, ~25% each, + center, ~50%): dropping on an **edge** splits the grid there (insert, per L4); dropping in the **center swaps** the two tiles' positions — not a "replace." VS-Code-editor-group-style interaction, chosen deliberately. |
+
+---
+
+### 4. Workspace detachment *(v3)*
+
+| ID | Requirement |
+|----|-------------|
+| D1 | A saved workspace is no longer owned by/scoped to a single worktree — saving a workspace **detaches** it from "the worktree it was created in." |
+| D2 | The per-worktree transient scratch canvas (unsaved, pre-save state) is unchanged — it still belongs to exactly one worktree, exactly as today. Only the post-save, named `WorkspaceDoc` becomes detached. |
+| D3 | The "Back to unsaved" action is removed for a detached workspace — there is no longer a single "owning worktree" to revert to. |
+| D4 | Detached workspaces are listed in a single global list, independent of which worktree (if any) is currently active — not nested under, or filtered by, "the current worktree." |
+| D5 | A user can open/view any detached workspace from that global list regardless of which worktree they're currently looking at. |
+| D6 | Viewing a detached workspace does not require first navigating into any particular worktree — it is reachable as its own destination. |
+| D7 | Tiles inside a detached workspace keep working exactly as before (live panes, any worktree, add/remove) — detachment changes *ownership/entry*, not tile behavior. |
+| D8 | Existing saved workspaces (created pre-v3, with a `contextKey`) are migrated to the detached model without data loss — no manual re-save required. |
+
+### 5. New-agent workspace affinity *(v3)*
+
+| ID | Requirement |
+|----|-------------|
+| S1 | Creating a new agent session can optionally specify a **source agent** (an existing session) it was spawned from. |
+| S2 | This works both from the in-app "New Agent"/"Direct Agent" dialogs and from a running agent's own shell (agent-invocable, e.g. via a CLI command available in its environment). |
+| S3 | When invoked from inside a running agent's shell with no explicit source specified, the source agent defaults to the invoking agent's own session — no manual ID lookup required. |
+| S4 | When the new agent's session is created, it automatically appears as a new tile in whichever workspace(s) currently contain a tile for the source agent's session — no manual "add tile" step required. |
+| S5 | If the source agent isn't tiled in any workspace, the new agent is created normally with no auto-tiling side effect (same as today). |
+| S6 | Auto-inserted tile placement is deterministic and reasonable by default (e.g. splits the source agent's own tile) — not a random/arbitrary position. |
+
+---
+
+## Options considered
+
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| A — Extend `LifecycleState` enum with `waiting_for_human` + `needs_review` | Single source of truth, flows through existing `session:state` broadcast/rollup code | Every switch/exhaustiveness check on `LifecycleState` across daemon+UI must add two cases | ✅ chosen |
+| B — Separate orthogonal flags alongside existing lifecycle | No breaking changes to existing enum consumers | Multiple independent fields to keep in sync and rank against each other — more UI branching | ❌ deferred |
+| — | — | — | — |
+| PR detection: **poll-based** (daemon timer calls existing `fetchPrForBranch`) | Reuses existing, working PR-detection service; only mechanism that can also detect exit (PR merged/closed) or a human/web-created PR; CLI-independent | Poll latency ≤60s (decided: `PR_POLL_INTERVAL_MS = 60_000`, see `03-interaction-states` Decision 3b) vs. instant | ✅ chosen |
+| PR detection: **hook-based** (agent's `PostToolUse` hook shells out on `gh pr create`) | Near-instant entry signal | Needs a separate implementation per CLI (only Claude Code hooks are proven in this codebase today); blind to human/web-created PRs; still can't detect merge/close — poller required regardless, making the hook pure duplication for entry only | ❌ deferred to fast-follow (as a latency accelerator on top of the poller, not a replacement) |
+| Tiling model: **i3-style n-ary split tree** | Maps 1:1 to nested flexbox, no phantom tree depth, natural fit for mouse-driven resize | Slightly more state to serialize than a strict binary tree | ✅ chosen |
+| Tiling model: **strict BSP (binary tree, dwm/bspwm-style)** | Simpler node shape (always 2 children) | A visual row of 3+ panes requires nested binary splits — dragging an "outer" divider resizes an invisible subtree, confusing for mouse users | ❌ deferred |
+
+**Decision A rationale:** reuses `session:state`, `worktreeRolledUpStatus`, and `StatusDot` infrastructure that already exists; TypeScript exhaustiveness checks surface every call site needing an update.
+
+---
+
+## Resolved design questions
+
+1. **Does `waiting_for_human` still need a separate, fragile TTY text-heuristic?** — **No.** v1 proposed matching question-shaped text patterns on TTY output. v2 replaces this entirely with R3 ("idle after ever having worked ⇒ waiting_for_human"), which is deterministic, needs no content inspection, and applies identically to TTY and JSON channels. This directly matches the ask: "Whenever it's Idle after it got to working at least once, it should ideally be in that [waiting-for-human] state."
+2. **Can an agent proactively signal "I created a PR" via a hook?** — **Feasible for Claude Code specifically (not built this round).** Research confirms `setupWorkspaceHooks` is already implemented for Claude Code (writes `SessionStart`/`UserPromptSubmit` hooks into `.claude/settings.json`) and the same mechanism could add a `PostToolUse` hook matching `Bash` commands containing `gh pr create`. Cursor/OpenCode hook equivalents are lower-confidence and unimplemented today. Chosen as a fast-follow latency accelerator, not the primary mechanism — see next.
+3. **So what actually detects `needs_review`?** — **The existing PR-detection service, polled.** vibe-station already has real PR detection: `daemon/src/services/github.ts` (`fetchPrForBranch`, direct GitHub REST API, not the `gh` CLI) and a route `GET /worktrees/:id/pr`, currently only pulled on-demand by the VCS panel UI. `needs_review` is driven by a new daemon-side poller (mirroring the existing lifecycle poller's shape) calling this same service on an interval and broadcasting `session:state` on change — because only polling can also observe the *exit* condition (PR merged/closed) and catches PRs made by a human or the GitHub web UI, not just ones the agent itself created via a hook.
+4. **Does `waiting_for_human` or `needs_review` win in a rollup?** — **`waiting_for_human` (R8).** It represents an active block on the agent's progress; `needs_review` is informational ("something's ready when you get to it").
+5. **Are tiles a live view into the real session, or a preview?** — **Live, in the real product; scripted/simulated in the POC (W3/W4, Non-goals).** The user explicitly wants to read and reply from inside a tile, not just see a status snapshot — that's the entire point of Workspaces over the existing single-pane layout.
+6. **Free-form or tiling — which is the default, and can both coexist?** — **Both modes ship; per-workspace, user's choice, no forced default beyond whatever the workspace was created with (proposed: free-form, since it requires no auto-arrangement to seed).** L1-L8.
+7. **Can a panel pane (right-side tool panel) be tiled independently?** — **Yes (W2).** Explicit ask; panel panes just don't carry session state so their border stays unset (W6a).
+8. **(v3) `cursor: grab` or `cursor: pointer` for the tile drag handle?** — **`cursor: grab`.** It's the CSS-spec-standard cursor for "this element is draggable," matching the user's ask for a hand cursor over the current 4-way `move` arrow; `pointer` is reserved for plain clickable elements, not drag handles.
+9. **(v3) Does direct-session color-border support require making direct sessions workspace-tileable?** — **No.** Re-reading the ask ("ensure that direct agents also support it") — "it" refers to the colored border/chrome, not tiling. Scoped narrowly to the direct session's own single-pane chrome (`AgentPaneSlot`/its wrapper) gaining the same color mapping already used by `WorkspaceCanvas`'s tile chrome. Whether direct sessions should *also* become workspace-tileable is a separate, bigger ask — recorded as an open question, not assumed.
+10. **(v5) Are worktree selection and workspace selection/viewing the same navigation state, or independent ones?** — **Fully independent, decoupled.** Selecting a worktree in the sidebar never switches the active/viewed workspace; opening a workspace never changes which worktree is "active." A workspace only ever appears in the sidebar's Workspaces section once its owning worktree has explicitly saved one — nothing shows automatically from merely selecting a worktree. This is the concrete answer to the prior open question "how does a user enter a detached workspace's view" (struck from Open questions below) — entry is its own destination, not routed through worktree selection. Exact sidebar widget placement (a single global section vs. some other layout) is still unconfirmed and remains open (see Open questions) — only the independence *principle* is settled here.
+11. **(v3) Is workspace detachment + source-agent spawn worth splitting into sub-features?** — **Yes, split (superseded by v5 — see below).** Both are multi-layer (data model + UI for detachment; daemon + CLI + client for spawn-affinity) — originally split into their own sub-feature plans (`01-workspace-detachment`, `02-source-agent-spawn`) per the sdlc skill's M6 guidance. **v5 update:** per user feedback ("Why do we still have 1 and 2... We don't need 4"), both were merged into `04-workspaces` as Phase 3/Phase 4 of that single plan instead of standalone sub-plan directories — see `04-workspaces`'s Revision context and its own Phase 3/Phase 4. Requirements D1-D8/S1-S6 and all design content are unchanged, only the document location moved.
+
+---
+
+## Screen layout — Workspace canvas (shipped, tiling mode)
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  ● "Review Sprint"   ⊙grab  Layout: [Free-form|●Tiling] [+Add tile]  │
+│ ┌───────────────────────┬───────────────────────────────────────┐  │
+│ │●auth-flow    ⊙grab     │●pwa-install         ⊙grab              │  │
+│ │ RED — waiting_for_human│ BLUE — working                        │  │
+│ │ (border AND StatusDot) │ (border AND StatusDot)                │  │
+│ │┌──────────────────────┐│┌─────────────────────────────────────┐│  │
+│ ││ "Which auth flow do  │││ ▸ Reading jsonAgent.ts…              ││  │
+│ ││  you want, A or B?"  │││ ▸ Editing updateTurnState…           ││  │
+│ │└──────────────────────┘│└─────────────────────────────────────┘│  │
+│ │[ Reply…            ⏎ ]│                                        │  │
+│ ├───────────────────────┤───────────────────────────────────────┤  │
+│ │●vcs-backend  ⊙grab     │ panel: VCS tool          vcs-backend  │  │
+│ │ VIOLET — needs_review  │ (unset border — no state, no dot)     │  │
+│ │ PR #42 open, 0 reviews │  main ◂ feature/x  · 3 commits ahead  │  │
+│ └───────────────────────┴───────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────────┘
+```
+- `●` in a tile header = the `StatusDot` glyph; the tile's whole border is also colored the same state — both render together, belt-and-suspenders (W6/W7/W11), sharing one `sessionStatus()` helper with direct-session chrome (W12).
+- `⊙grab` marks the tile-header drag handle: `cursor: grab` while draggable, `cursor: grabbing` while actively dragged (W10) — never the old 4-way "move" cursor.
+- Tiling mode: draggable dividers between adjacent tiles resize both; no gaps, no overlap. Dragging a tile *header* onto another tile (rather than a divider) triggers the drag-to-tile docking flow — see the dedicated layout below (L9).
+- Free-form mode: tiles have independent x/y/w/h, draggable anywhere, may overlap — same tile chrome, just untethered from the grid.
+- Mixed worktrees in one workspace (auth-flow, pwa-install, vcs-backend) is expected, not an edge case — but only reachable once this workspace is **saved** (W15); see "Add tile" picker below.
+- No "Back to unsaved" shown here because this is a saved/detached workspace (D3) — see "Workspace canvas, unsaved/transient" below for the pre-save toolbar.
+
+### Screen layout — Drag-to-tile docking (tiling mode, L9, shipped)
+
+```
+Dragging "auth-flow" tile's header over "pwa-install" tile:
+
+┌───────────────────────────────────────┐
+│ ░░░░░░░░░░░░ TOP (25%) ░░░░░░░░░░░░░░░ │   edge zones → split the grid,
+│ ░░░┌───────────────────────────┐░░░░░ │   inserting the dragged tile as
+│ L  │                           │  R   │   a new sibling on that side (L4)
+│ E  │      CENTER (50%)         │  I   │
+│ F  │   drop here → SWAP the    │  G   │   center zone → swap the two
+│ T  │   two tiles' positions    │  H   │   tiles' positions in place —
+│(25%)│  (not "replace")         │ T   │   not an insert, not a delete
+│ ░░░└───────────────────────────┘░░░░░ │
+│ ░░░░░░░░░░ BOTTOM (25%) ░░░░░░░░░░░░░ │
+└───────────────────────────────────────┘
+```
+- 5-zone overlay: 4 edges (~25% band each, measured from the nearest edge) + 1 center (~50%).
+- Edge drop = insert/split (same mechanics as L4's target+side model).
+- Center drop = swap (`swapPanes` in `tiling.ts`) — the two tiles trade places, grid shape unchanged.
+- VS-Code-editor-group / dockview-style interaction, chosen deliberately over free-invention.
+
+### Screen layout — Workspace canvas, unsaved/transient (W13, shipped)
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Unsaved canvas            Layout: [●Free-form|Tiling]  [+ Add tile] │
+│                             [ 💾 Save as workspace ]                 │
+│ ┌──────────────┐   ┌──────────────┐                                 │
+│ │ ●agent A      │   │ ●agent B      │      (scoped to THIS worktree  │
+│ │ BLUE—working  │   │ RED—waiting   │       only — no cross-worktree │
+│ └──────────────┘   └──────────────┘       tiles offered yet, W15)   │
+└─────────────────────────────────────────────────────────────────────┘
+
+Clicking "Save as workspace" opens an inline form (not a browser prompt()):
+
+│                             [ Workspace name______ ] [✓] [✕]         │
+```
+- Entering Workspace mode for a worktree with nothing saved seeds this transient scratch canvas from whatever panes are already open (W13) — no `WorkspaceDoc` is created yet.
+- "Save as workspace" swaps in an inline `<input>` + confirm/cancel buttons, not `window.prompt()`.
+- Confirming promotes the current arrangement into a real, named, detached `WorkspaceDoc` (W14) — only then does it appear in the sidebar's Workspaces list, and only then does the Add-tile picker start offering other worktrees/projects (W15).
+
+### Screen layout — Workspace canvas, detached (v3)
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Workspace: "Review Sprint" (detached)  Layout:[Free-form|●Tiling]   │
+│ ┌───────────────────────┬───────────────────────────────────────┐  │
+│ │ agent: auth-flow       │ agent: pwa-install          cursor    │  │
+│ │ RED — waiting_for_human│ BLUE — working                        │  │
+│ │  (grab-cursor header)  │  (grab-cursor header)                 │  │
+│ └───────────────────────┴───────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────────┘
+```
+- No "Back to unsaved" — a detached workspace has no single owning worktree to fall back to (D3).
+- Tile headers show a **grab** cursor (open hand), not the old 4-way move arrow (W10).
+- This view is reachable directly from the global Workspaces list (see sidebar below) — not gated behind first selecting a worktree (D6).
+
+### Sidebar — Workspaces section, before vs. after (v3)
+
+```
+BEFORE (per-worktree, today)             AFTER (v3, global/detached)
+┌───────────────────────────┐            ┌───────────────────────────┐
+│ ▾ auth-flow (worktree)     │            │ ▾ Workspaces               │
+│   Workspaces                │            │   ○ Review Sprint          │
+│   ○ Review Sprint           │            │   ○ Backend Triage         │
+│ ▾ pwa-install (worktree)   │            │  (no longer nested under    │
+│   Workspaces                │            │   any single worktree)      │
+│   ○ (none for this wt)      │            └───────────────────────────┘
+└───────────────────────────┘
+```
+- Today: `LeftSidebar.tsx` filters `workspaceDocs` by `contextKey === activeWorktreeId` — a workspace only appears while its creating worktree is active.
+- v3 proposal: one top-level "Workspaces" section, sibling to the worktree list, not nested inside any worktree's subtree — listing every detached `WorkspaceDoc` regardless of active worktree. **Flagged as needing user confirmation — real UX change to a shipped surface** (see Open questions).
+
+### "Add tile" picker (W8, W15), saved-workspace variant
+
+```
+┌─────────────────────────────────┐
+│  Add tile to workspace       [x]│
+│ ┌───────────────────────────────┤
+│ │ This worktree                  │
+│ │  ○ auth-flow / claude          │
+│ │  ○ Panel: VCS tool             │
+│ │ ▾ Project: vibe-station         │
+│ │   ▾ pwa-install (worktree)      │
+│ │     ○ pwa-install / cursor      │
+│ │   ▾ vcs-backend (worktree)      │
+│ │     ○ vcs-backend / vst         │
+│ └───────────────────────────────┤
+│                       [Add]     │
+└─────────────────────────────────┘
+```
+- Grouped **Project → Worktree → session/panel** — this cross-context grouping is offered **only for a saved (detached) workspace** (W15); an unsaved/transient scratch canvas's picker shows just its own worktree's available sessions, flat, no grouping.
+- Free-form mode: new tile drops at a cascade offset, no split-target/side controls.
+- Tiling mode: picking an item splits a target tile (defaults to the last-focused tile) on the axis best matching its current aspect ratio (L4).
+
+---
+
+## Priority & sequencing
+
+> **v4 restructure note:** reorganized per user feedback into exactly two top-level sub-features — state-machine work, then the entire Workspaces feature as one unit (was previously split 4 ways by "when the requirement was gathered," which the user found confusing). See `plan-agent-interaction-workspaces.md`'s Revision note for the full mapping.
+
+| Order | Sub-feature | Depends on |
+|-------|-------------|------------|
+| 1 | [`03-interaction-states`](./03-interaction-states/plan-03-agent-interaction-workspaces-interaction-states.md) — `waiting_for_human` + `needs_review` state machine (daemon `LifecycleState`, JSON-channel detection, PR poller, WS broadcast, rollup/`StatusDot`) — §1 (R1-R9) | none |
+| 2 | [`04-workspaces`](./04-workspaces/plan-04-agent-interaction-workspaces-workspaces.md) — the entire Workspaces feature as one unit: live-pane tiles, free-form + tiling layout modes, color mapping (§2-§3, W1-W9/L1-L8, **shipped**, see 04-workspaces Phase 1); cursor fix + direct-session color borders (W10/W12, **shipped**, see 04-workspaces Phase 2); workspace detachment (§4, D1-D8, see 04-workspaces Phase 3); source-agent spawn affinity (§5, S1-S6, see 04-workspaces Phase 4) | Consumes #1's color mapping for tile/pane coloring but is not blocked by it (already renders correctly for today's 5 states); within `04-workspaces`, Phase 3 (detachment) should land before/alongside Phase 4 (spawn affinity) since spawn affinity's "auto-insert into workspace(s)" scan is simpler once workspaces are a flat global list |
+
+## Open questions
+
+- Should the `needs_review` poller run per-worktree independently, or as one daemon-wide tick over all worktrees with open agent sessions (like the existing lifecycle poller)? — **Proposed answer:** one daemon-wide tick, mirroring `lifecycle.ts`'s `pollAll` shape, to reuse the same broadcast/error-isolation pattern.
+- Should a hook-based PR fast-path (Resolved Q2) be built once the poller ships? — **Proposed answer:** revisit after real GitHub API rate-limit behavior is observed in practice; only justified if the decided 60s poll interval (`03-interaction-states` Decision 3b) proves too slow for real usage.
+- Should workspaces be able to contain a tile pointing at a session that's since been deleted? — **Proposed answer:** tile shows a "session gone" placeholder rather than disappearing silently or reflowing the layout (matters more now that tiling mode reflows on removal).
+- GitHub API rate limits (60 req/hr unauthenticated) mean the PR poller effectively requires `GITHUB_TOKEN`/`GH_TOKEN` to be configured — should the daemon warn if `needs_review` is silently non-functional without one? — **Proposed answer:** yes, surface a one-time warning in daemon logs.
+- **(v3) Where does the global "Workspaces" list live in the sidebar, exactly?** — **Proposed:** a new top-level section, sibling to the worktree/project tree, always visible regardless of active worktree (see v3 sidebar sketch above). **Needs user confirmation** — real UX change to a shipped surface. *(v5: only the exact widget placement is open — the underlying principle that worktree selection and workspace viewing are independent nav states is now Resolved, see Resolved design questions #10.)*
+- ~~(v3) How does a user enter a detached workspace's view?~~ — **Resolved (v5).** A dedicated, independent view/entry point — never gated behind or coupled to worktree selection. See Resolved design questions #10.
+- **(v3) Should direct sessions also become full workspace-tileable (not just get a colored border)?** — **Proposed answer:** not this round — the user's ask reads narrowly as "the colored rectangles," and making direct sessions tileable is a materially bigger change (they'd need a `PaneOutlet`/tile identity they don't have today). Flagged, not decided — **needs user confirmation**.
+- **(v3) If a source agent's tile appears in multiple saved workspaces, does the new agent get auto-added to all of them, just the active one, or none (manual add only)?** — **Proposed answer:** all of them — matches S4's literal wording ("workspace(s)," plural) and requires no extra "which one did you mean" UI. **Genuinely underspecified — needs user confirmation**, especially since it's not yet decided whether one session can even appear in multiple saved workspaces at once (see next question).
+- **(v3) Can one session appear as a tile in more than one saved `WorkspaceDoc` simultaneously?** — Nothing today prevents it (tiles just reference a `sessionId`), but it's never been an explicit product decision. **Proposed answer:** allow it (no artificial single-workspace constraint) — simplest, and matches how tiles already work. **Needs user confirmation**.
+- **(v3) Does `vst worktree create`/`vst session create` need a new top-level daemon field (`spawnedFrom`) on `SessionRecord`, or can the client infer "spawned from X" without persisting it?** — **Proposed answer:** persist it — the client needs to reverse-lookup "which workspace(s) contain tile.sessionId === spawnedFrom" when a new session event arrives, which is only possible if the daemon round-trips the field back on `session:created`. **Needs confirmation during sub-plan review**, not blocking the PRD.
+- ~~(v3) Should W12's new direct-session state indicator be a colored border or the same `StatusDot` glyph used by workspace tiles?~~ — **Resolved, not actually a question (v4).** Both now render an actual colored border (workspace tiles additionally keep the dot) — no inconsistency to adjudicate. See Ground-truth correction under §2.

--- a/cli/src/commands/session/create.ts
+++ b/cli/src/commands/session/create.ts
@@ -22,6 +22,10 @@ export function registerSessionCreate(session: Command): void {
       new Option("--prompt-file <path>", "Read prompt from file").conflicts("prompt")
     )
     .option("--json", "Use the JSON agent-chat channel (channel: json)")
+    .option(
+      "--source-agent <sessionId>",
+      "SessionId this session was spawned from (defaults to $VST_SESSION when this CLI is invoked from inside a running agent's own shell)",
+    )
     .action(
       async (
         worktreeId: string,
@@ -33,6 +37,7 @@ export function registerSessionCreate(session: Command): void {
           prompt?: string;
           promptFile?: string;
           json?: boolean;
+          sourceAgent?: string;
         }
       ) => {
         // The daemon only consumes `prompt` for agent sessions (routes/sessions.ts:420) — a
@@ -48,6 +53,11 @@ export function registerSessionCreate(session: Command): void {
 
         const spinner = ora("Creating session...").start();
 
+        // Same defaulting rule as `vst worktree create` (agent-interaction-
+        // workspaces/04-workspaces Phase 4b, S3) — see that command for the
+        // full rationale.
+        const sourceAgentId = opts.sourceAgent ?? process.env.VST_SESSION ?? undefined;
+
         try {
           const result = await daemonPost<SessionCreateResponse>("/sessions", {
             worktreeId,
@@ -55,6 +65,7 @@ export function registerSessionCreate(session: Command): void {
             modeId: opts.mode,
             prompt,
             ...(opts.json ? { channel: "json" } : {}),
+            ...(sourceAgentId ? { sourceAgentId } : {}),
           });
 
           spinner.stop();

--- a/cli/src/commands/sourceAgent.test.ts
+++ b/cli/src/commands/sourceAgent.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command } from "commander";
+
+// --- 4b.T1/T2: --source-agent flag + $VST_SESSION defaulting (agent-interaction-
+// workspaces/04-workspaces Phase 4b) for both `vst worktree create` and
+// `vst session create`. No CLI-command test harness existed in this codebase
+// before this file — mock the two daemon-facing modules directly and drive
+// the registered commander action via a minimal parent Command tree, the
+// same shape program.ts wires up for real.
+
+const daemonPostMock = vi.fn(async () => ({
+  ok: true,
+  status: 201,
+  data: { id: "new-id", branch: "b", projectId: "p", worktreeId: "wt-1", type: "agent" },
+}));
+
+vi.mock("../lib/daemon-client.js", () => ({
+  daemonPost: (path: string, body?: unknown) => daemonPostMock(path, body),
+}));
+vi.mock("../lib/preflight.js", () => ({ preflight: vi.fn(async () => {}) }));
+
+const { registerWorktreeCreate } = await import("./worktree/create.js");
+const { registerSessionCreate } = await import("./session/create.js");
+
+function buildWorktreeProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  const worktree = program.command("worktree");
+  registerWorktreeCreate(worktree);
+  return program;
+}
+
+function buildSessionProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  const session = program.command("session");
+  registerSessionCreate(session);
+  return program;
+}
+
+describe("vst worktree create --source-agent", () => {
+  const originalVstSession = process.env.VST_SESSION;
+
+  beforeEach(() => {
+    daemonPostMock.mockClear();
+    delete process.env.VST_SESSION;
+  });
+  afterEach(() => {
+    if (originalVstSession === undefined) delete process.env.VST_SESSION;
+    else process.env.VST_SESSION = originalVstSession;
+  });
+
+  it("4b.T1 — explicit --source-agent sends sourceAgentId in the POST body", async () => {
+    const program = buildWorktreeProgram();
+    await program.parseAsync(
+      ["worktree", "create", "proj1", "--mode", "m1", "--source-agent", "sess-explicit"],
+      { from: "user" },
+    );
+    expect(daemonPostMock).toHaveBeenCalledWith(
+      "/worktrees",
+      expect.objectContaining({ sourceAgentId: "sess-explicit" }),
+    );
+  });
+
+  it("4b.T1 — no --source-agent but $VST_SESSION set in env defaults sourceAgentId to it", async () => {
+    process.env.VST_SESSION = "sess-from-env";
+    const program = buildWorktreeProgram();
+    await program.parseAsync(["worktree", "create", "proj1", "--mode", "m1"], { from: "user" });
+    expect(daemonPostMock).toHaveBeenCalledWith(
+      "/worktrees",
+      expect.objectContaining({ sourceAgentId: "sess-from-env" }),
+    );
+  });
+
+  it("4b.T2 — explicit --source-agent overrides $VST_SESSION when both are present", async () => {
+    process.env.VST_SESSION = "sess-from-env";
+    const program = buildWorktreeProgram();
+    await program.parseAsync(
+      ["worktree", "create", "proj1", "--mode", "m1", "--source-agent", "sess-explicit"],
+      { from: "user" },
+    );
+    expect(daemonPostMock).toHaveBeenCalledWith(
+      "/worktrees",
+      expect.objectContaining({ sourceAgentId: "sess-explicit" }),
+    );
+  });
+
+  it("omitting both --source-agent and $VST_SESSION sends no sourceAgentId at all (S5, no side effect)", async () => {
+    const program = buildWorktreeProgram();
+    await program.parseAsync(["worktree", "create", "proj1", "--mode", "m1"], { from: "user" });
+    const [, body] = daemonPostMock.mock.calls[0]!;
+    expect(body).not.toHaveProperty("sourceAgentId");
+  });
+});
+
+describe("vst session create --source-agent", () => {
+  const originalVstSession = process.env.VST_SESSION;
+
+  beforeEach(() => {
+    daemonPostMock.mockClear();
+    delete process.env.VST_SESSION;
+  });
+  afterEach(() => {
+    if (originalVstSession === undefined) delete process.env.VST_SESSION;
+    else process.env.VST_SESSION = originalVstSession;
+  });
+
+  it("4b.T1 — explicit --source-agent sends sourceAgentId in the POST body", async () => {
+    const program = buildSessionProgram();
+    await program.parseAsync(["session", "create", "wt-1", "--source-agent", "sess-explicit"], {
+      from: "user",
+    });
+    expect(daemonPostMock).toHaveBeenCalledWith(
+      "/sessions",
+      expect.objectContaining({ sourceAgentId: "sess-explicit" }),
+    );
+  });
+
+  it("4b.T1 — no --source-agent but $VST_SESSION set in env defaults sourceAgentId to it", async () => {
+    process.env.VST_SESSION = "sess-from-env";
+    const program = buildSessionProgram();
+    await program.parseAsync(["session", "create", "wt-1"], { from: "user" });
+    expect(daemonPostMock).toHaveBeenCalledWith(
+      "/sessions",
+      expect.objectContaining({ sourceAgentId: "sess-from-env" }),
+    );
+  });
+
+  it("4b.T2 — explicit --source-agent overrides $VST_SESSION when both are present", async () => {
+    process.env.VST_SESSION = "sess-from-env";
+    const program = buildSessionProgram();
+    await program.parseAsync(["session", "create", "wt-1", "--source-agent", "sess-explicit"], {
+      from: "user",
+    });
+    expect(daemonPostMock).toHaveBeenCalledWith(
+      "/sessions",
+      expect.objectContaining({ sourceAgentId: "sess-explicit" }),
+    );
+  });
+
+  it("omitting both --source-agent and $VST_SESSION sends no sourceAgentId at all (S5, no side effect)", async () => {
+    const program = buildSessionProgram();
+    await program.parseAsync(["session", "create", "wt-1"], { from: "user" });
+    const [, body] = daemonPostMock.mock.calls[0]!;
+    expect(body).not.toHaveProperty("sourceAgentId");
+  });
+});

--- a/cli/src/commands/worktree/create.ts
+++ b/cli/src/commands/worktree/create.ts
@@ -27,6 +27,10 @@ export function registerWorktreeCreate(worktree: Command): void {
       new Option("--prompt-file <path>", "Read prompt from file").conflicts("prompt")
     )
     .option("--json", "Use the JSON agent-chat channel for the main agent (channel: json)")
+    .option(
+      "--source-agent <sessionId>",
+      "SessionId this worktree's main agent was spawned from (defaults to $VST_SESSION when this CLI is invoked from inside a running agent's own shell)",
+    )
     .action(
       async (
         projectId: string,
@@ -40,6 +44,7 @@ export function registerWorktreeCreate(worktree: Command): void {
           prompt?: string;
           promptFile?: string;
           json?: boolean;
+          sourceAgent?: string;
         }
       ) => {
         if (!opts.mode) {
@@ -52,6 +57,15 @@ export function registerWorktreeCreate(worktree: Command): void {
 
         const spinner = ora("Creating worktree...").start();
 
+        // Defaults to $VST_SESSION (agent-interaction-workspaces/04-workspaces
+        // Phase 4b, S3) — set by the daemon on every spawned agent's own
+        // process env (routes/sessions.ts), so an agent running `vst worktree
+        // create` from its own shell gets source-agent affinity for free
+        // without passing --source-agent explicitly. From a human's own
+        // terminal (not inside an agent), $VST_SESSION is unset, so this is
+        // simply omitted — no side effect (S5).
+        const sourceAgentId = opts.sourceAgent ?? process.env.VST_SESSION ?? undefined;
+
         try {
           const result = await daemonPost<WorktreeCreateResponse>(
             "/worktrees",
@@ -63,6 +77,7 @@ export function registerWorktreeCreate(worktree: Command): void {
               branch: opts.branch,
               prompt,
               ...(opts.json ? { channel: "json" } : {}),
+              ...(sourceAgentId ? { sourceAgentId } : {}),
             }
           );
 

--- a/daemon/src/__tests__/jsonAgent.test.ts
+++ b/daemon/src/__tests__/jsonAgent.test.ts
@@ -278,8 +278,13 @@ describe("JsonAgentSession", () => {
     agent.enqueue({ message: "hi" });
     await agent.settled();
 
-    // Lifecycle flipped to idle in the persisted manifest (poller skips JSON).
-    expect(getProject(PROJECT_ID)!.directSessions[0]!.lifecycle.state).toBe("idle");
+    // Lifecycle flips to waiting_for_human (not idle) in the persisted
+    // manifest — R3 (plan 03, Decision 0/2): the poller skips JSON channel
+    // sessions entirely, so `drain()` is JSON's own R3 entry point, and
+    // reaching this finally block at all means a turn was actually
+    // processed — real, observable agent activity, not a genuinely-blank
+    // bootstrap state — so even the FIRST drain lands here, not on "idle".
+    expect(getProject(PROJECT_ID)!.directSessions[0]!.lifecycle.state).toBe("waiting_for_human");
   });
 
   it("Fix #1 — persists lifecycle idle even when the turn errors", async () => {
@@ -306,9 +311,49 @@ describe("JsonAgentSession", () => {
     agent.enqueue({ message: "x" });
     await agent.settled();
 
-    // turnState stays error (transcript) but the session is idle/ready.
+    // turnState stays error (transcript) but the session is ready for the
+    // next message — lifecycle lands on waiting_for_human (R3, same as any
+    // other drain — a turn was attempted, that's real activity, error or not).
     expect(agent.getMeta().turnState).toBe("error");
-    expect(getProject(PROJECT_ID)!.directSessions[0]!.lifecycle.state).toBe("idle");
+    expect(getProject(PROJECT_ID)!.directSessions[0]!.lifecycle.state).toBe("waiting_for_human");
+  });
+
+  it("1.T3 — EVERY turn's drain lands on waiting_for_human, including the first (R3, JSON channel)", async () => {
+    // Plan 03, Decision 0/2: R2 (immediate tool_use detection) is dropped;
+    // R3 ("idle after ever having worked") is the sole waiting_for_human
+    // entry path for EVERY channel, including JSON. The JSON channel has no
+    // tmux/pty for the poller to watch (`lifecycle.ts` skips it outright),
+    // so this session's own `drain()` is where that rule must apply instead.
+    // Unlike the TTY poller (which can observe a genuinely-blank, nothing-
+    // ever-happened session and correctly stay on plain "idle" the first
+    // time, R3a), `drain()`'s finally block is ONLY ever reached after
+    // `runOneTurn` actually processed a queued turn — that's real,
+    // observable agent activity by construction, with no "blank bootstrap"
+    // case to guard against. So there is no first-vs-later distinction on
+    // this channel: every drain, including the very first, lands on
+    // waiting_for_human.
+    const { JsonAgentSession } = await import("../services/jsonAgent.js");
+    const { getProject } = await import("../state/project-store.js");
+    const session = getProject(PROJECT_ID)!.directSessions[0]!;
+
+    const agent = new JsonAgentSession({
+      project,
+      worktree: null,
+      session,
+      plugin: mockPlugin([INIT, TEXT, RESULT].join("\n")),
+      daemonPort: 0,
+      cli: "claude",
+    });
+
+    agent.enqueue({ message: "first" });
+    await agent.settled();
+    expect(getProject(PROJECT_ID)!.directSessions[0]!.lifecycle.state).toBe("waiting_for_human");
+
+    // A human response resumes work (R4) via the existing new-turn-start path;
+    // that turn's own drain lands back on waiting_for_human too, not idle.
+    agent.enqueue({ message: "second" });
+    await agent.settled();
+    expect(getProject(PROJECT_ID)!.directSessions[0]!.lifecycle.state).toBe("waiting_for_human");
   });
 
   it("dispose() closes the session's own SQLite handle (opus review finding — fd leak on teardown)", async () => {

--- a/daemon/src/__tests__/lifecycle.test.ts
+++ b/daemon/src/__tests__/lifecycle.test.ts
@@ -148,7 +148,15 @@ describe("lifecycle polling behavior", () => {
     expect(emittedStateChanges()).not.toContain("idle");
   });
 
-  it("transitions to idle after IDLE_THRESHOLD_MS of unchanged content", async () => {
+  it("transitions to waiting_for_human after IDLE_THRESHOLD_MS of unchanged content, even on a session's very first idle-stable tick (R3)", async () => {
+    // The pane content NEVER CHANGES across the whole test — from the seed
+    // tick through the idle-threshold tick, it's the same frozen snapshot.
+    // A session only ever reaches this poller once it's "working", which
+    // only happens after its ready signal already printed visible content
+    // (see `everWorked`'s doc comment in lifecycle.ts) — so "genuinely
+    // blank, nothing has happened yet" is not achievable here. `everWorked`
+    // is seeded true unconditionally, so even this FIRST idle-stable tick
+    // lands on "waiting_for_human", not plain "idle".
     await seedProject("working");
     tmux.capturePane.mockResolvedValue("frozen pane content");
 
@@ -162,16 +170,17 @@ describe("lifecycle polling behavior", () => {
       await runLifecyclePollOnce(); // seed
 
       vi.setSystemTime(t0 + IDLE_THRESHOLD_MS + 100);
-      await runLifecyclePollOnce(); // should flip to idle
+      await runLifecyclePollOnce(); // should flip to waiting_for_human
     } finally {
       vi.useRealTimers();
     }
 
-    expect(await getCurrentState()).toBe("idle");
-    expect(emittedStateChanges()).toContain("idle");
+    expect(await getCurrentState()).toBe("waiting_for_human");
+    expect(emittedStateChanges()).toContain("waiting_for_human");
+    expect(emittedStateChanges()).not.toContain("idle");
   });
 
-  it("resets to working when content changes after idle", async () => {
+  it("resets to working when content changes after waiting_for_human", async () => {
     await seedProject("working");
     tmux.capturePane.mockResolvedValue("static");
 
@@ -182,7 +191,7 @@ describe("lifecycle polling behavior", () => {
       await runLifecyclePollOnce();
       vi.setSystemTime(t0 + IDLE_THRESHOLD_MS + 100);
       await runLifecyclePollOnce();
-      expect(await getCurrentState()).toBe("idle");
+      expect(await getCurrentState()).toBe("waiting_for_human");
 
       tmux.capturePane.mockResolvedValue("now changing");
       vi.setSystemTime(t0 + IDLE_THRESHOLD_MS + 200);
@@ -193,9 +202,66 @@ describe("lifecycle polling behavior", () => {
 
     expect(await getCurrentState()).toBe("working");
     const changes = emittedStateChanges();
-    expect(changes).toContain("idle");
+    expect(changes).toContain("waiting_for_human");
     expect(changes).toContain("working");
-    expect(changes.lastIndexOf("working")).toBeGreaterThan(changes.indexOf("idle"));
+    expect(changes.lastIndexOf("working")).toBeGreaterThan(changes.indexOf("waiting_for_human"));
+  });
+
+  // --- 1.T3: R3 "idle after ever working" (plan 03, Decision 2) ---
+
+  it("1.T3 — a session that has ALREADY resumed from waiting_for_human once lands on waiting_for_human again on its next idle-stable tick (R3)", async () => {
+    await seedProject("working");
+    tmux.capturePane.mockResolvedValue("static");
+
+    vi.useFakeTimers();
+    try {
+      const t0 = Date.now();
+      vi.setSystemTime(t0);
+      await runLifecyclePollOnce(); // seed
+      vi.setSystemTime(t0 + IDLE_THRESHOLD_MS + 100);
+      await runLifecyclePollOnce(); // first-ever idle-stable -> "waiting_for_human" (R3)
+      expect(await getCurrentState()).toBe("waiting_for_human");
+
+      // Pane changes again — a human responded (or the agent started a new
+      // turn) — this resumes to "working" (R4).
+      tmux.capturePane.mockResolvedValue("busy again");
+      vi.setSystemTime(t0 + IDLE_THRESHOLD_MS + 200);
+      await runLifecyclePollOnce();
+      expect(await getCurrentState()).toBe("working");
+
+      // Goes stable again -> waiting_for_human again.
+      tmux.capturePane.mockResolvedValue("static again");
+      vi.setSystemTime(t0 + IDLE_THRESHOLD_MS + 200);
+      await runLifecyclePollOnce(); // reseed the new stable hash
+      vi.setSystemTime(t0 + 2 * IDLE_THRESHOLD_MS + 300);
+      await runLifecyclePollOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(await getCurrentState()).toBe("waiting_for_human");
+    expect(emittedStateChanges()).toContain("waiting_for_human");
+  });
+
+  it("1.T3 — a human response (pane changes again) transitions waiting_for_human back to working (R4)", async () => {
+    await seedProject("waiting_for_human");
+    tmux.capturePane.mockResolvedValue("static");
+
+    vi.useFakeTimers();
+    try {
+      const t0 = Date.now();
+      vi.setSystemTime(t0);
+      await runLifecyclePollOnce(); // seed tracking for the waiting_for_human session
+
+      tmux.capturePane.mockResolvedValue("user typed something");
+      vi.setSystemTime(t0 + 100);
+      await runLifecyclePollOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(await getCurrentState()).toBe("working");
+    expect(emittedStateChanges()).toContain("working");
   });
 
   it("deletes tracking entry when pane disappears (session exit)", async () => {
@@ -240,9 +306,11 @@ describe("lifecycle polling behavior", () => {
       const t0 = Date.now();
       vi.setSystemTime(t0 + IDLE_THRESHOLD_MS + 100);
       await runLifecyclePollOnce();
-      // Bug reproduced: a fresh window immediately reads as "idle" because
-      // the leaked entry's `stableSince` is already older than the threshold.
-      expect(await getCurrentState()).toBe("idle");
+      // Bug reproduced: a fresh window immediately reads as idle-stable
+      // because the leaked entry's `stableSince` is already older than the
+      // threshold — lands on "waiting_for_human" since `everWorked` seeds
+      // true unconditionally.
+      expect(await getCurrentState()).toBe("waiting_for_human");
     } finally {
       vi.useRealTimers();
     }

--- a/daemon/src/__tests__/prPoller.test.ts
+++ b/daemon/src/__tests__/prPoller.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as githubNs from "../services/github.js";
+import * as broadcasterNs from "../broadcaster.js";
+import {
+  PR_POLL_INTERVAL_MS,
+  pollAllPrs,
+  _resetPrPollerWarningForTest,
+} from "../services/prPoller.js";
+import type { ProjectRecord, LifecycleState } from "../types.js";
+
+let tempDir: string;
+
+vi.mock("../services/paths.js", async () => {
+  const { join: pathJoin } = await import("node:path");
+  return {
+    vstHome: () => tempDir,
+    projectDir: (id: string) => pathJoin(tempDir, "projects", id),
+    manifestPath: (id: string) => pathJoin(tempDir, "projects", id, "manifest.json"),
+    manifestTmpPath: (id: string) => pathJoin(tempDir, "projects", id, "manifest.json.tmp"),
+    worktreePath: (id: string, wtId: string) =>
+      pathJoin(tempDir, "projects", id, "worktrees", wtId),
+    configPath: () => pathJoin(tempDir, "config.json"),
+    modesPath: () => pathJoin(tempDir, "modes.json"),
+    daemonLogPath: () => pathJoin(tempDir, "logs", "daemon.log"),
+    dbPath: () => pathJoin(tempDir, "vibe-station.db"),
+    cleanupSessionDataDir: () => {},
+  };
+});
+
+vi.mock("../services/github.js", () => ({
+  getRemoteUrl: vi.fn(),
+  parseGithubRepo: vi.fn(),
+  fetchPrForBranch: vi.fn(),
+}));
+
+vi.mock("../broadcaster.js", () => ({
+  notifySession: vi.fn(),
+  broadcastAll: vi.fn(),
+  registerConnection: vi.fn(),
+  unregisterConnection: vi.fn(),
+}));
+
+describe("PR poller configuration", () => {
+  it("polls once every 60s (Decision 3b)", () => {
+    expect(PR_POLL_INTERVAL_MS).toBe(60_000);
+  });
+});
+
+describe("PR poller behavior", () => {
+  const github = vi.mocked(githubNs);
+
+  async function seedProject(initialState: LifecycleState = "working"): Promise<void> {
+    const { _clearStoreForTest, addProject } = await import("../state/project-store.js");
+    _clearStoreForTest();
+    const record: ProjectRecord = {
+      id: "proj-pr",
+      absolutePath: join(tempDir, "repo"),
+      prefix: "pfx",
+      isGit: true,
+      defaultBranch: "main",
+      createdAt: new Date().toISOString(),
+      directSessions: [],
+      worktrees: [
+        {
+          id: "wt-pr",
+          branch: "feature-branch",
+          baseBranch: "main",
+          baseSha: "a".repeat(40),
+          createdAt: new Date().toISOString(),
+          sessions: [
+            {
+              id: "sess-pr",
+              slot: "m",
+              isMain: true,
+              type: "agent",
+              modeId: "mode",
+              tmuxName: "pane-pr",
+              lifecycle: {
+                state: initialState,
+                lastTransitionAt: new Date().toISOString(),
+              },
+            },
+          ],
+        },
+      ],
+    };
+    await addProject(record);
+  }
+
+  async function getCurrentState(): Promise<LifecycleState> {
+    const { getProject } = await import("../state/project-store.js");
+    return getProject("proj-pr")!.worktrees[0]!.sessions[0]!.lifecycle.state;
+  }
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "vst-prpoller-test-"));
+    await mkdir(join(tempDir, "projects", "proj-pr"), { recursive: true });
+    await mkdir(join(tempDir, "repo"), { recursive: true });
+    github.getRemoteUrl.mockReset();
+    github.parseGithubRepo.mockReset();
+    github.fetchPrForBranch.mockReset();
+    vi.mocked(broadcasterNs.broadcastAll).mockClear();
+    _resetPrPollerWarningForTest();
+    // Default happy path: a resolvable GitHub remote.
+    github.getRemoteUrl.mockResolvedValue("https://github.com/acme/widgets.git");
+    github.parseGithubRepo.mockReturnValue({ owner: "acme", repo: "widgets" });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("1b.T1 — an open non-draft PR transitions the worktree's main session to needs_review", async () => {
+    await seedProject("idle");
+    github.fetchPrForBranch.mockResolvedValue({
+      number: 7,
+      url: "https://github.com/acme/widgets/pull/7",
+      title: "Add widget",
+      state: "open",
+      merged: false,
+      draft: false,
+      author: "octocat",
+    });
+
+    await pollAllPrs();
+
+    expect(await getCurrentState()).toBe("needs_review");
+  });
+
+  it("does not flag a draft PR as needs_review", async () => {
+    await seedProject("idle");
+    github.fetchPrForBranch.mockResolvedValue({
+      number: 8,
+      url: "https://github.com/acme/widgets/pull/8",
+      title: "WIP widget",
+      state: "open",
+      merged: false,
+      draft: true,
+      author: "octocat",
+    });
+
+    await pollAllPrs();
+
+    expect(await getCurrentState()).toBe("idle");
+  });
+
+  it("1b.T2 — a merged PR transitions the session OUT of needs_review", async () => {
+    await seedProject("needs_review");
+    github.fetchPrForBranch.mockResolvedValue({
+      number: 7,
+      url: "https://github.com/acme/widgets/pull/7",
+      title: "Add widget",
+      state: "closed",
+      merged: true,
+      draft: false,
+      author: "octocat",
+    });
+
+    await pollAllPrs();
+
+    expect(await getCurrentState()).not.toBe("needs_review");
+    expect(await getCurrentState()).toBe("idle");
+  });
+
+  it("a closed-without-merge PR also transitions the session out of needs_review", async () => {
+    await seedProject("needs_review");
+    github.fetchPrForBranch.mockResolvedValue({
+      number: 9,
+      url: "https://github.com/acme/widgets/pull/9",
+      title: "Abandoned",
+      state: "closed",
+      merged: false,
+      draft: false,
+      author: "octocat",
+    });
+
+    await pollAllPrs();
+
+    expect(await getCurrentState()).toBe("idle");
+  });
+
+  it("no PR at all transitions the session out of needs_review", async () => {
+    await seedProject("needs_review");
+    github.fetchPrForBranch.mockResolvedValue(null);
+
+    await pollAllPrs();
+
+    expect(await getCurrentState()).toBe("idle");
+  });
+
+  it("leaves a done session alone even with an open PR", async () => {
+    await seedProject("done");
+    github.fetchPrForBranch.mockResolvedValue({
+      number: 7,
+      url: "https://github.com/acme/widgets/pull/7",
+      title: "Add widget",
+      state: "open",
+      merged: false,
+      draft: false,
+      author: "octocat",
+    });
+
+    await pollAllPrs();
+
+    expect(await getCurrentState()).toBe("done");
+  });
+
+  it("1b.T3 — a worktree with a non-GitHub remote is skipped without throwing", async () => {
+    await seedProject("idle");
+    github.parseGithubRepo.mockReturnValue(null);
+
+    await expect(pollAllPrs()).resolves.toBeUndefined();
+    expect(github.fetchPrForBranch).not.toHaveBeenCalled();
+    expect(await getCurrentState()).toBe("idle");
+  });
+
+  it("1b.T3 — a worktree with no resolvable remote at all is skipped without throwing", async () => {
+    await seedProject("idle");
+    github.getRemoteUrl.mockResolvedValue(null);
+
+    await expect(pollAllPrs()).resolves.toBeUndefined();
+    expect(github.fetchPrForBranch).not.toHaveBeenCalled();
+    expect(await getCurrentState()).toBe("idle");
+  });
+
+  it("skips a worktree with no main agent session, without throwing", async () => {
+    const { _clearStoreForTest, addProject } = await import("../state/project-store.js");
+    _clearStoreForTest();
+    const record: ProjectRecord = {
+      id: "proj-pr",
+      absolutePath: join(tempDir, "repo"),
+      prefix: "pfx",
+      isGit: true,
+      defaultBranch: "main",
+      createdAt: new Date().toISOString(),
+      directSessions: [],
+      worktrees: [
+        {
+          id: "wt-pr",
+          branch: "feature-branch",
+          baseBranch: "main",
+          baseSha: "a".repeat(40),
+          createdAt: new Date().toISOString(),
+          sessions: [],
+        },
+      ],
+    };
+    await addProject(record);
+
+    await expect(pollAllPrs()).resolves.toBeUndefined();
+    expect(github.fetchPrForBranch).not.toHaveBeenCalled();
+  });
+});

--- a/daemon/src/__tests__/protocol.test.ts
+++ b/daemon/src/__tests__/protocol.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { ServerMessage } from "../ws/protocol.js";
+
+// 1.T5 (plan 03, "Interaction States"): the WS protocol's `session:state`
+// schema is a hardcoded `z.enum([...])`, NOT derived from `LifecycleState`
+// (see plan Research §Protocol) — widening the daemon's `LifecycleState` TS
+// type does not widen this zod schema. This is a regression guard for 1.7's
+// edit to `daemon/src/ws/protocol.ts`'s three duplicated enum lists.
+describe("ws protocol — session:state accepts the new LifecycleState values (1.T5)", () => {
+  it("parses a session:state broadcast with state: 'waiting_for_human'", () => {
+    const msg = {
+      type: "session:state",
+      sessionId: "sess-1",
+      state: "waiting_for_human",
+    };
+    expect(() => ServerMessage.parse(msg)).not.toThrow();
+    const parsed = ServerMessage.parse(msg);
+    expect(parsed).toMatchObject({ type: "session:state", state: "waiting_for_human" });
+  });
+
+  it("parses a session:state broadcast with state: 'needs_review'", () => {
+    const msg = {
+      type: "session:state",
+      sessionId: "sess-2",
+      state: "needs_review",
+    };
+    expect(() => ServerMessage.parse(msg)).not.toThrow();
+    const parsed = ServerMessage.parse(msg);
+    expect(parsed).toMatchObject({ type: "session:state", state: "needs_review" });
+  });
+
+  it("still rejects an unknown/invalid state value", () => {
+    const msg = {
+      type: "session:state",
+      sessionId: "sess-3",
+      state: "totally_made_up",
+    };
+    expect(() => ServerMessage.parse(msg)).toThrow();
+  });
+
+  it("still parses every pre-existing state value (regression guard)", () => {
+    for (const state of ["not_started", "working", "idle", "done", "exited"] as const) {
+      const msg = { type: "session:state", sessionId: "sess-4", state };
+      expect(() => ServerMessage.parse(msg)).not.toThrow();
+    }
+  });
+});

--- a/daemon/src/__tests__/protocol.test.ts
+++ b/daemon/src/__tests__/protocol.test.ts
@@ -45,3 +45,31 @@ describe("ws protocol — session:state accepts the new LifecycleState values (1
     }
   });
 });
+
+// 4b.T3 (plan 04, "Workspaces"): session:created gains `spawnedFrom` —
+// present as a string, present as null, or absent entirely (pre-upgrade-
+// daemon compat) must all parse.
+describe("ws protocol — session:created accepts spawnedFrom (4b.T3)", () => {
+  const base = {
+    type: "session:created" as const,
+    sessionId: "sess-1",
+    worktreeId: "wt-1",
+    sessionType: "agent",
+  };
+
+  it("parses with spawnedFrom as a session id string", () => {
+    const msg = { ...base, spawnedFrom: "sess-source" };
+    expect(() => ServerMessage.parse(msg)).not.toThrow();
+    expect(ServerMessage.parse(msg)).toMatchObject({ spawnedFrom: "sess-source" });
+  });
+
+  it("parses with spawnedFrom: null (no source)", () => {
+    const msg = { ...base, spawnedFrom: null };
+    expect(() => ServerMessage.parse(msg)).not.toThrow();
+    expect(ServerMessage.parse(msg)).toMatchObject({ spawnedFrom: null });
+  });
+
+  it("parses with spawnedFrom absent entirely (pre-upgrade daemon compat)", () => {
+    expect(() => ServerMessage.parse(base)).not.toThrow();
+  });
+});

--- a/daemon/src/__tests__/sessions.test.ts
+++ b/daemon/src/__tests__/sessions.test.ts
@@ -531,6 +531,30 @@ describe("Session routes", () => {
     expect(fetched.state).toBe("not_started");
   });
 
+  it("4a.T1 — POST /sessions with sourceAgentId persists it as spawnedFrom on the new record", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/sessions",
+      payload: { worktreeId, type: "agent", modeId: "bugfix", sourceAgentId: "sess-source-2" },
+    });
+    expect(res.statusCode).toBe(201);
+    const created = res.json<{ id: string; spawnedFrom: string | null }>();
+    expect(created.spawnedFrom).toBe("sess-source-2");
+
+    const getRes = await app.inject({ method: "GET", url: `/sessions/${created.id}` });
+    expect(getRes.json<{ spawnedFrom: string | null }>().spawnedFrom).toBe("sess-source-2");
+  });
+
+  it("4a.T2 — POST /sessions omitting sourceAgentId still creates a session with spawnedFrom: null (regression)", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/sessions",
+      payload: { worktreeId, type: "agent", modeId: "bugfix" },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(res.json<{ spawnedFrom: string | null }>().spawnedFrom).toBeNull();
+  });
+
   it("JSON gate — channel:json with a claude (supported) mode → 201", async () => {
     const res = await app.inject({
       method: "POST",

--- a/daemon/src/__tests__/worktrees.test.ts
+++ b/daemon/src/__tests__/worktrees.test.ts
@@ -126,6 +126,38 @@ describe("Worktree routes", () => {
     expect(wt.baseSha).toMatch(/^[0-9a-f]{40}$/);
   });
 
+  it("4a.T1 — POST /worktrees with sourceAgentId persists it as spawnedFrom on the main session", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/worktrees",
+      payload: {
+        projectId,
+        branch: "spawned-from-test",
+        modeId: "bug-fix",
+        sourceAgentId: "sess-source-agent-1",
+      },
+    });
+    expect(res.statusCode).toBe(201);
+    const wt = res.json<{ mainSessionId: string }>();
+
+    const sessRes = await app.inject({ method: "GET", url: `/sessions/${wt.mainSessionId}` });
+    expect(sessRes.statusCode).toBe(200);
+    expect(sessRes.json<{ spawnedFrom: string | null }>().spawnedFrom).toBe("sess-source-agent-1");
+  });
+
+  it("4a.T2 — POST /worktrees omitting sourceAgentId creates a session with spawnedFrom: null (regression)", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/worktrees",
+      payload: { projectId, branch: "no-source-agent-test", modeId: "bug-fix" },
+    });
+    expect(res.statusCode).toBe(201);
+    const wt = res.json<{ mainSessionId: string }>();
+
+    const sessRes = await app.inject({ method: "GET", url: `/sessions/${wt.mainSessionId}` });
+    expect(sessRes.json<{ spawnedFrom: string | null }>().spawnedFrom).toBeNull();
+  });
+
   it("3.T5 — POST /worktrees {prompt} (no name) derives the same slug for both worktree.name and the main session's name", async () => {
     const res = await app.inject({
       method: "POST",

--- a/daemon/src/main.ts
+++ b/daemon/src/main.ts
@@ -14,6 +14,7 @@ import { buildServer } from "./server.js";
 import { loadAll } from "./state/project-store.js";
 import { recoverNotStartedSessions, sweepDirectPtySessionsOnBoot } from "./services/recover.js";
 import { startLifecyclePoller, stopLifecyclePoller } from "./services/lifecycle.js";
+import { startPrPoller, stopPrPoller } from "./services/prPoller.js";
 
 const VST_HOME = join(homedir(), ".vibe-station");
 const CONFIG_PATH = join(VST_HOME, "config.json");
@@ -170,11 +171,14 @@ async function main() {
 
   // Detect tmux pane death + drive session:exited / state transitions
   startLifecyclePoller();
+  // Poll for PR review-readiness → needs_review (plan 03, Decision 3/3b)
+  startPrPoller();
 
   // Graceful shutdown
   const shutdown = async (signal: string) => {
     console.log(`\nReceived ${signal}; shutting down…`);
     stopLifecyclePoller();
+    stopPrPoller();
     await app.close();
     await releaseLock();
     process.exit(0);

--- a/daemon/src/routes/sessions.ts
+++ b/daemon/src/routes/sessions.ts
@@ -58,6 +58,12 @@ const WorktreeSessionBody = z.object({
   useTmux: z.boolean().optional(),
   channel: z.enum(["tmux", "pty", "json"]).optional(),
   name: z.string().trim().max(60).optional(),
+  /** SessionId this session was spawned from (agent-interaction-workspaces/
+   *  04-workspaces Phase 4a) — from an agent's own `vst --source-agent`
+   *  invocation, or (future) an in-app dialog's source picker. Stored
+   *  as-is, never validated against a real session — an unknown/dangling
+   *  id is harmless (S5). */
+  sourceAgentId: z.string().optional(),
 });
 
 const DirectSessionBody = z.object({
@@ -69,6 +75,7 @@ const DirectSessionBody = z.object({
   useTmux: z.boolean().optional(),
   channel: z.enum(["tmux", "pty", "json"]).optional(),
   name: z.string().trim().max(60).optional(),
+  sourceAgentId: z.string().optional(),
 });
 
 const CreateSessionBody = z.union([WorktreeSessionBody, DirectSessionBody]);
@@ -371,6 +378,7 @@ export function serializeSession(worktreeId: string | null, projectId: string, s
     archivedAt: s.archivedAt ?? null,
     sortOrder: s.sortOrder,
     handoffSummary: s.handoffSummary ?? null,
+    spawnedFrom: s.spawnedFrom ?? null,
   };
 }
 
@@ -554,6 +562,7 @@ export function registerSessionRoutes(app: FastifyInstance): void {
           lastTransitionAt: new Date().toISOString(),
         },
         ...(type === "agent" && prompt ? { initialPrompt: prompt } : {}),
+        spawnedFrom: data.sourceAgentId ?? null,
       };
 
       // Spawn terminal immediately if type=terminal
@@ -599,6 +608,7 @@ export function registerSessionRoutes(app: FastifyInstance): void {
         worktreeId: null,
         sessionType: type,
         mode: typeof modeId === "string" ? modeId : undefined,
+        spawnedFrom: sessionRecord.spawnedFrom ?? null,
         snapshot: serializeSession(null, project.id, sessionRecord),
       });
 
@@ -685,6 +695,7 @@ export function registerSessionRoutes(app: FastifyInstance): void {
         lastTransitionAt: new Date().toISOString(),
       },
       ...(type === "agent" && prompt ? { initialPrompt: prompt } : {}),
+      spawnedFrom: data.sourceAgentId ?? null,
     };
 
     // Spawn terminal session immediately if type=terminal
@@ -740,6 +751,7 @@ export function registerSessionRoutes(app: FastifyInstance): void {
       worktreeId,
       sessionType: type,
       mode: typeof modeId === "string" ? modeId : undefined,
+      spawnedFrom: sessionRecord.spawnedFrom ?? null,
       snapshot: serializeSession(worktreeId, project.id, sessionRecord),
     });
 

--- a/daemon/src/routes/worktrees.ts
+++ b/daemon/src/routes/worktrees.ts
@@ -163,6 +163,10 @@ const CreateWorktreeBody = z.object({
   channel: z.enum(["tmux", "pty", "json"]).optional(),
   // Explicit cosmetic name (F1/F2) — always wins over the heuristic slug.
   name: z.string().trim().max(60).optional(),
+  /** SessionId this worktree's main agent session was spawned from
+   *  (agent-interaction-workspaces/04-workspaces Phase 4a) — see
+   *  WorktreeSessionBody's identical field in routes/sessions.ts. */
+  sourceAgentId: z.string().optional(),
 });
 
 async function runMainSpawnJob(opts: {
@@ -451,6 +455,7 @@ export function registerWorktreeRoutes(app: FastifyInstance): void {
           lastTransitionAt: new Date().toISOString(),
         },
         ...(result.data.prompt ? { initialPrompt: result.data.prompt } : {}),
+        spawnedFrom: result.data.sourceAgentId ?? null,
       };
 
       const worktreeRecord: WorktreeRecord = {
@@ -502,6 +507,7 @@ export function registerWorktreeRoutes(app: FastifyInstance): void {
         projectId,
         sessionType: "agent",
         mode: modeId,
+        spawnedFrom: mainSession.spawnedFrom ?? null,
         snapshot: serializeSession(wtId, projectId, mainSession),
       });
 

--- a/daemon/src/services/dbSchema.ts
+++ b/daemon/src/services/dbSchema.ts
@@ -99,6 +99,15 @@ export function ensureSchema(db: Database): void {
   // COLUMN` (idempotent: skipped once the column is present, safe to run on
   // every `getDb()` open like the rest of this function).
   addColumnIfMissing(db, "worktrees", "branchIsPlaceholder", "INTEGER NOT NULL DEFAULT 0");
+  // spawnedFrom (agent-interaction-workspaces/04-workspaces Phase 4a) — the
+  // sessionId this session was spawned from (via the in-app dialogs or a
+  // running agent's own `vst --source-agent` shell), or NULL when spawned
+  // with no source (the common case: a human via the dialogs with no source
+  // picker yet, Out of Scope this round). Write-once (Decision 7) — set at
+  // insert time, never updated. No FK enforcement: a deleted source session
+  // leaving a dangling id is harmless (Research: the client-side workspace
+  // tile scan simply won't find a match, S5).
+  addColumnIfMissing(db, "sessions", "spawnedFrom", "TEXT");
 }
 
 /** Add `column` to `table` via `ALTER TABLE` if `PRAGMA table_info` shows it's absent. */

--- a/daemon/src/services/jsonAgent.ts
+++ b/daemon/src/services/jsonAgent.ts
@@ -762,20 +762,34 @@ export class JsonAgentSession {
       this.running = false;
       if (this.turnState !== "error") this.setTurnState("idle");
       this.emitMeta();
-      // Persist lifecycle → idle now the queue has fully drained (Decision 11).
-      // The lifecycle poller deliberately skips JSON sessions, so nothing else
-      // flips the sidebar spinner back off. Even on a turn error the session is
-      // ready for the next message (the error lives in the transcript), so idle
-      // is correct. `POST /chat` / `startJsonCreateTurn` persist `working` while
-      // a turn is active/queued; this is the matching `idle` transition.
-      await this.persistLifecycle("idle");
+      // Persist lifecycle → waiting_for_human now the queue has fully
+      // drained (Decision 11). The lifecycle poller deliberately skips JSON
+      // sessions, so nothing else flips the sidebar spinner back off.
+      // `POST /chat` / `startJsonCreateTurn` persist `working` while a turn
+      // is active/queued; this is the matching post-turn transition.
+      //
+      // R3 (plan 03, Decision 2 / Decision 0 — R2 dropped, R3 is the sole
+      // waiting_for_human entry path for EVERY channel, not just TTY): reaching
+      // this finally block AT ALL means `runOneTurn` processed at least one
+      // turn in the `while` loop above — i.e. the session has, by construction,
+      // already "reached working" this cycle. There is no genesis-vs-later
+      // distinction to make here (unlike a naive reading of the TTY poller's
+      // `everWorked` flag might suggest) — R3a's carve-out ("never reached
+      // working stays idle") has no live manifestation in `drain()` at all,
+      // symmetric with why it has none in `lifecycle.ts`'s poller either (see
+      // that file's own `everWorked` doc comment). So every drain lands on
+      // `waiting_for_human`, including the very first one. Even on a turn
+      // error the session is ready for the next message (the error lives in
+      // the transcript), so the same choice applies.
+      await this.persistLifecycle("waiting_for_human");
     }
   }
 
   /** Persist the session lifecycle to the manifest (JSON channel, Decision 11). */
   private async persistLifecycle(state: LifecycleState): Promise<void> {
-    // Released sessions are terminal (`done`) — the drain's trailing `idle`
-    // must not demote them. See the `released` field comment.
+    // Released sessions are terminal (`done`) — the drain's trailing
+    // `waiting_for_human` (or any other non-terminal state) must not demote
+    // them. See the `released` field comment.
     if (this.released) return;
     try {
       const { persistLifecycleState } = await import("./lifecycle.js");

--- a/daemon/src/services/lifecycle.ts
+++ b/daemon/src/services/lifecycle.ts
@@ -32,7 +32,35 @@ export const IDLE_THRESHOLD_MS = 4000;
 /** Lines captured for idle hashing — compare full window, not only the last line. */
 export const CAPTURE_LINES = 20;
 
-type IdleTrack = { hash: string; stableSince: number };
+type IdleTrack = {
+  hash: string;
+  stableSince: number;
+  /**
+   * R3 — true once this session has reached "working" at least once.
+   * Seeded `true` the moment this poller starts tracking the session:
+   * `pollSession` already returns early for `"not_started"` (see the guard
+   * above), and a session only reaches `"working"` after its ready signal
+   * has already printed visible content (`getReadySignal()` — a prompt/
+   * banner, at minimum) — so "genuinely blank, nothing has happened yet"
+   * is not achievable by the time this poller ever captures a pane for a
+   * `"working"`/`"idle"`/`"waiting_for_human"` session. R3a's carve-out
+   * ("never reached working stays idle") has no live manifestation on this
+   * poller specifically.
+   *
+   * An earlier revision tried a stricter "only true after an OBSERVED hash
+   * change" rule, to guard against a hypothetical blank-session false
+   * positive — empirically wrong: live-tested against a real fast-completing
+   * turn, the whole response printed and stabilized between two 1s poll
+   * ticks, so no delta was ever observed and R3 silently never fired. Seed
+   * `true` unconditionally instead — both simpler and the only version that
+   * actually works given the poller's 1Hz sampling rate.
+   *
+   * Carried forward across hash resets so it survives for the life of the
+   * tracking entry (in-memory only — reset on daemon restart, see plan
+   * Research §R3's "ever worked" tracking).
+   */
+  everWorked: boolean;
+};
 const idleTracking = new Map<string, IdleTrack>();
 
 let pollerHandle: ReturnType<typeof setInterval> | null = null;
@@ -136,7 +164,11 @@ async function pollSession(
     // Terminals: skip idle/working churn — they're meaningless for shell sessions.
     if (session.type === "terminal") return;
 
-    if (session.lifecycle.state !== "working" && session.lifecycle.state !== "idle") {
+    if (
+      session.lifecycle.state !== "working" &&
+      session.lifecycle.state !== "idle" &&
+      session.lifecycle.state !== "waiting_for_human"
+    ) {
       return;
     }
 
@@ -147,21 +179,46 @@ async function pollSession(
 
     const entry = idleTracking.get(session.id);
     if (!entry) {
-      idleTracking.set(session.id, { hash: newHash, stableSince: now });
+      // A session only reaches "working" after its ready signal has already
+      // printed visible content (getReadySignal() — a prompt/banner, at
+      // minimum), so by the time this poller ever captures a pane for a
+      // "working"/"idle"/"waiting_for_human" session, "genuinely blank,
+      // nothing has happened yet" is not achievable — R3a's carve-out has no
+      // live manifestation here (see the field's doc comment). Empirically
+      // confirmed: requiring an OBSERVED hash change before flagging
+      // `everWorked` missed fast-completing turns entirely (the whole
+      // response can finish between two 1s poll ticks, so no delta is ever
+      // observed) — seeding true immediately is both correct and reliable.
+      idleTracking.set(session.id, { hash: newHash, stableSince: now, everWorked: true });
       return;
     }
 
     if (entry.hash !== newHash) {
-      idleTracking.set(session.id, { hash: newHash, stableSince: now });
-      if (session.lifecycle.state === "idle") {
+      // Pane output changed — resuming from idle/waiting_for_human (a human
+      // responded, or the agent started a new turn) is what flips lifecycle
+      // back to "working" (R4). `everWorked` is already true from the seed
+      // above, so it's just carried forward here, not derived from this event.
+      const resuming = session.lifecycle.state === "idle" || session.lifecycle.state === "waiting_for_human";
+      idleTracking.set(session.id, {
+        hash: newHash,
+        stableSince: now,
+        everWorked: entry.everWorked,
+      });
+      if (resuming) {
         await persistLifecycleState(projectId, worktreeId, session.id, "working");
       }
       return;
     }
 
     const stableAge = now - entry.stableSince;
-    if (stableAge >= IDLE_THRESHOLD_MS && session.lifecycle.state !== "idle") {
-      await persistLifecycleState(projectId, worktreeId, session.id, "idle");
+    if (stableAge >= IDLE_THRESHOLD_MS) {
+      // R3: once this session has ever reached "working" (per this poller's
+      // own observation), idle-stability lands on "waiting_for_human" instead
+      // of "idle" — R3a (never worked) still lands on plain "idle".
+      const target: LifecycleState = entry.everWorked ? "waiting_for_human" : "idle";
+      if (session.lifecycle.state !== target) {
+        await persistLifecycleState(projectId, worktreeId, session.id, target);
+      }
     }
     return;
   }
@@ -189,7 +246,11 @@ async function pollSession(
   // the hash-based detection. They stay "working" until exited (handled above).
   if (session.type === "terminal") return;
 
-  if (session.lifecycle.state !== "working" && session.lifecycle.state !== "idle") {
+  if (
+    session.lifecycle.state !== "working" &&
+    session.lifecycle.state !== "idle" &&
+    session.lifecycle.state !== "waiting_for_human"
+  ) {
     return;
   }
 
@@ -198,23 +259,48 @@ async function pollSession(
     const newHash = hashPane(output);
     const now = Date.now();
 
-    let entry = idleTracking.get(session.id);
+    const entry = idleTracking.get(session.id);
     if (!entry) {
-      idleTracking.set(session.id, { hash: newHash, stableSince: now });
+      // A session only reaches "working" after its ready signal has already
+      // printed visible content (getReadySignal() — a prompt/banner, at
+      // minimum), so by the time this poller ever captures a pane for a
+      // "working"/"idle"/"waiting_for_human" session, "genuinely blank,
+      // nothing has happened yet" is not achievable — R3a's carve-out has no
+      // live manifestation here (see the field's doc comment). Empirically
+      // confirmed: requiring an OBSERVED hash change before flagging
+      // `everWorked` missed fast-completing turns entirely (the whole
+      // response can finish between two 1s poll ticks, so no delta is ever
+      // observed) — seeding true immediately is both correct and reliable.
+      idleTracking.set(session.id, { hash: newHash, stableSince: now, everWorked: true });
       return;
     }
 
     if (entry.hash !== newHash) {
-      idleTracking.set(session.id, { hash: newHash, stableSince: now });
-      if (session.lifecycle.state === "idle") {
+      // Pane output changed — resuming from idle/waiting_for_human (a human
+      // responded, or the agent started a new turn) is what flips lifecycle
+      // back to "working" (R4). `everWorked` is already true from the seed
+      // above, so it's just carried forward here, not derived from this event.
+      const resuming = session.lifecycle.state === "idle" || session.lifecycle.state === "waiting_for_human";
+      idleTracking.set(session.id, {
+        hash: newHash,
+        stableSince: now,
+        everWorked: entry.everWorked,
+      });
+      if (resuming) {
         await persistLifecycleState(projectId, worktreeId, session.id, "working");
       }
       return;
     }
 
     const stableAge = now - entry.stableSince;
-    if (stableAge >= IDLE_THRESHOLD_MS && session.lifecycle.state !== "idle") {
-      await persistLifecycleState(projectId, worktreeId, session.id, "idle");
+    if (stableAge >= IDLE_THRESHOLD_MS) {
+      // R3: once this session has ever reached "working" (per this poller's
+      // own observation), idle-stability lands on "waiting_for_human" instead
+      // of "idle" — R3a (never worked) still lands on plain "idle".
+      const target: LifecycleState = entry.everWorked ? "waiting_for_human" : "idle";
+      if (session.lifecycle.state !== target) {
+        await persistLifecycleState(projectId, worktreeId, session.id, target);
+      }
     }
   } catch {
     // Capture pane failed — session may have just exited

--- a/daemon/src/services/prPoller.ts
+++ b/daemon/src/services/prPoller.ts
@@ -1,0 +1,156 @@
+/**
+ * PR-review poller (plan 03, "Interaction States", Decision 3/3b).
+ *
+ * Mirrors `lifecycle.ts`'s `pollAll`/`startLifecyclePoller`/`stopLifecyclePoller`
+ * shape: one `setInterval`, one sweep per tick over every worktree, not one
+ * timer per worktree. Every tick, checks each worktree's branch for an open
+ * non-draft PR via the existing `github.ts` service (`fetchPrForBranch`,
+ * already cached/rate-limit-aware) and flips the worktree's MAIN agent
+ * session's lifecycle to `"needs_review"` (R6/R7). When the PR is no longer
+ * open (merged, closed, or gone) while that session is currently
+ * `"needs_review"`, it reverts to `"working"`/`"idle"` (R6).
+ *
+ * `needs_review` is deliberately NOT part of the 1Hz `lifecycle.ts` poller's
+ * idle/working detection (its membership guard excludes it, same as
+ * done/exited) — this poller is its sole owner, entry and exit, matching R5
+ * ("absorbed into done/exited like every other non-terminal state, no
+ * special-case guard needed" — nothing OTHER than done/exited/this poller
+ * ever touches a `needs_review` session).
+ */
+
+import { getAllProjects } from "../state/project-store.js";
+import { getRemoteUrl, parseGithubRepo, fetchPrForBranch } from "./github.js";
+import { persistLifecycleState } from "./lifecycle.js";
+import { jsonAgentRegistry } from "../state/jsonAgentRegistry.js";
+import { sessionChannel } from "./channel.js";
+import type { SessionRecord } from "../types.js";
+
+/**
+ * 60s (Decision 3b): >= github.ts's own 30s cache TTL (polling faster is
+ * pure churn against a cached value), and — per-worktree — already at the
+ * unauthenticated GitHub rate-limit ceiling (60 req/hr) with a single
+ * worktree polled continuously, which is exactly why 1b.4's token warning
+ * exists. Not configurable this round (matches `lifecycle.ts`'s own
+ * `POLL_INTERVAL_MS` precedent).
+ */
+export const PR_POLL_INTERVAL_MS = 60_000;
+
+let pollerHandle: ReturnType<typeof setInterval> | null = null;
+
+/** 1b.4 — warn once per daemon lifetime, not once per tick. */
+let warnedNoToken = false;
+
+function hasGithubToken(): boolean {
+  return Boolean(process.env.GITHUB_TOKEN || process.env.GH_TOKEN);
+}
+
+/**
+ * Best-effort "what should this session fall back to, now that its PR is no
+ * longer open" (R6). The 1Hz lifecycle poller never touches a
+ * `needs_review` session (see module doc), so by the time this fires the
+ * session's activity is otherwise unobserved — a live JSON agent with a
+ * turn in flight reports "working"; everything else falls back to "idle"
+ * (matches plan CUJ 3's example transition).
+ */
+function fallbackStateFor(session: SessionRecord): "working" | "idle" {
+  if (sessionChannel(session) === "json") {
+    const agent = jsonAgentRegistry.get(session.id);
+    if (agent && agent.getMeta().turnState !== "idle") return "working";
+  }
+  return "idle";
+}
+
+async function pollWorktree(
+  projectId: string,
+  projectAbsolutePath: string,
+  worktreeId: string,
+  branch: string,
+  mainSession: SessionRecord | undefined,
+): Promise<void> {
+  if (!mainSession) return; // No agent session to attribute needs_review to.
+  // Terminal state — same as lifecycle.ts's own terminal-state early return.
+  if (mainSession.lifecycle.state === "done" || mainSession.lifecycle.state === "exited") return;
+
+  const remoteUrl = await getRemoteUrl(projectAbsolutePath);
+  const gh = remoteUrl ? parseGithubRepo(remoteUrl) : null;
+  if (!gh) return; // 1b.5 — non-GitHub remote, skip silently (matches GET /worktrees/:id/pr).
+
+  const pr = await fetchPrForBranch(gh.owner, gh.repo, branch);
+  const isReviewable = pr !== null && pr.state === "open" && !pr.draft;
+
+  if (isReviewable) {
+    if (mainSession.lifecycle.state !== "needs_review") {
+      await persistLifecycleState(projectId, worktreeId, mainSession.id, "needs_review");
+    }
+    return;
+  }
+
+  // PR merged/closed/gone — only act if WE are the one holding this session
+  // in needs_review; anything else (done/exited, handled above) wins as-is.
+  if (mainSession.lifecycle.state === "needs_review") {
+    await persistLifecycleState(projectId, worktreeId, mainSession.id, fallbackStateFor(mainSession));
+  }
+}
+
+/** Exported for deterministic daemon tests (single poll tick). */
+export async function pollAllPrs(): Promise<void> {
+  const projects = getAllProjects();
+
+  // 1b.4 — warn once, only when it's actually going to matter (more than one
+  // worktree means we're already past the point a single continuously-polled
+  // worktree already exhausts the unauthenticated rate limit — see Decision 3b).
+  const worktreeCount = projects.reduce((n, p) => n + p.worktrees.length, 0);
+  if (!warnedNoToken && !hasGithubToken() && worktreeCount > 1) {
+    warnedNoToken = true;
+    console.warn(
+      `[prPoller] No GITHUB_TOKEN/GH_TOKEN set — polling ${worktreeCount} worktrees for PR status ` +
+        `against the unauthenticated GitHub rate limit (60 req/hr). Set GITHUB_TOKEN to avoid rate-limiting.`,
+    );
+  }
+
+  await Promise.all(
+    projects.flatMap((project) =>
+      project.worktrees.map((worktree) => {
+        const mainSession = worktree.sessions.find((s) => s.isMain);
+        return pollWorktree(
+          project.id,
+          project.absolutePath,
+          worktree.id,
+          worktree.branch,
+          mainSession,
+        ).catch((err) => {
+          console.error(`[prPoller] Poll error for worktree ${worktree.id}:`, err);
+        });
+      }),
+    ),
+  );
+}
+
+export function startPrPoller(): void {
+  if (pollerHandle) return;
+  // Overlap guard — same rationale as lifecycle.ts's poller: a slow tick
+  // (many worktrees, slow GitHub API) must not stack on the next one.
+  let inFlight = false;
+  pollerHandle = setInterval(() => {
+    if (inFlight) return;
+    inFlight = true;
+    void pollAllPrs().finally(() => {
+      inFlight = false;
+    });
+  }, PR_POLL_INTERVAL_MS);
+  if (typeof pollerHandle === "object" && "unref" in pollerHandle) {
+    (pollerHandle as { unref(): void }).unref();
+  }
+}
+
+export function stopPrPoller(): void {
+  if (pollerHandle) {
+    clearInterval(pollerHandle);
+    pollerHandle = null;
+  }
+}
+
+/** Test helper — resets the once-per-lifetime token warning. */
+export function _resetPrPollerWarningForTest(): void {
+  warnedNoToken = false;
+}

--- a/daemon/src/state/project-store.ts
+++ b/daemon/src/state/project-store.ts
@@ -254,8 +254,8 @@ function writeProjectFull(record: ProjectRecord): void {
        VALUES (@id, @projectId, @name, @branch, @baseBranch, @baseSha, @createdAt, @pinnedAt, @sortOrder, @terminalSeq, @agentSeq, @branchIsPlaceholder)`,
     );
     const insertSession = db.prepare(
-      `INSERT INTO sessions (id, worktreeId, projectId, isMain, sortOrder, type, modeId, name, nameSource, tmuxName, useTmux, channel, state, reason, lastTransitionAt, transcriptKind, transcriptPath, agentChatId, modelOverride, pinnedAt, initialPrompt, archivedAt, handoffSummary)
-       VALUES (@id, @worktreeId, @projectId, @isMain, @sortOrder, @type, @modeId, @name, @nameSource, @tmuxName, @useTmux, @channel, @state, @reason, @lastTransitionAt, @transcriptKind, @transcriptPath, @agentChatId, @modelOverride, @pinnedAt, @initialPrompt, @archivedAt, @handoffSummary)`,
+      `INSERT INTO sessions (id, worktreeId, projectId, isMain, sortOrder, type, modeId, name, nameSource, tmuxName, useTmux, channel, state, reason, lastTransitionAt, transcriptKind, transcriptPath, agentChatId, modelOverride, pinnedAt, initialPrompt, archivedAt, handoffSummary, spawnedFrom)
+       VALUES (@id, @worktreeId, @projectId, @isMain, @sortOrder, @type, @modeId, @name, @nameSource, @tmuxName, @useTmux, @channel, @state, @reason, @lastTransitionAt, @transcriptKind, @transcriptPath, @agentChatId, @modelOverride, @pinnedAt, @initialPrompt, @archivedAt, @handoffSummary, @spawnedFrom)`,
     );
 
     for (const w of p.worktrees) {

--- a/daemon/src/state/sqliteRowMappers.ts
+++ b/daemon/src/state/sqliteRowMappers.ts
@@ -39,6 +39,7 @@ export interface SessionRow {
   initialPrompt: string | null;
   archivedAt: string | null;
   handoffSummary: string | null;
+  spawnedFrom: string | null;
 }
 
 export function rowToSession(row: SessionRow): SessionRecord {
@@ -72,6 +73,7 @@ export function rowToSession(row: SessionRow): SessionRecord {
     ...(row.initialPrompt != null ? { initialPrompt: row.initialPrompt } : {}),
     ...(row.archivedAt != null ? { archivedAt: row.archivedAt } : {}),
     ...(row.handoffSummary != null ? { handoffSummary: row.handoffSummary } : {}),
+    ...(row.spawnedFrom != null ? { spawnedFrom: row.spawnedFrom } : {}),
   };
 }
 
@@ -115,6 +117,7 @@ export function sessionToRow(session: SessionRecord, projectId: string, worktree
     initialPrompt: session.initialPrompt ?? null,
     archivedAt: session.archivedAt ?? null,
     handoffSummary: session.handoffSummary ?? null,
+    spawnedFrom: session.spawnedFrom ?? null,
   };
 }
 

--- a/daemon/src/types.ts
+++ b/daemon/src/types.ts
@@ -252,6 +252,18 @@ export interface SessionRecord {
    * `null`/absent when no handoff was requested or it timed out.
    */
   handoffSummary?: string | null;
+  /**
+   * SessionId this session was spawned from — set from `sourceAgentId` in the
+   * create request body (in-app dialogs, or a running agent's own shell via
+   * `vst ... --source-agent`), or absent/null when created with no source
+   * (the common case today: Out of Scope this round for the in-app dialogs,
+   * which have no source-agent picker UI yet). Write-once: set at creation,
+   * never mutated afterward (agent-interaction-workspaces/04-workspaces
+   * Phase 4a, Decision 7). No FK enforcement — a deleted source session
+   * leaving a dangling id is harmless (the web-ui's workspace-tile scan
+   * simply finds no match, S5).
+   */
+  spawnedFrom?: string | null;
 }
 
 export interface WorktreeRecord {

--- a/daemon/src/types.ts
+++ b/daemon/src/types.ts
@@ -5,7 +5,14 @@
 
 export type { CliId } from "./agent-plugins/registry.js";
 
-export type LifecycleState = "not_started" | "working" | "idle" | "done" | "exited";
+export type LifecycleState =
+  | "not_started"
+  | "working"
+  | "idle"
+  | "waiting_for_human"
+  | "needs_review"
+  | "done"
+  | "exited";
 
 export interface SessionLifecycle {
   state: LifecycleState;

--- a/daemon/src/ws/protocol.ts
+++ b/daemon/src/ws/protocol.ts
@@ -206,8 +206,24 @@ const SessionCreatedSnapshot = z.object({
   tmuxName: z.string(),
   useTmux: z.boolean().optional().default(true),
   channel: z.enum(["tmux", "pty", "json"]).optional(),
-  state: z.enum(["not_started", "working", "idle", "done", "exited"]),
-  lifecycleState: z.enum(["not_started", "working", "idle", "done", "exited"]),
+  state: z.enum([
+    "not_started",
+    "working",
+    "idle",
+    "waiting_for_human",
+    "needs_review",
+    "done",
+    "exited",
+  ]),
+  lifecycleState: z.enum([
+    "not_started",
+    "working",
+    "idle",
+    "waiting_for_human",
+    "needs_review",
+    "done",
+    "exited",
+  ]),
   createdAt: z.string(),
   pinnedAt: z.string().nullable().optional(),
   /** Set for a session archived by a reset (Decision 2/9); null otherwise. */
@@ -227,7 +243,15 @@ const SessionCreatedEvent = z.object({
 const SessionStateEvent = z.object({
   type: z.literal("session:state"),
   sessionId: z.string(),
-  state: z.enum(["not_started", "working", "idle", "done", "exited"]),
+  state: z.enum([
+    "not_started",
+    "working",
+    "idle",
+    "waiting_for_human",
+    "needs_review",
+    "done",
+    "exited",
+  ]),
   reason: z.string().optional(),
 });
 

--- a/daemon/src/ws/protocol.ts
+++ b/daemon/src/ws/protocol.ts
@@ -238,6 +238,13 @@ const SessionCreatedEvent = z.object({
   sessionType: z.string(),
   mode: z.string().optional(),
   snapshot: SessionCreatedSnapshot.optional(),
+  /** SessionId this session was spawned from, or null (agent-interaction-
+   *  workspaces/04-workspaces Phase 4b). Present (not omitted) even when
+   *  null so the web-ui can tell "this daemon build supports the field, and
+   *  it's genuinely unset" apart from "old daemon, field absent entirely" —
+   *  both are treated identically client-side (skip the auto-insert scan),
+   *  but the distinction matters for future debugging. */
+  spawnedFrom: z.string().nullable().optional(),
 });
 
 const SessionStateEvent = z.object({

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -19,8 +19,9 @@
 FROM node:24-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    tmux git procps curl ripgrep \
+    tmux git procps curl ripgrep ca-certificates \
     python3 make g++ \
+  && update-ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g pnpm@9.0.0 @google/gemini-cli

--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -3,6 +3,8 @@ import { Workspace } from "./routes/Workspace";
 import { LoginScreen } from "./components/auth/LoginScreen";
 import { TopBar } from "./components/layout/TopBar";
 import { useAuth } from "./hooks/useAuth";
+import { DevStatePanel } from "./components/dev/DevStatePanel";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 
 function AppShell() {
   const { authed, loading, onLoginSuccess } = useAuth();
@@ -46,16 +48,24 @@ function AppShell() {
   }
 
   return (
-    <Routes>
-      <Route path="/" element={<Workspace />} />
-      <Route path="/settings" element={<Workspace />} />
-      <Route path="/worktree" element={<Workspace />} />
-      <Route path="/worktree/:wtId" element={<Workspace />} />
-      <Route path="/worktree/:wtId/:sessionId" element={<Workspace />} />
-      <Route path="/session/:directSessionId" element={<Workspace />} />
-      <Route path="/workspace" element={<Navigate to="/worktree" replace />} />
-      <Route path="/dashboard" element={<Navigate to="/" replace />} />
-    </Routes>
+    <>
+      {/* Boundary wraps just the routed content, not DevStatePanel — so the
+          dev state-simulator popup stays usable for debugging even if the
+          workspace tree itself crashes (see ErrorBoundary.tsx). */}
+      <ErrorBoundary label="Workspace">
+        <Routes>
+          <Route path="/" element={<Workspace />} />
+          <Route path="/settings" element={<Workspace />} />
+          <Route path="/worktree" element={<Workspace />} />
+          <Route path="/worktree/:wtId" element={<Workspace />} />
+          <Route path="/worktree/:wtId/:sessionId" element={<Workspace />} />
+          <Route path="/session/:directSessionId" element={<Workspace />} />
+          <Route path="/workspace" element={<Navigate to="/worktree" replace />} />
+          <Route path="/dashboard" element={<Navigate to="/" replace />} />
+        </Routes>
+      </ErrorBoundary>
+      <DevStatePanel />
+    </>
   );
 }
 

--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -17,7 +17,6 @@ function AppShell() {
           layoutMode="login"
           projects={[]}
           worktrees={[]}
-          sessions={[]}
           isMobile={false}
           onToggleLeftSidebar={() => {}}
           leftSidebarCollapsed={false}
@@ -35,7 +34,6 @@ function AppShell() {
           layoutMode="login"
           projects={[]}
           worktrees={[]}
-          sessions={[]}
           isMobile={false}
           onToggleLeftSidebar={() => {}}
           leftSidebarCollapsed={false}
@@ -60,6 +58,11 @@ function AppShell() {
           <Route path="/worktree/:wtId" element={<Workspace />} />
           <Route path="/worktree/:wtId/:sessionId" element={<Workspace />} />
           <Route path="/session/:directSessionId" element={<Workspace />} />
+          {/* Detached-workspace view (agent-interaction-workspaces/04-workspaces
+              Phase 3a, Decision 4) — a saved WorkspaceDoc's own route,
+              independent of any worktree. "/workspace" (singular, no param,
+              just above) is a pre-existing stale redirect and unrelated. */}
+          <Route path="/workspaces/:workspaceId" element={<Workspace />} />
           <Route path="/workspace" element={<Navigate to="/worktree" replace />} />
           <Route path="/dashboard" element={<Navigate to="/" replace />} />
         </Routes>

--- a/web-ui/src/a11y/a11y.test.tsx
+++ b/web-ui/src/a11y/a11y.test.tsx
@@ -3,22 +3,27 @@ import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect } from "vitest";
 import axe from "axe-core";
 import { TopBar } from "@/components/layout/TopBar";
+import { PaneOutletProvider } from "@/components/layout/paneOutlets";
 import { Dialog } from "@/components/dialogs/Dialog";
 
 describe("a11y smoke", () => {
   it("TopBar has no axe violations", async () => {
     const { container } = render(
       <MemoryRouter>
-        <TopBar
-          projects={[]}
-          worktrees={[]}
-          sessions={[]}
-          isMobile={false}
-          onToggleLeftSidebar={() => {}}
-          leftSidebarCollapsed={false}
-          mobileSidebarOpen={false}
-          onOpenQuickOpen={() => {}}
-        />
+        {/* TopBar always renders inside one in the real app (Workspace.tsx) —
+            it now hosts a ToolbarOutlet (WorkspaceCanvas's portaled
+            toolbar), which needs the registry context. */}
+        <PaneOutletProvider>
+          <TopBar
+            projects={[]}
+            worktrees={[]}
+            isMobile={false}
+            onToggleLeftSidebar={() => {}}
+            leftSidebarCollapsed={false}
+            mobileSidebarOpen={false}
+            onOpenQuickOpen={() => {}}
+          />
+        </PaneOutletProvider>
       </MemoryRouter>,
     );
     const results = await axe.run(container);

--- a/web-ui/src/api/types.ts
+++ b/web-ui/src/api/types.ts
@@ -109,6 +109,9 @@ export interface Session {
   archivedAt?: string | null;
   /** Handoff summary written during a `reset --handoff`. Only ever set on an archived row. */
   handoffSummary?: string | null;
+  /** SessionId this session was spawned from, or null (agent-interaction-
+   *  workspaces/04-workspaces Phase 4). Write-once, set at creation. */
+  spawnedFrom?: string | null;
 }
 
 /** Token / cost usage numbers (mirror of daemon `UsageInfo`). */
@@ -279,6 +282,10 @@ export type WSEvent =
       mode?: string;
       /** Full session row for optimistic UI (daemon v1+) */
       snapshot?: Session;
+      /** SessionId this session was spawned from, or null (agent-interaction-
+       *  workspaces/04-workspaces Phase 4b). Absent ≡ pre-upgrade daemon —
+       *  treat identically to null (skip the auto-insert scan, Phase 4c). */
+      spawnedFrom?: string | null;
     }
   | {
       type: "session:state";

--- a/web-ui/src/api/types.ts
+++ b/web-ui/src/api/types.ts
@@ -55,7 +55,21 @@ export type FileScope = "worktree" | "project";
 
 export type SessionType = "agent" | "terminal";
 
-export type SessionState = "not_started" | "working" | "idle" | "done" | "exited";
+/**
+ * `waiting_for_human` (idle-after-having-worked, R3) and `needs_review` (open
+ * PR poller) are both wired up daemon-side as of
+ * .vibekit/feature-plans/wip/agent-interaction-workspaces/03-interaction-states —
+ * real `session:state` events carry these values, not just the dev-only
+ * state-simulation panel (components/dev/DevStatePanel.tsx).
+ */
+export type SessionState =
+  | "not_started"
+  | "working"
+  | "idle"
+  | "waiting_for_human"
+  | "needs_review"
+  | "done"
+  | "exited";
 
 /**
  * Execution channel (mirror of daemon `Channel`). `json` = structured JSON

--- a/web-ui/src/components/ErrorBoundary.tsx
+++ b/web-ui/src/components/ErrorBoundary.tsx
@@ -1,0 +1,78 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  /** Shown in the fallback card so the user/dev knows roughly what broke. */
+  label?: string;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * Last-resort error boundary. Without one, ANY uncaught throw anywhere in the
+ * tree unmounts the whole React root, leaving a blank page with no signal —
+ * this is exactly what happened when `crypto.randomUUID()` threw on an
+ * insecure-context origin (see lib/uuid.ts) with nothing above the workspace
+ * tree to catch it. This boundary turns that failure mode into a visible
+ * error card instead, and keeps the rest of the app framework (TopBar, route)
+ * usable so the user isn't stuck.
+ */
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  override state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error(`[ErrorBoundary${this.props.label ? `: ${this.props.label}` : ""}]`, error, info.componentStack);
+  }
+
+  private reset = (): void => {
+    this.setState({ error: null });
+  };
+
+  override render(): ReactNode {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+    return (
+      <div
+        style={{
+          padding: 24,
+          margin: 16,
+          border: "1px solid var(--border-default, #444)",
+          borderRadius: 8,
+          background: "var(--bg-secondary, #1a1a1a)",
+          color: "var(--fg-primary, #eee)",
+          fontFamily: "var(--font-sans, sans-serif)",
+          maxWidth: 640,
+        }}
+      >
+        <div style={{ fontWeight: 600, marginBottom: 8 }}>
+          {this.props.label ? `${this.props.label} crashed` : "Something went wrong"}
+        </div>
+        <div style={{ fontSize: 13, opacity: 0.8, marginBottom: 12, whiteSpace: "pre-wrap" }}>
+          {error.message}
+        </div>
+        <button
+          type="button"
+          onClick={this.reset}
+          style={{
+            font: "inherit",
+            fontSize: 13,
+            padding: "6px 12px",
+            borderRadius: 6,
+            border: "1px solid var(--border-default, #444)",
+            background: "var(--bg-primary, #111)",
+            color: "inherit",
+            cursor: "pointer",
+          }}
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+}

--- a/web-ui/src/components/dev/DevStatePanel.tsx
+++ b/web-ui/src/components/dev/DevStatePanel.tsx
@@ -1,0 +1,203 @@
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useServerStore } from "@/hooks/useServerStore";
+import { useWorkspaceStore } from "@/hooks/useStore";
+import type { SessionState } from "@/api/types";
+
+/**
+ * Dev-only floating popup for faking `session:state` transitions on real
+ * sessions, without touching the daemon at all. Patches the client-side
+ * stores directly (same two calls the real WS handler makes in
+ * useServerSync.ts) — purely for visually testing the Workspaces feature's
+ * colored-border interaction states.
+ *
+ * Toggle with Ctrl+Shift+D (Cmd+Shift+D on Mac). Not a real feature — a real
+ * `session:state` WS event, or a page reload, resets any fake state applied
+ * here, since server truth always wins.
+ */
+const STATES: SessionState[] = [
+  "not_started",
+  "working",
+  "idle",
+  "waiting_for_human",
+  "needs_review",
+  "done",
+  "exited",
+];
+
+export function DevStatePanel(): ReactNode {
+  const devEnabled =
+    import.meta.env.DEV || localStorage.getItem("vs:devpanel") === "1";
+
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState({ x: 24, y: 24 });
+  const [sessionId, setSessionId] = useState<string>("");
+  const [state, setState] = useState<SessionState>("working");
+
+  const sessions = useServerStore((s) => s.sessions);
+
+  const drag = useRef<{ startX: number; startY: number; origX: number; origY: number } | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (!devEnabled) return;
+    function onKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === "d") {
+        e.preventDefault();
+        setOpen((o) => !o);
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [devEnabled]);
+
+  useEffect(() => {
+    if (!devEnabled) return;
+    function onMove(e: MouseEvent) {
+      const d = drag.current;
+      if (!d) return;
+      setPos({ x: d.origX + (e.clientX - d.startX), y: d.origY + (e.clientY - d.startY) });
+    }
+    function onUp() {
+      drag.current = null;
+    }
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+    return () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    };
+  }, [devEnabled]);
+
+  if (!devEnabled || !open) return null;
+
+  function handleApply() {
+    if (!sessionId) return;
+    useServerStore.getState().applySessionUpdated(sessionId, { state, lifecycleState: state });
+    useWorkspaceStore.getState().patchSessionState(sessionId, state);
+  }
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        left: pos.x,
+        top: pos.y,
+        zIndex: 2000,
+        width: 280,
+        background: "#1e1e1e",
+        color: "#e0e0e0",
+        border: "1px solid #444",
+        borderRadius: 6,
+        boxShadow: "0 8px 24px rgba(0,0,0,0.5)",
+        fontSize: 12,
+        fontFamily: "system-ui, sans-serif",
+        overflow: "hidden",
+      }}
+    >
+      <div
+        onMouseDown={(e) => {
+          drag.current = {
+            startX: e.clientX,
+            startY: e.clientY,
+            origX: pos.x,
+            origY: pos.y,
+          };
+        }}
+        style={{
+          cursor: "move",
+          padding: "6px 10px",
+          background: "#2a2a2a",
+          borderBottom: "1px solid #444",
+          fontWeight: 600,
+          userSelect: "none",
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+      >
+        <span>DEV: State Simulator</span>
+        <button
+          onClick={() => setOpen(false)}
+          style={{
+            background: "transparent",
+            border: "none",
+            color: "#aaa",
+            cursor: "pointer",
+            fontSize: 14,
+            lineHeight: 1,
+          }}
+          aria-label="Close"
+        >
+          ×
+        </button>
+      </div>
+
+      <div style={{ padding: 10, display: "flex", flexDirection: "column", gap: 8 }}>
+        <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+          Session
+          <select
+            value={sessionId}
+            onChange={(e) => setSessionId(e.target.value)}
+            style={{
+              background: "#111",
+              color: "#e0e0e0",
+              border: "1px solid #444",
+              borderRadius: 4,
+              padding: "4px 6px",
+            }}
+          >
+            <option value="">— select session —</option>
+            {sessions.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name ?? s.id}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+          State
+          <select
+            value={state}
+            onChange={(e) => setState(e.target.value as SessionState)}
+            style={{
+              background: "#111",
+              color: "#e0e0e0",
+              border: "1px solid #444",
+              borderRadius: 4,
+              padding: "4px 6px",
+            }}
+          >
+            {STATES.map((st) => (
+              <option key={st} value={st}>
+                {st}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <button
+          onClick={handleApply}
+          disabled={!sessionId}
+          style={{
+            background: sessionId ? "#3b6fe0" : "#444",
+            color: "#fff",
+            border: "none",
+            borderRadius: 4,
+            padding: "6px 8px",
+            cursor: sessionId ? "pointer" : "not-allowed",
+            fontWeight: 600,
+          }}
+        >
+          Apply
+        </button>
+
+        <p style={{ margin: 0, color: "#888", fontSize: 10, lineHeight: 1.4 }}>
+          Local-only fake — a real `session:state` event or a page reload
+          resets this (server truth wins).
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/web-ui/src/components/layout/AgentPaneSlot.test.tsx
+++ b/web-ui/src/components/layout/AgentPaneSlot.test.tsx
@@ -124,7 +124,7 @@ describe("AgentPaneSlot remount invariant (4.T5 / Decision 14)", () => {
   it("3.T3 — hides the upload overlay for a session marked done (its pane is released)", () => {
     // "Mark as done" kills the tmux/pty process just like an exit does, so the
     // live-terminal-only upload overlay must be gated for `done` too.
-    const done: Session = { ...session("tty1", "tmux"), lifecycleState: "done" };
+    const done: Session = { ...session("tty1", "tmux"), state: "done", lifecycleState: "done" };
     const { container } = render(<AgentPaneSlot api={api} sessionId="tty1" session={done} />);
     expect(container.querySelector('[data-testid="terminal"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="channel-toggle"]')).not.toBeNull();
@@ -136,7 +136,7 @@ describe("AgentPaneSlot remount invariant (4.T5 / Decision 14)", () => {
     // normal flow BELOW its own "Session exited / Resume" banner (no overlap),
     // so AgentPaneSlot keeps passing it even when exited. The upload overlay is
     // a plain top-corner overlay that only makes sense live, so it stays gated.
-    const exited: Session = { ...session("tty1", "tmux"), lifecycleState: "exited" };
+    const exited: Session = { ...session("tty1", "tmux"), state: "exited", lifecycleState: "exited" };
     const { container } = render(<AgentPaneSlot api={api} sessionId="tty1" session={exited} />);
     expect(terminalMounts).toBe(1);
     expect(container.querySelector('[data-testid="terminal"]')).not.toBeNull();
@@ -161,5 +161,44 @@ describe("AgentPaneSlot remount invariant (4.T5 / Decision 14)", () => {
     expect(terminalMounts).toBe(1);
     expect(terminalUnmounts).toBe(0);
     expect(container.querySelector('[data-testid="terminal"]')?.getAttribute("data-session")).toBe("tty1");
+  });
+
+  // --- Colored border reflects live `.state`, not stale `.lifecycleState` ---
+  // Regression: the live `session:state` WS handler (useServerSync.ts) only
+  // ever patches `.state` on the session object, never `.lifecycleState` (that
+  // field is only set from the initial REST fetch, or by the dev-only
+  // state-simulation panel which patches both — masking this bug in manual
+  // testing via that panel). Reading `.lifecycleState` for the border color
+  // left it permanently stuck on the value from page load.
+  it("borders the pane by `session.state`, ignoring a stale/mismatched `session.lifecycleState`", () => {
+    const s: Session = {
+      ...session("tty1", "tmux"),
+      state: "waiting_for_human",
+      lifecycleState: "exited", // deliberately stale/wrong — must be ignored
+    };
+    const { container } = render(<AgentPaneSlot api={api} sessionId="tty1" session={s} />);
+    const root = container.querySelector(".agent-pane-slot");
+    expect(root?.className).toContain("agent-pane-slot--waiting_for_human");
+    expect(root?.className).not.toContain("agent-pane-slot--exited");
+  });
+
+  it("hides the status border entirely when the showAgentStatusBorders toggle is off", async () => {
+    const { useWorkspaceStore } = await import("@/hooks/useStore");
+    const prev = useWorkspaceStore.getState().showAgentStatusBorders;
+    // Flip the store BEFORE mounting, so the component's initial render already
+    // reflects it — a post-mount setState would need an act() wrapper here.
+    useWorkspaceStore.setState({ showAgentStatusBorders: false });
+    try {
+      const s: Session = { ...session("tty1", "tmux"), state: "waiting_for_human" };
+      const { container, unmount } = render(<AgentPaneSlot api={api} sessionId="tty1" session={s} />);
+      const root = container.querySelector(".agent-pane-slot");
+      expect(root?.className).not.toContain("agent-pane-slot--waiting_for_human");
+      // Unmount before restoring the store so the restore-setState below (which
+      // RTL's own auto-cleanup can't precede) doesn't update a still-subscribed,
+      // still-mounted component outside of act().
+      unmount();
+    } finally {
+      useWorkspaceStore.setState({ showAgentStatusBorders: prev });
+    }
   });
 });

--- a/web-ui/src/components/layout/AgentPaneSlot.tsx
+++ b/web-ui/src/components/layout/AgentPaneSlot.tsx
@@ -4,6 +4,8 @@ import { TerminalPane } from "./TerminalPane";
 import { TerminalChannelToggle } from "./TerminalChannelToggle";
 import { TerminalAttachmentUpload } from "./TerminalAttachmentUpload";
 import { ChatPane } from "./ChatPane";
+import { sessionStatus } from "@/lib/worktreeStatus";
+import { useWorkspaceStore } from "@/hooks/useStore";
 
 interface AgentPaneSlotProps {
   api: ApiInstance;
@@ -38,10 +40,24 @@ export function AgentPaneSlot({ api, sessionId, session }: AgentPaneSlotProps) {
   // `done` releases the pane exactly like `exited` does (the daemon kills the
   // tmux/pty process), so the upload overlay — which only makes sense against a
   // live terminal — is hidden for both.
-  const terminalLive =
-    !isJson && session?.lifecycleState !== "exited" && session?.lifecycleState !== "done";
+  // `session.state` (not `.lifecycleState`) — the live `session:state` WS
+  // handler (useServerSync.ts) only patches `.state` on the session object;
+  // `.lifecycleState` is only ever set from the initial REST fetch (or by the
+  // dev-only state-simulation panel, which patches both, masking this in
+  // manual testing). Reading `.lifecycleState` here left both the border
+  // color below and this terminal-live check permanently stuck on whatever
+  // value the session had on page load. WorkspaceCanvas.tsx already reads
+  // `.state` for the same reason — match it.
+  const terminalLive = !isJson && session?.state !== "exited" && session?.state !== "done";
+  // Same colored-rectangle treatment as a workspace tile (WorkspaceCanvas.tsx's
+  // `.workspace-canvas__tile--<status>`), on the pane's own chrome — this
+  // component is shared by the classic single-agent-pane view AND direct
+  // sessions (no tile header to host a StatusDot dot in either case), so a
+  // border is the only "colored rectangle" surface available here.
+  const showAgentStatusBorders = useWorkspaceStore((s) => s.showAgentStatusBorders);
+  const status = session && showAgentStatusBorders ? sessionStatus(session.state) : null;
   return (
-    <div className="agent-pane-slot">
+    <div className={`agent-pane-slot${status ? ` agent-pane-slot--${status}` : ""}`}>
       <div
         className="agent-pane-slot__terminal"
         style={isJson ? { display: "none" } : { flex: 1, minHeight: 0, display: "flex" }}

--- a/web-ui/src/components/layout/Layout.test.tsx
+++ b/web-ui/src/components/layout/Layout.test.tsx
@@ -50,6 +50,9 @@ describe("Layout orientation toggle remount invariant", () => {
             toolPanelTab: "files",
             terminalDockVisible: false,
             toolSplitOrientation: "horizontal",
+          layoutMode: "classic",
+          activeWorkspaceId: null,
+          scratchCanvas: null,
           },
         },
       });
@@ -88,6 +91,9 @@ describe("Layout orientation toggle remount invariant", () => {
             toolPanelTab: "files",
             terminalDockVisible: false,
             toolSplitOrientation: "vertical",
+          layoutMode: "classic",
+          activeWorkspaceId: null,
+          scratchCanvas: null,
           },
         },
       });
@@ -122,6 +128,9 @@ describe("Layout orientation toggle remount invariant", () => {
             toolPanelTab: "files",
             terminalDockVisible: false,
             toolSplitOrientation: "horizontal",
+          layoutMode: "classic",
+          activeWorkspaceId: null,
+          scratchCanvas: null,
           },
         },
       });

--- a/web-ui/src/components/layout/Layout.test.tsx
+++ b/web-ui/src/components/layout/Layout.test.tsx
@@ -53,6 +53,7 @@ describe("Layout orientation toggle remount invariant", () => {
           layoutMode: "classic",
           activeWorkspaceId: null,
           scratchCanvas: null,
+          canvasToolbarVisible: true,
           },
         },
       });
@@ -94,6 +95,7 @@ describe("Layout orientation toggle remount invariant", () => {
           layoutMode: "classic",
           activeWorkspaceId: null,
           scratchCanvas: null,
+          canvasToolbarVisible: true,
           },
         },
       });
@@ -131,6 +133,7 @@ describe("Layout orientation toggle remount invariant", () => {
           layoutMode: "classic",
           activeWorkspaceId: null,
           scratchCanvas: null,
+          canvasToolbarVisible: true,
           },
         },
       });

--- a/web-ui/src/components/layout/Layout.tsx
+++ b/web-ui/src/components/layout/Layout.tsx
@@ -17,6 +17,13 @@ interface LayoutProps {
   toolPanel?: ReactNode;
   /** Bottom region — terminal dock. Pass `null` when unavailable. */
   terminalDock?: ReactNode;
+  /** Tiled/free-form workspace canvas — rendered instead of the classic agent/tools/
+   *  terminal split when the active worktree's `layoutMode` is "workspace". */
+  workspaceCanvas?: ReactNode;
+  /** Every live agent/terminal/tools pane for the active context, permanently mounted
+   *  once regardless of classic vs. workspace mode — see PaneHostLayer.tsx. Rendered
+   *  unconditionally as an always-mounted sibling, never inside a conditional branch. */
+  paneHostLayer?: ReactNode;
   leftColumnPx: number;
   /** Whether the desktop sidebar is collapsed to its icon rail (hides the drag handle). */
   leftSidebarCollapsed?: boolean;
@@ -34,6 +41,8 @@ export function Layout({
   agentPane,
   toolPanel,
   terminalDock,
+  workspaceCanvas,
+  paneHostLayer,
   leftColumnPx,
   leftSidebarCollapsed,
   onLeftSidebarResize,
@@ -41,7 +50,17 @@ export function Layout({
   mobileSidebarOpen,
   onMobileSidebarClose,
 }: LayoutProps) {
-  const { toolPanelVisible, terminalDockVisible, toolSplitOrientation, activeWorktreeId, activeDirectContextId } = useLayout();
+  const {
+    toolPanelVisible,
+    terminalDockVisible,
+    toolSplitOrientation,
+    activeWorktreeId,
+    activeDirectContextId,
+    // ⚠️ `layoutMode` here is the per-worktree pane-arrangement mode
+    // ("classic" | "workspace") from useLayout()/WorktreeLayout — unrelated to
+    // TopBar's page-routing `layoutMode` prop. Alias it to avoid collisions.
+    layoutMode: paneLayoutMode,
+  } = useLayout();
 
   const mainContentRef = useRef<HTMLDivElement>(null);
 
@@ -172,6 +191,7 @@ export function Layout({
             {dashboardPane}
           </div>
         </div>
+        {paneHostLayer}
       </div>
     );
   }
@@ -252,7 +272,7 @@ export function Layout({
     agentWrapper()
   );
 
-  const mainColumnInner = showTerminalDock ? (
+  const classicMainColumnInner = showTerminalDock ? (
     <PanelGroup
       direction="vertical"
       autoSaveId={`vs-ide-dock-${wt}`}
@@ -269,6 +289,9 @@ export function Layout({
   ) : (
     topRow
   );
+
+  const mainColumnInner =
+    paneLayoutMode === "workspace" && workspaceCanvas != null ? workspaceCanvas : classicMainColumnInner;
 
   const mainColumn = (
     <div
@@ -299,6 +322,7 @@ export function Layout({
         {mainColumn}
       </div>
       {fullscreenOverlay}
+      {paneHostLayer}
     </div>
   );
 }

--- a/web-ui/src/components/layout/LeftSidebar.test.tsx
+++ b/web-ui/src/components/layout/LeftSidebar.test.tsx
@@ -1,7 +1,7 @@
 import { createElement } from "react";
 import { render, screen, waitFor, fireEvent, within, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { ReactNode } from "react";
 import type { DragEndEvent } from "@dnd-kit/core";
@@ -1190,5 +1190,106 @@ describe("LeftSidebar", () => {
       // the rename input as normal.
       expect(await screen.findByLabelText("Rename")).toBeInTheDocument();
     });
+  });
+});
+
+// --- Phase 3b: global Workspaces section (agent-interaction-workspaces/
+// 04-workspaces, Decision 6) ---
+describe("LeftSidebar - global Workspaces section", () => {
+  const api = createMockApi();
+
+  const workspaceDocs = {
+    "doc-other-wt": {
+      id: "doc-other-wt",
+      name: "Created elsewhere",
+      contextKey: "wt-2", // NOT the active worktree
+      mode: "free" as const,
+      tiles: [],
+      tree: null,
+      freeRects: {},
+    },
+    "doc-no-wt": {
+      id: "doc-no-wt",
+      name: "Created with nothing active",
+      contextKey: "", // simulates a doc saved with no active worktree at creation time
+      mode: "free" as const,
+      tiles: [],
+      tree: null,
+      freeRects: {},
+    },
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+    useWorkspaceStore.persist.clearStorage?.();
+    useWorkspaceStore.setState({
+      activeProjectId: "proj-a",
+      activeWorktreeId: "wt-1", // active worktree differs from BOTH docs' contextKey
+      activeSessionId: "sess-main",
+      sessionStates: {},
+      lastSessionByWorktree: {},
+      diffScopeByWorktree: {},
+      hideInactiveWorktrees: false,
+      workspaceDocs,
+    });
+    useServerStore.setState({ projects: [], worktrees: [], sessions: [], loaded: false });
+  });
+
+  it("3b.T1 — lists a saved workspace regardless of which worktree (or none) created it or is active", async () => {
+    render(
+      <MemoryRouter>
+        <Harness api={api}>
+          <LeftSidebar api={api} />
+        </Harness>
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Created elsewhere")).toBeInTheDocument();
+      expect(screen.getByText("Created with nothing active")).toBeInTheDocument();
+    });
+  });
+
+  it("still lists both workspaces with NO active worktree at all (dashboard)", async () => {
+    useWorkspaceStore.setState({ activeWorktreeId: null });
+    render(
+      <MemoryRouter>
+        <Harness api={api}>
+          <LeftSidebar api={api} />
+        </Harness>
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Created elsewhere")).toBeInTheDocument();
+      expect(screen.getByText("Created with nothing active")).toBeInTheDocument();
+    });
+  });
+
+  it("3b.T2 — clicking a workspace row navigates to /workspaces/<id> without mutating activeWorktreeId", async () => {
+    const user = userEvent.setup();
+    // A sibling location-reporter inside the same Router context observes the
+    // navigation (useNavigate mutates Router-internal history; there's no
+    // other Router-agnostic way to assert the URL actually changed).
+    function LocationProbe() {
+      const location = useLocation();
+      return <div data-testid="location-probe">{location.pathname}</div>;
+    }
+    render(
+      <MemoryRouter initialEntries={["/worktree/wt-1"]}>
+        <Harness api={api}>
+          <LeftSidebar api={api} />
+        </Harness>
+        <LocationProbe />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId("location-probe").textContent).toBe("/worktree/wt-1");
+
+    const row = await screen.findByText("Created elsewhere");
+    await user.click(row);
+
+    expect(screen.getByTestId("location-probe").textContent).toBe("/workspaces/doc-other-wt");
+    // setActiveWorkspace (the old per-worktree pointer mechanism) must NOT be
+    // invoked by this click anymore — Decision 4 moved this to routing.
+    expect(useWorkspaceStore.getState().activeWorktreeId).toBe("wt-1");
+    expect(useWorkspaceStore.getState().layoutByWorktree["wt-1"]?.activeWorkspaceId ?? null).toBeNull();
   });
 });

--- a/web-ui/src/components/layout/LeftSidebar.tsx
+++ b/web-ui/src/components/layout/LeftSidebar.tsx
@@ -1,4 +1,4 @@
-import { Check, ChevronDown, ChevronRight, EyeOff, Filter, FolderPlus, FolderTree, Moon, MoreHorizontal, Pin, Plus, SlidersHorizontal, Trash2, Type } from "lucide-react";
+import { Check, ChevronDown, ChevronRight, EyeOff, Filter, Folder, FolderOpen, FolderPlus, FolderTree, Moon, MoreHorizontal, Pin, Plus, SlidersHorizontal, Trash2, Type } from "lucide-react";
 import { useTheme } from "@/hooks/useTheme";
 import { createPortal } from "react-dom";
 import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from "react";
@@ -511,25 +511,28 @@ export function LeftSidebar({
     } catch { /* ignore */ }
   }, [workspacesOpen]);
 
-  /** Saved workspaces for the currently active worktree only (this section is
-   *  worktree-scoped, per the spec — dashboard/no-worktree hides it entirely). */
-  const workspacesForActiveWorktree = useMemo(() => {
-    if (!activeWorktreeId) return [];
-    return Object.values(workspaceDocs).filter((d) => d.contextKey === activeWorktreeId);
-  }, [workspaceDocs, activeWorktreeId]);
-  const workspacesScopeKey = activeWorktreeId ? `workspaces:${activeWorktreeId}` : "";
+  /** ALL saved workspaces, globally — detached from any owning worktree
+   *  (agent-interaction-workspaces/04-workspaces Phase 3b, Decision 6). A
+   *  saved workspace is independent once created, so it's listed regardless
+   *  of which worktree (or none — the dashboard) is currently active.
+   *  `contextKey` (the worktree it was originally created in) is provenance
+   *  only now, not a filter (Decision 5). */
+  const allWorkspaces = useMemo(() => Object.values(workspaceDocs), [workspaceDocs]);
+  /** Single global ordering key — the section is no longer per-worktree, so
+   *  its reorder state isn't either. */
+  const workspacesScopeKey = "workspaces:global";
   const orderedWorkspaces = useMemo(() => {
-    const ids = workspacesForActiveWorktree.map((d) => d.id);
+    const ids = allWorkspaces.map((d) => d.id);
     const order = applyLocalSortOrder(workspaceOrder[workspacesScopeKey], ids);
-    const byId = new Map(workspacesForActiveWorktree.map((d) => [d.id, d]));
+    const byId = new Map(allWorkspaces.map((d) => [d.id, d]));
     return order.map((id) => byId.get(id)!).filter(Boolean);
-  }, [workspacesForActiveWorktree, workspaceOrder, workspacesScopeKey]);
-  const activeWorkspaceId = activeWorktreeId
-    ? (layoutByWorktree[activeWorktreeId]?.activeWorkspaceId ?? null)
+  }, [allWorkspaces, workspaceOrder, workspacesScopeKey]);
+  /** "Currently viewing this workspace" is route-driven now (Decision 4), not
+   *  a per-worktree pointer — highlight the row whose id matches the open
+   *  `/workspaces/:id` route. */
+  const activeDetachedWorkspaceId = location.pathname.startsWith("/workspaces/")
+    ? location.pathname.slice("/workspaces/".length)
     : null;
-  const activeLayoutMode = activeWorktreeId
-    ? (layoutByWorktree[activeWorktreeId]?.layoutMode ?? "classic")
-    : "classic";
 
   const [newSessProject, setNewSessProject] = useState<Project | null>(null);
   const [directAgentProject, setDirectAgentProject] = useState<Project | null>(null);
@@ -1115,12 +1118,12 @@ export function LeftSidebar({
             </DndContext>
           </section>
         ) : null}
-        {/* Saved workspace layouts (tiled/free-form pane arrangements) for the
-            currently active worktree only — this section is worktree-scoped,
-            unlike Pinned/Projects above. Hidden entirely when there's no
-            active worktree (e.g. dashboard route). Reorder + rename are both
-            purely client-side (no daemon route exists for WorkspaceDoc). */}
-        {!collapsed && activeWorktreeId ? (
+        {/* Saved workspace layouts (tiled/free-form pane arrangements) — GLOBAL,
+            listed regardless of which worktree (or none) is currently active;
+            a saved workspace is detached from its creating worktree (Phase 3,
+            Decision 4/6). Reorder + rename are both purely client-side (no
+            daemon route exists for WorkspaceDoc). */}
+        {!collapsed ? (
           <section className="workspaces-section" aria-label="Workspaces">
             <div className="sidebar-projects-heading pinned-section__heading">
               <span className="sidebar-projects-heading__gutter" aria-hidden />
@@ -1165,7 +1168,7 @@ export function LeftSidebar({
                     strategy={verticalListSortingStrategy}
                   >
                     {orderedWorkspaces.map((ws) => {
-                      const isActive = activeWorkspaceId === ws.id && activeLayoutMode === "workspace";
+                      const isActive = activeDetachedWorkspaceId === ws.id;
                       return (
                         <SortableRow key={ws.id} id={ws.id}>
                           {({ setNodeRef, style, attributes, listeners }) => (
@@ -1185,13 +1188,13 @@ export function LeftSidebar({
                                 onKeyDown={(e) => {
                                   if (e.key === "Enter" || e.key === " ") {
                                     e.preventDefault();
-                                    setActiveWorkspace(activeWorktreeId, ws.id);
-                                    setLayoutMode(activeWorktreeId, "workspace");
+                                    if (isMobile) setMobileSidebarOpen(false);
+                                    navigate(`/workspaces/${ws.id}`);
                                   }
                                 }}
                                 onClick={() => {
-                                  setActiveWorkspace(activeWorktreeId, ws.id);
-                                  setLayoutMode(activeWorktreeId, "workspace");
+                                  if (isMobile) setMobileSidebarOpen(false);
+                                  navigate(`/workspaces/${ws.id}`);
                                 }}
                                 onDoubleClick={(e) => {
                                   e.preventDefault();
@@ -1316,7 +1319,7 @@ export function LeftSidebar({
                 onClick={() => toggleProj(p.id)}
               >
                 <span className="tree-row__chevron tree-row__project-chevron" aria-hidden>
-                  {openProj.has(p.id) ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+                  {openProj.has(p.id) ? <FolderOpen size={14} /> : <Folder size={14} />}
                 </span>
                 <span className="tree-row__label">
                   {collapsed ? disambiguatedAbbrev(p.name, p.id, visibleProjects) : p.name}

--- a/web-ui/src/components/layout/LeftSidebar.tsx
+++ b/web-ui/src/components/layout/LeftSidebar.tsx
@@ -1,4 +1,4 @@
-import { Check, ChevronDown, ChevronRight, EyeOff, Filter, FolderPlus, FolderTree, Moon, MoreHorizontal, Pin, Plus, SlidersHorizontal, Type } from "lucide-react";
+import { Check, ChevronDown, ChevronRight, EyeOff, Filter, FolderPlus, FolderTree, Moon, MoreHorizontal, Pin, Plus, SlidersHorizontal, Trash2, Type } from "lucide-react";
 import { useTheme } from "@/hooks/useTheme";
 import { createPortal } from "react-dom";
 import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from "react";
@@ -19,7 +19,7 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import type { ApiInstance } from "@/api";
 import type { Project, Session, SessionState, Worktree } from "@/api/types";
-import { computeNewSortOrder, useWorkspaceStore } from "@/hooks/useStore";
+import { computeNewSortOrder, useWorkspaceStore, type WorkspaceDoc } from "@/hooks/useStore";
 import { useServerStore } from "@/hooks/useServerStore";
 import { useLayout } from "@/hooks/useLayout";
 import { useDragClickGuard } from "@/hooks/useDragClickGuard";
@@ -140,7 +140,7 @@ function disambiguatedAbbrev(
 /** Map SessionState to WorktreeRolledUpStatus for StatusDot. */
 function sessionStateToStatus(state: SessionState): WorktreeRolledUpStatus {
   if (state === "not_started") return "spawning";
-  return state; // working, idle, done, exited all map directly
+  return state; // working, idle, waiting_for_human, needs_review, done, exited all map directly
 }
 
 function worktreeIsInactive(sessions: Session[], live: Record<string, SessionState | undefined>): boolean {
@@ -285,6 +285,19 @@ export function LeftSidebar({
   // express a cross-project pinned order (Decision 1 exception). ---
   const sortOrders = useWorkspaceStore((s) => s.sortOrders);
   const setSortOrder = useWorkspaceStore((s) => s.setSortOrder);
+  // --- Saved workspace layouts (per-worktree, purely client-side — no daemon
+  // route exists for any of this). Reorder mirrors the pinned sub-lists'
+  // local-only `sortOrders` mechanism above (`workspaceOrder` + `reorderWorkspace`),
+  // since WorkspaceDoc order can't be expressed by the server's sortOrder column
+  // at all (there's no server entity). ---
+  const workspaceDocs = useWorkspaceStore((s) => s.workspaceDocs);
+  const workspaceOrder = useWorkspaceStore((s) => s.workspaceOrder);
+  const reorderWorkspace = useWorkspaceStore((s) => s.reorderWorkspace);
+  const renameWorkspace = useWorkspaceStore((s) => s.renameWorkspace);
+  const deleteWorkspace = useWorkspaceStore((s) => s.deleteWorkspace);
+  const setActiveWorkspace = useWorkspaceStore((s) => s.setActiveWorkspace);
+  const setLayoutMode = useWorkspaceStore((s) => s.setLayoutMode);
+  const layoutByWorktree = useWorkspaceStore((s) => s.layoutByWorktree);
   const dndSensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }));
   /**
    * Suppresses the browser's trailing `click` after a drag-to-reorder, which
@@ -308,7 +321,7 @@ export function LeftSidebar({
   // value. Including `site` ensures only the row actually double-clicked
   // ever renders an input.
   const [inlineRename, setInlineRename] = useState<
-    { kind: "worktree" | "session"; id: string; site: "pinned" | "tree" } | null
+    { kind: "worktree" | "session" | "workspace"; id: string; site: "pinned" | "tree" } | null
   >(null);
   const [inlineValue, setInlineValue] = useState("");
   const inlineInputRef = useRef<HTMLInputElement>(null);
@@ -318,7 +331,7 @@ export function LeftSidebar({
   }, [inlineRename]);
 
   function startInlineRename(
-    kind: "worktree" | "session",
+    kind: "worktree" | "session" | "workspace",
     id: string,
     currentLabel: string,
     site: "pinned" | "tree",
@@ -356,10 +369,17 @@ export function LeftSidebar({
       void api.renameWorktree(target.id, trimmed).catch(() => {
         /* surface errors later */
       });
-    } else {
+    } else if (target.kind === "session") {
       void api.renameSession(target.id, trimmed).catch(() => {
         /* surface errors later */
       });
+    } else {
+      // Workspace: purely client-side entity, no daemon route — commit
+      // straight to the store. Unlike worktree/session rename, there's no
+      // server-computed default to fall back to on empty input, so an empty
+      // submission is treated as a no-op (keeps the previous name) rather
+      // than clearing it.
+      if (trimmed) renameWorkspace(target.id, trimmed);
     }
   }
 
@@ -399,6 +419,21 @@ export function LeftSidebar({
     next.splice(from, 1);
     next.splice(to, 0, String(active.id));
     setSortOrder(scopeKey, next);
+  }
+
+  /** Workspaces-section reorder — client-only, mirrors `handleReorder` above
+   *  but writes to `workspaceOrder`/`reorderWorkspace` (no daemon route). */
+  function handleWorkspaceReorder(scopeKey: string, currentIds: string[], e: DragEndEvent) {
+    markDrag();
+    const { active, over } = e;
+    if (!over || active.id === over.id) return;
+    const from = currentIds.indexOf(String(active.id));
+    const to = currentIds.indexOf(String(over.id));
+    if (from === -1 || to === -1) return;
+    const next = currentIds.slice();
+    next.splice(from, 1);
+    next.splice(to, 0, String(active.id));
+    reorderWorkspace(scopeKey, next);
   }
 
   /** Non-pinned worktree/direct-session reorder — real server `sortOrder`
@@ -460,6 +495,42 @@ export function LeftSidebar({
   const hideInactiveWorktrees = useWorkspaceStore((s) => s.hideInactiveWorktrees);
   const toggleInactiveWorktreesFilter = useWorkspaceStore((s) => s.toggleInactiveWorktreesFilter);
 
+  /** "Workspaces" section collapse state — mirrors `openProj`'s
+   *  localStorage-persisted chevron-disclosure pattern above, just a single
+   *  boolean instead of a per-project Set since there's only one section. */
+  const [workspacesOpen, setWorkspacesOpen] = useState<boolean>(() => {
+    try {
+      const saved = localStorage.getItem("sidebar:workspacesOpen");
+      if (saved != null) return saved === "1";
+    } catch { /* ignore */ }
+    return true;
+  });
+  useEffect(() => {
+    try {
+      localStorage.setItem("sidebar:workspacesOpen", workspacesOpen ? "1" : "0");
+    } catch { /* ignore */ }
+  }, [workspacesOpen]);
+
+  /** Saved workspaces for the currently active worktree only (this section is
+   *  worktree-scoped, per the spec — dashboard/no-worktree hides it entirely). */
+  const workspacesForActiveWorktree = useMemo(() => {
+    if (!activeWorktreeId) return [];
+    return Object.values(workspaceDocs).filter((d) => d.contextKey === activeWorktreeId);
+  }, [workspaceDocs, activeWorktreeId]);
+  const workspacesScopeKey = activeWorktreeId ? `workspaces:${activeWorktreeId}` : "";
+  const orderedWorkspaces = useMemo(() => {
+    const ids = workspacesForActiveWorktree.map((d) => d.id);
+    const order = applyLocalSortOrder(workspaceOrder[workspacesScopeKey], ids);
+    const byId = new Map(workspacesForActiveWorktree.map((d) => [d.id, d]));
+    return order.map((id) => byId.get(id)!).filter(Boolean);
+  }, [workspacesForActiveWorktree, workspaceOrder, workspacesScopeKey]);
+  const activeWorkspaceId = activeWorktreeId
+    ? (layoutByWorktree[activeWorktreeId]?.activeWorkspaceId ?? null)
+    : null;
+  const activeLayoutMode = activeWorktreeId
+    ? (layoutByWorktree[activeWorktreeId]?.layoutMode ?? "classic")
+    : "classic";
+
   const [newSessProject, setNewSessProject] = useState<Project | null>(null);
   const [directAgentProject, setDirectAgentProject] = useState<Project | null>(null);
   const [addProjectOpen, setAddProjectOpen] = useState(false);
@@ -480,6 +551,7 @@ export function LeftSidebar({
   const [pendingDelete, setPendingDelete] = useState<Worktree | null>(null);
   const [pendingDismiss, setPendingDismiss] = useState<Worktree | null>(null);
   const [pendingDismissSession, setPendingDismissSession] = useState<Session | null>(null);
+  const [pendingDeleteWorkspace, setPendingDeleteWorkspace] = useState<WorkspaceDoc | null>(null);
 
   // Subscribe to live session output for every session we know about so the
   // rollup picks up state transitions in real time. The set of ids comes from
@@ -662,6 +734,22 @@ export function LeftSidebar({
       await api.deleteSession(sess.id);
     } catch {
       /* surface errors later */
+    }
+  }
+
+  /** Client-side-only delete (no daemon call) — mirrors the confirm-dialog
+   *  pattern used for worktree/session deletion above, but synchronous. If
+   *  the deleted workspace was the active one for its worktree, fall the
+   *  worktree back to classic layout so the UI doesn't point at a workspace
+   *  that no longer exists. */
+  function confirmDeleteWorkspace() {
+    if (!pendingDeleteWorkspace) return;
+    const ws = pendingDeleteWorkspace;
+    setPendingDeleteWorkspace(null);
+    deleteWorkspace(ws.id);
+    if (layoutByWorktree[ws.contextKey]?.activeWorkspaceId === ws.id) {
+      setActiveWorkspace(ws.contextKey, null);
+      setLayoutMode(ws.contextKey, "classic");
     }
   }
 
@@ -1025,6 +1113,143 @@ export function LeftSidebar({
                 })}
               </SortableContext>
             </DndContext>
+          </section>
+        ) : null}
+        {/* Saved workspace layouts (tiled/free-form pane arrangements) for the
+            currently active worktree only — this section is worktree-scoped,
+            unlike Pinned/Projects above. Hidden entirely when there's no
+            active worktree (e.g. dashboard route). Reorder + rename are both
+            purely client-side (no daemon route exists for WorkspaceDoc). */}
+        {!collapsed && activeWorktreeId ? (
+          <section className="workspaces-section" aria-label="Workspaces">
+            <div className="sidebar-projects-heading pinned-section__heading">
+              <span className="sidebar-projects-heading__gutter" aria-hidden />
+              <button
+                type="button"
+                className="tree-row__project-expand"
+                style={{ flex: 1 }}
+                aria-expanded={workspacesOpen}
+                aria-label={`${workspacesOpen ? "Collapse" : "Expand"} Workspaces`}
+                onClick={() => setWorkspacesOpen((v) => !v)}
+              >
+                <span className="tree-row__chevron" aria-hidden>
+                  {workspacesOpen ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+                </span>
+                <span className="sidebar-projects-heading__title">Workspaces</span>
+              </button>
+            </div>
+            {workspacesOpen ? (
+              orderedWorkspaces.length === 0 ? (
+                <div
+                  className="empty-state"
+                  style={{ padding: "var(--space-2) var(--space-3)", opacity: 0.6 }}
+                >
+                  No workspaces yet
+                </div>
+              ) : (
+                <DndContext
+                  sensors={dndSensors}
+                  collisionDetection={closestCenter}
+                  onDragStart={markDrag}
+                  onDragCancel={markDrag}
+                  onDragEnd={(e) =>
+                    handleWorkspaceReorder(
+                      workspacesScopeKey,
+                      orderedWorkspaces.map((d) => d.id),
+                      e,
+                    )
+                  }
+                >
+                  <SortableContext
+                    items={orderedWorkspaces.map((d) => d.id)}
+                    strategy={verticalListSortingStrategy}
+                  >
+                    {orderedWorkspaces.map((ws) => {
+                      const isActive = activeWorkspaceId === ws.id && activeLayoutMode === "workspace";
+                      return (
+                        <SortableRow key={ws.id} id={ws.id}>
+                          {({ setNodeRef, style, attributes, listeners }) => (
+                            <div
+                              ref={setNodeRef}
+                              style={style}
+                              className="wt-row-wrap"
+                              {...attributes}
+                              {...listeners}
+                            >
+                              <div
+                                className="tree-row tree-row--worktree"
+                                data-active={isActive}
+                                style={{ position: "relative" }}
+                                role="button"
+                                tabIndex={0}
+                                onKeyDown={(e) => {
+                                  if (e.key === "Enter" || e.key === " ") {
+                                    e.preventDefault();
+                                    setActiveWorkspace(activeWorktreeId, ws.id);
+                                    setLayoutMode(activeWorktreeId, "workspace");
+                                  }
+                                }}
+                                onClick={() => {
+                                  setActiveWorkspace(activeWorktreeId, ws.id);
+                                  setLayoutMode(activeWorktreeId, "workspace");
+                                }}
+                                onDoubleClick={(e) => {
+                                  e.preventDefault();
+                                  e.stopPropagation();
+                                  startInlineRename("workspace", ws.id, ws.name, "tree");
+                                }}
+                              >
+                                <div className="wt-row__expand">
+                                  {inlineRename?.kind === "workspace" &&
+                                  inlineRename.id === ws.id &&
+                                  inlineRename.site === "tree" ? (
+                                    <input
+                                      ref={inlineInputRef}
+                                      className="wt-row__label wt-row__rename-input"
+                                      aria-label="Rename"
+                                      value={inlineValue}
+                                      autoFocus
+                                      onClick={(e) => e.stopPropagation()}
+                                      onPointerDown={(e) => e.stopPropagation()}
+                                      onChange={(e) => setInlineValue(e.target.value)}
+                                      onBlur={commitInlineRename}
+                                      onKeyDown={(e) => {
+                                        e.stopPropagation();
+                                        if (e.key === "Enter") { e.preventDefault(); commitInlineRename(); }
+                                        if (e.key === "Escape") { e.preventDefault(); setInlineRename(null); }
+                                      }}
+                                      maxLength={60}
+                                    />
+                                  ) : (
+                                    <span className="wt-row__label">{ws.name}</span>
+                                  )}
+                                </div>
+                                <div className="wt-row__trail" style={{ position: "relative", zIndex: 2 }}>
+                                  <button
+                                    type="button"
+                                    className="icon-btn wt-menu-trigger tree-row__action"
+                                    aria-label={`Delete workspace ${ws.name}`}
+                                    title="Delete workspace"
+                                    onPointerDown={(e) => e.stopPropagation()}
+                                    onClick={(e) => {
+                                      e.preventDefault();
+                                      e.stopPropagation();
+                                      setPendingDeleteWorkspace(ws);
+                                    }}
+                                  >
+                                    <Trash2 size={14} />
+                                  </button>
+                                </div>
+                              </div>
+                            </div>
+                          )}
+                        </SortableRow>
+                      );
+                    })}
+                  </SortableContext>
+                </DndContext>
+              )
+            ) : null}
           </section>
         ) : null}
         <div className="sidebar-projects-heading">
@@ -1553,6 +1778,19 @@ export function LeftSidebar({
         confirmLabel="Dismiss"
         onConfirm={() => void confirmDismissSession()}
         onCancel={() => setPendingDismissSession(null)}
+      />
+
+      <ConfirmDialog
+        open={pendingDeleteWorkspace !== null}
+        title="Delete workspace?"
+        message={
+          pendingDeleteWorkspace
+            ? `Remove the saved workspace “${pendingDeleteWorkspace.name}”? This can't be undone.`
+            : ""
+        }
+        confirmLabel="Delete"
+        onConfirm={confirmDeleteWorkspace}
+        onCancel={() => setPendingDeleteWorkspace(null)}
       />
 
       {wtMenu

--- a/web-ui/src/components/layout/PaneHostLayer.tsx
+++ b/web-ui/src/components/layout/PaneHostLayer.tsx
@@ -1,0 +1,65 @@
+import { createPortal } from "react-dom";
+import type { ReactNode } from "react";
+import { usePaneOutletElement } from "./paneOutlets";
+
+/**
+ * agent:<sessionId> | terminal:<sessionId> | tools:<worktreeId>
+ *
+ * Identifies a permanently-mounted live pane. See PaneOutletRegistry
+ * (paneOutlets.tsx) for how a pane's rendered output finds its way to
+ * wherever it should currently be displayed.
+ */
+export type PaneKey = `agent:${string}` | `terminal:${string}` | `tools:${string}`;
+
+interface PaneHostLayerProps {
+  /** Every pane that should be mounted right now. */
+  paneKeys: PaneKey[];
+  /** Supplies the actual <AgentPaneSlot>/<TerminalPane>/<ToolPanel> element for a key. */
+  renderPane: (key: PaneKey) => ReactNode;
+}
+
+/**
+ * Keeps every live pane (agent chat, terminal, tools) PERMANENTLY mounted at
+ * a single, stable position in the React tree — this component's own render
+ * — for the pane's entire session lifetime. Per the repo's hard invariant
+ * (see AGENTS.md): unmounting a live pane sends `session:close` to the
+ * daemon and kills the underlying PTY/stream, so panes must never be
+ * removed from the tree just because a layout transition (classic <->
+ * workspace tiling, tab switches, etc.) changes where they're displayed.
+ *
+ * Each pane's rendered output is portaled (via `createPortal`, which moves
+ * only the DOM node, not the React tree position) into whichever
+ * `<PaneOutlet>` currently claims that pane's key. If no outlet currently
+ * claims it, the pane renders into an offscreen hidden holder instead of
+ * unmounting — so it keeps running, just invisible.
+ *
+ * `PaneHostLayer` itself is layout-mode-agnostic: it doesn't know or care
+ * whether classic or workspace-tiled layout is active. Callers (e.g.
+ * Layout.tsx) mount it unconditionally as a sibling and simply feed it
+ * whichever `paneKeys` should be alive right now.
+ */
+export function PaneHostLayer({ paneKeys, renderPane }: PaneHostLayerProps) {
+  return (
+    <>
+      {paneKeys.map((key) => (
+        <PaneHostSlot key={key} paneKey={key}>
+          {renderPane(key)}
+        </PaneHostSlot>
+      ))}
+    </>
+  );
+}
+
+function PaneHostSlot({ paneKey, children }: { paneKey: PaneKey; children: ReactNode }) {
+  const outlet = usePaneOutletElement(paneKey);
+
+  // This div's position as a child of PaneHostLayer never changes shape
+  // based on paneKey content — only whether `outlet` is null flips between
+  // the offscreen class and portaling. React never remounts `children`
+  // (the actual pane) because of this; only the portal target changes.
+  return (
+    <div className={outlet ? undefined : "pane-holder--offscreen"}>
+      {outlet ? createPortal(children, outlet) : children}
+    </div>
+  );
+}

--- a/web-ui/src/components/layout/StatusDot.tsx
+++ b/web-ui/src/components/layout/StatusDot.tsx
@@ -1,6 +1,8 @@
 import type { WorktreeRolledUpStatus } from "@/lib/worktreeStatus";
 
 const GLYPH: Record<WorktreeRolledUpStatus, string> = {
+  waiting_for_human: "!",
+  needs_review: "◆",
   working: "●",
   spawning: "◐",
   idle: "○",

--- a/web-ui/src/components/layout/ToolPanel.tsx
+++ b/web-ui/src/components/layout/ToolPanel.tsx
@@ -17,6 +17,22 @@ interface ToolPanelProps {
   scope?: FileScope;
   /** Worktree's base branch (e.g. "main"), for the VCS tab's upstream-commits group label. */
   baseBranch?: string;
+  /**
+   * True when this same ToolPanel instance is currently portaled into a
+   * workspace-canvas tile (WorkspaceCanvas.tsx) rather than the classic
+   * docked tool-panel region. The tile already has its own close (removes
+   * the tile) and fullscreen (click title bar) controls in that context —
+   * this panel's own fullscreen/close buttons would be redundant at best
+   * (two different "fullscreen" behaviors) and actively confusing at worst
+   * ("close" here means `toggleToolPanel()`, the classic dock's visibility
+   * flag — clicking it from inside a tile just blanks the tile's content
+   * with no obvious way back except the top bar's unrelated toggle).
+   * ToolPanel is a single shared instance/pane (per the never-unmount
+   * invariant) portaled to whichever outlet is currently live, so this has
+   * to be a prop threaded from the call site (Workspace.tsx), not something
+   * ToolPanel can determine on its own.
+   */
+  hidePanelControls?: boolean;
 }
 
 const TABS: { id: ToolTab; label: string }[] = [
@@ -32,7 +48,13 @@ const TABS: { id: ToolTab; label: string }[] = [
  * (web browser + emulators) and Artifacts are placeholders until their backends
  * land.
  */
-export function ToolPanel({ api, worktreeId, scope = "worktree", baseBranch }: ToolPanelProps) {
+export function ToolPanel({
+  api,
+  worktreeId,
+  scope = "worktree",
+  baseBranch,
+  hidePanelControls = false,
+}: ToolPanelProps) {
   const { toolPanelTab, setToolPanelTab, toggleToolPanel } = useLayout();
 
   return (
@@ -54,19 +76,23 @@ export function ToolPanel({ api, worktreeId, scope = "worktree", baseBranch }: T
           ))}
         </div>
         {/* Panel-level controls — fullscreen + close act on the whole tool
-            panel (whichever tool is shown), so they live on the selector bar. */}
-        <div className="tool-panel__tabs-actions">
-          <ToolFullscreenButton />
-          <button
-            type="button"
-            className="tab tab--icon tool-bar-btn"
-            aria-label="Close tool panel"
-            title="Close tool panel"
-            onClick={() => toggleToolPanel()}
-          >
-            <X size={13} />
-          </button>
-        </div>
+            panel (whichever tool is shown), so they live on the selector bar.
+            Hidden inside a workspace-canvas tile — see `hidePanelControls`'s
+            doc comment; the tile's own header already owns both concepts. */}
+        {!hidePanelControls ? (
+          <div className="tool-panel__tabs-actions">
+            <ToolFullscreenButton />
+            <button
+              type="button"
+              className="tab tab--icon tool-bar-btn"
+              aria-label="Close tool panel"
+              title="Close tool panel"
+              onClick={() => toggleToolPanel()}
+            >
+              <X size={13} />
+            </button>
+          </div>
+        ) : null}
       </div>
       <div className="tool-panel__body">
         {worktreeId == null ? (

--- a/web-ui/src/components/layout/TopBar.test.tsx
+++ b/web-ui/src/components/layout/TopBar.test.tsx
@@ -1,0 +1,155 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, beforeEach } from "vitest";
+import { TopBar } from "./TopBar";
+import { PaneOutletProvider } from "./paneOutlets";
+import { DEFAULT_WORKTREE_LAYOUT, useWorkspaceStore, type CanvasGeometry } from "@/hooks/useStore";
+import type { Project, Worktree } from "@/api/types";
+
+const W1 = "wt-1";
+
+const projects: Project[] = [
+  {
+    id: "proj-1",
+    name: "Proj A",
+    path: "/tmp/proj-a",
+    prefix: "proj-a",
+    isGit: true,
+    createdAt: new Date().toISOString(),
+    hidden: false,
+  },
+];
+const worktrees: Worktree[] = [
+  { id: W1, projectId: "proj-1", branch: "main", baseBranch: "main", createdAt: new Date().toISOString(), pinnedAt: null },
+];
+
+const emptyCanvas: CanvasGeometry = { mode: "free", tiles: [], tree: null, freeRects: {} };
+
+function renderTopBar() {
+  return render(
+    <MemoryRouter>
+      <PaneOutletProvider>
+        <TopBar
+          projects={projects}
+          worktrees={worktrees}
+          isMobile={false}
+          onToggleLeftSidebar={() => {}}
+          leftSidebarCollapsed={false}
+          mobileSidebarOpen={false}
+          onOpenQuickOpen={() => {}}
+        />
+      </PaneOutletProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("TopBar - canvas mode pane toggles", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useWorkspaceStore.persist.clearStorage?.();
+  });
+
+  function setCanvasMode(overrides: Partial<typeof DEFAULT_WORKTREE_LAYOUT> = {}) {
+    useWorkspaceStore.setState({
+      activeProjectId: "proj-1",
+      activeWorktreeId: W1,
+      activeDirectContextId: null,
+      layoutByWorktree: {
+        [W1]: { ...DEFAULT_WORKTREE_LAYOUT, layoutMode: "workspace", scratchCanvas: emptyCanvas, ...overrides },
+      },
+      workspaceDocs: {},
+    });
+  }
+
+  function setClassicMode() {
+    useWorkspaceStore.setState({
+      activeProjectId: "proj-1",
+      activeWorktreeId: W1,
+      activeDirectContextId: null,
+      layoutByWorktree: { [W1]: { ...DEFAULT_WORKTREE_LAYOUT, layoutMode: "classic" } },
+      workspaceDocs: {},
+    });
+  }
+
+  it("disables the split-orientation and terminal-dock buttons in canvas mode", () => {
+    setCanvasMode();
+    renderTopBar();
+    expect(screen.getByLabelText("Toggle agent/tools split orientation")).toBeDisabled();
+    expect(screen.getByLabelText("Toggle terminal dock")).toBeDisabled();
+  });
+
+  it("leaves the split-orientation and terminal-dock buttons enabled in classic mode", () => {
+    setClassicMode();
+    renderTopBar();
+    expect(screen.getByLabelText("Toggle agent/tools split orientation")).toBeEnabled();
+    expect(screen.getByLabelText("Toggle terminal dock")).toBeEnabled();
+  });
+
+  it("Tools button adds/removes a canvas tile (not content visibility) in canvas mode", async () => {
+    const user = userEvent.setup();
+    setCanvasMode();
+    renderTopBar();
+    const toolsBtn = screen.getByLabelText("Add Tools tile to canvas");
+    await user.click(toolsBtn);
+    expect(useWorkspaceStore.getState().layoutByWorktree[W1]!.scratchCanvas!.tiles).toHaveLength(1);
+    expect(screen.getByLabelText("Remove Tools tile from canvas")).toBeInTheDocument();
+    // The content-visibility flag this button used to control is untouched.
+    expect(useWorkspaceStore.getState().layoutByWorktree[W1]!.toolPanelVisible).toBe(
+      DEFAULT_WORKTREE_LAYOUT.toolPanelVisible,
+    );
+  });
+
+  it("Tools button toggles toolPanelVisible in classic mode (unchanged behavior)", async () => {
+    const user = userEvent.setup();
+    setClassicMode();
+    renderTopBar();
+    await user.click(screen.getByLabelText("Toggle tool panel"));
+    expect(useWorkspaceStore.getState().layoutByWorktree[W1]!.toolPanelVisible).toBe(
+      !DEFAULT_WORKTREE_LAYOUT.toolPanelVisible,
+    );
+  });
+
+  // The dedicated canvas toolbar itself lives in WorkspaceCanvas now (its own
+  // row above the canvas body), not in TopBar — TopBar only owns the chip
+  // that drives `canvasToolbarVisible`. See WorkspaceCanvas.test.tsx for the
+  // "does the row actually show/hide" half of this behavior.
+  it("keeps the canvas chip (mode toggle + chevron) mounted in both pane layout modes", () => {
+    setClassicMode();
+    const { unmount } = renderTopBar();
+    expect(screen.getByLabelText("Toggle workspace canvas layout")).toBeInTheDocument();
+    expect(screen.getByLabelText("Show canvas toolbar")).toBeInTheDocument();
+    unmount();
+
+    setCanvasMode();
+    renderTopBar();
+    expect(screen.getByLabelText("Toggle workspace canvas layout")).toBeInTheDocument();
+    expect(screen.getByLabelText("Hide canvas toolbar")).toBeInTheDocument();
+  });
+
+  it("disables the chevron outside canvas mode and enables it inside", () => {
+    setClassicMode();
+    const { unmount } = renderTopBar();
+    expect(screen.getByLabelText("Show canvas toolbar")).toBeDisabled();
+    unmount();
+
+    setCanvasMode();
+    renderTopBar();
+    expect(screen.getByLabelText("Hide canvas toolbar")).toBeEnabled();
+  });
+
+  it("chevron toggles canvasToolbarVisible (the flag WorkspaceCanvas's own toolbar row reads)", async () => {
+    const user = userEvent.setup();
+    setCanvasMode();
+    renderTopBar();
+    // Default visible (canvasToolbarVisible defaults true).
+    const hideBtn = screen.getByLabelText("Hide canvas toolbar");
+    expect(hideBtn).toHaveAttribute("aria-expanded", "true");
+    await user.click(hideBtn);
+    expect(useWorkspaceStore.getState().layoutByWorktree[W1]!.canvasToolbarVisible).toBe(false);
+    const showBtn = screen.getByLabelText("Show canvas toolbar");
+    expect(showBtn).toHaveAttribute("aria-expanded", "false");
+    await user.click(showBtn);
+    expect(useWorkspaceStore.getState().layoutByWorktree[W1]!.canvasToolbarVisible).toBe(true);
+  });
+});

--- a/web-ui/src/components/layout/TopBar.tsx
+++ b/web-ui/src/components/layout/TopBar.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import {
   Columns2,
+  LayoutGrid,
   PanelBottom,
   PanelLeft,
   PanelRight,
@@ -77,6 +78,12 @@ export function TopBar({
     toggleTerminalDock,
     toolSplitOrientation,
     toggleToolSplitOrientation,
+    // ⚠️ NAMING TRAP: this is the per-worktree pane-arrangement mode
+    // ("classic" | "workspace") from useLayout()'s WorktreeLayout slice —
+    // unrelated to this component's own `layoutMode` prop (page-routing:
+    // "workspace" | "dashboard" | "settings" | ...). Alias it.
+    layoutMode: paneLayoutMode,
+    setLayoutMode,
   } = useLayout();
   const clearWorkspaceSelection = useWorkspaceStore((s) => s.clearWorkspaceSelection);
 
@@ -237,19 +244,39 @@ export function TopBar({
               <Search size={18} />
             </button>
             <div className="top-bar__pane-toggles" role="toolbar" aria-label="Workspace panes">
-              <button
-                type="button"
-                className="top-bar__pane-btn"
-                aria-label="Toggle agent/tools split orientation"
-                title={
-                  toolSplitOrientation === "horizontal"
-                    ? "Stack agent and tools vertically"
-                    : "Place agent and tools side by side"
-                }
-                onClick={toggleToolSplitOrientation}
-              >
-                {toolSplitOrientation === "horizontal" ? <Columns2 size={17} /> : <Rows2 size={17} />}
-              </button>
+              {layoutMode === "workspace" && activeWorktreeId ? (
+                <button
+                  type="button"
+                  className={`top-bar__pane-btn ${paneLayoutMode === "workspace" ? "top-bar__pane-btn--on" : ""}`}
+                  aria-pressed={paneLayoutMode === "workspace"}
+                  aria-label="Toggle workspace canvas layout"
+                  title={
+                    paneLayoutMode === "workspace"
+                      ? "Switch to classic layout"
+                      : "Switch to workspace canvas (tiled/free-form panes)"
+                  }
+                  onClick={() =>
+                    setLayoutMode(activeWorktreeId, paneLayoutMode === "workspace" ? "classic" : "workspace")
+                  }
+                >
+                  <LayoutGrid size={17} />
+                </button>
+              ) : null}
+              {paneLayoutMode !== "workspace" ? (
+                <button
+                  type="button"
+                  className="top-bar__pane-btn"
+                  aria-label="Toggle agent/tools split orientation"
+                  title={
+                    toolSplitOrientation === "horizontal"
+                      ? "Stack agent and tools vertically"
+                      : "Place agent and tools side by side"
+                  }
+                  onClick={toggleToolSplitOrientation}
+                >
+                  {toolSplitOrientation === "horizontal" ? <Columns2 size={17} /> : <Rows2 size={17} />}
+                </button>
+              ) : null}
               <button
                 type="button"
                 className={`top-bar__pane-btn ${terminalDockVisible ? "top-bar__pane-btn--on" : ""}`}

--- a/web-ui/src/components/layout/TopBar.tsx
+++ b/web-ui/src/components/layout/TopBar.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import {
+  ChevronDown,
+  ChevronUp,
   Columns2,
   LayoutGrid,
-  PanelBottom,
   PanelLeft,
   PanelRight,
   PanelTop,
@@ -17,6 +18,7 @@ import type { Project, Session, Worktree } from "@/api/types";
 import { sessionLabel } from "@/lib/sessionLabel";
 import { ConnectionStatus } from "@/components/layout/ConnectionStatus";
 import { Logo } from "@/components/shared/Logo";
+import { ToolbarOutlet, WORKSPACE_CANVAS_TOOLBAR_KEY } from "@/components/layout/paneOutlets";
 
 function shortcutHints() {
   if (typeof navigator === "undefined") {
@@ -37,15 +39,20 @@ function shortcutHints() {
 interface TopBarProps {
   /** Dashboard keeps projects sidebar; omits quick open, terminal layout, and pane toggles.
    *  login = unauthenticated state — only shows brand + "not signed in" chip, no sidebar.
-   *  direct-session = terminal-only view for direct sessions (no worktree). */
-  layoutMode?: "workspace" | "dashboard" | "settings" | "login" | "direct-session";
+   *  direct-session = terminal-only view for direct sessions (no worktree).
+   *  workspace-view = detached saved-workspace view (agent-interaction-workspaces/
+   *  04-workspaces Phase 3c) — no owning worktree, so (like dashboard) it omits
+   *  quick open and the per-worktree pane toggles; the canvas is fully
+   *  self-contained instead. */
+  layoutMode?: "workspace" | "dashboard" | "settings" | "login" | "direct-session" | "workspace-view";
   projects: Project[];
   worktrees: Worktree[];
-  sessions: Session[];
   /** Direct session for breadcrumb (when layoutMode === "direct-session") */
   directSession?: Session;
   /** Project for direct session breadcrumb */
   directSessionProject?: Project;
+  /** Viewed WorkspaceDoc's name for breadcrumb (when layoutMode === "workspace-view") */
+  viewedWorkspaceName?: string;
   isMobile: boolean;
   onToggleLeftSidebar: () => void;
   leftSidebarCollapsed: boolean;
@@ -58,9 +65,9 @@ export function TopBar({
   layoutMode = "workspace",
   projects,
   worktrees,
-  sessions,
   directSession,
   directSessionProject,
+  viewedWorkspaceName,
   isMobile,
   onToggleLeftSidebar,
   leftSidebarCollapsed,
@@ -71,13 +78,16 @@ export function TopBar({
   const {
     activeProjectId,
     activeWorktreeId,
-    activeSessionId,
     toolPanelVisible,
     toggleToolPanel,
     terminalDockVisible,
     toggleTerminalDock,
     toolSplitOrientation,
     toggleToolSplitOrientation,
+    canvasToolbarVisible,
+    toggleCanvasToolbar,
+    hasWorktreeToolsTile,
+    toggleWorktreeToolsTile,
     // ⚠️ NAMING TRAP: this is the per-worktree pane-arrangement mode
     // ("classic" | "workspace") from useLayout()'s WorktreeLayout slice —
     // unrelated to this component's own `layoutMode` prop (page-routing:
@@ -89,7 +99,6 @@ export function TopBar({
 
   const project = projects.find((p) => p.id === activeProjectId);
   const wt = worktrees.find((w) => w.id === activeWorktreeId);
-  const session = sessions.find((s) => s.id === activeSessionId);
 
   const hints = shortcutHints();
 
@@ -102,10 +111,16 @@ export function TopBar({
     if (brandRef.current) setBrandWidth(brandRef.current.offsetWidth);
   }, []);
 
-  // padding-left(12) + toggle(36) + gap(8) + brand + gap(8) = offset already consumed before crumb.
+  // Target x = leftColumnPx + 12 (the sidebar's right edge, PLUS the same
+  // --space-3 left padding every content panel below uses — WorkspaceCanvas's
+  // own toolbar row and every other pane's chrome all start there, not flush
+  // against the bare sidebar edge — see workspace-canvas.css's
+  // `.workspace-canvas__toolbar` padding). This top bar's own left
+  // padding-left(12) + toggle(36) + gap(8) + brand + gap(8) is the offset
+  // already consumed before the crumb, so the two +12/-12 cancel out.
   const crumbMarginLeft =
     !isMobile && !leftSidebarCollapsed && leftColumnPx != null && brandWidth > 0
-      ? Math.max(8, leftColumnPx - 12 - 36 - 8 - brandWidth - 8)
+      ? Math.max(8, leftColumnPx - 36 - 8 - brandWidth - 8)
       : undefined;
 
   const crumbParts: { label: string; highlight?: boolean }[] = [];
@@ -116,10 +131,15 @@ export function TopBar({
   } else if (layoutMode === "direct-session") {
     if (directSessionProject) crumbParts.push({ label: directSessionProject.name });
     if (directSession) crumbParts.push({ label: sessionLabel(directSession), highlight: true });
+  } else if (layoutMode === "workspace-view") {
+    crumbParts.push({ label: viewedWorkspaceName ?? "Workspace", highlight: true });
   } else {
+    // Project > Worktree is enough — the active agent tab is already visible
+    // in the agent pane's own TabsStrip; naming it again in the breadcrumb
+    // was redundant, and crowded the crumb once the workspace-canvas toolbar
+    // moved into this same bar.
     if (project) crumbParts.push({ label: project.name });
     if (wt) crumbParts.push({ label: wt.branch, highlight: true });
-    if (session) crumbParts.push({ label: sessionLabel(session) });
   }
 
   const crumbTitle = crumbParts.map((p) => p.label).join(" › ") || undefined;
@@ -131,7 +151,9 @@ export function TopBar({
         ? "Settings"
         : layoutMode === "direct-session"
           ? [directSessionProject?.name, directSession ? sessionLabel(directSession) : null].filter(Boolean).join(" · ") || "Direct Session"
-          : [project?.name, wt ? `${wt.id} ${wt.branch}` : null].filter(Boolean).join(" · ") || undefined;
+          : layoutMode === "workspace-view"
+            ? (viewedWorkspaceName ?? "Workspace")
+            : [project?.name, wt ? `${wt.id} ${wt.branch}` : null].filter(Boolean).join(" · ") || undefined;
 
   const crumbNode = crumbParts.length === 0 ? (
     <span className="top-bar__crumb-seg">—</span>
@@ -150,27 +172,50 @@ export function TopBar({
   if (layoutMode === "login") {
     return (
       <header className="top-bar">
-        <span
-          className="top-bar__brand"
-          style={{
-            marginLeft: "var(--space-3)",
-            display: "inline-flex",
-            alignItems: "center",
-            gap: "var(--space-2)",
-          }}
-        >
-          <Logo />
-          Vibe Station
-        </span>
-        <div className="top-bar__end">
-          <span className="top-bar__login-status">● not signed in</span>
+        <div className="top-bar__row">
+          <span
+            className="top-bar__brand"
+            style={{
+              marginLeft: "var(--space-3)",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "var(--space-2)",
+            }}
+          >
+            <Logo />
+            Vibe Station
+          </span>
+          <div className="top-bar__end">
+            <span className="top-bar__login-status">● not signed in</span>
+          </div>
         </div>
       </header>
     );
   }
 
+  // The workspace-canvas toolbar (mode toggle / doc name / save / add tile)
+  // is portaled up into THIS bar in exactly ONE case: the detached
+  // /workspaces/:id page, where there's plenty of room top-right (no
+  // per-worktree pane-toggle icons compete for space there).
+  //
+  // The classic per-worktree canvas mode deliberately does NOT portal: that
+  // toolbar renders as WorkspaceCanvas's own dedicated full-height row
+  // directly above the canvas body, disclosed/hidden by the chevron in the
+  // canvas chip below (`toggleCanvasToolbar` → `canvasToolbarVisible`, which
+  // WorkspaceCanvas reads as a prop). Squeezing it into this bar's
+  // single-line height budget made it read as "just more top bar" instead of
+  // a canvas toolbar.
+  const isWorkspaceViewToolbar = layoutMode === "workspace-view";
+  // The canvas chip (mode toggle + disclosure chevron) exists only for a
+  // worktree in the classic per-worktree flow; the chevron inside it is
+  // disabled — not unmounted — when that worktree isn't currently in canvas
+  // mode, so the pair never appears/disappears independently of each other.
+  const canvasChipWorktreeId = layoutMode === "workspace" ? activeWorktreeId : null;
+  const inCanvasMode = paneLayoutMode === "workspace";
+
   return (
     <header className="top-bar">
+      <div className="top-bar__row">
       <button
         type="button"
         className="icon-btn"
@@ -209,6 +254,10 @@ export function TopBar({
             <span className="top-bar__crumb-seg top-bar__mobile-line">Dashboard</span>
           ) : layoutMode === "settings" ? (
             <span className="top-bar__crumb-seg top-bar__mobile-line">Settings</span>
+          ) : layoutMode === "workspace-view" ? (
+            <span className="top-bar__crumb-seg top-bar__crumb-seg--highlight top-bar__mobile-line">
+              {viewedWorkspaceName ?? "Workspace"}
+            </span>
           ) : (
             <>
               <span className="top-bar__crumb-seg top-bar__mobile-line">{project?.name ?? "—"}</span>
@@ -231,6 +280,13 @@ export function TopBar({
         </div>
       )}
       <div className="top-bar__end">
+        {isWorkspaceViewToolbar ? (
+          // Detached workspace view: plenty of room top-right, same row as
+          // the crumb — no per-worktree pane-toggle icons compete for space
+          // here, so this doesn't need the compacted under-crumb treatment
+          // the classic per-worktree canvas mode gets.
+          <ToolbarOutlet paneKey={WORKSPACE_CANVAS_TOOLBAR_KEY} />
+        ) : null}
         <ConnectionStatus />
         {layoutMode === "workspace" || layoutMode === "direct-session" ? (
           <>
@@ -244,56 +300,118 @@ export function TopBar({
               <Search size={18} />
             </button>
             <div className="top-bar__pane-toggles" role="toolbar" aria-label="Workspace panes">
-              {layoutMode === "workspace" && activeWorktreeId ? (
-                <button
-                  type="button"
-                  className={`top-bar__pane-btn ${paneLayoutMode === "workspace" ? "top-bar__pane-btn--on" : ""}`}
-                  aria-pressed={paneLayoutMode === "workspace"}
-                  aria-label="Toggle workspace canvas layout"
-                  title={
-                    paneLayoutMode === "workspace"
-                      ? "Switch to classic layout"
-                      : "Switch to workspace canvas (tiled/free-form panes)"
-                  }
-                  onClick={() =>
-                    setLayoutMode(activeWorktreeId, paneLayoutMode === "workspace" ? "classic" : "workspace")
-                  }
-                >
-                  <LayoutGrid size={17} />
-                </button>
+              {canvasChipWorktreeId ? (
+                // One visually-merged pill holding TWO independent buttons:
+                // enter/leave canvas mode, and (thin, narrower) disclose the
+                // canvas's own toolbar. They read as a unit because they act
+                // on the same thing, but each stays a real, separately
+                // focusable/labelled <button> — the chevron is never a
+                // decoration hanging off the grid button.
+                <div className="top-bar__canvas-chip">
+                  <button
+                    type="button"
+                    className={`top-bar__pane-btn ${inCanvasMode ? "top-bar__pane-btn--on" : ""}`}
+                    aria-pressed={inCanvasMode}
+                    aria-label="Toggle workspace canvas layout"
+                    title={
+                      inCanvasMode
+                        ? "Switch to classic layout"
+                        : "Switch to workspace canvas (tiled/free-form panes)"
+                    }
+                    onClick={() =>
+                      setLayoutMode(canvasChipWorktreeId, inCanvasMode ? "classic" : "workspace")
+                    }
+                  >
+                    <LayoutGrid size={17} />
+                  </button>
+                  <button
+                    type="button"
+                    className="top-bar__pane-btn top-bar__canvas-chip-chevron"
+                    aria-expanded={inCanvasMode ? canvasToolbarVisible : undefined}
+                    // Same visible-but-disabled treatment as the split-
+                    // orientation / terminal-dock buttons below: outside
+                    // canvas mode there's no dedicated bar to disclose, but
+                    // unmounting it would make the chip's second half blink
+                    // in and out as the mode toggles.
+                    disabled={!inCanvasMode}
+                    aria-label={
+                      !inCanvasMode
+                        ? "Show canvas toolbar"
+                        : canvasToolbarVisible
+                          ? "Hide canvas toolbar"
+                          : "Show canvas toolbar"
+                    }
+                    title={
+                      !inCanvasMode
+                        ? "Only available in canvas mode — switch to the workspace canvas first"
+                        : canvasToolbarVisible
+                          ? "Hide canvas toolbar (mode, save, add tile)"
+                          : "Show canvas toolbar (mode, save, add tile)"
+                    }
+                    onClick={toggleCanvasToolbar}
+                  >
+                    {inCanvasMode && canvasToolbarVisible ? (
+                      <ChevronUp size={15} />
+                    ) : (
+                      <ChevronDown size={15} />
+                    )}
+                  </button>
+                </div>
               ) : null}
-              {paneLayoutMode !== "workspace" ? (
-                <button
-                  type="button"
-                  className="top-bar__pane-btn"
-                  aria-label="Toggle agent/tools split orientation"
-                  title={
-                    toolSplitOrientation === "horizontal"
+              <button
+                type="button"
+                className="top-bar__pane-btn"
+                aria-label="Toggle agent/tools split orientation"
+                disabled={paneLayoutMode === "workspace"}
+                title={
+                  paneLayoutMode === "workspace"
+                    ? "Not applicable in canvas mode — each pane is its own tile"
+                    : toolSplitOrientation === "horizontal"
                       ? "Stack agent and tools vertically"
                       : "Place agent and tools side by side"
-                  }
-                  onClick={toggleToolSplitOrientation}
-                >
-                  {toolSplitOrientation === "horizontal" ? <Columns2 size={17} /> : <Rows2 size={17} />}
-                </button>
-              ) : null}
+                }
+                onClick={toggleToolSplitOrientation}
+              >
+                {toolSplitOrientation === "horizontal" ? <Columns2 size={17} /> : <Rows2 size={17} />}
+              </button>
               <button
                 type="button"
                 className={`top-bar__pane-btn ${terminalDockVisible ? "top-bar__pane-btn--on" : ""}`}
                 aria-pressed={terminalDockVisible}
                 aria-label="Toggle terminal dock"
-                title={`Toggle terminal dock (${hints.terminal})`}
+                disabled={paneLayoutMode === "workspace"}
+                title={
+                  paneLayoutMode === "workspace"
+                    ? "Not applicable in canvas mode — every terminal is its own tile (use Add tile)"
+                    : `Toggle terminal dock (${hints.terminal})`
+                }
                 onClick={toggleTerminalDock}
               >
                 <SquareTerminal size={17} />
               </button>
               <button
                 type="button"
-                className={`top-bar__pane-btn ${toolPanelVisible ? "top-bar__pane-btn--on" : ""}`}
-                aria-pressed={toolPanelVisible}
-                aria-label="Toggle tool panel"
-                title="Toggle tool panel"
-                onClick={toggleToolPanel}
+                className={`top-bar__pane-btn ${
+                  (paneLayoutMode === "workspace" ? hasWorktreeToolsTile : toolPanelVisible)
+                    ? "top-bar__pane-btn--on"
+                    : ""
+                }`}
+                aria-pressed={paneLayoutMode === "workspace" ? hasWorktreeToolsTile : toolPanelVisible}
+                aria-label={
+                  paneLayoutMode === "workspace"
+                    ? hasWorktreeToolsTile
+                      ? "Remove Tools tile from canvas"
+                      : "Add Tools tile to canvas"
+                    : "Toggle tool panel"
+                }
+                title={
+                  paneLayoutMode === "workspace"
+                    ? hasWorktreeToolsTile
+                      ? "Remove Tools tile from canvas"
+                      : "Add Tools tile to canvas"
+                    : "Toggle tool panel"
+                }
+                onClick={paneLayoutMode === "workspace" ? toggleWorktreeToolsTile : toggleToolPanel}
               >
                 {/* Vertical split docks the tool panel to the top, so mirror
                     that with a top-panel icon instead of the right-panel one. */}
@@ -302,6 +420,7 @@ export function TopBar({
             </div>
           </>
         ) : null}
+      </div>
       </div>
     </header>
   );

--- a/web-ui/src/components/layout/WorkspaceCanvas.test.tsx
+++ b/web-ui/src/components/layout/WorkspaceCanvas.test.tsx
@@ -1,0 +1,279 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { act } from "@testing-library/react";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { describe, it, expect, beforeEach } from "vitest";
+import { WorkspaceCanvas } from "./WorkspaceCanvas";
+import { PaneOutletProvider, ToolbarOutlet, WORKSPACE_CANVAS_TOOLBAR_KEY } from "./paneOutlets";
+import { DEFAULT_WORKTREE_LAYOUT, useWorkspaceStore, type CanvasGeometry } from "@/hooks/useStore";
+
+const W1 = "wt-1";
+
+// WorkspaceCanvas calls useNavigate() (saveAsWorkspace navigates to the new
+// doc's /workspaces/:id route) — needs a Router ancestor even when a test
+// never triggers a save.
+function renderCanvas(canvasToolbarVisible = true) {
+  return render(
+    <MemoryRouter>
+      <PaneOutletProvider>
+        <WorkspaceCanvas
+          worktreeId={W1}
+          agentSessions={[]}
+          terminalSessions={[]}
+          hasTools
+          toolPanelVisible
+          terminalDockVisible
+          allSessions={[]}
+          worktrees={[]}
+          projects={[]}
+          canvasToolbarVisible={canvasToolbarVisible}
+        />
+      </PaneOutletProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("WorkspaceCanvas - canvas toolbar disclosure", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useWorkspaceStore.persist.clearStorage?.();
+    useWorkspaceStore.setState({
+      layoutByWorktree: {},
+      workspaceDocs: {},
+    });
+  });
+
+  it("does not render its toolbar row when canvasToolbarVisible is false", () => {
+    renderCanvas(false);
+    expect(screen.queryByRole("toolbar", { name: "Workspace canvas" })).not.toBeInTheDocument();
+  });
+
+  it("renders its toolbar as a dedicated row above the canvas body when canvasToolbarVisible is true", () => {
+    const { container } = renderCanvas(true);
+    const toolbar = screen.getByRole("toolbar", { name: "Workspace canvas" });
+    expect(toolbar).toBeInTheDocument();
+    // Its OWN row — a direct child of `.workspace-canvas`, immediately before
+    // the body — not portaled up into the top bar (that placement is the
+    // detached /workspaces/:id view's alone).
+    expect(toolbar.parentElement).toHaveClass("workspace-canvas");
+    expect(toolbar.nextElementSibling).toHaveClass("workspace-canvas__body");
+    expect(toolbar).not.toHaveClass("workspace-canvas__toolbar--portaled");
+    expect(container.querySelector(".workspace-canvas__toolbar")).toBe(toolbar);
+  });
+
+  it("stays inline even when a toolbar outlet is registered (only the detached view portals)", () => {
+    render(
+      <MemoryRouter>
+        <PaneOutletProvider>
+          <ToolbarOutlet paneKey={WORKSPACE_CANVAS_TOOLBAR_KEY} />
+          <WorkspaceCanvas
+            worktreeId={W1}
+            agentSessions={[]}
+            terminalSessions={[]}
+            hasTools
+            toolPanelVisible
+            terminalDockVisible
+            allSessions={[]}
+            worktrees={[]}
+            projects={[]}
+            canvasToolbarVisible
+          />
+        </PaneOutletProvider>
+      </MemoryRouter>,
+    );
+    const toolbar = screen.getByRole("toolbar", { name: "Workspace canvas" });
+    expect(toolbar.parentElement).toHaveClass("workspace-canvas");
+  });
+});
+
+describe("WorkspaceCanvas - Add tile picker cross-worktree note", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useWorkspaceStore.persist.clearStorage?.();
+    useWorkspaceStore.setState({ layoutByWorktree: {}, workspaceDocs: {} });
+  });
+
+  it("shows the cross-worktree note on an unsaved (scratch) canvas", async () => {
+    const user = userEvent.setup();
+    renderCanvas();
+    await user.click(screen.getByText("Add tile"));
+    expect(
+      screen.getByText("To add panes from other worktrees, save this canvas as a workspace."),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the cross-worktree note on the detached (saved) workspace-view — the only place isSaved is ever true", async () => {
+    const user = userEvent.setup();
+    const docId = "doc-1";
+    const canvas: CanvasGeometry = { mode: "free", tiles: [], tree: null, freeRects: {} };
+    useWorkspaceStore.setState({
+      workspaceDocs: { [docId]: { id: docId, name: "Doc", contextKey: W1, ...canvas } },
+    });
+    render(
+      <MemoryRouter>
+        <PaneOutletProvider>
+          <WorkspaceCanvas
+            worktreeId={W1}
+            agentSessions={[]}
+            terminalSessions={[]}
+            hasTools
+            toolPanelVisible
+            terminalDockVisible
+            allSessions={[]}
+            worktrees={[]}
+            projects={[]}
+            canvasToolbarVisible
+            detachedWorkspaceId={docId}
+          />
+        </PaneOutletProvider>
+      </MemoryRouter>,
+    );
+    await user.click(screen.getByText("Add tile"));
+    expect(
+      screen.queryByText("To add panes from other worktrees, save this canvas as a workspace."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("a worktree's classic canvas never binds to a saved doc even if a stale activeWorkspaceId is present (regression)", async () => {
+    const user = userEvent.setup();
+    const docId = "doc-1";
+    const canvas: CanvasGeometry = { mode: "free", tiles: [], tree: null, freeRects: {} };
+    useWorkspaceStore.setState({
+      layoutByWorktree: {
+        [W1]: { activeWorkspaceId: docId, scratchCanvas: { mode: "free", tiles: [], tree: null, freeRects: {} } } as never,
+      },
+      workspaceDocs: { [docId]: { id: docId, name: "Doc", contextKey: W1, ...canvas } },
+    });
+    renderCanvas();
+    expect(screen.getByText("Unsaved canvas")).toBeInTheDocument();
+    expect(screen.queryByText("Doc")).not.toBeInTheDocument();
+    await user.click(screen.getByText("Add tile"));
+    expect(
+      screen.getByText("To add panes from other worktrees, save this canvas as a workspace."),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("WorkspaceCanvas - saveAsWorkspace detachment", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useWorkspaceStore.persist.clearStorage?.();
+    useWorkspaceStore.setState({
+      layoutByWorktree: {
+        [W1]: {
+          ...DEFAULT_WORKTREE_LAYOUT,
+          scratchCanvas: { mode: "free", tiles: [{ id: "t1", kind: "tools" }], tree: null, freeRects: {} },
+        },
+      },
+      workspaceDocs: {},
+    });
+  });
+
+  it("creates a detached doc, clears the scratch canvas, and navigates to /workspaces/:id — without setting activeWorkspaceId", async () => {
+    const user = userEvent.setup();
+    function LocationProbe() {
+      const location = useLocation();
+      return <div data-testid="location">{location.pathname}</div>;
+    }
+    render(
+      <MemoryRouter initialEntries={[`/worktree/${W1}`]}>
+        <LocationProbe />
+        <PaneOutletProvider>
+          <WorkspaceCanvas
+            worktreeId={W1}
+            agentSessions={[]}
+            terminalSessions={[]}
+            hasTools={false}
+            toolPanelVisible
+            terminalDockVisible
+            allSessions={[]}
+            worktrees={[]}
+            projects={[]}
+            canvasToolbarVisible
+          />
+        </PaneOutletProvider>
+      </MemoryRouter>,
+    );
+    await user.click(screen.getByText("Save as workspace"));
+    await user.type(screen.getByLabelText("Workspace name"), "My Workspace");
+    await user.click(screen.getByLabelText("Confirm save workspace"));
+
+    const state = useWorkspaceStore.getState();
+    const docs = Object.values(state.workspaceDocs);
+    expect(docs).toHaveLength(1);
+    expect(docs[0]!.name).toBe("My Workspace");
+    expect(docs[0]!.tiles).toHaveLength(1);
+    // Detached: the worktree never remembers it (no setActiveWorkspace call).
+    expect(state.layoutByWorktree[W1]!.activeWorkspaceId).toBeNull();
+    // Its own scratch canvas was cleared and reset — NOT bound to the saved
+    // doc's tiles (the pre-existing seed effect immediately reconstructs an
+    // empty canvas from whatever's still open in this worktree, `hasTools`
+    // false + no sessions here means genuinely empty — see its own doc
+    // comment in WorkspaceCanvas.tsx).
+    expect(state.layoutByWorktree[W1]!.scratchCanvas?.tiles).toHaveLength(0);
+    // Navigated to the new doc's own route.
+    expect(screen.getByTestId("location")).toHaveTextContent(`/workspaces/${docs[0]!.id}`);
+  });
+});
+
+describe("WorkspaceCanvas - fullscreen reconciliation", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useWorkspaceStore.persist.clearStorage?.();
+  });
+
+  it("un-hides the remaining tile when the fullscreen tile is removed by an external store mutation", () => {
+    const canvas: CanvasGeometry = {
+      mode: "free",
+      tiles: [
+        { id: "tile-a", kind: "tools" },
+        { id: "tile-b", kind: "agent", sessionId: "sess-b" },
+      ],
+      tree: null,
+      freeRects: {
+        "tile-a": { x: 0, y: 0, w: 40, h: 40 },
+        "tile-b": { x: 50, y: 0, w: 40, h: 40 },
+      },
+    };
+    useWorkspaceStore.setState({
+      layoutByWorktree: { [W1]: { scratchCanvas: canvas } as never },
+      workspaceDocs: {},
+    });
+    renderCanvas();
+
+    // Click (not drag) tile-a's title bar to enter fullscreen — every OTHER
+    // tile (tile-b) hides via `display:none` while a tile is fullscreen.
+    const headers = screen.getAllByTitle("Click to fullscreen · drag to move");
+    act(() => {
+      headers[0]!.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, clientX: 0, clientY: 0 }));
+      window.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+    });
+    expect(screen.getByTitle("Click to exit fullscreen")).toBeInTheDocument();
+    const tileB = screen.getByText("agent").closest(".workspace-canvas__tile") as HTMLElement;
+    expect(tileB.style.display).toBe("none");
+
+    // Externally remove the (fullscreen) tile-a via the store, as
+    // toggleWorktreeToolsTile does from TopBar — WorkspaceCanvas has no
+    // direct hook into this removal, only the reconciliation effect.
+    act(() => {
+      useWorkspaceStore.setState({
+        layoutByWorktree: {
+          [W1]: {
+            scratchCanvas: {
+              mode: "free",
+              tiles: [{ id: "tile-b", kind: "agent", sessionId: "sess-b" }],
+              tree: null,
+              freeRects: { "tile-b": { x: 50, y: 0, w: 40, h: 40 } },
+            },
+          } as never,
+        },
+      });
+    });
+
+    // tile-b is no longer hidden — the dangling fullscreenTileId ("tile-a")
+    // was reconciled away instead of permanently hiding every other tile.
+    expect(screen.queryByTitle("Click to exit fullscreen")).not.toBeInTheDocument();
+    const tileBAfter = screen.getByText("agent").closest(".workspace-canvas__tile") as HTMLElement;
+    expect(tileBAfter.style.display).not.toBe("none");
+  });
+});

--- a/web-ui/src/components/layout/WorkspaceCanvas.tsx
+++ b/web-ui/src/components/layout/WorkspaceCanvas.tsx
@@ -1,9 +1,12 @@
 import "@/styles/workspace-canvas.css";
 import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
-import { Check, Plus, Save, X } from "lucide-react";
+import { createPortal } from "react-dom";
+import { useNavigate } from "react-router-dom";
+import { Bot, Check, FolderOpen, GitBranch, Minimize2, PanelRight, Plus, Save, SquareTerminal, X } from "lucide-react";
 import type { Project, Session, Worktree } from "@/api/types";
 import {
   buildBalancedTree,
+  findLeafId,
   insertPane,
   removePane,
   resizeSplit,
@@ -14,18 +17,28 @@ import {
 } from "@/lib/tiling";
 import {
   useWorkspaceStore,
+  insertTileIntoCanvas,
+  removeTileFromCanvas,
   type CanvasGeometry,
   type FreeRect,
   type TileKind,
   type TileSpec,
 } from "@/hooks/useStore";
-import { PaneOutlet } from "@/components/layout/paneOutlets";
+import { PaneOutlet, usePaneOutletElement, WORKSPACE_CANVAS_TOOLBAR_KEY } from "@/components/layout/paneOutlets";
 import { StatusDot } from "@/components/layout/StatusDot";
 import { sessionStatus } from "@/lib/worktreeStatus";
 import { sessionLabel } from "@/lib/sessionLabel";
 import { randomId } from "@/lib/uuid";
 
 interface WorkspaceCanvasProps {
+  /**
+   * Owning worktree for the classic per-worktree flow (scratch canvas +
+   * `layoutByWorktree[worktreeId].activeWorkspaceId`). In detached-workspace-
+   * view mode (`detachedWorkspaceId` set — agent-interaction-workspaces/
+   * 04-workspaces Phase 3c) this is used only as a provenance fallback for
+   * anything that needs *some* worktreeId (e.g. a tile missing its own
+   * `tile.worktreeId`) — pass the doc's own `contextKey` in that case.
+   */
   worktreeId: string;
   /** This worktree's agent-type sessions. */
   agentSessions: Session[];
@@ -43,20 +56,29 @@ interface WorkspaceCanvasProps {
   worktrees: Worktree[];
   /** Every project app-wide (picker grouping). */
   projects: Project[];
+  /**
+   * Detached-workspace-view mode: when set, the canvas binds directly to
+   * `workspaceDocs[detachedWorkspaceId]` — the ONLY place a saved doc is ever
+   * bound to this component. The classic per-worktree placement (this prop
+   * unset) never binds to a saved doc at all, always the worktree's own
+   * `scratchCanvas` — see the module doc comment. The caller (Workspace.tsx)
+   * has already confirmed the doc exists before rendering with this prop set.
+   */
+  detachedWorkspaceId?: string;
+  /**
+   * Whether this canvas's own dedicated toolbar row (mode toggle / doc name
+   * / save / add tile), rendered directly above the canvas body, should show
+   * right now. Driven by `layoutByWorktree[worktreeId].canvasToolbarVisible`
+   * — the flag the disclosure chevron in TopBar's canvas chip toggles
+   * (`useLayout().canvasToolbarVisible`). The detached `/workspaces/:id`
+   * view passes a hardcoded `true`: it has no disclosure control, and its
+   * toolbar lives portaled top-right in TopBar rather than in this row.
+   */
+  canvasToolbarVisible: boolean;
 }
 
 function clamp(v: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, v));
-}
-
-function findLeafId(root: LayoutNode | null, tileId: string): string | null {
-  if (!root) return null;
-  if (root.type === "leaf") return root.tileId === tileId ? root.id : null;
-  for (const child of root.children) {
-    const found = findLeafId(child, tileId);
-    if (found) return found;
-  }
-  return null;
 }
 
 function paneKeyForTile(tile: TileSpec, worktreeId: string): string {
@@ -80,13 +102,16 @@ interface DropTarget {
 /**
  * Tiled/free-form canvas for workspace-mode.
  *
- * Backing store is EITHER the worktree's transient `scratchCanvas` (the top
- * bar's classic↔workspace toggle — unsaved, never in the sidebar, this
- * worktree's own panes only) OR a saved `WorkspaceDoc` once one is active
- * (picked in the sidebar, or just created via "Save as workspace"). Both
- * expose the same `CanvasGeometry`, so everything below — rendering, drag,
+ * Backing store: for the classic per-worktree placement this is ALWAYS the
+ * worktree's transient `scratchCanvas` — a worktree is either in canvas mode
+ * or not, full stop, it never "remembers" a saved workspace. Saving promotes
+ * the scratch canvas into a real, named, detached `WorkspaceDoc` and
+ * navigates away to its own `/workspaces/:id` route (`saveAsWorkspace`
+ * below) — that route is the ONLY place a saved doc is ever viewed/edited,
+ * via `detachedWorkspaceId`/`isDetachedView`. Both placements expose the
+ * same `CanvasGeometry` shape, so everything below — rendering, drag,
  * resize, tiling — runs against `canvas`/`patchCanvas()` regardless of which
- * is live. Only a SAVED workspace may host cross-worktree tiles.
+ * is live. Only a SAVED (detached) workspace may host cross-worktree tiles.
  *
  * Per tile it renders a chrome wrapper hosting a <PaneOutlet> that
  * PaneHostLayer (mounted once, unconditionally, by the caller) portals the
@@ -102,17 +127,22 @@ export function WorkspaceCanvas({
   allSessions,
   worktrees,
   projects,
+  detachedWorkspaceId,
+  canvasToolbarVisible,
 }: WorkspaceCanvasProps) {
   const layoutByWorktree = useWorkspaceStore((s) => s.layoutByWorktree);
   const workspaceDocs = useWorkspaceStore((s) => s.workspaceDocs);
-  const setActiveWorkspace = useWorkspaceStore((s) => s.setActiveWorkspace);
   const showAgentStatusBorders = useWorkspaceStore((s) => s.showAgentStatusBorders);
+  const navigate = useNavigate();
 
-  const activeWorkspaceId = layoutByWorktree[worktreeId]?.activeWorkspaceId ?? null;
-  const savedDoc = activeWorkspaceId ? workspaceDocs[activeWorkspaceId] : undefined;
+  const isDetachedView = !!detachedWorkspaceId;
+  // Classic per-worktree placement NEVER reads a saved doc — see the module
+  // doc comment above. `savedDoc`/`isSaved` are only ever true for the
+  // detached `/workspaces/:id` view.
+  const savedDoc = isDetachedView ? workspaceDocs[detachedWorkspaceId as string] : undefined;
   const savedDocId = savedDoc?.id ?? null;
-  const scratch = layoutByWorktree[worktreeId]?.scratchCanvas ?? null;
-  /** The live canvas: the saved doc when one is active, else the transient scratch. */
+  const scratch = isDetachedView ? null : (layoutByWorktree[worktreeId]?.scratchCanvas ?? null);
+  /** The live canvas: the saved doc for the detached view, else the transient scratch. */
   const canvas: CanvasGeometry | null = savedDoc ?? scratch;
   const isSaved = !!savedDoc;
 
@@ -129,6 +159,21 @@ export function WorkspaceCanvas({
   // mouseup reads the hover through a ref — the window listener closes over the
   // render that started the drag, so React state alone would be stale there.
   const dropTargetRef = useRef<DropTarget | null>(null);
+  /** Tile currently expanded to fill the viewport — toggled by clicking (not
+   *  dragging) its title bar. Null = no tile is fullscreen. */
+  const [fullscreenTileId, setFullscreenTileId] = useState<string | null>(null);
+  function toggleFullscreen(tileId: string) {
+    setFullscreenTileId((cur) => (cur === tileId ? null : tileId));
+  }
+  // Escape backs out of fullscreen — standard convention, cheap to support.
+  useEffect(() => {
+    if (!fullscreenTileId) return;
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") setFullscreenTileId(null);
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [fullscreenTileId]);
 
   /** Read the CURRENT canvas straight from the store (drag handlers, post-mount). */
   function readCanvas(): CanvasGeometry | null {
@@ -150,6 +195,10 @@ export function WorkspaceCanvas({
   // nothing appears in the sidebar's Workspaces list until the user asks for it.
   const seededForRef = useRef<string | null>(null);
   useEffect(() => {
+    // Detached view has no scratch canvas to seed — a missing doc here means
+    // "not found," which the caller (Workspace.tsx) already redirects away
+    // from before this ever renders; nothing to do on this component's side.
+    if (isDetachedView) return;
     if (canvas) {
       seededForRef.current = null;
       return;
@@ -181,6 +230,31 @@ export function WorkspaceCanvas({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [worktreeId, canvas]);
 
+  // MUST run before the early return below (rules-of-hooks) — every hook in
+  // this component has to execute on every render regardless of `canvas`.
+  //
+  // Only the DETACHED /workspaces/:id view portals its toolbar up into
+  // TopBar (top-right, where that page has room). The classic per-worktree
+  // canvas keeps its toolbar as its OWN dedicated row above the body — see
+  // the render below — so `toolbarPortalEl` stays null there even when some
+  // other route has an outlet registered.
+  const toolbarOutletEl = usePaneOutletElement(WORKSPACE_CANVAS_TOOLBAR_KEY);
+  const toolbarPortalEl = isDetachedView ? toolbarOutletEl : null;
+
+  // Reconcile a dangling `fullscreenTileId` against whatever tile set is
+  // CURRENTLY live — every non-fullscreen tile hides via `display:none`
+  // (renderTileChrome below), so a fullscreen id pointing at a since-removed
+  // tile would hide the entire canvas permanently. Covers `removeTile`
+  // below AND any removal that happens outside this component entirely
+  // (e.g. the TopBar Tools-tile toggle's store action, which has no way to
+  // reach this component-local state directly).
+  useEffect(() => {
+    if (!canvas) return;
+    if (fullscreenTileId && !canvas.tiles.some((t) => t.id === fullscreenTileId)) {
+      setFullscreenTileId(null);
+    }
+  }, [canvas, fullscreenTileId]);
+
   if (!canvas) {
     return <div className="workspace-canvas workspace-canvas--loading" />;
   }
@@ -192,6 +266,7 @@ export function WorkspaceCanvas({
   for (const s of agentSessions) sessionById.set(s.id, s);
   for (const s of terminalSessions) sessionById.set(s.id, s);
   const worktreeById = new Map(worktrees.map((w) => [w.id, w]));
+  const projectById = new Map(projects.map((p) => [p.id, p]));
 
   const placedSessionIds = new Set(
     cv.tiles.filter((t) => t.sessionId).map((t) => t.sessionId as string),
@@ -274,51 +349,30 @@ export function WorkspaceCanvas({
   }
 
   function addTile(kind: TileKind, sessionId?: string, tileWorktreeId?: string) {
-    const id = randomId();
-    const tile: TileSpec = { id, kind, sessionId };
-    // Only stamp the owning worktree when it isn't the one we're viewing —
-    // keeps same-worktree tiles byte-identical to the pre-cross-context shape.
-    if (tileWorktreeId && tileWorktreeId !== worktreeId) tile.worktreeId = tileWorktreeId;
-    const nextTiles = [...cv.tiles, tile];
-    if (cv.mode === "tiled") {
-      let nextTree: LayoutNode | null;
-      if (!cv.tree || cv.tiles.length === 0) {
-        nextTree = insertPane(null, null, "right", id);
-      } else {
-        const lastTileId = cv.tiles[cv.tiles.length - 1]!.id;
-        const targetLeafId = findLeafId(cv.tree, lastTileId);
-        nextTree = insertPane(cv.tree, targetLeafId, "right", id);
-      }
-      patchCanvas({ tiles: nextTiles, tree: nextTree });
-    } else {
-      const cascade = cv.tiles.length;
-      const rect: FreeRect = {
-        x: 6 + (cascade % 5) * 5,
-        y: 6 + (cascade % 5) * 5,
-        w: 42,
-        h: 42,
-      };
-      patchCanvas({ tiles: nextTiles, freeRects: { ...cv.freeRects, [id]: rect } });
-    }
+    // Shared with the Phase 4c auto-insert (Decision 8) — see
+    // `insertTileIntoCanvas`'s own doc comment in useStore.ts.
+    const next = insertTileIntoCanvas(cv, kind, sessionId, tileWorktreeId, worktreeId);
+    patchCanvas(next);
     setPickerOpen(false);
   }
 
   function removeTile(tileId: string) {
-    const nextTiles = cv.tiles.filter((t) => t.id !== tileId);
-    const nextFreeRects = { ...cv.freeRects };
-    delete nextFreeRects[tileId];
-    let nextTree = cv.tree;
-    if (cv.mode === "tiled") {
-      const leafId = findLeafId(cv.tree, tileId);
-      nextTree = leafId ? removePane(cv.tree, leafId) : cv.tree;
-    }
-    patchCanvas({ tiles: nextTiles, freeRects: nextFreeRects, tree: nextTree });
+    // Shared with the TopBar Tools-tile toggle (useStore.ts's
+    // `toggleWorktreeToolsTile`) — one tree/free-rect removal
+    // implementation. `fullscreenTileId` cleanup is handled by the
+    // reconciliation effect above, not inline here, so it also covers
+    // removals this component didn't itself trigger.
+    patchCanvas(removeTileFromCanvas(cv, tileId));
   }
 
   /**
-   * Promote the transient canvas into a real, named WorkspaceDoc: snapshot its
-   * geometry, make it the active workspace, and drop the scratch (it's now
-   * superseded). From here the Add-tile picker also offers other worktrees.
+   * Promote the transient canvas into a real, named, DETACHED WorkspaceDoc:
+   * snapshot its geometry, drop the scratch (it's now superseded — this
+   * worktree goes back to a fresh, empty canvas next time it's opened), and
+   * navigate to the doc's own `/workspaces/:id` route. The worktree never
+   * "remembers" the saved doc (no `setActiveWorkspace` call) — from here on
+   * the ONLY place this doc is viewed/edited is its own route, where the
+   * Add-tile picker also offers other worktrees' panes.
    */
   function saveAsWorkspace() {
     const name = saveName.trim() || "Workspace";
@@ -328,10 +382,10 @@ export function WorkspaceCanvas({
     if (cur) {
       store.updateWorkspaceDoc(id, { tiles: cur.tiles, tree: cur.tree, freeRects: cur.freeRects });
     }
-    store.setActiveWorkspace(worktreeId, id);
     store.clearScratchCanvas(worktreeId);
     setSavePromptOpen(false);
     setSaveName("");
+    navigate(`/workspaces/${id}`);
   }
 
   // Free-form drag: window-level mousemove/mouseup, fixed drag-start baseline
@@ -346,8 +400,17 @@ export function WorkspaceCanvas({
     const startX = e.clientX;
     const startY = e.clientY;
     const startRect = { ...rect };
+    // Same threshold idiom as startTileDrag below — without it, the tiniest
+    // mouse jitter during a click nudges the tile by a fraction of a percent,
+    // AND a plain click (title-bar-click-to-fullscreen) would never reach
+    // `onUp` with zero movement to distinguish it from a real drag.
+    let armed = false;
 
     function onMove(ev: MouseEvent) {
+      if (!armed) {
+        if (Math.abs(ev.clientX - startX) + Math.abs(ev.clientY - startY) < 5) return;
+        armed = true;
+      }
       const dxPct = ((ev.clientX - startX) / containerRect.width) * 100;
       const dyPct = ((ev.clientY - startY) / containerRect.height) * 100;
       const nextX = clamp(startRect.x + dxPct, 0, Math.max(0, 100 - startRect.w));
@@ -361,6 +424,7 @@ export function WorkspaceCanvas({
     function onUp() {
       window.removeEventListener("mousemove", onMove);
       window.removeEventListener("mouseup", onUp);
+      if (!armed) toggleFullscreen(tileId);
     }
     window.addEventListener("mousemove", onMove);
     window.addEventListener("mouseup", onUp);
@@ -530,6 +594,7 @@ export function WorkspaceCanvas({
       setDrop(null);
       setDraggingTileId(null);
       if (armed && target) applyDrop(tileId, target);
+      else if (!armed) toggleFullscreen(tileId);
     }
     window.addEventListener("mousemove", onMove);
     window.addEventListener("mouseup", onUp);
@@ -537,15 +602,28 @@ export function WorkspaceCanvas({
 
   function renderTileChrome(tile: TileSpec, style?: CSSProperties): ReactNode {
     const session = tile.sessionId ? sessionById.get(tile.sessionId) : undefined;
-    const baseLabel =
-      tile.kind === "tools" ? "Tools" : session ? sessionLabel(session) : tile.kind;
-    const otherWorktree =
-      tile.worktreeId && tile.worktreeId !== worktreeId
-        ? worktreeById.get(tile.worktreeId)
+    // Fully-qualified tile label so a saved (possibly cross-worktree/cross-
+    // project) workspace never has ambiguous same-named tiles:
+    //   agent/terminal, worktree-scoped: "Project > Worktree > Agent"
+    //   agent/terminal, no worktree (direct session, hypothetical today —
+    //     the cross-context picker never offers one, kept for correctness):
+    //     "Project > Agent"
+    //   tools tile: "Project > Tools" (no worktree segment, per design)
+    const tileWorktree = tile.worktreeId ? worktreeById.get(tile.worktreeId) : worktreeById.get(worktreeId);
+    const tileProject = session
+      ? projectById.get(session.projectId)
+      : tileWorktree
+        ? projectById.get(tileWorktree.projectId)
         : undefined;
-    const label = otherWorktree
-      ? `${baseLabel} · ${otherWorktree.name || otherWorktree.branch}`
-      : baseLabel;
+    const projectName = tileProject?.name;
+    const label =
+      tile.kind === "tools"
+        ? [projectName, "Tools"].filter(Boolean).join(" > ")
+        : session
+          ? [projectName, session.worktreeId ? (tileWorktree?.name || tileWorktree?.branch) : null, sessionLabel(session)]
+              .filter(Boolean)
+              .join(" > ")
+          : tile.kind;
     const status =
       tile.kind !== "tools" && session && showAgentStatusBorders
         ? sessionStatus(session.state)
@@ -553,6 +631,24 @@ export function WorkspaceCanvas({
     const paneKey = paneKeyForTile(tile, worktreeId);
     const outletVisible =
       tile.kind === "tools" ? toolPanelVisible : tile.kind === "terminal" ? terminalDockVisible : true;
+
+    // Fullscreen (click, not drag, on the title bar — see startDrag/
+    // startTileDrag's `!armed` branches). The fullscreen tile escapes
+    // whatever position/size `style` would otherwise give it (free-mode %
+    // rect, or tiled-mode flex sizing) via `position: fixed` — same escape-
+    // the-container technique as the classic agent/tools/terminal pane
+    // fullscreen (`.pane-viewport-fullscreen`, Layout.tsx/AGENTS.md), which
+    // works regardless of DOM nesting depth (tiled mode can nest a tile
+    // several split levels deep). Every OTHER tile hides via `display: none`
+    // (not unmounted — panes stay mounted per the never-unmount invariant,
+    // see paneOutlets.tsx) so only the fullscreen one is visible/interactive.
+    const isFullscreen = fullscreenTileId === tile.id;
+    const isHiddenForFullscreen = fullscreenTileId !== null && !isFullscreen;
+    const tileStyle: CSSProperties = isFullscreen
+      ? { position: "fixed", inset: 0 }
+      : isHiddenForFullscreen
+        ? { ...style, display: "none" }
+        : (style ?? {});
 
     return (
       <div
@@ -562,11 +658,20 @@ export function WorkspaceCanvas({
         }}
         className={`workspace-canvas__tile${
           draggingTileId === tile.id ? " workspace-canvas__tile--dragging" : ""
-        }${status ? ` workspace-canvas__tile--${status}` : ""}`}
-        style={style}
+        }${status ? ` workspace-canvas__tile--${status}` : ""}${
+          isFullscreen ? " workspace-canvas__tile--fullscreen" : ""
+        }`}
+        style={tileStyle}
       >
         <div
           className="workspace-canvas__tile-header"
+          title={
+            isFullscreen
+              ? "Click to exit fullscreen"
+              : cv.mode === "free"
+                ? "Click to fullscreen · drag to move"
+                : "Click to fullscreen · drag to rearrange"
+          }
           onMouseDown={
             cv.mode === "free"
               ? (e) => startDrag(e, tile.id)
@@ -574,19 +679,26 @@ export function WorkspaceCanvas({
           }
         >
           {status ? <StatusDot status={status} /> : null}
-          <span className="workspace-canvas__tile-label">{label}</span>
+          <span className="workspace-canvas__tile-label" title={label}>{label}</span>
+          {/* Fullscreen: swap "remove tile" for "exit fullscreen" — clicking
+              the header already exits fullscreen too (same toggle), this is
+              just a second, more discoverable affordance for it. Removing a
+              tile while fullscreen would need its own confirmation-adjacent
+              thought (which one? still fullscreen after?) that isn't worth
+              designing for when a plain header-click already gets you out. */}
           <button
             type="button"
             className="workspace-canvas__tile-close"
-            aria-label={`Remove ${label} tile`}
-            title="Remove from canvas"
+            aria-label={isFullscreen ? "Exit fullscreen" : `Remove ${label} tile`}
+            title={isFullscreen ? "Exit fullscreen" : "Remove from canvas"}
             onMouseDown={(e) => e.stopPropagation()}
             onClick={(e) => {
               e.stopPropagation();
-              removeTile(tile.id);
+              if (isFullscreen) toggleFullscreen(tile.id);
+              else removeTile(tile.id);
             }}
           >
-            <X size={13} />
+            {isFullscreen ? <Minimize2 size={13} /> : <X size={13} />}
           </button>
         </div>
         <div className="workspace-canvas__tile-body">
@@ -596,7 +708,7 @@ export function WorkspaceCanvas({
             <div className="workspace-canvas__tile-hidden">Hidden — toggle it on in the top bar</div>
           )}
         </div>
-        {cv.mode === "free" ? (
+        {cv.mode === "free" && !isFullscreen ? (
           <div
             className="workspace-canvas__tile-resize"
             onMouseDown={(e) => startResize(e, tile.id)}
@@ -645,9 +757,16 @@ export function WorkspaceCanvas({
     );
   }
 
-  return (
-    <div className="workspace-canvas">
-      <div className="workspace-canvas__toolbar" role="toolbar" aria-label="Workspace canvas">
+  // toolbarPortalEl computed above (before the early return, rules-of-hooks).
+  // In the detached view it falls back to rendering inline (this component's
+  // own row) on the rare frame where TopBar hasn't registered the outlet
+  // yet, so the toolbar is never just missing.
+  const toolbarNode = (
+      <div
+        className={`workspace-canvas__toolbar${toolbarPortalEl ? " workspace-canvas__toolbar--portaled" : ""}`}
+        role="toolbar"
+        aria-label="Workspace canvas"
+      >
         <div className="workspace-canvas__toolbar-left">
           <div className="workspace-canvas__mode-toggle" role="group" aria-label="Canvas mode">
             <button
@@ -667,20 +786,14 @@ export function WorkspaceCanvas({
               Tiling
             </button>
           </div>
+          {/* `isSaved` is only ever true for the detached /workspaces/:id
+              route — the classic per-worktree placement always shows its own
+              scratch canvas, never a saved doc, so there's no "back to
+              unsaved" concept to offer here anymore (see module doc). */}
           {isSaved ? (
-            <>
-              <span className="workspace-canvas__doc-name" title="Saved workspace">
-                {savedDoc.name}
-              </span>
-              <button
-                type="button"
-                className="workspace-canvas__ghost-btn"
-                title="Leave this saved workspace and go back to the unsaved canvas"
-                onClick={() => setActiveWorkspace(worktreeId, null)}
-              >
-                Back to unsaved
-              </button>
-            </>
+            <span className="workspace-canvas__doc-name" title="Saved workspace">
+              {savedDoc.name}
+            </span>
           ) : (
             <span className="workspace-canvas__doc-name workspace-canvas__doc-name--unsaved">
               Unsaved canvas
@@ -768,7 +881,11 @@ export function WorkspaceCanvas({
                     className="workspace-canvas__picker-item"
                     onClick={() => addTile("agent", s.id)}
                   >
-                    {sessionLabel(s)} <span className="workspace-canvas__picker-kind">agent</span>
+                    <span className="workspace-canvas__picker-item-main">
+                      <Bot size={13} className="workspace-canvas__picker-icon" />
+                      {sessionLabel(s)}
+                    </span>
+                    <span className="workspace-canvas__picker-kind">agent</span>
                   </button>
                 ))}
                 {availableTerminals.map((s) => (
@@ -778,7 +895,11 @@ export function WorkspaceCanvas({
                     className="workspace-canvas__picker-item"
                     onClick={() => addTile("terminal", s.id)}
                   >
-                    {sessionLabel(s)} <span className="workspace-canvas__picker-kind">terminal</span>
+                    <span className="workspace-canvas__picker-item-main">
+                      <SquareTerminal size={13} className="workspace-canvas__picker-icon" />
+                      {sessionLabel(s)}
+                    </span>
+                    <span className="workspace-canvas__picker-kind">terminal</span>
                   </button>
                 ))}
                 {canAddTools ? (
@@ -787,47 +908,88 @@ export function WorkspaceCanvas({
                     className="workspace-canvas__picker-item"
                     onClick={() => addTile("tools")}
                   >
-                    Tools <span className="workspace-canvas__picker-kind">tools</span>
+                    <span className="workspace-canvas__picker-item-main">
+                      <PanelRight size={13} className="workspace-canvas__picker-icon" />
+                      Tools
+                    </span>
+                    <span className="workspace-canvas__picker-kind">tools</span>
                   </button>
                 ) : null}
                 {/* Cross-context panes — saved workspaces only (see otherContextGroups). */}
                 {otherContextGroups.map((group) => (
                   <div key={group.project.id} className="workspace-canvas__picker-group">
-                    <div className="workspace-canvas__picker-heading">{group.project.name}</div>
+                    <div className="workspace-canvas__picker-heading">
+                      <FolderOpen size={13} className="workspace-canvas__picker-icon" />
+                      {group.project.name}
+                    </div>
                     {group.worktrees.map(({ worktree, sessions, canAddTools: wtTools }) => (
                       <div key={worktree.id}>
                         <div className="workspace-canvas__picker-subheading">
+                          <GitBranch size={12} className="workspace-canvas__picker-icon" />
                           {worktree.name || worktree.branch}
                         </div>
-                        {sessions.map((s) => (
-                          <button
-                            key={s.id}
-                            type="button"
-                            className="workspace-canvas__picker-item"
-                            onClick={() => addTile(s.type as TileKind, s.id, worktree.id)}
-                          >
-                            {sessionLabel(s)}{" "}
-                            <span className="workspace-canvas__picker-kind">{s.type}</span>
-                          </button>
-                        ))}
-                        {wtTools ? (
-                          <button
-                            type="button"
-                            className="workspace-canvas__picker-item"
-                            onClick={() => addTile("tools", undefined, worktree.id)}
-                          >
-                            Tools <span className="workspace-canvas__picker-kind">tools</span>
-                          </button>
-                        ) : null}
+                        <div className="workspace-canvas__picker-subitems">
+                          <span className="workspace-canvas__picker-indent-line" aria-hidden />
+                          {sessions.map((s) => (
+                            <button
+                              key={s.id}
+                              type="button"
+                              className="workspace-canvas__picker-item"
+                              onClick={() => addTile(s.type as TileKind, s.id, worktree.id)}
+                            >
+                              <span className="workspace-canvas__picker-item-main">
+                                {s.type === "agent" ? (
+                                  <Bot size={13} className="workspace-canvas__picker-icon" />
+                                ) : (
+                                  <SquareTerminal size={13} className="workspace-canvas__picker-icon" />
+                                )}
+                                {sessionLabel(s)}
+                              </span>
+                              <span className="workspace-canvas__picker-kind">{s.type}</span>
+                            </button>
+                          ))}
+                          {wtTools ? (
+                            <button
+                              type="button"
+                              className="workspace-canvas__picker-item"
+                              onClick={() => addTile("tools", undefined, worktree.id)}
+                            >
+                              <span className="workspace-canvas__picker-item-main">
+                                <PanelRight size={13} className="workspace-canvas__picker-icon" />
+                                Tools
+                              </span>
+                              <span className="workspace-canvas__picker-kind">tools</span>
+                            </button>
+                          ) : null}
+                        </div>
                       </div>
                     ))}
                   </div>
                 ))}
+                {/* Unsaved (transient) canvases only ever offer THIS worktree's
+                    own sessions/tools above — otherContextGroups stays empty
+                    until "Save as workspace" promotes it (see !isSaved guard
+                    there). Make that limitation legible instead of the
+                    cross-worktree section just silently never appearing. */}
+                {!isSaved ? (
+                  <div className="workspace-canvas__picker-note" role="note">
+                    To add panes from other worktrees, save this canvas as a workspace.
+                  </div>
+                ) : null}
               </div>
             ) : null}
           </div>
         </div>
       </div>
+  );
+
+  return (
+    <div className="workspace-canvas">
+      {canvasToolbarVisible
+        ? toolbarPortalEl
+          ? createPortal(toolbarNode, toolbarPortalEl)
+          : toolbarNode
+        : null}
       <div className="workspace-canvas__body" ref={canvasBodyRef}>
         {cv.tiles.length === 0 ? (
           <div className="workspace-canvas__empty">

--- a/web-ui/src/components/layout/WorkspaceCanvas.tsx
+++ b/web-ui/src/components/layout/WorkspaceCanvas.tsx
@@ -1,0 +1,869 @@
+import "@/styles/workspace-canvas.css";
+import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
+import { Check, Plus, Save, X } from "lucide-react";
+import type { Project, Session, Worktree } from "@/api/types";
+import {
+  buildBalancedTree,
+  insertPane,
+  removePane,
+  resizeSplit,
+  swapPanes,
+  type LayoutNode,
+  type Side,
+  type SplitNode,
+} from "@/lib/tiling";
+import {
+  useWorkspaceStore,
+  type CanvasGeometry,
+  type FreeRect,
+  type TileKind,
+  type TileSpec,
+} from "@/hooks/useStore";
+import { PaneOutlet } from "@/components/layout/paneOutlets";
+import { StatusDot } from "@/components/layout/StatusDot";
+import { sessionStatus } from "@/lib/worktreeStatus";
+import { sessionLabel } from "@/lib/sessionLabel";
+import { randomId } from "@/lib/uuid";
+
+interface WorkspaceCanvasProps {
+  worktreeId: string;
+  /** This worktree's agent-type sessions. */
+  agentSessions: Session[];
+  /** This worktree's terminal-type sessions. */
+  terminalSessions: Session[];
+  /** Mirrors Layout.tsx's `hasToolPanel` check — whether a tools region exists at all. */
+  hasTools: boolean;
+  /** Mirrors Layout.tsx's `showToolPanel` — omit the tools tile's outlet when hidden. */
+  toolPanelVisible: boolean;
+  /** Mirrors Layout.tsx's `showTerminalDock` — omit terminal tiles' outlets when hidden. */
+  terminalDockVisible: boolean;
+  /** EVERY session app-wide — a SAVED workspace can tile panes from other worktrees. */
+  allSessions: Session[];
+  /** Every worktree app-wide (picker grouping + cross-context tile labels). */
+  worktrees: Worktree[];
+  /** Every project app-wide (picker grouping). */
+  projects: Project[];
+}
+
+function clamp(v: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, v));
+}
+
+function findLeafId(root: LayoutNode | null, tileId: string): string | null {
+  if (!root) return null;
+  if (root.type === "leaf") return root.tileId === tileId ? root.id : null;
+  for (const child of root.children) {
+    const found = findLeafId(child, tileId);
+    if (found) return found;
+  }
+  return null;
+}
+
+function paneKeyForTile(tile: TileSpec, worktreeId: string): string {
+  if (tile.kind === "tools") return `tools:${tile.worktreeId ?? worktreeId}`;
+  return `${tile.kind}:${tile.sessionId}`;
+}
+
+/** Drop zones of a tile under a dragged tile — VS Code / dockview's 4-edge + center model. */
+type DropZone = Side | "center";
+
+/** Edge band depth as a fraction of the target tile (each edge 25%, center 50%). */
+const EDGE_FRACTION = 0.25;
+
+interface DropTarget {
+  targetTileId: string;
+  zone: DropZone;
+  /** Highlight rect, in px relative to the canvas body element. */
+  rect: { left: number; top: number; width: number; height: number };
+}
+
+/**
+ * Tiled/free-form canvas for workspace-mode.
+ *
+ * Backing store is EITHER the worktree's transient `scratchCanvas` (the top
+ * bar's classic↔workspace toggle — unsaved, never in the sidebar, this
+ * worktree's own panes only) OR a saved `WorkspaceDoc` once one is active
+ * (picked in the sidebar, or just created via "Save as workspace"). Both
+ * expose the same `CanvasGeometry`, so everything below — rendering, drag,
+ * resize, tiling — runs against `canvas`/`patchCanvas()` regardless of which
+ * is live. Only a SAVED workspace may host cross-worktree tiles.
+ *
+ * Per tile it renders a chrome wrapper hosting a <PaneOutlet> that
+ * PaneHostLayer (mounted once, unconditionally, by the caller) portals the
+ * live pane into — panes are never mounted here (AGENTS.md invariant).
+ */
+export function WorkspaceCanvas({
+  worktreeId,
+  agentSessions,
+  terminalSessions,
+  hasTools,
+  toolPanelVisible,
+  terminalDockVisible,
+  allSessions,
+  worktrees,
+  projects,
+}: WorkspaceCanvasProps) {
+  const layoutByWorktree = useWorkspaceStore((s) => s.layoutByWorktree);
+  const workspaceDocs = useWorkspaceStore((s) => s.workspaceDocs);
+  const setActiveWorkspace = useWorkspaceStore((s) => s.setActiveWorkspace);
+  const showAgentStatusBorders = useWorkspaceStore((s) => s.showAgentStatusBorders);
+
+  const activeWorkspaceId = layoutByWorktree[worktreeId]?.activeWorkspaceId ?? null;
+  const savedDoc = activeWorkspaceId ? workspaceDocs[activeWorkspaceId] : undefined;
+  const savedDocId = savedDoc?.id ?? null;
+  const scratch = layoutByWorktree[worktreeId]?.scratchCanvas ?? null;
+  /** The live canvas: the saved doc when one is active, else the transient scratch. */
+  const canvas: CanvasGeometry | null = savedDoc ?? scratch;
+  const isSaved = !!savedDoc;
+
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+  const canvasBodyRef = useRef<HTMLDivElement | null>(null);
+  const tileRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const splitRefs = useRef<Record<string, HTMLDivElement | null>>({});
+
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [savePromptOpen, setSavePromptOpen] = useState(false);
+  const [saveName, setSaveName] = useState("");
+  const [draggingTileId, setDraggingTileId] = useState<string | null>(null);
+  const [dropTarget, setDropTarget] = useState<DropTarget | null>(null);
+  // mouseup reads the hover through a ref — the window listener closes over the
+  // render that started the drag, so React state alone would be stale there.
+  const dropTargetRef = useRef<DropTarget | null>(null);
+
+  /** Read the CURRENT canvas straight from the store (drag handlers, post-mount). */
+  function readCanvas(): CanvasGeometry | null {
+    const store = useWorkspaceStore.getState();
+    if (savedDocId) return store.workspaceDocs[savedDocId] ?? null;
+    return store.layoutByWorktree[worktreeId]?.scratchCanvas ?? null;
+  }
+
+  /** Write to whichever backing store is live. */
+  function patchCanvas(patch: Partial<CanvasGeometry>) {
+    const store = useWorkspaceStore.getState();
+    if (savedDocId) store.updateWorkspaceDoc(savedDocId, patch);
+    else store.updateScratchCanvas(worktreeId, patch);
+  }
+
+  // Seed the transient canvas the first time workspace mode is entered for this
+  // worktree with nothing saved selected — from whatever panes are already open.
+  // This creates NO WorkspaceDoc (that's what "Save as workspace" is for), so
+  // nothing appears in the sidebar's Workspaces list until the user asks for it.
+  const seededForRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (canvas) {
+      seededForRef.current = null;
+      return;
+    }
+    if (seededForRef.current === worktreeId) return;
+    seededForRef.current = worktreeId;
+
+    const tiles: TileSpec[] = [];
+    const freeRects: Record<string, FreeRect> = {};
+    let cascade = 0;
+    const push = (kind: TileKind, sessionId?: string) => {
+      const id = randomId();
+      tiles.push({ id, kind, sessionId });
+      freeRects[id] = {
+        x: 4 + (cascade % 5) * 5,
+        y: 4 + (cascade % 5) * 5,
+        w: 44,
+        h: 44,
+      };
+      cascade += 1;
+    };
+    for (const s of agentSessions) push("agent", s.id);
+    for (const s of terminalSessions) push("terminal", s.id);
+    if (hasTools) push("tools");
+
+    useWorkspaceStore
+      .getState()
+      .updateScratchCanvas(worktreeId, { mode: "free", tiles, tree: null, freeRects });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [worktreeId, canvas]);
+
+  if (!canvas) {
+    return <div className="workspace-canvas workspace-canvas--loading" />;
+  }
+  // Local alias so TS keeps the non-null narrowing inside the closures below.
+  const cv: CanvasGeometry = canvas;
+
+  const sessionById = new Map<string, Session>();
+  for (const s of allSessions) sessionById.set(s.id, s);
+  for (const s of agentSessions) sessionById.set(s.id, s);
+  for (const s of terminalSessions) sessionById.set(s.id, s);
+  const worktreeById = new Map(worktrees.map((w) => [w.id, w]));
+
+  const placedSessionIds = new Set(
+    cv.tiles.filter((t) => t.sessionId).map((t) => t.sessionId as string),
+  );
+  const placedToolWorktrees = new Set(
+    cv.tiles.filter((t) => t.kind === "tools").map((t) => t.worktreeId ?? worktreeId),
+  );
+  const availableAgents = agentSessions.filter((s) => !placedSessionIds.has(s.id));
+  const availableTerminals = terminalSessions.filter((s) => !placedSessionIds.has(s.id));
+  const canAddTools = hasTools && !placedToolWorktrees.has(worktreeId);
+
+  /**
+   * Cross-context picker content — ONLY offered for a saved workspace. A
+   * transient canvas stays single-worktree by design (the caller's
+   * PaneHostLayer scope for it is exactly this worktree's panes).
+   */
+  const otherContextGroups = !isSaved
+    ? []
+    : projects
+        .map((project) => ({
+          project,
+          worktrees: worktrees
+            .filter((w) => w.projectId === project.id && w.id !== worktreeId)
+            .map((w) => ({
+              worktree: w,
+              sessions: allSessions.filter(
+                (s) =>
+                  s.worktreeId === w.id &&
+                  (s.type === "agent" || s.type === "terminal") &&
+                  !placedSessionIds.has(s.id),
+              ),
+              canAddTools: !placedToolWorktrees.has(w.id),
+            }))
+            .filter((entry) => entry.sessions.length > 0 || entry.canAddTools),
+        }))
+        .filter((group) => group.worktrees.length > 0);
+
+  const pickerEmpty =
+    availableAgents.length === 0 &&
+    availableTerminals.length === 0 &&
+    !canAddTools &&
+    otherContextGroups.length === 0;
+
+  function handleModeChange(next: "tiled" | "free") {
+    if (cv.mode === next) return;
+    if (next === "tiled") {
+      const order = [...cv.tiles].sort((a, b) => {
+        const ra = cv.freeRects[a.id];
+        const rb = cv.freeRects[b.id];
+        const ay = ra?.y ?? 0;
+        const by = rb?.y ?? 0;
+        if (ay !== by) return ay - by;
+        return (ra?.x ?? 0) - (rb?.x ?? 0);
+      });
+      const tree = buildBalancedTree(order.map((t) => t.id));
+      patchCanvas({ mode: "tiled", tree });
+    } else {
+      const rects: Record<string, FreeRect> = {};
+      const containerRect = bodyRef.current?.getBoundingClientRect();
+      if (containerRect && containerRect.width > 0 && containerRect.height > 0) {
+        for (const tile of cv.tiles) {
+          const el = tileRefs.current[tile.id];
+          if (!el) continue;
+          const r = el.getBoundingClientRect();
+          rects[tile.id] = {
+            x: clamp(((r.left - containerRect.left) / containerRect.width) * 100, 0, 100),
+            y: clamp(((r.top - containerRect.top) / containerRect.height) * 100, 0, 100),
+            w: clamp((r.width / containerRect.width) * 100, 5, 100),
+            h: clamp((r.height / containerRect.height) * 100, 5, 100),
+          };
+        }
+      }
+      // Fallback for any tile whose live rect couldn't be read: even cascade.
+      cv.tiles.forEach((tile, i) => {
+        if (rects[tile.id]) return;
+        rects[tile.id] = { x: 4 + (i % 5) * 5, y: 4 + (i % 5) * 5, w: 44, h: 44 };
+      });
+      patchCanvas({ mode: "free", freeRects: rects });
+    }
+  }
+
+  function addTile(kind: TileKind, sessionId?: string, tileWorktreeId?: string) {
+    const id = randomId();
+    const tile: TileSpec = { id, kind, sessionId };
+    // Only stamp the owning worktree when it isn't the one we're viewing —
+    // keeps same-worktree tiles byte-identical to the pre-cross-context shape.
+    if (tileWorktreeId && tileWorktreeId !== worktreeId) tile.worktreeId = tileWorktreeId;
+    const nextTiles = [...cv.tiles, tile];
+    if (cv.mode === "tiled") {
+      let nextTree: LayoutNode | null;
+      if (!cv.tree || cv.tiles.length === 0) {
+        nextTree = insertPane(null, null, "right", id);
+      } else {
+        const lastTileId = cv.tiles[cv.tiles.length - 1]!.id;
+        const targetLeafId = findLeafId(cv.tree, lastTileId);
+        nextTree = insertPane(cv.tree, targetLeafId, "right", id);
+      }
+      patchCanvas({ tiles: nextTiles, tree: nextTree });
+    } else {
+      const cascade = cv.tiles.length;
+      const rect: FreeRect = {
+        x: 6 + (cascade % 5) * 5,
+        y: 6 + (cascade % 5) * 5,
+        w: 42,
+        h: 42,
+      };
+      patchCanvas({ tiles: nextTiles, freeRects: { ...cv.freeRects, [id]: rect } });
+    }
+    setPickerOpen(false);
+  }
+
+  function removeTile(tileId: string) {
+    const nextTiles = cv.tiles.filter((t) => t.id !== tileId);
+    const nextFreeRects = { ...cv.freeRects };
+    delete nextFreeRects[tileId];
+    let nextTree = cv.tree;
+    if (cv.mode === "tiled") {
+      const leafId = findLeafId(cv.tree, tileId);
+      nextTree = leafId ? removePane(cv.tree, leafId) : cv.tree;
+    }
+    patchCanvas({ tiles: nextTiles, freeRects: nextFreeRects, tree: nextTree });
+  }
+
+  /**
+   * Promote the transient canvas into a real, named WorkspaceDoc: snapshot its
+   * geometry, make it the active workspace, and drop the scratch (it's now
+   * superseded). From here the Add-tile picker also offers other worktrees.
+   */
+  function saveAsWorkspace() {
+    const name = saveName.trim() || "Workspace";
+    const cur = readCanvas();
+    const store = useWorkspaceStore.getState();
+    const id = store.createWorkspace(worktreeId, name, cur?.mode ?? "free");
+    if (cur) {
+      store.updateWorkspaceDoc(id, { tiles: cur.tiles, tree: cur.tree, freeRects: cur.freeRects });
+    }
+    store.setActiveWorkspace(worktreeId, id);
+    store.clearScratchCanvas(worktreeId);
+    setSavePromptOpen(false);
+    setSaveName("");
+  }
+
+  // Free-form drag: window-level mousemove/mouseup, fixed drag-start baseline
+  // (Layout.tsx's startSidebarResize idiom) — never incremental against the
+  // live rect, or the tile chases the cursor.
+  function startDrag(e: React.MouseEvent, tileId: string) {
+    e.preventDefault();
+    const container = bodyRef.current;
+    const rect = cv.freeRects[tileId];
+    if (!container || !rect) return;
+    const containerRect = container.getBoundingClientRect();
+    const startX = e.clientX;
+    const startY = e.clientY;
+    const startRect = { ...rect };
+
+    function onMove(ev: MouseEvent) {
+      const dxPct = ((ev.clientX - startX) / containerRect.width) * 100;
+      const dyPct = ((ev.clientY - startY) / containerRect.height) * 100;
+      const nextX = clamp(startRect.x + dxPct, 0, Math.max(0, 100 - startRect.w));
+      const nextY = clamp(startRect.y + dyPct, 0, Math.max(0, 100 - startRect.h));
+      const cur = readCanvas();
+      if (!cur) return;
+      patchCanvas({
+        freeRects: { ...cur.freeRects, [tileId]: { ...startRect, x: nextX, y: nextY } },
+      });
+    }
+    function onUp() {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    }
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+  }
+
+  function startResize(e: React.MouseEvent, tileId: string) {
+    e.preventDefault();
+    e.stopPropagation();
+    const container = bodyRef.current;
+    const rect = cv.freeRects[tileId];
+    if (!container || !rect) return;
+    const containerRect = container.getBoundingClientRect();
+    const startX = e.clientX;
+    const startY = e.clientY;
+    const startRect = { ...rect };
+
+    function onMove(ev: MouseEvent) {
+      const dwPct = ((ev.clientX - startX) / containerRect.width) * 100;
+      const dhPct = ((ev.clientY - startY) / containerRect.height) * 100;
+      const nextW = clamp(startRect.w + dwPct, 12, Math.max(12, 100 - startRect.x));
+      const nextH = clamp(startRect.h + dhPct, 10, Math.max(10, 100 - startRect.y));
+      const cur = readCanvas();
+      if (!cur) return;
+      patchCanvas({
+        freeRects: { ...cur.freeRects, [tileId]: { ...startRect, w: nextW, h: nextH } },
+      });
+    }
+    function onUp() {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    }
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+  }
+
+  // Tiled divider drag: baseSizes captured ONCE at drag-start (the two
+  // adjacent children's sizes right now), deltaFraction computed cumulative-
+  // from-drag-start against a fixed container-of-this-split size — never
+  // incremental, per lib/tiling.ts's resizeSplit contract.
+  function startDividerDrag(e: React.MouseEvent, node: SplitNode, dividerIndex: number) {
+    e.preventDefault();
+    const splitEl = splitRefs.current[node.id] ?? bodyRef.current;
+    if (!splitEl) return;
+    const splitRect = splitEl.getBoundingClientRect();
+    const totalPx = node.axis === "row" ? splitRect.width : splitRect.height;
+    const startX = e.clientX;
+    const startY = e.clientY;
+    const baseSizes: [number, number] = [
+      node.sizes[dividerIndex] ?? 0.5,
+      node.sizes[dividerIndex + 1] ?? 0.5,
+    ];
+    const splitId = node.id;
+
+    function onMove(ev: MouseEvent) {
+      const deltaPx = node.axis === "row" ? ev.clientX - startX : ev.clientY - startY;
+      const deltaFraction = totalPx > 0 ? deltaPx / totalPx : 0;
+      const cur = readCanvas();
+      if (!cur || !cur.tree) return;
+      const nextTree = resizeSplit(cur.tree, splitId, dividerIndex, deltaFraction, baseSizes);
+      patchCanvas({ tree: nextTree });
+    }
+    function onUp() {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    }
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+  }
+
+  /**
+   * Which tile (and which of its 5 zones) is under the cursor. Edge zones are
+   * the outer 25% measured from the NEAREST edge (so they read as triangles
+   * meeting at the corners, exactly like VS Code's editor-group drop targets);
+   * anything further in than that on all four sides is the center zone.
+   */
+  function hitTestDrop(clientX: number, clientY: number, draggedTileId: string): DropTarget | null {
+    const bodyRect = canvasBodyRef.current?.getBoundingClientRect();
+    if (!bodyRect) return null;
+    for (const [tileId, el] of Object.entries(tileRefs.current)) {
+      if (!el || tileId === draggedTileId) continue;
+      const r = el.getBoundingClientRect();
+      if (r.width <= 0 || r.height <= 0) continue;
+      if (clientX < r.left || clientX > r.right || clientY < r.top || clientY > r.bottom) continue;
+
+      const fx = (clientX - r.left) / r.width;
+      const fy = (clientY - r.top) / r.height;
+      const distances: Array<[Side, number]> = [
+        ["left", fx],
+        ["right", 1 - fx],
+        ["top", fy],
+        ["bottom", 1 - fy],
+      ];
+      let nearest = distances[0]!;
+      for (const d of distances) if (d[1] < nearest[1]) nearest = d;
+      const zone: DropZone = nearest[1] >= EDGE_FRACTION ? "center" : nearest[0];
+
+      const left = r.left - bodyRect.left;
+      const top = r.top - bodyRect.top;
+      let rect = { left, top, width: r.width, height: r.height };
+      if (zone === "left") rect = { left, top, width: r.width / 2, height: r.height };
+      else if (zone === "right")
+        rect = { left: left + r.width / 2, top, width: r.width / 2, height: r.height };
+      else if (zone === "top") rect = { left, top, width: r.width, height: r.height / 2 };
+      else if (zone === "bottom")
+        rect = { left, top: top + r.height / 2, width: r.width, height: r.height / 2 };
+
+      return { targetTileId: tileId, zone, rect };
+    }
+    return null;
+  }
+
+  function setDrop(next: DropTarget | null) {
+    dropTargetRef.current = next;
+    setDropTarget(next);
+  }
+
+  function applyDrop(draggedTileId: string, target: DropTarget) {
+    const cur = readCanvas();
+    if (!cur || cur.mode !== "tiled" || !cur.tree) return;
+    if (target.targetTileId === draggedTileId) return;
+
+    // Center = swap the two tiles' positions (NOT replace: replacing would have
+    // to evict a live pane off the canvas, and a pane leaving the canvas is the
+    // close button's job, never an accidental drop's).
+    if (target.zone === "center") {
+      patchCanvas({ tree: swapPanes(cur.tree, draggedTileId, target.targetTileId) });
+      return;
+    }
+
+    // Edge = re-home the dragged leaf next to the target. insertPane only ever
+    // inserts a NEW leaf, so the dragged tile's existing leaf must come out
+    // first; re-resolve the target leaf afterwards because removePane collapses
+    // single-child splits and may have restructured around it.
+    const draggedLeafId = findLeafId(cur.tree, draggedTileId);
+    if (!draggedLeafId) return;
+    const afterRemove = removePane(cur.tree, draggedLeafId);
+    const targetLeafId = findLeafId(afterRemove, target.targetTileId);
+    if (!targetLeafId) return;
+    // `tiles` is untouched — it's the flat list of WHAT is placed; only the tree
+    // says WHERE.
+    patchCanvas({ tree: insertPane(afterRemove, targetLeafId, target.zone, draggedTileId) });
+  }
+
+  /**
+   * Tiled-mode header drag → drop onto another tile's edge (split) or center
+   * (swap). Same window-level mousemove/mouseup idiom as every other drag here.
+   */
+  function startTileDrag(e: React.MouseEvent, tileId: string) {
+    e.preventDefault();
+    const startX = e.clientX;
+    const startY = e.clientY;
+    let armed = false;
+
+    function onMove(ev: MouseEvent) {
+      if (!armed) {
+        // Small threshold so a click on the header (e.g. to focus) isn't a drag.
+        if (Math.abs(ev.clientX - startX) + Math.abs(ev.clientY - startY) < 5) return;
+        armed = true;
+        setDraggingTileId(tileId);
+      }
+      setDrop(hitTestDrop(ev.clientX, ev.clientY, tileId));
+    }
+    function onUp() {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+      const target = dropTargetRef.current;
+      setDrop(null);
+      setDraggingTileId(null);
+      if (armed && target) applyDrop(tileId, target);
+    }
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+  }
+
+  function renderTileChrome(tile: TileSpec, style?: CSSProperties): ReactNode {
+    const session = tile.sessionId ? sessionById.get(tile.sessionId) : undefined;
+    const baseLabel =
+      tile.kind === "tools" ? "Tools" : session ? sessionLabel(session) : tile.kind;
+    const otherWorktree =
+      tile.worktreeId && tile.worktreeId !== worktreeId
+        ? worktreeById.get(tile.worktreeId)
+        : undefined;
+    const label = otherWorktree
+      ? `${baseLabel} · ${otherWorktree.name || otherWorktree.branch}`
+      : baseLabel;
+    const status =
+      tile.kind !== "tools" && session && showAgentStatusBorders
+        ? sessionStatus(session.state)
+        : null;
+    const paneKey = paneKeyForTile(tile, worktreeId);
+    const outletVisible =
+      tile.kind === "tools" ? toolPanelVisible : tile.kind === "terminal" ? terminalDockVisible : true;
+
+    return (
+      <div
+        key={tile.id}
+        ref={(el) => {
+          tileRefs.current[tile.id] = el;
+        }}
+        className={`workspace-canvas__tile${
+          draggingTileId === tile.id ? " workspace-canvas__tile--dragging" : ""
+        }${status ? ` workspace-canvas__tile--${status}` : ""}`}
+        style={style}
+      >
+        <div
+          className="workspace-canvas__tile-header"
+          onMouseDown={
+            cv.mode === "free"
+              ? (e) => startDrag(e, tile.id)
+              : (e) => startTileDrag(e, tile.id)
+          }
+        >
+          {status ? <StatusDot status={status} /> : null}
+          <span className="workspace-canvas__tile-label">{label}</span>
+          <button
+            type="button"
+            className="workspace-canvas__tile-close"
+            aria-label={`Remove ${label} tile`}
+            title="Remove from canvas"
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation();
+              removeTile(tile.id);
+            }}
+          >
+            <X size={13} />
+          </button>
+        </div>
+        <div className="workspace-canvas__tile-body">
+          {outletVisible ? (
+            <PaneOutlet paneKey={paneKey} />
+          ) : (
+            <div className="workspace-canvas__tile-hidden">Hidden — toggle it on in the top bar</div>
+          )}
+        </div>
+        {cv.mode === "free" ? (
+          <div
+            className="workspace-canvas__tile-resize"
+            onMouseDown={(e) => startResize(e, tile.id)}
+          />
+        ) : null}
+      </div>
+    );
+  }
+
+  function renderNode(node: LayoutNode): ReactNode {
+    if (node.type === "leaf") {
+      const tile = cv.tiles.find((t) => t.id === node.tileId);
+      if (!tile) return null;
+      return renderTileChrome(tile);
+    }
+    return (
+      <div
+        key={node.id}
+        ref={(el) => {
+          splitRefs.current[node.id] = el;
+        }}
+        className={`workspace-canvas__split workspace-canvas__split--${node.axis}`}
+      >
+        {node.children.flatMap((child, i) => {
+          const items: ReactNode[] = [
+            <div
+              key={child.id}
+              className="workspace-canvas__split-item"
+              style={{ flex: `${node.sizes[i] ?? 1} 1 0%` }}
+            >
+              {renderNode(child)}
+            </div>,
+          ];
+          if (i < node.children.length - 1) {
+            items.push(
+              <div
+                key={`${child.id}-divider`}
+                className={`workspace-canvas__divider workspace-canvas__divider--${node.axis}`}
+                onMouseDown={(e) => startDividerDrag(e, node, i)}
+              />,
+            );
+          }
+          return items;
+        })}
+      </div>
+    );
+  }
+
+  return (
+    <div className="workspace-canvas">
+      <div className="workspace-canvas__toolbar" role="toolbar" aria-label="Workspace canvas">
+        <div className="workspace-canvas__toolbar-left">
+          <div className="workspace-canvas__mode-toggle" role="group" aria-label="Canvas mode">
+            <button
+              type="button"
+              className={`workspace-canvas__mode-btn ${cv.mode === "free" ? "workspace-canvas__mode-btn--on" : ""}`}
+              aria-pressed={cv.mode === "free"}
+              onClick={() => handleModeChange("free")}
+            >
+              Free-form
+            </button>
+            <button
+              type="button"
+              className={`workspace-canvas__mode-btn ${cv.mode === "tiled" ? "workspace-canvas__mode-btn--on" : ""}`}
+              aria-pressed={cv.mode === "tiled"}
+              onClick={() => handleModeChange("tiled")}
+            >
+              Tiling
+            </button>
+          </div>
+          {isSaved ? (
+            <>
+              <span className="workspace-canvas__doc-name" title="Saved workspace">
+                {savedDoc.name}
+              </span>
+              <button
+                type="button"
+                className="workspace-canvas__ghost-btn"
+                title="Leave this saved workspace and go back to the unsaved canvas"
+                onClick={() => setActiveWorkspace(worktreeId, null)}
+              >
+                Back to unsaved
+              </button>
+            </>
+          ) : (
+            <span className="workspace-canvas__doc-name workspace-canvas__doc-name--unsaved">
+              Unsaved canvas
+            </span>
+          )}
+        </div>
+        <div className="workspace-canvas__toolbar-right">
+          {!isSaved ? (
+            <div className="workspace-canvas__save">
+              {savePromptOpen ? (
+                <form
+                  className="workspace-canvas__save-form"
+                  onSubmit={(e) => {
+                    e.preventDefault();
+                    saveAsWorkspace();
+                  }}
+                >
+                  <input
+                    className="workspace-canvas__save-input"
+                    aria-label="Workspace name"
+                    placeholder="Workspace name"
+                    value={saveName}
+                    autoFocus
+                    maxLength={60}
+                    onChange={(e) => setSaveName(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Escape") {
+                        e.preventDefault();
+                        setSavePromptOpen(false);
+                        setSaveName("");
+                      }
+                    }}
+                  />
+                  <button
+                    type="submit"
+                    className="workspace-canvas__add-btn"
+                    aria-label="Confirm save workspace"
+                    title="Save"
+                  >
+                    <Check size={14} />
+                  </button>
+                  <button
+                    type="button"
+                    className="workspace-canvas__add-btn"
+                    aria-label="Cancel save workspace"
+                    title="Cancel"
+                    onClick={() => {
+                      setSavePromptOpen(false);
+                      setSaveName("");
+                    }}
+                  >
+                    <X size={14} />
+                  </button>
+                </form>
+              ) : (
+                <button
+                  type="button"
+                  className="workspace-canvas__add-btn"
+                  title="Save this arrangement as a named workspace"
+                  onClick={() => setSavePromptOpen(true)}
+                >
+                  <Save size={14} /> Save as workspace
+                </button>
+              )}
+            </div>
+          ) : null}
+          <div className="workspace-canvas__add">
+            <button
+              type="button"
+              className="workspace-canvas__add-btn"
+              onClick={() => setPickerOpen((v) => !v)}
+              aria-expanded={pickerOpen}
+            >
+              <Plus size={14} /> Add tile
+            </button>
+            {pickerOpen ? (
+              <div className="workspace-canvas__picker" role="menu">
+                {pickerEmpty ? (
+                  <div className="workspace-canvas__picker-empty">Everything's already on the canvas</div>
+                ) : null}
+                {availableAgents.map((s) => (
+                  <button
+                    key={s.id}
+                    type="button"
+                    className="workspace-canvas__picker-item"
+                    onClick={() => addTile("agent", s.id)}
+                  >
+                    {sessionLabel(s)} <span className="workspace-canvas__picker-kind">agent</span>
+                  </button>
+                ))}
+                {availableTerminals.map((s) => (
+                  <button
+                    key={s.id}
+                    type="button"
+                    className="workspace-canvas__picker-item"
+                    onClick={() => addTile("terminal", s.id)}
+                  >
+                    {sessionLabel(s)} <span className="workspace-canvas__picker-kind">terminal</span>
+                  </button>
+                ))}
+                {canAddTools ? (
+                  <button
+                    type="button"
+                    className="workspace-canvas__picker-item"
+                    onClick={() => addTile("tools")}
+                  >
+                    Tools <span className="workspace-canvas__picker-kind">tools</span>
+                  </button>
+                ) : null}
+                {/* Cross-context panes — saved workspaces only (see otherContextGroups). */}
+                {otherContextGroups.map((group) => (
+                  <div key={group.project.id} className="workspace-canvas__picker-group">
+                    <div className="workspace-canvas__picker-heading">{group.project.name}</div>
+                    {group.worktrees.map(({ worktree, sessions, canAddTools: wtTools }) => (
+                      <div key={worktree.id}>
+                        <div className="workspace-canvas__picker-subheading">
+                          {worktree.name || worktree.branch}
+                        </div>
+                        {sessions.map((s) => (
+                          <button
+                            key={s.id}
+                            type="button"
+                            className="workspace-canvas__picker-item"
+                            onClick={() => addTile(s.type as TileKind, s.id, worktree.id)}
+                          >
+                            {sessionLabel(s)}{" "}
+                            <span className="workspace-canvas__picker-kind">{s.type}</span>
+                          </button>
+                        ))}
+                        {wtTools ? (
+                          <button
+                            type="button"
+                            className="workspace-canvas__picker-item"
+                            onClick={() => addTile("tools", undefined, worktree.id)}
+                          >
+                            Tools <span className="workspace-canvas__picker-kind">tools</span>
+                          </button>
+                        ) : null}
+                      </div>
+                    ))}
+                  </div>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </div>
+      <div className="workspace-canvas__body" ref={canvasBodyRef}>
+        {cv.tiles.length === 0 ? (
+          <div className="workspace-canvas__empty">
+            No tiles — add one to get started
+          </div>
+        ) : cv.mode === "free" ? (
+          <div className="workspace-canvas__free" ref={bodyRef}>
+            {cv.tiles.map((tile) => {
+              const rect = cv.freeRects[tile.id] ?? { x: 4, y: 4, w: 40, h: 40 };
+              return renderTileChrome(tile, {
+                position: "absolute",
+                left: `${rect.x}%`,
+                top: `${rect.y}%`,
+                width: `${rect.w}%`,
+                height: `${rect.h}%`,
+              });
+            })}
+          </div>
+        ) : (
+          <div className="workspace-canvas__tiled" ref={bodyRef}>
+            {cv.tree ? renderNode(cv.tree) : null}
+          </div>
+        )}
+        {dropTarget ? (
+          <div
+            className={`workspace-canvas__drop-zone workspace-canvas__drop-zone--${dropTarget.zone}`}
+            style={{
+              left: dropTarget.rect.left,
+              top: dropTarget.rect.top,
+              width: dropTarget.rect.width,
+              height: dropTarget.rect.height,
+            }}
+            aria-hidden
+          />
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/web-ui/src/components/layout/paneOutlets.test.tsx
+++ b/web-ui/src/components/layout/paneOutlets.test.tsx
@@ -1,0 +1,26 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PaneOutlet, PaneOutletProvider } from "./paneOutlets";
+
+describe("PaneOutlet", () => {
+  it("is a full-size flex column container", () => {
+    // Regression guard: every pane root that gets portaled into an outlet
+    // (`.agent-pane-slot`, `.terminal-pane-root`, `.tool-panel`) sizes itself
+    // with `flex: 1; min-height: 0`. If this div is left as a plain block, the
+    // `flex: 1` is inert, the pane falls back to `height: auto` and sizes to
+    // intrinsic content — a fresh xterm collapses to ~0px inside its workspace
+    // tile. jsdom does no layout, so assert the contract on the inline style.
+    const { container } = render(
+      <PaneOutletProvider>
+        <PaneOutlet paneKey="agent:s1" />
+      </PaneOutletProvider>,
+    );
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.style.display).toBe("flex");
+    expect(el.style.flexDirection).toBe("column");
+    expect(el.style.width).toBe("100%");
+    expect(el.style.height).toBe("100%");
+    expect(el.style.minHeight).toBe("0");
+    expect(el.style.minWidth).toBe("0");
+  });
+});

--- a/web-ui/src/components/layout/paneOutlets.tsx
+++ b/web-ui/src/components/layout/paneOutlets.tsx
@@ -133,6 +133,42 @@ export function PaneOutlet({ paneKey }: { paneKey: string }) {
   );
 }
 
+/** paneKey `WorkspaceCanvas.tsx` portals its toolbar (mode toggle, saved-doc
+ *  name, Save as workspace, Add tile) into, via `ToolbarOutlet` below —
+ *  mounted by `TopBar.tsx` for the detached `/workspaces/:id` page ONLY,
+ *  which has room top-right and no per-worktree pane toggles competing for
+ *  it. The classic per-worktree canvas does not portal: it keeps that
+ *  toolbar as its own dedicated row above the canvas body. */
+export const WORKSPACE_CANVAS_TOOLBAR_KEY = "workspace-canvas-toolbar";
+
+/**
+ * Same registry as `PaneOutlet`, but for small inline chrome (e.g. the
+ * workspace canvas's mode/save/add-tile toolbar on the detached
+ * `/workspaces/:id` page, portaled up into `TopBar` — see
+ * `WorkspaceCanvas.tsx`'s `usePaneOutletElement(WORKSPACE_CANVAS_TOOLBAR_KEY)`
+ * call) rather than a
+ * pane that needs to fill its container. Row-flex, sized to content, not
+ * stretched to 100%/100% like `PaneOutlet`.
+ */
+export function ToolbarOutlet({ paneKey }: { paneKey: string }) {
+  const { register, unregister } = useRegistry();
+
+  const refCallback = useCallback(
+    (el: HTMLDivElement | null) => {
+      if (el) register(paneKey, el);
+      else unregister(paneKey);
+    },
+    [paneKey, register, unregister],
+  );
+
+  return (
+    <div
+      ref={refCallback}
+      style={{ display: "flex", alignItems: "center", minWidth: 0 }}
+    />
+  );
+}
+
 /** Returns the current outlet DOM node for `paneKey`, or null if none is mounted. */
 export function usePaneOutletElement(paneKey: string): HTMLElement | null {
   const { getOutlet, subscribe } = useRegistry();

--- a/web-ui/src/components/layout/paneOutlets.tsx
+++ b/web-ui/src/components/layout/paneOutlets.tsx
@@ -1,0 +1,150 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+/**
+ * PaneOutletRegistry — a live directory of `<PaneOutlet>` DOM nodes keyed by
+ * paneKey. `PaneHostLayer` (see PaneHostLayer.tsx) reads this registry via
+ * `usePaneOutletElement` to decide where to portal each permanently-mounted
+ * pane's rendered output. The Map itself lives in a ref (not React state) so
+ * registration/unregistration never triggers a re-render on its own; each
+ * key has its own tiny subscriber list so only components actually watching
+ * that key re-render when its outlet element changes.
+ */
+
+type Listener = () => void;
+
+interface RegistryValue {
+  register: (key: string, el: HTMLElement | null) => void;
+  unregister: (key: string) => void;
+  getOutlet: (key: string) => HTMLElement | null;
+  subscribe: (key: string, listener: Listener) => () => void;
+}
+
+const PaneOutletRegistryContext = createContext<RegistryValue | null>(null);
+
+export function PaneOutletProvider({ children }: { children: ReactNode }) {
+  const outletsRef = useRef<Map<string, HTMLElement | null>>(new Map());
+  const listenersRef = useRef<Map<string, Set<Listener>>>(new Map());
+
+  const notify = useCallback((key: string) => {
+    const listeners = listenersRef.current.get(key);
+    if (!listeners) return;
+    for (const listener of listeners) listener();
+  }, []);
+
+  const register = useCallback(
+    (key: string, el: HTMLElement | null) => {
+      outletsRef.current.set(key, el);
+      notify(key);
+    },
+    [notify],
+  );
+
+  const unregister = useCallback(
+    (key: string) => {
+      outletsRef.current.delete(key);
+      notify(key);
+    },
+    [notify],
+  );
+
+  const getOutlet = useCallback((key: string) => outletsRef.current.get(key) ?? null, []);
+
+  const subscribe = useCallback((key: string, listener: Listener) => {
+    let listeners = listenersRef.current.get(key);
+    if (!listeners) {
+      listeners = new Set();
+      listenersRef.current.set(key, listeners);
+    }
+    listeners.add(listener);
+    return () => {
+      listeners!.delete(listener);
+      if (listeners!.size === 0) listenersRef.current.delete(key);
+    };
+  }, []);
+
+  const value = useMemo<RegistryValue>(
+    () => ({ register, unregister, getOutlet, subscribe }),
+    [register, unregister, getOutlet, subscribe],
+  );
+
+  return (
+    <PaneOutletRegistryContext.Provider value={value}>
+      {children}
+    </PaneOutletRegistryContext.Provider>
+  );
+}
+
+function useRegistry(): RegistryValue {
+  const ctx = useContext(PaneOutletRegistryContext);
+  if (!ctx) {
+    throw new Error("PaneOutlet components must be used within a PaneOutletProvider");
+  }
+  return ctx;
+}
+
+/**
+ * Renders the DOM node other components portal into for `paneKey`. Mount
+ * exactly one of these wherever a pane should currently be visible (e.g.
+ * inside a workspace tile); unmount it (e.g. tile closes/layout changes) and
+ * `usePaneOutletElement` reports null for that key again — the pane itself
+ * stays mounted elsewhere (see PaneHostLayer), it just loses its visible home.
+ */
+export function PaneOutlet({ paneKey }: { paneKey: string }) {
+  const { register, unregister } = useRegistry();
+
+  const refCallback = useCallback(
+    (el: HTMLDivElement | null) => {
+      if (el) register(paneKey, el);
+      else unregister(paneKey);
+    },
+    [paneKey, register, unregister],
+  );
+
+  // MUST be a flex column container, not a plain block. Every pane root that
+  // gets portaled in here (`.agent-pane-slot`, `.terminal-pane-root`,
+  // `.tool-panel`) sizes itself with `flex: 1; min-height: 0` — the shape it
+  // needs inside classic layout's `.pane-stack`. In a *block* parent `flex: 1`
+  // is inert, so the pane falls back to `height: auto` and sizes to its
+  // intrinsic content instead of to the outlet: a fresh xterm (no rows yet)
+  // collapses to ~0px, and a warmed-up one overflows past the tile. Making the
+  // outlet a flex container reproduces `.pane-stack`'s height propagation, so
+  // panes fill the outlet exactly and stay responsive when the tile resizes.
+  return (
+    <div
+      ref={refCallback}
+      style={{
+        width: "100%",
+        height: "100%",
+        minWidth: 0,
+        minHeight: 0,
+        display: "flex",
+        flexDirection: "column",
+      }}
+    />
+  );
+}
+
+/** Returns the current outlet DOM node for `paneKey`, or null if none is mounted. */
+export function usePaneOutletElement(paneKey: string): HTMLElement | null {
+  const { getOutlet, subscribe } = useRegistry();
+  const [, forceRender] = useState(0);
+
+  useEffect(() => {
+    // The outlet may have registered/unregistered between the render that
+    // read `getOutlet` and this effect running — re-check once on mount/key
+    // change, then stay in sync via the subscription for subsequent changes.
+    forceRender((v) => v + 1);
+    return subscribe(paneKey, () => forceRender((v) => v + 1));
+  }, [paneKey, subscribe]);
+
+  return getOutlet(paneKey);
+}

--- a/web-ui/src/components/settings/AppearanceSetting.tsx
+++ b/web-ui/src/components/settings/AppearanceSetting.tsx
@@ -1,4 +1,5 @@
 import { useTheme } from "@/hooks/useTheme";
+import { useWorkspaceStore } from "@/hooks/useStore";
 import { SectionHeader } from "./SectionHeader";
 
 function Row({
@@ -92,6 +93,8 @@ function SegmentedControl({
 
 export function AppearanceSetting() {
   const { theme, font, toggleTheme, toggleFont } = useTheme();
+  const showAgentStatusBorders = useWorkspaceStore((s) => s.showAgentStatusBorders);
+  const toggleAgentStatusBorders = useWorkspaceStore((s) => s.toggleAgentStatusBorders);
 
   return (
     <div>
@@ -125,6 +128,23 @@ export function AppearanceSetting() {
             ]}
             value={font}
             onChange={(v) => { if (v !== font) toggleFont(); }}
+          />
+        }
+      />
+
+      <Row
+        label="Agent status borders"
+        description="Color the border around agent panes and workspace tiles by interaction state (waiting for human, needs review, working, etc)."
+        control={
+          <SegmentedControl
+            options={[
+              { value: "on", label: "On" },
+              { value: "off", label: "Off" },
+            ]}
+            value={showAgentStatusBorders ? "on" : "off"}
+            onChange={(v) => {
+              if ((v === "on") !== showAgentStatusBorders) toggleAgentStatusBorders();
+            }}
           />
         }
       />

--- a/web-ui/src/hooks/useLayout.test.ts
+++ b/web-ui/src/hooks/useLayout.test.ts
@@ -57,4 +57,30 @@ describe("useLayout", () => {
     const layout = useWorkspaceStore.getState().layoutByWorktree[WT_ID] ?? DEFAULT_WORKTREE_LAYOUT;
     expect(layout.terminalDockVisible).toBe(!DEFAULT_WORKTREE_LAYOUT.terminalDockVisible);
   });
+
+  it("exposes canvasToolbarVisible defaulting true, flipped by toggleCanvasToolbar", () => {
+    const { result } = renderHook(() => useLayout());
+    expect(result.current.canvasToolbarVisible).toBe(true);
+    act(() => useWorkspaceStore.getState().toggleCanvasToolbar());
+    const { result: result2 } = renderHook(() => useLayout());
+    expect(result2.current.canvasToolbarVisible).toBe(false);
+  });
+
+  it("hasWorktreeToolsTile reflects the active canvas's tiles, updated by toggleWorktreeToolsTile", () => {
+    useWorkspaceStore.setState({
+      layoutByWorktree: {
+        [WT_ID]: { ...DEFAULT_WORKTREE_LAYOUT, scratchCanvas: { mode: "free", tiles: [], tree: null, freeRects: {} } },
+      },
+    });
+    const { result } = renderHook(() => useLayout());
+    expect(result.current.hasWorktreeToolsTile).toBe(false);
+
+    act(() => useWorkspaceStore.getState().toggleWorktreeToolsTile());
+    const { result: result2 } = renderHook(() => useLayout());
+    expect(result2.current.hasWorktreeToolsTile).toBe(true);
+
+    act(() => useWorkspaceStore.getState().toggleWorktreeToolsTile());
+    const { result: result3 } = renderHook(() => useLayout());
+    expect(result3.current.hasWorktreeToolsTile).toBe(false);
+  });
 });

--- a/web-ui/src/hooks/useLayout.ts
+++ b/web-ui/src/hooks/useLayout.ts
@@ -20,12 +20,20 @@ export function useLayout() {
   const setActiveSession = useWorkspaceStore((s) => s.setActiveSession);
   const setActiveTerminalSession = useWorkspaceStore((s) => s.setActiveTerminalSession);
   const setActiveWorktree = useWorkspaceStore((s) => s.setActiveWorktree);
+  const setLayoutMode = useWorkspaceStore((s) => s.setLayoutMode);
+  const setActiveWorkspace = useWorkspaceStore((s) => s.setActiveWorkspace);
 
   return {
     toolPanelVisible: activeLayout.toolPanelVisible,
     toolPanelTab: activeLayout.toolPanelTab,
     terminalDockVisible: activeLayout.terminalDockVisible,
     toolSplitOrientation: activeLayout.toolSplitOrientation ?? "horizontal",
+    /** Pane-arrangement mode ("classic" | "workspace") for the active worktree/direct
+     *  context. NOT the page-routing `layoutMode` prop TopBar/Workspace pass around
+     *  ("workspace"|"dashboard"|"settings"|...) — callers destructuring this should
+     *  alias it (e.g. `const { layoutMode: paneLayoutMode } = useLayout();`). */
+    layoutMode: activeLayout.layoutMode ?? "classic",
+    activeWorkspaceId: activeLayout.activeWorkspaceId ?? null,
     activeWorktreeId,
     activeDirectContextId,
     activeSessionId,
@@ -38,5 +46,7 @@ export function useLayout() {
     setActiveSession,
     setActiveTerminalSession,
     setActiveWorktree,
+    setLayoutMode,
+    setActiveWorkspace,
   };
 }

--- a/web-ui/src/hooks/useLayout.ts
+++ b/web-ui/src/hooks/useLayout.ts
@@ -17,11 +17,26 @@ export function useLayout() {
   const setToolPanelTab = useWorkspaceStore((s) => s.setToolPanelTab);
   const toggleTerminalDock = useWorkspaceStore((s) => s.toggleTerminalDock);
   const toggleToolSplitOrientation = useWorkspaceStore((s) => s.toggleToolSplitOrientation);
+  const toggleCanvasToolbar = useWorkspaceStore((s) => s.toggleCanvasToolbar);
+  const toggleWorktreeToolsTile = useWorkspaceStore((s) => s.toggleWorktreeToolsTile);
   const setActiveSession = useWorkspaceStore((s) => s.setActiveSession);
   const setActiveTerminalSession = useWorkspaceStore((s) => s.setActiveTerminalSession);
   const setActiveWorktree = useWorkspaceStore((s) => s.setActiveWorktree);
   const setLayoutMode = useWorkspaceStore((s) => s.setLayoutMode);
-  const setActiveWorkspace = useWorkspaceStore((s) => s.setActiveWorkspace);
+
+  // Canvas-mode "does this worktree's scratch canvas already have a Tools
+  // tile" — a worktree's classic canvas is ALWAYS its own scratch canvas now
+  // (it never binds to a saved WorkspaceDoc, see WorkspaceCanvas.tsx's
+  // module doc), so this only ever reads `scratchCanvas`. Mirrors
+  // WorkspaceCanvas.tsx's own `placedToolWorktrees` resolution
+  // (tile.worktreeId ?? the worktree this canvas is viewed in), so this
+  // selector and the renderer never disagree about which tile "counts" as
+  // this worktree's Tools tile.
+  const hasWorktreeToolsTile = layoutKey
+    ? !!activeLayout.scratchCanvas?.tiles.some(
+        (t) => t.kind === "tools" && (t.worktreeId ?? layoutKey) === layoutKey,
+      )
+    : false;
 
   return {
     toolPanelVisible: activeLayout.toolPanelVisible,
@@ -33,7 +48,10 @@ export function useLayout() {
      *  ("workspace"|"dashboard"|"settings"|...) — callers destructuring this should
      *  alias it (e.g. `const { layoutMode: paneLayoutMode } = useLayout();`). */
     layoutMode: activeLayout.layoutMode ?? "classic",
-    activeWorkspaceId: activeLayout.activeWorkspaceId ?? null,
+    /** Show/hide the workspace-canvas toolbar's disclosure under the crumb (classic per-worktree canvas placement only). */
+    canvasToolbarVisible: activeLayout.canvasToolbarVisible ?? true,
+    /** Whether the scratch canvas already has a Tools tile for this worktree — canvas mode's Tools-button "on" state. */
+    hasWorktreeToolsTile,
     activeWorktreeId,
     activeDirectContextId,
     activeSessionId,
@@ -43,10 +61,11 @@ export function useLayout() {
     setToolPanelTab,
     toggleTerminalDock,
     toggleToolSplitOrientation,
+    toggleCanvasToolbar,
+    toggleWorktreeToolsTile,
     setActiveSession,
     setActiveTerminalSession,
     setActiveWorktree,
     setLayoutMode,
-    setActiveWorkspace,
   };
 }

--- a/web-ui/src/hooks/useServerSync.test.ts
+++ b/web-ui/src/hooks/useServerSync.test.ts
@@ -1,8 +1,9 @@
 import { renderHook, waitFor, act } from "@testing-library/react";
-import { describe, expect, it, beforeEach } from "vitest";
+import { describe, expect, it, beforeEach, vi } from "vitest";
 import { createMockApi } from "@/api/mock";
 import { useServerSync } from "./useServerSync";
 import { useServerStore } from "./useServerStore";
+import { useWorkspaceStore } from "./useStore";
 
 /**
  * 1.T4 — the daemon already broadcasts `name`/`archivedAt` (and now
@@ -85,5 +86,137 @@ describe("useServerSync — session:updated reconciliation", () => {
     const after = useServerStore.getState().sessions.find((x) => x.id === "sess-main");
     expect(after?.name).toBe(before?.name);
     expect(after?.archivedAt).toBe(before?.archivedAt);
+  });
+});
+
+// --- Phase 4c: auto-insert a tile for a session:created carrying spawnedFrom
+// (agent-interaction-workspaces/04-workspaces) ---
+describe("useServerSync — session:created auto-insert (Phase 4c)", () => {
+  const DOC_ID = "doc-1";
+  const SOURCE_ID = "sess-source";
+
+  function seedOneMatchingDoc() {
+    useWorkspaceStore.setState({
+      workspaceDocs: {
+        [DOC_ID]: {
+          id: DOC_ID,
+          name: "Review Sprint",
+          contextKey: "wt-1",
+          mode: "free",
+          tiles: [{ id: "tile-source", kind: "agent", sessionId: SOURCE_ID }],
+          tree: null,
+          freeRects: { "tile-source": { x: 0, y: 0, w: 40, h: 40 } },
+        },
+      },
+    });
+  }
+
+  beforeEach(() => {
+    useServerStore.setState({ projects: [], worktrees: [], sessions: [], loaded: false });
+    useWorkspaceStore.setState({ workspaceDocs: {} });
+  });
+
+  it("4c.T1 — a session:created with spawnedFrom matching exactly one workspace's tile auto-inserts a new tile there", async () => {
+    seedOneMatchingDoc();
+    const api = createMockApi();
+    renderHook(() => useServerSync(api));
+    await waitFor(() => expect(useServerStore.getState().loaded).toBe(true));
+
+    act(() => {
+      api.__test.emit({
+        type: "session:created",
+        sessionId: "sess-new",
+        worktreeId: "wt-1",
+        sessionType: "agent",
+        spawnedFrom: SOURCE_ID,
+      });
+    });
+
+    await waitFor(() => {
+      const doc = useWorkspaceStore.getState().workspaceDocs[DOC_ID]!;
+      expect(doc.tiles.some((t) => t.sessionId === "sess-new")).toBe(true);
+      expect(doc.tiles).toHaveLength(2);
+    });
+  });
+
+  it("4c.T2 — a session:created with spawnedFrom matching no tile anywhere results in no tile insert, no error (S5)", async () => {
+    seedOneMatchingDoc();
+    const api = createMockApi();
+    renderHook(() => useServerSync(api));
+    await waitFor(() => expect(useServerStore.getState().loaded).toBe(true));
+
+    act(() => {
+      api.__test.emit({
+        type: "session:created",
+        sessionId: "sess-new",
+        worktreeId: "wt-1",
+        sessionType: "agent",
+        spawnedFrom: "sess-nobody-tiles-this",
+      });
+    });
+
+    // Give any (incorrectly-scheduled) insert a chance, then confirm nothing changed.
+    await new Promise((r) => setTimeout(r, 50));
+    const doc = useWorkspaceStore.getState().workspaceDocs[DOC_ID]!;
+    expect(doc.tiles).toHaveLength(1);
+  });
+
+  it("4c.T3 — a session:created with spawnedFrom absent behaves identically to pre-Phase-4 (no scan attempted, CUJ 6)", async () => {
+    seedOneMatchingDoc();
+    const api = createMockApi();
+    renderHook(() => useServerSync(api));
+    await waitFor(() => expect(useServerStore.getState().loaded).toBe(true));
+
+    act(() => {
+      api.__test.emit({
+        type: "session:created",
+        sessionId: "sess-new",
+        worktreeId: "wt-1",
+        sessionType: "agent",
+        // spawnedFrom omitted entirely — old-daemon / no-source create.
+      });
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+    const doc = useWorkspaceStore.getState().workspaceDocs[DOC_ID]!;
+    expect(doc.tiles).toHaveLength(1);
+  });
+
+  it("logs and skips (no insert into either) when the source is tiled in MORE THAN ONE workspace (Risk #9/#10, not yet confirmed)", async () => {
+    seedOneMatchingDoc();
+    useWorkspaceStore.setState((s) => ({
+      workspaceDocs: {
+        ...s.workspaceDocs,
+        "doc-2": {
+          id: "doc-2",
+          name: "Also has it",
+          contextKey: "wt-1",
+          mode: "free",
+          tiles: [{ id: "tile-source-2", kind: "agent", sessionId: SOURCE_ID }],
+          tree: null,
+          freeRects: {},
+        },
+      },
+    }));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const api = createMockApi();
+    renderHook(() => useServerSync(api));
+    await waitFor(() => expect(useServerStore.getState().loaded).toBe(true));
+
+    act(() => {
+      api.__test.emit({
+        type: "session:created",
+        sessionId: "sess-new",
+        worktreeId: "wt-1",
+        sessionType: "agent",
+        spawnedFrom: SOURCE_ID,
+      });
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(useWorkspaceStore.getState().workspaceDocs[DOC_ID]!.tiles).toHaveLength(1);
+    expect(useWorkspaceStore.getState().workspaceDocs["doc-2"]!.tiles).toHaveLength(1);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 });

--- a/web-ui/src/hooks/useServerSync.ts
+++ b/web-ui/src/hooks/useServerSync.ts
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import type { ApiInstance } from "@/api";
 import type { Session } from "@/api/types";
 import { useServerStore } from "./useServerStore";
-import { useWorkspaceStore } from "./useStore";
+import { useWorkspaceStore, findWorkspacesTilingSession } from "./useStore";
 
 /**
  * Module-level in-flight guard. Collapses three refresh triggers that all
@@ -103,9 +103,36 @@ export function useServerSync(api: ApiInstance): void {
       if (ev.type === "worktree:updated") applyWorktreeUpdated(ev.worktree);
     });
     const offSessCreated = api.on("session:created", (ev) => {
-      if (ev.type === "session:created" && ev.snapshot) {
+      if (ev.type !== "session:created") return;
+      if (ev.snapshot) {
         applySessionCreated(ev.snapshot);
         patchSessionState(ev.snapshot.id, ev.snapshot.state);
+      }
+      // Phase 4c (agent-interaction-workspaces/04-workspaces): a session
+      // spawned from a currently-tiled source auto-inserts as a new tile,
+      // splitting the source's own tile (S4/S6/Decision 8). `spawnedFrom`
+      // absent or null (CUJ 6 — no source, the common case today) skips this
+      // entirely — no scan, no behavior change from before Phase 4.
+      if (ev.spawnedFrom) {
+        const store = useWorkspaceStore.getState();
+        const matches = findWorkspacesTilingSession(ev.spawnedFrom, store.workspaceDocs);
+        if (matches.length === 1) {
+          store.insertTileIntoWorkspaceDoc(
+            matches[0]!.id,
+            ev.sessionType,
+            ev.sessionId,
+            ev.worktreeId ?? undefined,
+          );
+        } else if (matches.length > 1) {
+          // Multi-workspace fan-out (S4's proposed "insert into all") is
+          // still pending user confirmation (plan Risk #9/#10) — log and
+          // skip rather than guessing which of "all" / "the active one" /
+          // "none" is correct.
+          console.warn(
+            `[workspaces] session ${ev.spawnedFrom} is tiled in ${matches.length} workspaces at once; ` +
+              `auto-insert for new session ${ev.sessionId} skipped pending Risk #9/#10 confirmation.`,
+          );
+        }
       }
     });
     const offSessState = api.on("session:state", (ev) => {

--- a/web-ui/src/hooks/useStore.test.ts
+++ b/web-ui/src/hooks/useStore.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import type { Session } from "@/api/types";
-import { useWorkspaceStore } from "@/hooks/useStore";
+import {
+  useWorkspaceStore,
+  insertTileIntoCanvas,
+  removeTileFromCanvas,
+  findWorkspacesTilingSession,
+  DEFAULT_WORKTREE_LAYOUT,
+  type CanvasGeometry,
+} from "@/hooks/useStore";
 
 const P1 = "project-1";
 const W1 = "wt-1";
@@ -201,5 +208,293 @@ describe("useWorkspaceStore - file memory per context", () => {
     useWorkspaceStore.getState().setActiveFile("/orphan.ts");
     expect(useWorkspaceStore.getState().lastFileByWorktree).toEqual({});
     expect(useWorkspaceStore.getState().activeFilePath).toBe("/orphan.ts");
+  });
+});
+
+// --- v14 -> v15 migration: workspace detachment (agent-interaction-workspaces/
+// 04-workspaces Phase 3a, Decision 5/Risk #7) ---
+describe("useWorkspaceStore - v14 -> v15 migration (workspace detachment)", () => {
+  const STORAGE_KEY = "vibestation:workspace";
+
+  const doc = {
+    id: "doc-1",
+    name: "Review Sprint",
+    contextKey: W1,
+    mode: "free" as const,
+    tiles: [{ id: "tile-1", kind: "agent" as const, sessionId: "sess-1" }],
+    tree: null,
+    freeRects: { "tile-1": { x: 0, y: 0, w: 40, h: 40 } },
+  };
+
+  function v14Layout(activeWorkspaceId: string | null) {
+    return {
+      toolPanelVisible: true,
+      toolPanelTab: "files",
+      terminalDockVisible: false,
+      toolSplitOrientation: "horizontal",
+      layoutMode: "workspace",
+      activeWorkspaceId,
+      scratchCanvas: null,
+    };
+  }
+
+  beforeEach(async () => {
+    localStorage.clear();
+    await useWorkspaceStore.persist.clearStorage?.();
+  });
+
+  it("3a.T1 — a saved WorkspaceDoc survives the migration with no data loss", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          workspaceDocs: { [doc.id]: doc },
+          layoutByWorktree: { [W1]: v14Layout(doc.id) },
+        },
+        version: 14,
+      }),
+    );
+
+    await useWorkspaceStore.persist.rehydrate();
+
+    const state = useWorkspaceStore.getState();
+    expect(state.workspaceDocs[doc.id]).toEqual(doc);
+  });
+
+  it("3a.T2 — clears layoutByWorktree[wtId].activeWorkspaceId when it pointed at a saved doc (Risk #7)", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          workspaceDocs: { [doc.id]: doc },
+          layoutByWorktree: { [W1]: v14Layout(doc.id) },
+        },
+        version: 14,
+      }),
+    );
+
+    await useWorkspaceStore.persist.rehydrate();
+
+    const state = useWorkspaceStore.getState();
+    expect(state.layoutByWorktree[W1]?.activeWorkspaceId).toBeNull();
+    // Everything else on the entry is preserved, only the pointer is cleared.
+    expect(state.layoutByWorktree[W1]?.toolPanelVisible).toBe(true);
+    expect(state.layoutByWorktree[W1]?.layoutMode).toBe("workspace");
+  });
+
+  it("leaves activeWorkspaceId alone when it's null or points at nothing (no-op case)", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          workspaceDocs: {},
+          layoutByWorktree: { [W2]: v14Layout(null) },
+        },
+        version: 14,
+      }),
+    );
+
+    await useWorkspaceStore.persist.rehydrate();
+
+    const state = useWorkspaceStore.getState();
+    expect(state.layoutByWorktree[W2]?.activeWorkspaceId).toBeNull();
+  });
+});
+
+// --- insertTileIntoCanvas / findWorkspacesTilingSession (agent-interaction-
+// workspaces/04-workspaces Phase 4c, Decision 8) ---
+describe("insertTileIntoCanvas", () => {
+  it("appends a free-mode tile with a cascading rect and no worktreeId when it matches sameWorktreeId", () => {
+    const canvas: CanvasGeometry = { mode: "free", tiles: [], tree: null, freeRects: {} };
+    const next = insertTileIntoCanvas(canvas, "agent", "sess-1", W1, W1);
+    expect(next.tiles).toHaveLength(1);
+    expect(next.tiles[0]).toMatchObject({ kind: "agent", sessionId: "sess-1" });
+    expect(next.tiles[0]!.worktreeId).toBeUndefined();
+    expect(next.freeRects[next.tiles[0]!.id]).toBeDefined();
+  });
+
+  it("stamps worktreeId on the tile when it differs from sameWorktreeId (cross-context tile)", () => {
+    const canvas: CanvasGeometry = { mode: "free", tiles: [], tree: null, freeRects: {} };
+    const next = insertTileIntoCanvas(canvas, "agent", "sess-1", W2, W1);
+    expect(next.tiles[0]!.worktreeId).toBe(W2);
+  });
+
+  it("builds a fresh tree when inserting the first tile in tiled mode", () => {
+    const canvas: CanvasGeometry = { mode: "tiled", tiles: [], tree: null, freeRects: {} };
+    const next = insertTileIntoCanvas(canvas, "agent", "sess-1");
+    expect(next.tree).not.toBeNull();
+    expect(next.tree!.type).toBe("leaf");
+  });
+
+  it("splits off the tree's last tile when inserting a second tile in tiled mode", () => {
+    const canvas: CanvasGeometry = { mode: "tiled", tiles: [], tree: null, freeRects: {} };
+    const withOne = insertTileIntoCanvas(canvas, "agent", "sess-1");
+    const withTwo = insertTileIntoCanvas(withOne, "agent", "sess-2");
+    expect(withTwo.tiles).toHaveLength(2);
+    expect(withTwo.tree!.type).toBe("split");
+  });
+
+  it("never mutates the input canvas", () => {
+    const canvas: CanvasGeometry = { mode: "free", tiles: [], tree: null, freeRects: {} };
+    insertTileIntoCanvas(canvas, "agent", "sess-1");
+    expect(canvas.tiles).toHaveLength(0);
+  });
+});
+
+describe("findWorkspacesTilingSession", () => {
+  const doc = (id: string, sessionIds: string[]) => ({
+    id,
+    name: id,
+    contextKey: W1,
+    mode: "free" as const,
+    tiles: sessionIds.map((sid, i) => ({ id: `tile-${i}`, kind: "agent" as const, sessionId: sid })),
+    tree: null,
+    freeRects: {},
+  });
+
+  it("returns every doc that tiles the given sessionId", () => {
+    const docs = {
+      a: doc("a", ["sess-1"]),
+      b: doc("b", ["sess-2"]),
+      c: doc("c", ["sess-1", "sess-3"]),
+    };
+    const matches = findWorkspacesTilingSession("sess-1", docs);
+    expect(matches.map((d) => d.id).sort()).toEqual(["a", "c"]);
+  });
+
+  it("returns an empty array when no doc tiles the session", () => {
+    const docs = { a: doc("a", ["sess-1"]) };
+    expect(findWorkspacesTilingSession("sess-nobody", docs)).toEqual([]);
+  });
+});
+
+describe("removeTileFromCanvas", () => {
+  it("drops the tile from `tiles` and its free-mode rect", () => {
+    const empty: CanvasGeometry = { mode: "free", tiles: [], tree: null, freeRects: {} };
+    const withTile = insertTileIntoCanvas(empty, "agent", "sess-1");
+    const tileId = withTile.tiles[0]!.id;
+    const next = removeTileFromCanvas(withTile, tileId);
+    expect(next.tiles).toHaveLength(0);
+    expect(next.freeRects[tileId]).toBeUndefined();
+  });
+
+  it("collapses the tiled-mode tree around the removed leaf", () => {
+    const empty: CanvasGeometry = { mode: "tiled", tiles: [], tree: null, freeRects: {} };
+    const withOne = insertTileIntoCanvas(empty, "agent", "sess-1");
+    const withTwo = insertTileIntoCanvas(withOne, "agent", "sess-2");
+    const firstTileId = withTwo.tiles[0]!.id;
+    const next = removeTileFromCanvas(withTwo, firstTileId);
+    expect(next.tiles).toHaveLength(1);
+    expect(next.tree!.type).toBe("leaf");
+  });
+
+  it("never mutates the input canvas", () => {
+    const empty: CanvasGeometry = { mode: "free", tiles: [], tree: null, freeRects: {} };
+    const withTile = insertTileIntoCanvas(empty, "agent", "sess-1");
+    const tileId = withTile.tiles[0]!.id;
+    removeTileFromCanvas(withTile, tileId);
+    expect(withTile.tiles).toHaveLength(1);
+  });
+
+  it("is a no-op (returns tiles unchanged) for an unknown tile id", () => {
+    const empty: CanvasGeometry = { mode: "free", tiles: [], tree: null, freeRects: {} };
+    const withTile = insertTileIntoCanvas(empty, "agent", "sess-1");
+    const next = removeTileFromCanvas(withTile, "nonexistent");
+    expect(next.tiles).toHaveLength(1);
+  });
+});
+
+// --- toggleWorktreeToolsTile / toggleCanvasToolbar (canvas-mode top-bar
+// rework: the Tools button adds/removes a canvas tile instead of toggling
+// content visibility; the new chevron discloses/hides the canvas toolbar) ---
+describe("useWorkspaceStore - toggleWorktreeToolsTile", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useWorkspaceStore.persist.clearStorage?.();
+    useWorkspaceStore.setState({
+      activeWorktreeId: W1,
+      activeDirectContextId: null,
+      layoutByWorktree: {},
+      workspaceDocs: {},
+    });
+  });
+
+  it("is a no-op when no canvas (scratch or saved) exists yet for the active worktree", () => {
+    const before = useWorkspaceStore.getState();
+    useWorkspaceStore.getState().toggleWorktreeToolsTile();
+    const after = useWorkspaceStore.getState();
+    expect(after).toBe(before);
+    expect(after.layoutByWorktree[W1]).toBeUndefined();
+  });
+
+  it("adds a Tools tile to the scratch canvas when none exists, then removes it on a second toggle", () => {
+    useWorkspaceStore.setState({
+      layoutByWorktree: {
+        [W1]: { ...DEFAULT_WORKTREE_LAYOUT, scratchCanvas: { mode: "free", tiles: [], tree: null, freeRects: {} } },
+      },
+    });
+    useWorkspaceStore.getState().toggleWorktreeToolsTile();
+    const afterAdd = useWorkspaceStore.getState().layoutByWorktree[W1]!.scratchCanvas!;
+    expect(afterAdd.tiles).toHaveLength(1);
+    expect(afterAdd.tiles[0]).toMatchObject({ kind: "tools" });
+
+    useWorkspaceStore.getState().toggleWorktreeToolsTile();
+    const afterRemove = useWorkspaceStore.getState().layoutByWorktree[W1]!.scratchCanvas!;
+    expect(afterRemove.tiles).toHaveLength(0);
+  });
+
+  it("does not add a second Tools tile sharing the same pane key (regression: worktreeId-fallback mismatch)", () => {
+    useWorkspaceStore.setState({
+      layoutByWorktree: {
+        [W1]: { ...DEFAULT_WORKTREE_LAYOUT, scratchCanvas: { mode: "free", tiles: [], tree: null, freeRects: {} } },
+      },
+    });
+    useWorkspaceStore.getState().toggleWorktreeToolsTile();
+    useWorkspaceStore.getState().toggleWorktreeToolsTile();
+    useWorkspaceStore.getState().toggleWorktreeToolsTile();
+    const canvas = useWorkspaceStore.getState().layoutByWorktree[W1]!.scratchCanvas!;
+    const toolsTiles = canvas.tiles.filter((t) => t.kind === "tools");
+    expect(toolsTiles).toHaveLength(1);
+  });
+
+  it("always targets the scratch canvas, ignoring a stale activeWorkspaceId (a worktree never binds to a saved doc)", () => {
+    const docId = "doc-1";
+    useWorkspaceStore.setState({
+      layoutByWorktree: {
+        [W1]: {
+          ...DEFAULT_WORKTREE_LAYOUT,
+          activeWorkspaceId: docId,
+          scratchCanvas: { mode: "free", tiles: [], tree: null, freeRects: {} },
+        },
+      },
+      workspaceDocs: {
+        [docId]: { id: docId, name: "Doc", contextKey: W1, mode: "free", tiles: [], tree: null, freeRects: {} },
+      },
+    });
+    useWorkspaceStore.getState().toggleWorktreeToolsTile();
+    const state = useWorkspaceStore.getState();
+    expect(state.layoutByWorktree[W1]!.scratchCanvas!.tiles).toHaveLength(1);
+    // The doc is untouched — it's never a target for this action.
+    expect(state.workspaceDocs[docId]!.tiles).toHaveLength(0);
+  });
+});
+
+describe("useWorkspaceStore - toggleCanvasToolbar", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useWorkspaceStore.persist.clearStorage?.();
+    useWorkspaceStore.setState({
+      activeWorktreeId: W1,
+      activeDirectContextId: null,
+      layoutByWorktree: {},
+    });
+  });
+
+  it("flips canvasToolbarVisible from the default (true) to false and back", () => {
+    expect(DEFAULT_WORKTREE_LAYOUT.canvasToolbarVisible).toBe(true);
+    useWorkspaceStore.getState().toggleCanvasToolbar();
+    expect(useWorkspaceStore.getState().layoutByWorktree[W1]!.canvasToolbarVisible).toBe(false);
+    useWorkspaceStore.getState().toggleCanvasToolbar();
+    expect(useWorkspaceStore.getState().layoutByWorktree[W1]!.canvasToolbarVisible).toBe(true);
   });
 });

--- a/web-ui/src/hooks/useStore.ts
+++ b/web-ui/src/hooks/useStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import type { DiffScope, Session, SessionState } from "@/api/types";
-import type { LayoutNode } from "@/lib/tiling";
+import { findLeafId, insertPane, removePane, type LayoutNode } from "@/lib/tiling";
 import { randomId } from "@/lib/uuid";
 
 /** Tools hosted by the right-side tool panel (one visible at a time). */
@@ -42,6 +42,16 @@ export interface WorktreeLayout {
    * a real, named, cross-context WorkspaceDoc.
    */
   scratchCanvas: CanvasGeometry | null;
+  /**
+   * Whether the workspace-canvas toolbar (mode toggle / doc name / save /
+   * add tile — portaled into TopBar via WORKSPACE_CANVAS_TOOLBAR_KEY, see
+   * paneOutlets.tsx) is currently disclosed under the crumb in the classic
+   * per-worktree canvas view. Defaults true (the toolbar IS the canvas's
+   * primary UI — hiding it by default would make canvas mode look broken on
+   * first use). Only meaningful for that placement; the detached
+   * `/workspaces/:id` view always shows its toolbar regardless of this flag.
+   */
+  canvasToolbarVisible: boolean;
 }
 
 export const DEFAULT_WORKTREE_LAYOUT: WorktreeLayout = {
@@ -52,6 +62,7 @@ export const DEFAULT_WORKTREE_LAYOUT: WorktreeLayout = {
   layoutMode: "classic",
   activeWorkspaceId: null,
   scratchCanvas: null,
+  canvasToolbarVisible: true,
 };
 
 export type TileKind = "agent" | "terminal" | "tools";
@@ -97,7 +108,15 @@ export interface CanvasGeometry {
 export interface WorkspaceDoc extends CanvasGeometry {
   id: string;
   name: string;
-  /** worktreeId this workspace was created in (drives the sidebar's per-worktree list). */
+  /**
+   * worktreeId this workspace was originally created in. Provenance/display
+   * only (e.g. a future "created in ‹name›" hint) — a saved workspace is
+   * detached from its creating worktree (Phase 3, agent-interaction-
+   * workspaces/04-workspaces): the sidebar's Workspaces section lists every
+   * doc globally and this field is no longer read as an ownership/filter
+   * gate anywhere. Kept (not removed) to avoid a field-removal migration —
+   * every existing stored doc already has a valid value.
+   */
   contextKey: string;
 }
 
@@ -168,6 +187,15 @@ export interface WorkspaceState {
   toggleTerminalDock: () => void;
   /** Flip the agent pane ↔ tool panel split between horizontal and vertical. */
   toggleToolSplitOrientation: () => void;
+  /** Show/hide the workspace-canvas toolbar's disclosure under the crumb (classic per-worktree canvas placement only). */
+  toggleCanvasToolbar: () => void;
+  /**
+   * Canvas-mode equivalent of `toggleToolPanel`: instead of toggling content
+   * visibility inside an already-placed Tools tile, adds/removes the Tools
+   * tile itself on the active worktree's canvas (saved doc if one is active,
+   * else the transient scratch canvas). No-op if no canvas exists yet.
+   */
+  toggleWorktreeToolsTile: () => void;
   setActiveWorktree: (projectId: string, worktreeId: string, sessions?: Session[]) => void;
   /** Set (or clear with null) the direct-session layout context (project id). */
   setActiveDirectContext: (projectId: string | null) => void;
@@ -222,6 +250,19 @@ export interface WorkspaceState {
   renameWorkspace: (id: string, name: string) => void;
   deleteWorkspace: (id: string) => void;
   updateWorkspaceDoc: (id: string, patch: Partial<Omit<WorkspaceDoc, "id" | "contextKey">>) => void;
+  /**
+   * Insert a new tile into a saved WorkspaceDoc, splitting off its last tile
+   * (same split-target+side model as `WorkspaceCanvas.tsx`'s "Add tile"
+   * picker, Decision 8 — single insert implementation, not a parallel one).
+   * A no-op if `docId` doesn't resolve to a doc. Used by both the manual
+   * "Add tile" flow and the Phase 4c `session:created` auto-insert listener.
+   */
+  insertTileIntoWorkspaceDoc: (
+    docId: string,
+    kind: TileKind,
+    sessionId?: string,
+    tileWorktreeId?: string,
+  ) => void;
   reorderWorkspace: (scopeKey: string, orderedIds: string[]) => void;
   setActiveWorkspace: (worktreeId: string, workspaceId: string | null) => void;
   setLayoutMode: (worktreeId: string, mode: "classic" | "workspace") => void;
@@ -238,6 +279,83 @@ export const EMPTY_CANVAS_GEOMETRY: CanvasGeometry = {
   tree: null,
   freeRects: {},
 };
+
+/**
+ * Pure tile-insert core, shared by BOTH `WorkspaceCanvas.tsx`'s "Add tile"
+ * picker (manual) and `insertTileIntoWorkspaceDoc` below (Phase 4c's
+ * `session:created` auto-insert) — agent-interaction-workspaces/04-workspaces
+ * Decision 8: one implementation, not two divergent ones, so a manually- and
+ * an auto-inserted tile behave identically. Splits off the canvas's LAST
+ * tile (side "right") in tiled mode; cascades a new free-rect in free mode.
+ * Returns a NEW `CanvasGeometry`-shaped patch — never mutates `canvas`.
+ *
+ * `sameWorktreeId`: the tile's own `worktreeId` is only stamped when it
+ * differs from this — keeps same-context tiles byte-identical to the
+ * pre-cross-context tile shape (pass the viewed worktreeId for the scratch-
+ * canvas case, or the doc's own `contextKey` for a saved-doc case).
+ */
+export function insertTileIntoCanvas(
+  canvas: CanvasGeometry,
+  kind: TileKind,
+  sessionId?: string,
+  tileWorktreeId?: string,
+  sameWorktreeId?: string,
+): CanvasGeometry {
+  const id = randomId();
+  const tile: TileSpec = { id, kind, sessionId };
+  if (tileWorktreeId && tileWorktreeId !== sameWorktreeId) tile.worktreeId = tileWorktreeId;
+  const nextTiles = [...canvas.tiles, tile];
+  if (canvas.mode === "tiled") {
+    let nextTree: LayoutNode | null;
+    if (!canvas.tree || canvas.tiles.length === 0) {
+      nextTree = insertPane(null, null, "right", id);
+    } else {
+      const lastTileId = canvas.tiles[canvas.tiles.length - 1]!.id;
+      const targetLeafId = findLeafId(canvas.tree, lastTileId);
+      nextTree = insertPane(canvas.tree, targetLeafId, "right", id);
+    }
+    return { ...canvas, tiles: nextTiles, tree: nextTree };
+  }
+  const cascade = canvas.tiles.length;
+  const rect: FreeRect = { x: 6 + (cascade % 5) * 5, y: 6 + (cascade % 5) * 5, w: 42, h: 42 };
+  return { ...canvas, tiles: nextTiles, freeRects: { ...canvas.freeRects, [id]: rect } };
+}
+
+/**
+ * Pure tile-remove core — the inverse of `insertTileIntoCanvas` above, and the
+ * single implementation shared by `WorkspaceCanvas.tsx`'s tile-close button
+ * and the store's `toggleWorktreeToolsTile` action, so both stay in sync on
+ * tree/free-rect cleanup instead of drifting into two divergent removals.
+ * Returns a NEW `CanvasGeometry` — never mutates `canvas`. Callers that track
+ * a fullscreen-tile id locally (WorkspaceCanvas's `fullscreenTileId` state)
+ * are responsible for reconciling it themselves afterwards — this function
+ * has no way to reach component-local React state.
+ */
+export function removeTileFromCanvas(canvas: CanvasGeometry, tileId: string): CanvasGeometry {
+  const nextTiles = canvas.tiles.filter((t) => t.id !== tileId);
+  const nextFreeRects = { ...canvas.freeRects };
+  delete nextFreeRects[tileId];
+  let nextTree = canvas.tree;
+  if (canvas.mode === "tiled") {
+    const leafId = findLeafId(canvas.tree, tileId);
+    nextTree = leafId ? removePane(canvas.tree, leafId) : canvas.tree;
+  }
+  return { ...canvas, tiles: nextTiles, freeRects: nextFreeRects, tree: nextTree };
+}
+
+/**
+ * Every saved WorkspaceDoc that currently tiles `sessionId` (agent-
+ * interaction-workspaces/04-workspaces Phase 4c, Research "Client-side
+ * auto-insert target"). `workspaceDocs` is already a flat, global map
+ * regardless of Phase 3's detachment status — this scan doesn't care whether
+ * a matched doc is "the active one" or not, it just finds every match.
+ */
+export function findWorkspacesTilingSession(
+  sessionId: string,
+  workspaceDocs: Record<string, WorkspaceDoc>,
+): WorkspaceDoc[] {
+  return Object.values(workspaceDocs).filter((doc) => doc.tiles.some((t) => t.sessionId === sessionId));
+}
 
 /**
  * Compute the moved item's new fractional `sortOrder` value from the real
@@ -349,6 +467,46 @@ export const useWorkspaceStore = create<WorkspaceState>()(
               : DEFAULT_WORKTREE_LAYOUT;
             const next = cur.toolSplitOrientation === "horizontal" ? "vertical" : "horizontal";
             return patchLayout(s, { toolSplitOrientation: next });
+          }),
+        toggleCanvasToolbar: () =>
+          set((s) => {
+            const key = layoutKey(s);
+            const cur = key
+              ? (s.layoutByWorktree[key] ?? DEFAULT_WORKTREE_LAYOUT)
+              : DEFAULT_WORKTREE_LAYOUT;
+            return patchLayout(s, { canvasToolbarVisible: !cur.canvasToolbarVisible });
+          }),
+        // A worktree's classic canvas is ALWAYS its own scratch canvas (a
+        // worktree never binds to a saved WorkspaceDoc — see
+        // WorkspaceCanvas.tsx's module doc); this only ever targets
+        // `scratchCanvas`, never `workspaceDocs`.
+        toggleWorktreeToolsTile: () =>
+          set((s) => {
+            const key = layoutKey(s);
+            if (!key) return s;
+            const cur = s.layoutByWorktree[key] ?? DEFAULT_WORKTREE_LAYOUT;
+            const canvas = cur.scratchCanvas;
+            // Nothing to toggle before the canvas has been seeded (e.g. a
+            // click landing before WorkspaceCanvas's seed effect commits) —
+            // no-op rather than creating a canvas containing only a tools
+            // tile, which would starve the seed effect of ever running.
+            if (!canvas) return s;
+            // Same fallback resolution WorkspaceCanvas itself uses for
+            // `placedToolWorktrees`/`paneKeyForTile` (tile.worktreeId ??
+            // the worktree this canvas is being viewed in) — must match, or
+            // this can add a second tools tile sharing one pane key/outlet.
+            const existing = canvas.tiles.find(
+              (t) => t.kind === "tools" && (t.worktreeId ?? key) === key,
+            );
+            const nextCanvas = existing
+              ? removeTileFromCanvas(canvas, existing.id)
+              : insertTileIntoCanvas(canvas, "tools", undefined, key, key);
+            return {
+              layoutByWorktree: {
+                ...s.layoutByWorktree,
+                [key]: { ...cur, scratchCanvas: nextCanvas },
+              },
+            };
           }),
         setActiveWorktree: (projectId, worktreeId, sessions) =>
           set((s) => {
@@ -535,6 +693,15 @@ export const useWorkspaceStore = create<WorkspaceState>()(
               workspaceDocs: { ...s.workspaceDocs, [id]: { ...doc, ...patch } },
             };
           }),
+        insertTileIntoWorkspaceDoc: (docId, kind, sessionId, tileWorktreeId) =>
+          set((s) => {
+            const doc = s.workspaceDocs[docId];
+            if (!doc) return s;
+            const next = insertTileIntoCanvas(doc, kind, sessionId, tileWorktreeId, doc.contextKey);
+            return {
+              workspaceDocs: { ...s.workspaceDocs, [docId]: { ...doc, ...next } },
+            };
+          }),
         reorderWorkspace: (scopeKey, orderedIds) =>
           set((s) => ({
             workspaceOrder: { ...s.workspaceOrder, [scopeKey]: orderedIds },
@@ -585,7 +752,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
     },
     {
       name: "vibestation:workspace",
-      version: 14,
+      version: 16,
       migrate: (persisted, version) => {
         const p = persisted as Record<string, unknown> | null;
         if (!p || typeof p !== "object") return persisted;
@@ -613,6 +780,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
               layoutMode: "classic",
               activeWorkspaceId: null,
               scratchCanvas: null,
+              canvasToolbarVisible: true,
             };
           }
           p.layoutByWorktree = next;
@@ -640,6 +808,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
               layoutMode: "classic",
               activeWorkspaceId: null,
               scratchCanvas: null,
+              canvasToolbarVisible: true,
             };
           }
           p.layoutByWorktree = next;
@@ -664,6 +833,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
               layoutMode: "classic",
               activeWorkspaceId: null,
               scratchCanvas: null,
+              canvasToolbarVisible: true,
             };
           }
           p.layoutByWorktree = next;
@@ -688,6 +858,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
               layoutMode: "classic",
               activeWorkspaceId: null,
               scratchCanvas: null,
+              canvasToolbarVisible: true,
             };
           }
           p.layoutByWorktree = next;
@@ -706,6 +877,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
               layoutMode: entry?.layoutMode ?? "classic",
               activeWorkspaceId: entry?.activeWorkspaceId ?? null,
               scratchCanvas: entry?.scratchCanvas ?? null,
+              canvasToolbarVisible: entry?.canvasToolbarVisible ?? true,
             };
           }
           p.layoutByWorktree = next;
@@ -732,6 +904,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
               layoutMode: entry?.layoutMode ?? "classic",
               activeWorkspaceId: entry?.activeWorkspaceId ?? null,
               scratchCanvas: entry?.scratchCanvas ?? null,
+              canvasToolbarVisible: entry?.canvasToolbarVisible ?? true,
             };
           }
           p.layoutByWorktree = next;
@@ -754,6 +927,60 @@ export const useWorkspaceStore = create<WorkspaceState>()(
               layoutMode: entry?.layoutMode ?? "classic",
               activeWorkspaceId: entry?.activeWorkspaceId ?? null,
               scratchCanvas: entry?.scratchCanvas ?? null,
+              canvasToolbarVisible: entry?.canvasToolbarVisible ?? true,
+            };
+          }
+          p.layoutByWorktree = next;
+        }
+        // v14 → v15: workspace detachment (agent-interaction-workspaces/04-workspaces
+        // Phase 3a, Decision 5/Risk #7). A saved WorkspaceDoc is no longer owned by
+        // the worktree it was created in — viewing one moves to the route-driven
+        // `/workspaces/:id` view (Decision 4), not `layoutByWorktree[wtId].
+        // activeWorkspaceId`. That pointer's old meaning ("this worktree's canvas
+        // is currently showing saved workspace X") is gone, so clear any entry that
+        // still points at a saved doc — leaving it would make WorkspaceCanvas's
+        // per-worktree flow (Phase 3c) incorrectly think it's still displaying that
+        // now-detached doc. `contextKey` itself is untouched — kept as provenance
+        // (Decision 5), no data loss, no doc dropped from `workspaceDocs`.
+        if (version < 15) {
+          const old = p.layoutByWorktree as Record<string, unknown>;
+          const docs = (p.workspaceDocs ?? {}) as Record<string, unknown>;
+          const next: Record<string, WorktreeLayout> = {};
+          for (const [wt, raw] of Object.entries(old ?? {})) {
+            const entry = raw as Partial<WorktreeLayout> | undefined;
+            const pointsAtSavedDoc = !!entry?.activeWorkspaceId && !!docs[entry.activeWorkspaceId];
+            next[wt] = {
+              toolPanelVisible: entry?.toolPanelVisible ?? true,
+              toolPanelTab: (entry?.toolPanelTab ?? "files") as ToolTab,
+              terminalDockVisible: entry?.terminalDockVisible ?? false,
+              toolSplitOrientation: entry?.toolSplitOrientation ?? "horizontal",
+              layoutMode: entry?.layoutMode ?? "classic",
+              activeWorkspaceId: pointsAtSavedDoc ? null : (entry?.activeWorkspaceId ?? null),
+              scratchCanvas: entry?.scratchCanvas ?? null,
+              canvasToolbarVisible: entry?.canvasToolbarVisible ?? true,
+            };
+          }
+          p.layoutByWorktree = next;
+        }
+        // v15 → v16: canvas-mode toolbar disclosure (the workspace-canvas
+        // toolbar's TopBar placement gained a show/hide control). Default
+        // visible for every existing entry — the toolbar is the canvas's
+        // primary UI, so a silent default-hidden would make canvas mode look
+        // broken on first load post-upgrade.
+        if (version < 16) {
+          const old = p.layoutByWorktree as Record<string, unknown>;
+          const next: Record<string, WorktreeLayout> = {};
+          for (const [wt, raw] of Object.entries(old ?? {})) {
+            const entry = raw as Partial<WorktreeLayout> | undefined;
+            next[wt] = {
+              toolPanelVisible: entry?.toolPanelVisible ?? true,
+              toolPanelTab: (entry?.toolPanelTab ?? "files") as ToolTab,
+              terminalDockVisible: entry?.terminalDockVisible ?? false,
+              toolSplitOrientation: entry?.toolSplitOrientation ?? "horizontal",
+              layoutMode: entry?.layoutMode ?? "classic",
+              activeWorkspaceId: entry?.activeWorkspaceId ?? null,
+              scratchCanvas: entry?.scratchCanvas ?? null,
+              canvasToolbarVisible: entry?.canvasToolbarVisible ?? true,
             };
           }
           p.layoutByWorktree = next;

--- a/web-ui/src/hooks/useStore.ts
+++ b/web-ui/src/hooks/useStore.ts
@@ -1,6 +1,8 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import type { DiffScope, Session, SessionState } from "@/api/types";
+import type { LayoutNode } from "@/lib/tiling";
+import { randomId } from "@/lib/uuid";
 
 /** Tools hosted by the right-side tool panel (one visible at a time). */
 export type ToolTab = "files" | "devices" | "artifacts" | "vcs";
@@ -26,6 +28,20 @@ export interface WorktreeLayout {
   terminalDockVisible: boolean;
   /** "horizontal" = agent | tools side by side; "vertical" = agent / tools stacked. */
   toolSplitOrientation: ToolSplitOrientation;
+  /** "classic" = today's fixed split; "workspace" = tiled/free-form canvas of live panes. */
+  layoutMode: "classic" | "workspace";
+  /** Which saved WorkspaceDoc (below) is currently loaded for this worktree, if any. */
+  activeWorkspaceId: string | null;
+  /**
+   * The TRANSIENT canvas for this worktree — what the top bar's classic↔workspace
+   * toggle drops you into when no saved workspace is selected. Same geometry
+   * payload as a WorkspaceDoc, but it is NOT a WorkspaceDoc: it has no name, never
+   * appears in the sidebar's Workspaces list, and is scoped to this worktree's own
+   * panes only (no cross-worktree tiles). Persisted only incidentally, because
+   * `layoutByWorktree` is persisted — "Save as workspace" is what promotes it into
+   * a real, named, cross-context WorkspaceDoc.
+   */
+  scratchCanvas: CanvasGeometry | null;
 }
 
 export const DEFAULT_WORKTREE_LAYOUT: WorktreeLayout = {
@@ -33,7 +49,57 @@ export const DEFAULT_WORKTREE_LAYOUT: WorktreeLayout = {
   toolPanelTab: "files",
   terminalDockVisible: false,
   toolSplitOrientation: "horizontal",
+  layoutMode: "classic",
+  activeWorkspaceId: null,
+  scratchCanvas: null,
 };
+
+export type TileKind = "agent" | "terminal" | "tools";
+
+export interface TileSpec {
+  id: string;
+  kind: TileKind;
+  /** For "agent"/"terminal" tiles: the underlying session id. Undefined for "tools". */
+  sessionId?: string;
+  /**
+   * Owning worktree for a CROSS-CONTEXT tile (a saved workspace can host panes
+   * from other worktrees/projects). Undefined means "the worktree this canvas is
+   * being viewed in" — every tile on a transient canvas, and every same-worktree
+   * tile, leaves it undefined. Load-bearing for "tools" tiles, whose pane key is
+   * `tools:${worktreeId}`; carried on agent/terminal tiles too, for grouping/labels.
+   */
+  worktreeId?: string;
+}
+
+export interface FreeRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/**
+ * The pure geometry payload of a canvas — everything WorkspaceCanvas reads and
+ * writes while you drag/resize/add/remove tiles. Shared verbatim by the saved
+ * `WorkspaceDoc` (below) and the transient `WorktreeLayout.scratchCanvas`, so the
+ * canvas component can run against either backing store unchanged.
+ */
+export interface CanvasGeometry {
+  mode: "tiled" | "free";
+  tiles: TileSpec[];
+  /** Tiling-mode layout tree (see lib/tiling.ts). Null when mode is "free" or canvas is empty. */
+  tree: LayoutNode | null;
+  /** Free-mode per-tile rects, keyed by TileSpec.id. Empty/unused when mode is "tiled". */
+  freeRects: Record<string, FreeRect>;
+}
+
+/** A saved, named workspace layout — a tiled or free-form arrangement of tiles. */
+export interface WorkspaceDoc extends CanvasGeometry {
+  id: string;
+  name: string;
+  /** worktreeId this workspace was created in (drives the sidebar's per-worktree list). */
+  contextKey: string;
+}
 
 /** IDE viewport fullscreen for the agent pane, tool panel, or terminal dock (not persisted). */
 export type WorkspacePaneFullscreen = "agent" | "tools" | "terminal";
@@ -83,6 +149,11 @@ export interface WorkspaceState {
   leftSidebarWidthPx: number;
   /** Hide worktrees whose agent sessions are all explicitly marked done (not exited) */
   hideInactiveWorktrees: boolean;
+  /** Show the colored border around agent panes/workspace tiles keyed to
+   *  interaction state (waiting_for_human red, needs_review violet, etc).
+   *  Client-side view preference (persisted); does not affect the sidebar's
+   *  StatusDot, which always shows. Defaults on. */
+  showAgentStatusBorders: boolean;
   mobileSidebarOpen: boolean;
   /** Transient attach state between openSession and session:opened */
   sessionAttachState: Record<string, "pending" | "attached">;
@@ -113,6 +184,7 @@ export interface WorkspaceState {
   setLeftSidebarWidthPx: (px: number) => void;
   setMobileSidebarOpen: (open: boolean) => void;
   toggleInactiveWorktreesFilter: () => void;
+  toggleAgentStatusBorders: () => void;
   clearWorkspaceSelection: () => void;
   toggleDotFiles: () => void;
   patchSessionState: (sessionId: string, state: SessionState) => void;
@@ -141,7 +213,31 @@ export interface WorkspaceState {
    */
   sortOrders: Record<string, string[]>;
   setSortOrder: (scopeKey: string, orderedIds: string[]) => void;
+
+  /** Saved workspace layouts, keyed by WorkspaceDoc.id. */
+  workspaceDocs: Record<string, WorkspaceDoc>;
+  /** Display order of workspace ids for a given scope key (e.g. `workspaces:${worktreeId}`) — mirrors the existing `sortOrders` client-only-reorder pattern (see line 142/395). */
+  workspaceOrder: Record<string, string[]>;
+  createWorkspace: (contextKey: string, name: string, mode: "tiled" | "free") => string;
+  renameWorkspace: (id: string, name: string) => void;
+  deleteWorkspace: (id: string) => void;
+  updateWorkspaceDoc: (id: string, patch: Partial<Omit<WorkspaceDoc, "id" | "contextKey">>) => void;
+  reorderWorkspace: (scopeKey: string, orderedIds: string[]) => void;
+  setActiveWorkspace: (worktreeId: string, workspaceId: string | null) => void;
+  setLayoutMode: (worktreeId: string, mode: "classic" | "workspace") => void;
+  /** Create-or-patch this worktree's transient (unsaved) canvas geometry. */
+  updateScratchCanvas: (worktreeId: string, patch: Partial<CanvasGeometry>) => void;
+  /** Drop the transient canvas (e.g. after "Save as workspace" promoted it). */
+  clearScratchCanvas: (worktreeId: string) => void;
 }
+
+/** Starting point for a freshly-entered transient canvas. */
+export const EMPTY_CANVAS_GEOMETRY: CanvasGeometry = {
+  mode: "free",
+  tiles: [],
+  tree: null,
+  freeRects: {},
+};
 
 /**
  * Compute the moved item's new fractional `sortOrder` value from the real
@@ -183,10 +279,13 @@ const initial = {
   leftSidebarCollapsed: false,
   leftSidebarWidthPx: 220,
   hideInactiveWorktrees: true,
+  showAgentStatusBorders: true,
   mobileSidebarOpen: false,
   sessionAttachState: {} as Record<string, "pending" | "attached">,
   workspacePaneFullscreen: null as WorkspacePaneFullscreen | null,
   sortOrders: {} as Record<string, string[]>,
+  workspaceDocs: {} as Record<string, WorkspaceDoc>,
+  workspaceOrder: {} as Record<string, string[]>,
 };
 
 export const useWorkspaceStore = create<WorkspaceState>()(
@@ -352,6 +451,8 @@ export const useWorkspaceStore = create<WorkspaceState>()(
         setMobileSidebarOpen: (open) => set({ mobileSidebarOpen: open }),
         toggleInactiveWorktreesFilter: () =>
           set((s) => ({ hideInactiveWorktrees: !s.hideInactiveWorktrees })),
+        toggleAgentStatusBorders: () =>
+          set((s) => ({ showAgentStatusBorders: !s.showAgentStatusBorders })),
         setWorkspacePaneFullscreen: (next) => set({ workspacePaneFullscreen: next }),
         clearWorkspaceSelection: () =>
           set({
@@ -394,11 +495,97 @@ export const useWorkspaceStore = create<WorkspaceState>()(
           set((s) => ({
             sortOrders: { ...s.sortOrders, [scopeKey]: orderedIds },
           })),
+        createWorkspace: (contextKey, name, mode) => {
+          const id = randomId();
+          set((s) => ({
+            workspaceDocs: {
+              ...s.workspaceDocs,
+              [id]: {
+                id,
+                name,
+                contextKey,
+                mode,
+                tiles: [],
+                tree: null,
+                freeRects: {},
+              },
+            },
+          }));
+          return id;
+        },
+        renameWorkspace: (id, name) =>
+          set((s) => {
+            const doc = s.workspaceDocs[id];
+            if (!doc) return s;
+            return {
+              workspaceDocs: { ...s.workspaceDocs, [id]: { ...doc, name } },
+            };
+          }),
+        deleteWorkspace: (id) =>
+          set((s) => {
+            const next = { ...s.workspaceDocs };
+            delete next[id];
+            return { workspaceDocs: next };
+          }),
+        updateWorkspaceDoc: (id, patch) =>
+          set((s) => {
+            const doc = s.workspaceDocs[id];
+            if (!doc) return s;
+            return {
+              workspaceDocs: { ...s.workspaceDocs, [id]: { ...doc, ...patch } },
+            };
+          }),
+        reorderWorkspace: (scopeKey, orderedIds) =>
+          set((s) => ({
+            workspaceOrder: { ...s.workspaceOrder, [scopeKey]: orderedIds },
+          })),
+        setActiveWorkspace: (worktreeId, workspaceId) =>
+          set((s) => {
+            const cur = s.layoutByWorktree[worktreeId] ?? DEFAULT_WORKTREE_LAYOUT;
+            return {
+              layoutByWorktree: {
+                ...s.layoutByWorktree,
+                [worktreeId]: { ...cur, activeWorkspaceId: workspaceId },
+              },
+            };
+          }),
+        setLayoutMode: (worktreeId, mode) =>
+          set((s) => {
+            const cur = s.layoutByWorktree[worktreeId] ?? DEFAULT_WORKTREE_LAYOUT;
+            return {
+              layoutByWorktree: {
+                ...s.layoutByWorktree,
+                [worktreeId]: { ...cur, layoutMode: mode },
+              },
+            };
+          }),
+        updateScratchCanvas: (worktreeId, patch) =>
+          set((s) => {
+            const cur = s.layoutByWorktree[worktreeId] ?? DEFAULT_WORKTREE_LAYOUT;
+            const scratch = cur.scratchCanvas ?? EMPTY_CANVAS_GEOMETRY;
+            return {
+              layoutByWorktree: {
+                ...s.layoutByWorktree,
+                [worktreeId]: { ...cur, scratchCanvas: { ...scratch, ...patch } },
+              },
+            };
+          }),
+        clearScratchCanvas: (worktreeId) =>
+          set((s) => {
+            const cur = s.layoutByWorktree[worktreeId];
+            if (!cur || cur.scratchCanvas == null) return s;
+            return {
+              layoutByWorktree: {
+                ...s.layoutByWorktree,
+                [worktreeId]: { ...cur, scratchCanvas: null },
+              },
+            };
+          }),
       };
     },
     {
       name: "vibestation:workspace",
-      version: 12,
+      version: 14,
       migrate: (persisted, version) => {
         const p = persisted as Record<string, unknown> | null;
         if (!p || typeof p !== "object") return persisted;
@@ -423,6 +610,9 @@ export const useWorkspaceStore = create<WorkspaceState>()(
               toolPanelTab: "files",
               terminalDockVisible: terminalVisible,
               toolSplitOrientation: "horizontal",
+              layoutMode: "classic",
+              activeWorkspaceId: null,
+              scratchCanvas: null,
             };
           }
           p.layoutByWorktree = next;
@@ -447,6 +637,9 @@ export const useWorkspaceStore = create<WorkspaceState>()(
               toolPanelTab: (treeWasOpen ? "files" : (entry?.toolPanelTab ?? "files")) as ToolTab,
               terminalDockVisible: entry?.terminalDockVisible ?? false,
               toolSplitOrientation: "horizontal",
+              layoutMode: "classic",
+              activeWorkspaceId: null,
+              scratchCanvas: null,
             };
           }
           p.layoutByWorktree = next;
@@ -468,6 +661,9 @@ export const useWorkspaceStore = create<WorkspaceState>()(
               toolPanelTab: (tab === "browser" || tab === "emulator" ? "devices" : (tab ?? "files")) as ToolTab,
               terminalDockVisible: entry?.terminalDockVisible ?? false,
               toolSplitOrientation: "horizontal",
+              layoutMode: "classic",
+              activeWorkspaceId: null,
+              scratchCanvas: null,
             };
           }
           p.layoutByWorktree = next;
@@ -489,6 +685,9 @@ export const useWorkspaceStore = create<WorkspaceState>()(
               toolPanelTab: (tab === "preview" ? "files" : (tab ?? "files")) as ToolTab,
               terminalDockVisible: entry?.terminalDockVisible ?? false,
               toolSplitOrientation: "horizontal",
+              layoutMode: "classic",
+              activeWorkspaceId: null,
+              scratchCanvas: null,
             };
           }
           p.layoutByWorktree = next;
@@ -504,6 +703,9 @@ export const useWorkspaceStore = create<WorkspaceState>()(
               toolPanelTab: (entry?.toolPanelTab ?? "files") as ToolTab,
               terminalDockVisible: entry?.terminalDockVisible ?? false,
               toolSplitOrientation: entry?.toolSplitOrientation ?? "horizontal",
+              layoutMode: entry?.layoutMode ?? "classic",
+              activeWorkspaceId: entry?.activeWorkspaceId ?? null,
+              scratchCanvas: entry?.scratchCanvas ?? null,
             };
           }
           p.layoutByWorktree = next;
@@ -514,6 +716,47 @@ export const useWorkspaceStore = create<WorkspaceState>()(
         // the new default so done worktrees hide consistently across clients.
         if (version < 11) {
           p.hideInactiveWorktrees = true;
+        }
+        // v11 → v13 (v12 had no layoutByWorktree shape change): add layoutMode +
+        // activeWorkspaceId to every existing WorktreeLayout entry, default classic/null.
+        if (version < 13) {
+          const old = p.layoutByWorktree as Record<string, unknown>;
+          const next: Record<string, WorktreeLayout> = {};
+          for (const [wt, raw] of Object.entries(old ?? {})) {
+            const entry = raw as Partial<WorktreeLayout> | undefined;
+            next[wt] = {
+              toolPanelVisible: entry?.toolPanelVisible ?? true,
+              toolPanelTab: (entry?.toolPanelTab ?? "files") as ToolTab,
+              terminalDockVisible: entry?.terminalDockVisible ?? false,
+              toolSplitOrientation: entry?.toolSplitOrientation ?? "horizontal",
+              layoutMode: entry?.layoutMode ?? "classic",
+              activeWorkspaceId: entry?.activeWorkspaceId ?? null,
+              scratchCanvas: entry?.scratchCanvas ?? null,
+            };
+          }
+          p.layoutByWorktree = next;
+          if (!p.workspaceDocs) p.workspaceDocs = {};
+          if (!p.workspaceOrder) p.workspaceOrder = {};
+        }
+        // v13 → v14: workspace mode no longer auto-creates a named WorkspaceDoc.
+        // Add the transient `scratchCanvas` slot (null = "nothing scratched yet",
+        // seeded lazily from the worktree's live panes on first entry).
+        if (version < 14) {
+          const old = p.layoutByWorktree as Record<string, unknown>;
+          const next: Record<string, WorktreeLayout> = {};
+          for (const [wt, raw] of Object.entries(old ?? {})) {
+            const entry = raw as Partial<WorktreeLayout> | undefined;
+            next[wt] = {
+              toolPanelVisible: entry?.toolPanelVisible ?? true,
+              toolPanelTab: (entry?.toolPanelTab ?? "files") as ToolTab,
+              terminalDockVisible: entry?.terminalDockVisible ?? false,
+              toolSplitOrientation: entry?.toolSplitOrientation ?? "horizontal",
+              layoutMode: entry?.layoutMode ?? "classic",
+              activeWorkspaceId: entry?.activeWorkspaceId ?? null,
+              scratchCanvas: entry?.scratchCanvas ?? null,
+            };
+          }
+          p.layoutByWorktree = next;
         }
         return p;
       },
@@ -537,7 +780,10 @@ export const useWorkspaceStore = create<WorkspaceState>()(
         leftSidebarCollapsed: s.leftSidebarCollapsed,
         leftSidebarWidthPx: s.leftSidebarWidthPx,
         hideInactiveWorktrees: s.hideInactiveWorktrees,
+        showAgentStatusBorders: s.showAgentStatusBorders,
         sortOrders: s.sortOrders,
+        workspaceDocs: s.workspaceDocs,
+        workspaceOrder: s.workspaceOrder,
       }),
     },
   ),

--- a/web-ui/src/hooks/useWorkspaceKeyboardShortcuts.ts
+++ b/web-ui/src/hooks/useWorkspaceKeyboardShortcuts.ts
@@ -1,10 +1,21 @@
 import { useEffect } from "react";
 import { useWorkspaceStore } from "@/hooks/useStore";
 
-/** ⌘/Ctrl+Shift+F/P → Files/Preview tool tab; ⌘/Ctrl+Shift+Z → terminal dock; ⌘/Ctrl+P quick-open files */
+/**
+ * ⌘/Ctrl+Shift+F/P → Files/Preview tool tab; ⌘/Ctrl+Shift+Z → terminal dock;
+ * ⌘/Ctrl+P quick-open files.
+ *
+ * `canvasMode`: in workspace-canvas mode the terminal dock's visibility flag
+ * no longer means anything (every terminal is its own tile, forced-visible —
+ * see Workspace.tsx's `<WorkspaceCanvas>` props) and its TopBar button is
+ * disabled to match, so ⌘⇧Z is made a no-op there too — a disabled button
+ * with a live shortcut behind it would silently flip a flag the UI shows as
+ * inert, surprising the user when they later leave canvas mode.
+ */
 export function useWorkspaceKeyboardShortcuts(
   setQuickOpen: (v: boolean | ((p: boolean) => boolean)) => void,
   enabled = true,
+  canvasMode = false,
 ) {
   useEffect(() => {
     if (!enabled) return;
@@ -42,12 +53,12 @@ export function useWorkspaceKeyboardShortcuts(
           setToolPanelTab("files");
         } else if (k === "Z") {
           e.preventDefault();
-          toggleTerminalDock();
+          if (!canvasMode) toggleTerminalDock();
         }
       }
     };
 
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [setQuickOpen, enabled]);
+  }, [setQuickOpen, enabled, canvasMode]);
 }

--- a/web-ui/src/lib/tiling.ts
+++ b/web-ui/src/lib/tiling.ts
@@ -3,8 +3,12 @@
  * tiling design research. Pure functions — every op returns a NEW root,
  * never mutates its input, so React state updates are trivial.
  *
- * DEV-ONLY POC code (web-ui/workspaces-demo.html), not wired into the real
- * app. See .vibekit/feature-plans/wip/agent-interaction-workspaces/.
+ * Actively used by the real app — `WorkspaceCanvas.tsx` (tiling-mode canvas)
+ * and `useStore.ts` (`insertTileIntoWorkspaceDoc`, Phase 4c auto-insert).
+ * The original design was validated first as a standalone POC artifact
+ * (`.scratch/workspaces-poc.html`, superseded/historical — see
+ * .vibekit/feature-plans/wip/agent-interaction-workspaces/04-workspaces);
+ * this file is the real, shipped implementation, not that POC.
  */
 
 export type Axis = "row" | "column";
@@ -280,4 +284,15 @@ export function collectTileIds(root: LayoutNode | null): string[] {
   if (!root) return [];
   if (root.type === "leaf") return [root.tileId];
   return root.children.flatMap(collectTileIds);
+}
+
+/** Find the leaf NODE's own id (not the tile id) hosting `tileId`, or null. */
+export function findLeafId(root: LayoutNode | null, tileId: string): string | null {
+  if (!root) return null;
+  if (root.type === "leaf") return root.tileId === tileId ? root.id : null;
+  for (const child of root.children) {
+    const found = findLeafId(child, tileId);
+    if (found) return found;
+  }
+  return null;
 }

--- a/web-ui/src/lib/tiling.ts
+++ b/web-ui/src/lib/tiling.ts
@@ -1,0 +1,283 @@
+/**
+ * n-ary split-tree tiling engine (i3-style), per the Workspaces PRD §3 /
+ * tiling design research. Pure functions — every op returns a NEW root,
+ * never mutates its input, so React state updates are trivial.
+ *
+ * DEV-ONLY POC code (web-ui/workspaces-demo.html), not wired into the real
+ * app. See .vibekit/feature-plans/wip/agent-interaction-workspaces/.
+ */
+
+export type Axis = "row" | "column";
+
+export interface SplitNode {
+  id: string;
+  type: "split";
+  axis: Axis;
+  children: LayoutNode[];
+  /** Same length as children; sums to ~1 (normalized after every mutation). */
+  sizes: number[];
+}
+
+export interface LeafNode {
+  id: string;
+  type: "leaf";
+  tileId: string;
+}
+
+export type LayoutNode = SplitNode | LeafNode;
+
+let idSeq = 0;
+function nextId(prefix: string): string {
+  idSeq += 1;
+  return `${prefix}-${idSeq}`;
+}
+
+export type Side = "left" | "right" | "top" | "bottom";
+
+function axisForSide(side: Side): Axis {
+  return side === "left" || side === "right" ? "row" : "column";
+}
+
+function normalize(sizes: number[]): number[] {
+  const sum = sizes.reduce((a, b) => a + b, 0);
+  if (sum <= 0) return sizes.map(() => 1 / sizes.length);
+  return sizes.map((s) => s / sum);
+}
+
+function findParent(
+  root: LayoutNode,
+  targetId: string,
+): { parent: SplitNode; index: number } | null {
+  if (root.type === "leaf") return null;
+  for (let i = 0; i < root.children.length; i++) {
+    const child = root.children[i];
+    if (!child) continue;
+    if (child.id === targetId) return { parent: root, index: i };
+    const found = findParent(child, targetId);
+    if (found) return found;
+  }
+  return null;
+}
+
+function findNode(root: LayoutNode | null, id: string): LayoutNode | null {
+  if (!root) return null;
+  if (root.id === id) return root;
+  if (root.type === "leaf") return null;
+  for (const child of root.children) {
+    const found = findNode(child, id);
+    if (found) return found;
+  }
+  return null;
+}
+
+/** Deep clone — cheap enough for a POC's tree sizes, keeps ops pure/simple. */
+function clone<T>(node: T): T {
+  return JSON.parse(JSON.stringify(node));
+}
+
+/**
+ * Insert a new leaf next to `targetLeafId`, on `side`. If the target's
+ * parent already splits along the matching axis, the new leaf joins as a
+ * sibling (halving the target's size). Otherwise the target leaf is
+ * replaced in-place by a new 2-child split container.
+ */
+export function insertPane(
+  root: LayoutNode | null,
+  targetLeafId: string | null,
+  side: Side,
+  newTileId: string,
+): LayoutNode {
+  const newLeaf: LeafNode = { id: nextId("leaf"), type: "leaf", tileId: newTileId };
+  if (!root || !targetLeafId) return newLeaf;
+
+  const next = clone(root);
+  const axis = axisForSide(side);
+  const before = side === "left" || side === "top";
+
+  const loc = findParent(next, targetLeafId);
+  if (loc && loc.parent.axis === axis) {
+    const insertAt = before ? loc.index : loc.index + 1;
+    const half = (loc.parent.sizes[loc.index] ?? 1) / 2;
+    loc.parent.sizes[loc.index] = half;
+    loc.parent.sizes.splice(insertAt, 0, half);
+    loc.parent.children.splice(insertAt, 0, newLeaf);
+    return next;
+  }
+
+  // Replace the target leaf itself with a new split container.
+  const target = findNode(next, targetLeafId);
+  if (!target) return next; // target vanished — no-op, caller should re-render from fresh state
+  const replacement: SplitNode = {
+    id: nextId("split"),
+    type: "split",
+    axis,
+    children: before ? [newLeaf, clone(target)] : [clone(target), newLeaf],
+    sizes: [0.5, 0.5],
+  };
+  if (target.id === next.id) return replacement; // target was root
+  const parentLoc = findParent(next, targetLeafId);
+  if (parentLoc) parentLoc.parent.children[parentLoc.index] = replacement;
+  return next;
+}
+
+/**
+ * Remove a leaf; its size is redistributed to remaining siblings. A
+ * single-child parent collapses into that child, merging same-axis nesting
+ * so dividers never end up orphaned one level too deep.
+ */
+export function removePane(root: LayoutNode | null, leafId: string): LayoutNode | null {
+  if (!root) return null;
+  if (root.type === "leaf") return root.id === leafId ? null : root;
+
+  const next = clone(root);
+  const loc = findParent(next, leafId);
+  if (!loc) return next; // not found — no-op
+
+  loc.parent.children.splice(loc.index, 1);
+  loc.parent.sizes.splice(loc.index, 1);
+  loc.parent.sizes = normalize(loc.parent.sizes);
+
+  return collapseSingleChildren(next);
+}
+
+/** Recursively collapse any split left with exactly one child, merging same-axis nesting. */
+function collapseSingleChildren(node: LayoutNode): LayoutNode | null {
+  if (node.type === "leaf") return node;
+
+  node.children = node.children
+    .map((c) => collapseSingleChildren(c))
+    .filter((c): c is LayoutNode => c !== null);
+
+  if (node.children.length === 0) return null;
+  const only = node.children[0];
+  if (node.children.length === 1 && only) return only;
+
+  // Merge same-axis grandchildren up one level (avoids row>row nesting).
+  const merged: LayoutNode[] = [];
+  const mergedSizes: number[] = [];
+  node.children.forEach((child, i) => {
+    if (!child) return;
+    if (child.type === "split" && child.axis === node.axis) {
+      const scale = node.sizes[i] ?? 1;
+      child.children.forEach((gc, j) => {
+        if (!gc) return;
+        merged.push(gc);
+        mergedSizes.push((child.sizes[j] ?? 1) * scale);
+      });
+    } else {
+      merged.push(child);
+      mergedSizes.push(node.sizes[i] ?? 1);
+    }
+  });
+  node.children = merged;
+  node.sizes = normalize(mergedSizes);
+  return node;
+}
+
+/**
+ * Swap two tiles' positions in the tree by exchanging the `tileId` of their
+ * leaves — the tree's SHAPE and every split size are untouched, so the two
+ * panes simply trade rectangles. This is what a "drop on the center zone" does
+ * (see WorkspaceCanvas's drag-to-tile); an edge-zone drop instead restructures
+ * via removePane + insertPane. No-op if either tile isn't in the tree.
+ */
+export function swapPanes(
+  root: LayoutNode | null,
+  tileIdA: string,
+  tileIdB: string,
+): LayoutNode | null {
+  if (!root || tileIdA === tileIdB) return root;
+  const next = clone(root);
+  let leafA: LeafNode | null = null;
+  let leafB: LeafNode | null = null;
+  const visit = (node: LayoutNode) => {
+    if (node.type === "leaf") {
+      if (node.tileId === tileIdA) leafA = node;
+      else if (node.tileId === tileIdB) leafB = node;
+      return;
+    }
+    node.children.forEach(visit);
+  };
+  visit(next);
+  if (!leafA || !leafB) return next;
+  (leafA as LeafNode).tileId = tileIdB;
+  (leafB as LeafNode).tileId = tileIdA;
+  return next;
+}
+
+/**
+ * Zero-sum resize of two adjacent children in one split container, clamped
+ * to a minimum. `deltaFraction` is the TOTAL delta since the drag started
+ * (not since the last mousemove) — callers must compute it against a fixed
+ * drag-start baseline, not against the live/already-mutated tree, or the
+ * resize compounds every tick and the divider runs away under the cursor.
+ * `baseSizes` — the [a, b] sizes at drag-start — makes that baseline
+ * explicit and unambiguous rather than relying on caller discipline alone.
+ */
+export function resizeSplit(
+  root: LayoutNode | null,
+  splitId: string,
+  dividerIndex: number,
+  deltaFraction: number,
+  baseSizes: [number, number],
+  minFraction = 0.12,
+): LayoutNode | null {
+  if (!root) return null;
+  const next = clone(root);
+  const node = findNode(next, splitId);
+  if (!node || node.type !== "split") return next;
+
+  const a = dividerIndex;
+  const b = dividerIndex + 1;
+  if (a < 0 || b >= node.sizes.length) return next;
+
+  let newA = baseSizes[0] + deltaFraction;
+  let newB = baseSizes[1] - deltaFraction;
+  if (newA < minFraction) {
+    const diff = minFraction - newA;
+    newA = minFraction;
+    newB -= diff;
+  }
+  if (newB < minFraction) {
+    const diff = minFraction - newB;
+    newB = minFraction;
+    newA -= diff;
+  }
+  node.sizes[a] = newA;
+  node.sizes[b] = newB;
+  return next;
+}
+
+/**
+ * Deterministic free-form → tiled conversion: sort tiles in reading order
+ * (top-to-bottom band, then left-to-right), then recursively bisect —
+ * NOT a geometry-faithful reconstruction (free-form tiles can overlap, so
+ * none exists), but order-preserving and simple. Axis alternates per depth.
+ */
+export function buildBalancedTree(
+  tileIdsInReadingOrder: string[],
+  axis: Axis = "row",
+): LayoutNode | null {
+  if (tileIdsInReadingOrder.length === 0) return null;
+  if (tileIdsInReadingOrder.length === 1) {
+    return { id: nextId("leaf"), type: "leaf", tileId: tileIdsInReadingOrder[0]! };
+  }
+  const mid = Math.ceil(tileIdsInReadingOrder.length / 2);
+  const left = tileIdsInReadingOrder.slice(0, mid);
+  const right = tileIdsInReadingOrder.slice(mid);
+  const nextAxis: Axis = axis === "row" ? "column" : "row";
+  return {
+    id: nextId("split"),
+    type: "split",
+    axis,
+    children: [buildBalancedTree(left, nextAxis)!, buildBalancedTree(right, nextAxis)!],
+    sizes: [left.length / tileIdsInReadingOrder.length, right.length / tileIdsInReadingOrder.length],
+  };
+}
+
+/** Collect leaf tileIds in tree order (used to render + to seed the reverse conversion). */
+export function collectTileIds(root: LayoutNode | null): string[] {
+  if (!root) return [];
+  if (root.type === "leaf") return [root.tileId];
+  return root.children.flatMap(collectTileIds);
+}

--- a/web-ui/src/lib/uuid.ts
+++ b/web-ui/src/lib/uuid.ts
@@ -1,0 +1,42 @@
+/**
+ * Random id generator that works outside secure contexts.
+ *
+ * `crypto.randomUUID` is only exposed on secure origins (https:// and
+ * localhost). Vibe Station's web UI is routinely opened over plain HTTP on a
+ * LAN IP or hostname (phone/tablet/other machine on the network — see the PWA
+ * support), where `crypto.randomUUID` is `undefined` and calling it throws
+ * `TypeError: crypto.randomUUID is not a function`. There is no React error
+ * boundary above the workspace tree, so such a throw blanks the entire app.
+ *
+ * `crypto.getRandomValues` IS available in insecure contexts, so use it when
+ * `randomUUID` is missing and only fall back to `Math.random` if even that is
+ * gone. Output is always a v4-shaped UUID string; these ids are local layout
+ * identifiers, not security tokens.
+ */
+export function randomId(): string {
+  const c: Crypto | undefined = typeof globalThis !== "undefined" ? globalThis.crypto : undefined;
+  if (c && typeof c.randomUUID === "function") return c.randomUUID();
+
+  const bytes = new Uint8Array(16);
+  if (c && typeof c.getRandomValues === "function") {
+    c.getRandomValues(bytes);
+  } else {
+    for (let i = 0; i < 16; i += 1) bytes[i] = Math.floor(Math.random() * 256);
+  }
+  // RFC 4122 v4 bits.
+  bytes[6] = (bytes[6]! & 0x0f) | 0x40;
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+  const hex: string[] = [];
+  for (let i = 0; i < 16; i += 1) hex.push(bytes[i]!.toString(16).padStart(2, "0"));
+  return (
+    hex.slice(0, 4).join("") +
+    "-" +
+    hex.slice(4, 6).join("") +
+    "-" +
+    hex.slice(6, 8).join("") +
+    "-" +
+    hex.slice(8, 10).join("") +
+    "-" +
+    hex.slice(10, 16).join("")
+  );
+}

--- a/web-ui/src/lib/worktreeStatus.test.ts
+++ b/web-ui/src/lib/worktreeStatus.test.ts
@@ -50,4 +50,21 @@ describe("worktreeRolledUpStatus", () => {
     const sessions = [sess("a", "working")];
     expect(worktreeRolledUpStatus(sessions, { a: "idle" })).toBe("idle");
   });
+
+  // --- 2.T1: waiting_for_human / needs_review rollup precedence (R8) ---
+
+  it("rolls up to waiting_for_human over working", () => {
+    const sessions = [sess("a", "waiting_for_human"), sess("b", "working")];
+    expect(worktreeRolledUpStatus(sessions, {})).toBe("waiting_for_human");
+  });
+
+  it("rolls up to needs_review over working", () => {
+    const sessions = [sess("a", "needs_review"), sess("b", "working")];
+    expect(worktreeRolledUpStatus(sessions, {})).toBe("needs_review");
+  });
+
+  it("prefers waiting_for_human over needs_review when both present", () => {
+    const sessions = [sess("a", "needs_review"), sess("b", "waiting_for_human")];
+    expect(worktreeRolledUpStatus(sessions, {})).toBe("waiting_for_human");
+  });
 });

--- a/web-ui/src/lib/worktreeStatus.ts
+++ b/web-ui/src/lib/worktreeStatus.ts
@@ -1,6 +1,8 @@
 import type { Session, SessionState } from "@/api/types";
 
 export type WorktreeRolledUpStatus =
+  | "waiting_for_human"
+  | "needs_review"
   | "working"
   | "spawning"
   | "idle"
@@ -8,7 +10,13 @@ export type WorktreeRolledUpStatus =
   | "exited"
   | "none";
 
+// PRD R8 precedence: waiting_for_human outranks needs_review outranks
+// working — one session actively blocking on a human dominates the whole
+// worktree's displayed status; a ready-for-review PR is informational and
+// ranks just above ordinary activity, not above an active block.
 const rank: Record<WorktreeRolledUpStatus, number> = {
+  waiting_for_human: 8,
+  needs_review: 7,
   working: 6,
   spawning: 5,
   idle: 4,
@@ -16,6 +24,33 @@ const rank: Record<WorktreeRolledUpStatus, number> = {
   exited: 2,
   none: 1,
 };
+
+/**
+ * Single-session status — the per-session equivalent of `worktreeRolledUpStatus`'s
+ * inner mapping, same color scheme. Shared by `WorkspaceCanvas.tsx` (tile chrome)
+ * and `AgentPaneSlot.tsx` (direct-session chrome) so both surfaces use one source
+ * of truth for "what color does this session's state map to."
+ */
+export function sessionStatus(state: SessionState): WorktreeRolledUpStatus {
+  switch (state) {
+    case "not_started":
+      return "spawning";
+    case "working":
+      return "working";
+    case "idle":
+      return "idle";
+    case "waiting_for_human":
+      return "waiting_for_human";
+    case "needs_review":
+      return "needs_review";
+    case "done":
+      return "done";
+    case "exited":
+      return "exited";
+    default:
+      return "none";
+  }
+}
 
 /**
  * Single status for a worktree row: working > spawning (not_started) > idle > done > exited > none.
@@ -40,6 +75,8 @@ export function worktreeRolledUpStatus(
     if (st === "not_started") step = "spawning";
     else if (st === "working") step = "working";
     else if (st === "idle") step = "idle";
+    else if (st === "waiting_for_human") step = "waiting_for_human";
+    else if (st === "needs_review") step = "needs_review";
     else if (st === "done") step = "done";
     else if (st === "exited") step = "exited";
     else step = "none";

--- a/web-ui/src/routes/Workspace.tsx
+++ b/web-ui/src/routes/Workspace.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { api } from "@/api";
 import { Layout } from "@/components/layout/Layout";
@@ -11,7 +11,11 @@ import { PaneTools } from "@/components/layout/PaneTools";
 import { ToolPanel } from "@/components/layout/ToolPanel";
 import { DashboardPanel } from "@/components/layout/DashboardPanel";
 import { SettingsPanel } from "@/components/settings/SettingsPanel";
+import { PaneOutletProvider, PaneOutlet } from "@/components/layout/paneOutlets";
+import { PaneHostLayer, type PaneKey } from "@/components/layout/PaneHostLayer";
+import { WorkspaceCanvas } from "@/components/layout/WorkspaceCanvas";
 import { useWorkspaceStore } from "@/hooks/useStore";
+import { useLayout } from "@/hooks/useLayout";
 import { useServerStore } from "@/hooks/useServerStore";
 import { useServerSync } from "@/hooks/useServerSync";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
@@ -47,6 +51,11 @@ export function Workspace() {
   const setLeftSidebarWidthPx = useWorkspaceStore((s) => s.setLeftSidebarWidthPx);
   const mobileSidebarOpen = useWorkspaceStore((s) => s.mobileSidebarOpen);
   const setMobileSidebarOpen = useWorkspaceStore((s) => s.setMobileSidebarOpen);
+
+  // Layout.tsx reads its own `layoutMode` (aliased there as `paneLayoutMode`) to
+  // decide whether to render `workspaceCanvas`; this route only needs the
+  // region-visibility flags to pass down to <WorkspaceCanvas>.
+  const { toolPanelVisible, terminalDockVisible, activeWorkspaceId } = useLayout();
 
   const [quickOpen, setQuickOpen] = useState(false);
 
@@ -174,28 +183,129 @@ export function Workspace() {
   const leftColumnPx = isMobile ? 280 : leftSidebarCollapsed ? 52 : leftSidebarWidthPx;
 
   const activeTerminalSessionId = useWorkspaceStore((s) => s.activeTerminalSessionId);
-  const activeSession = activeSessionId
-    ? sessions.find((s) => s.id === activeSessionId)
-    : undefined;
   const activeTerminalSession = activeTerminalSessionId
     ? sessions.find((s) => s.id === activeTerminalSessionId)
     : undefined;
 
+  // Every live pane (agent/terminal/tools) for the active worktree — mounted
+  // ONCE via a single, always-mounted <PaneHostLayer> below, regardless of
+  // classic vs. workspace mode, so a mode toggle (or a tab switch) never
+  // remounts a live TerminalPane/AgentPaneSlot (ghost-PTY-stream bug, see
+  // AGENTS.md). Direct sessions are exempt — they keep their own direct
+  // rendering untouched (workspace mode is worktree-only).
+  const worktreeAgentSessions = useMemo(
+    () => sessions.filter((s) => s.worktreeId === activeWorktreeId && s.type === "agent"),
+    [sessions, activeWorktreeId],
+  );
+  const worktreeTerminalSessions = useMemo(
+    () => sessions.filter((s) => s.worktreeId === activeWorktreeId && s.type === "terminal"),
+    [sessions, activeWorktreeId],
+  );
+  // A SAVED workspace may tile panes from other worktrees/projects; those panes
+  // are outside the active worktree's own always-mounted set above, so union
+  // them in — otherwise their <PaneOutlet> would have nothing to portal into.
+  // The transient (unsaved) canvas never needs this: it only ever references
+  // this worktree's own sessions.
+  const workspaceDocs = useWorkspaceStore((s) => s.workspaceDocs);
+  const crossContextPaneKeys = useMemo<PaneKey[]>(() => {
+    if (!activeWorktreeId || isDirectSession || !activeWorkspaceId) return [];
+    const doc = workspaceDocs[activeWorkspaceId];
+    if (!doc) return [];
+    const keys: PaneKey[] = [];
+    for (const tile of doc.tiles) {
+      if (tile.kind === "tools") {
+        keys.push(`tools:${tile.worktreeId ?? activeWorktreeId}`);
+      } else if (tile.sessionId && sessions.some((s) => s.id === tile.sessionId)) {
+        keys.push(`${tile.kind}:${tile.sessionId}`);
+      }
+    }
+    return keys;
+  }, [activeWorktreeId, isDirectSession, activeWorkspaceId, workspaceDocs, sessions]);
+  const worktreePaneKeys = useMemo<PaneKey[]>(() => {
+    if (!activeWorktreeId || isDirectSession) return [];
+    const keys: PaneKey[] = [];
+    for (const s of worktreeAgentSessions) keys.push(`agent:${s.id}`);
+    for (const s of worktreeTerminalSessions) keys.push(`terminal:${s.id}`);
+    keys.push(`tools:${activeWorktreeId}`);
+    for (const k of crossContextPaneKeys) if (!keys.includes(k)) keys.push(k);
+    return keys;
+  }, [
+    activeWorktreeId,
+    isDirectSession,
+    worktreeAgentSessions,
+    worktreeTerminalSessions,
+    crossContextPaneKeys,
+  ]);
+  const renderWorktreePane = useCallback(
+    (key: PaneKey): ReactNode => {
+      if (key.startsWith("agent:")) {
+        const id = key.slice("agent:".length);
+        return <AgentPaneSlot api={api} sessionId={id} session={sessions.find((s) => s.id === id)} />;
+      }
+      if (key.startsWith("terminal:")) {
+        const id = key.slice("terminal:".length);
+        return <TerminalPane api={api} sessionId={id} session={sessions.find((s) => s.id === id)} />;
+      }
+      const wtId = key.slice("tools:".length);
+      return (
+        <ToolPanel
+          api={api}
+          worktreeId={wtId}
+          baseBranch={worktrees.find((w) => w.id === wtId)?.baseBranch}
+        />
+      );
+    },
+    [sessions, worktrees],
+  );
+  const worktreePaneHostLayer = (
+    <PaneHostLayer paneKeys={worktreePaneKeys} renderPane={renderWorktreePane} />
+  );
+
   const agentPane = (
     <div className="pane-stack">
       <TabsStrip api={api} worktreeId={activeWorktreeId} kind="agent" />
-      {/* TerminalPane stays permanently mounted; ChatPane is toggled beside it
-          by CSS visibility for JSON-channel agents (Decision 14). */}
-      <AgentPaneSlot api={api} sessionId={activeSessionId} session={activeSession} />
+      {/* The live AgentPaneSlot is portaled in via <PaneOutlet> from the
+          shared PaneHostLayer above — never rendered directly here — so it
+          stays mounted across a classic <-> workspace layoutMode toggle. */}
+      {activeSessionId ? (
+        <PaneOutlet paneKey={`agent:${activeSessionId}`} />
+      ) : (
+        <div className="empty-state">No agent session</div>
+      )}
     </div>
   );
 
   const terminalDock = (
     <div className="pane-stack">
       <TabsStrip api={api} worktreeId={activeWorktreeId} kind="terminal" />
-      <TerminalPane api={api} sessionId={activeTerminalSessionId} session={activeTerminalSession} />
+      {activeTerminalSessionId ? (
+        <PaneOutlet paneKey={`terminal:${activeTerminalSessionId}`} />
+      ) : (
+        <div className="empty-state">No terminal session</div>
+      )}
     </div>
   );
+
+  const worktreeToolPanel = activeWorktreeId ? (
+    <PaneOutlet paneKey={`tools:${activeWorktreeId}`} />
+  ) : (
+    <ToolPanel api={api} worktreeId={null} />
+  );
+
+  const workspaceCanvas =
+    activeWorktreeId && !isDirectSession ? (
+      <WorkspaceCanvas
+        worktreeId={activeWorktreeId}
+        agentSessions={worktreeAgentSessions}
+        terminalSessions={worktreeTerminalSessions}
+        hasTools
+        toolPanelVisible={toolPanelVisible}
+        terminalDockVisible={terminalDockVisible}
+        allSessions={sessions}
+        worktrees={worktrees}
+        projects={projects}
+      />
+    ) : null;
 
   // Direct session: identical to the worktree layout, minus the agent TabsStrip
   // (a direct session is a single agent — no agent tabs). The tool panel and
@@ -235,6 +345,7 @@ export function Workspace() {
         : "workspace";
 
   return (
+    <PaneOutletProvider>
     <div className="workspace-route">
       {!isFullWidthPane ? (
         isDirectSession ? (
@@ -304,16 +415,13 @@ export function Workspace() {
               }
             : {
                 agentPane,
-                toolPanel: (
-                  <ToolPanel
-                    api={api}
-                    worktreeId={activeWorktreeId}
-                    baseBranch={worktrees.find((w) => w.id === activeWorktreeId)?.baseBranch}
-                  />
-                ),
+                toolPanel: worktreeToolPanel,
                 terminalDock,
+                workspaceCanvas,
+                paneHostLayer: worktreePaneHostLayer,
               })}
       />
     </div>
+    </PaneOutletProvider>
   );
 }

--- a/web-ui/src/routes/Workspace.tsx
+++ b/web-ui/src/routes/Workspace.tsx
@@ -27,10 +27,13 @@ import { QuickOpen } from "@/components/dialogs/QuickOpen";
 export function Workspace() {
   const location = useLocation();
   const navigate = useNavigate();
-  const params = useParams<{ directSessionId?: string }>();
+  const params = useParams<{ directSessionId?: string; workspaceId?: string }>();
   const isDashboard = location.pathname === "/";
   const isSettings = location.pathname === "/settings";
   const isDirectSession = location.pathname.startsWith("/session/");
+  // Detached-workspace view (agent-interaction-workspaces/04-workspaces Phase 3,
+  // Decision 4) — a saved WorkspaceDoc's own route, independent of any worktree.
+  const isWorkspaceView = location.pathname.startsWith("/workspaces/");
   const isFullWidthPane = isDashboard || isSettings;
 
   // Server data lives in `useServerStore`, populated and refreshed by
@@ -53,9 +56,10 @@ export function Workspace() {
   const setMobileSidebarOpen = useWorkspaceStore((s) => s.setMobileSidebarOpen);
 
   // Layout.tsx reads its own `layoutMode` (aliased there as `paneLayoutMode`) to
-  // decide whether to render `workspaceCanvas`; this route only needs the
-  // region-visibility flags to pass down to <WorkspaceCanvas>.
-  const { toolPanelVisible, terminalDockVisible, activeWorkspaceId } = useLayout();
+  // decide whether to render `workspaceCanvas`; this route needs the same
+  // flag too, to tell `ToolPanel` when it's currently live inside a
+  // workspace-canvas tile (see `hidePanelControls`).
+  const { layoutMode: paneLayoutMode, canvasToolbarVisible } = useLayout();
 
   const [quickOpen, setQuickOpen] = useState(false);
 
@@ -72,10 +76,26 @@ export function Workspace() {
     return projects.find((p) => p.id === directSession.projectId) ?? null;
   }, [directSession, projects]);
 
+  // Derive the detached workspace being viewed, if any (Phase 3a.4). `workspaceDocs`
+  // is client-only persisted state (zustand `persist`, hydrated synchronously from
+  // localStorage) — no `bundleLoaded` gate needed the way directSession's redirect
+  // effect below needs one for server-fetched `sessions`.
+  const workspaceDocs = useWorkspaceStore((s) => s.workspaceDocs);
+  const viewedWorkspace = useMemo(() => {
+    if (!isWorkspaceView || !params.workspaceId) return null;
+    return workspaceDocs[params.workspaceId] ?? null;
+  }, [isWorkspaceView, params.workspaceId, workspaceDocs]);
+
   useWorkspaceUrlSync(bundleLoaded, worktrees, sessions);
   // Quick Open + pane shortcuts work in both worktree and direct-session modes
-  // (direct sessions browse the project base dir); only full-width panes opt out.
-  useWorkspaceKeyboardShortcuts(setQuickOpen, !isFullWidthPane);
+  // (direct sessions browse the project base dir); only full-width panes (and
+  // the detached workspace view, which has no single owning worktree/project
+  // to scope a file search to) opt out.
+  useWorkspaceKeyboardShortcuts(
+    setQuickOpen,
+    !isFullWidthPane && !isWorkspaceView,
+    paneLayoutMode === "workspace",
+  );
 
   // Clear worktree context when entering direct session mode (mutual exclusion)
   useEffect(() => {
@@ -89,6 +109,21 @@ export function Workspace() {
       });
     }
   }, [isDirectSession, bundleLoaded]);
+
+  // Same mutual exclusion for the detached workspace view — it isn't "owned"
+  // by any single worktree (that's the whole point of Phase 3), so clear any
+  // leftover worktree/direct-session context on entry.
+  useEffect(() => {
+    if (!isWorkspaceView) return;
+    const s = useWorkspaceStore.getState();
+    if (s.activeWorktreeId || s.activeSessionId) {
+      useWorkspaceStore.setState({
+        activeWorktreeId: null,
+        activeSessionId: null,
+        activeFilePath: null,
+      });
+    }
+  }, [isWorkspaceView]);
 
   // Bind the direct-session layout context (project id) so the tool panel /
   // terminal dock toggles persist per project, and the Files tree + terminals
@@ -108,6 +143,17 @@ export function Workspace() {
     }
   }, [isDirectSession, bundleLoaded, params.directSessionId, directSession, navigate]);
 
+  // Redirect to dashboard if the workspace doc no longer exists (deleted, or a
+  // stale/invalid id in the URL — Risk #8, Phase 3c.3). Mirrors the direct-
+  // session pattern above; no `bundleLoaded` gate since `workspaceDocs` isn't
+  // server-fetched.
+  useEffect(() => {
+    if (!isWorkspaceView) return;
+    if (params.workspaceId && !viewedWorkspace) {
+      navigate("/", { replace: true });
+    }
+  }, [isWorkspaceView, params.workspaceId, viewedWorkspace, navigate]);
+
   // Update browser tab title to reflect current context
   useEffect(() => {
     if (isSettings) {
@@ -115,13 +161,25 @@ export function Workspace() {
     } else if (isDirectSession && directSession) {
       const projectName = directSessionProject?.name ?? "Direct";
       document.title = `${sessionLabel(directSession)} — ${projectName} — Vibe Station`;
+    } else if (isWorkspaceView && viewedWorkspace) {
+      document.title = `${viewedWorkspace.name} — Vibe Station`;
     } else if (isDashboard || !activeWorktreeId) {
       document.title = "Vibe Station";
     } else {
       const wt = worktrees.find((w) => w.id === activeWorktreeId);
       document.title = wt ? `${wt.branch} — Vibe Station` : "Vibe Station";
     }
-  }, [activeWorktreeId, worktrees, isDashboard, isSettings, isDirectSession, directSession, directSessionProject]);
+  }, [
+    activeWorktreeId,
+    worktrees,
+    isDashboard,
+    isSettings,
+    isDirectSession,
+    directSession,
+    directSessionProject,
+    isWorkspaceView,
+    viewedWorkspace,
+  ]);
 
   // Open the WS eagerly so the ConnectionStatus pill reflects daemon health
   // even before the first session subscription. The api client owns reconnects.
@@ -201,41 +259,26 @@ export function Workspace() {
     () => sessions.filter((s) => s.worktreeId === activeWorktreeId && s.type === "terminal"),
     [sessions, activeWorktreeId],
   );
-  // A SAVED workspace may tile panes from other worktrees/projects; those panes
-  // are outside the active worktree's own always-mounted set above, so union
-  // them in — otherwise their <PaneOutlet> would have nothing to portal into.
-  // The transient (unsaved) canvas never needs this: it only ever references
-  // this worktree's own sessions.
-  const workspaceDocs = useWorkspaceStore((s) => s.workspaceDocs);
-  const crossContextPaneKeys = useMemo<PaneKey[]>(() => {
-    if (!activeWorktreeId || isDirectSession || !activeWorkspaceId) return [];
-    const doc = workspaceDocs[activeWorkspaceId];
-    if (!doc) return [];
-    const keys: PaneKey[] = [];
-    for (const tile of doc.tiles) {
-      if (tile.kind === "tools") {
-        keys.push(`tools:${tile.worktreeId ?? activeWorktreeId}`);
-      } else if (tile.sessionId && sessions.some((s) => s.id === tile.sessionId)) {
-        keys.push(`${tile.kind}:${tile.sessionId}`);
-      }
-    }
-    return keys;
-  }, [activeWorktreeId, isDirectSession, activeWorkspaceId, workspaceDocs, sessions]);
+  // A worktree's classic per-worktree canvas placement is ALWAYS its own
+  // transient scratch canvas now — it never binds to a saved WorkspaceDoc
+  // (see WorkspaceCanvas.tsx's module doc), so its pane-key set is just its
+  // own sessions + tools, no cross-worktree union needed. A saved doc's
+  // cross-worktree panes are handled entirely by `detachedWorkspacePaneKeys`
+  // below, for the doc's own `/workspaces/:id` route.
   const worktreePaneKeys = useMemo<PaneKey[]>(() => {
     if (!activeWorktreeId || isDirectSession) return [];
     const keys: PaneKey[] = [];
     for (const s of worktreeAgentSessions) keys.push(`agent:${s.id}`);
     for (const s of worktreeTerminalSessions) keys.push(`terminal:${s.id}`);
     keys.push(`tools:${activeWorktreeId}`);
-    for (const k of crossContextPaneKeys) if (!keys.includes(k)) keys.push(k);
     return keys;
-  }, [
-    activeWorktreeId,
-    isDirectSession,
-    worktreeAgentSessions,
-    worktreeTerminalSessions,
-    crossContextPaneKeys,
-  ]);
+  }, [activeWorktreeId, isDirectSession, worktreeAgentSessions, worktreeTerminalSessions]);
+  // Whether ToolPanel instances rendered via this pane-key registry are
+  // CURRENTLY live inside a workspace-canvas tile (either the classic
+  // per-worktree canvas, or the detached /workspaces/:id view — both use
+  // this same `renderWorktreePane`) rather than the classic docked tool
+  // panel — see `ToolPanel`'s `hidePanelControls` prop.
+  const inWorkspaceCanvas = isWorkspaceView || paneLayoutMode === "workspace";
   const renderWorktreePane = useCallback(
     (key: PaneKey): ReactNode => {
       if (key.startsWith("agent:")) {
@@ -252,14 +295,52 @@ export function Workspace() {
           api={api}
           worktreeId={wtId}
           baseBranch={worktrees.find((w) => w.id === wtId)?.baseBranch}
+          hidePanelControls={inWorkspaceCanvas}
         />
       );
     },
-    [sessions, worktrees],
+    [sessions, worktrees, inWorkspaceCanvas],
   );
   const worktreePaneHostLayer = (
     <PaneHostLayer paneKeys={worktreePaneKeys} renderPane={renderWorktreePane} />
   );
+
+  // Detached workspace view (Phase 3c): the viewed doc's own pane set, derived
+  // straight from its tiles, WITHOUT requiring an `activeWorktreeId` (there
+  // isn't one — this route has no owning worktree; a worktree's own classic
+  // canvas placement is always its own scratch canvas, never a saved doc —
+  // see WorkspaceCanvas.tsx's module doc). Reuses `renderWorktreePane`, which
+  // is already generic over the `agent:`/`terminal:`/`tools:` key prefixes.
+  const detachedWorkspacePaneKeys = useMemo<PaneKey[]>(() => {
+    if (!viewedWorkspace) return [];
+    const keys: PaneKey[] = [];
+    for (const tile of viewedWorkspace.tiles) {
+      if (tile.kind === "tools") {
+        keys.push(`tools:${tile.worktreeId ?? viewedWorkspace.contextKey}`);
+      } else if (tile.sessionId && sessions.some((s) => s.id === tile.sessionId)) {
+        keys.push(`${tile.kind}:${tile.sessionId}`);
+      }
+    }
+    return keys;
+  }, [viewedWorkspace, sessions]);
+  const detachedWorkspacePaneHostLayer = (
+    <PaneHostLayer paneKeys={detachedWorkspacePaneKeys} renderPane={renderWorktreePane} />
+  );
+  const detachedWorkspaceCanvas = viewedWorkspace ? (
+    <WorkspaceCanvas
+      worktreeId={viewedWorkspace.contextKey}
+      agentSessions={[]}
+      terminalSessions={[]}
+      hasTools
+      toolPanelVisible
+      terminalDockVisible
+      allSessions={sessions}
+      worktrees={worktrees}
+      projects={projects}
+      detachedWorkspaceId={viewedWorkspace.id}
+      canvasToolbarVisible
+    />
+  ) : null;
 
   const agentPane = (
     <div className="pane-stack">
@@ -299,11 +380,18 @@ export function Workspace() {
         agentSessions={worktreeAgentSessions}
         terminalSessions={worktreeTerminalSessions}
         hasTools
-        toolPanelVisible={toolPanelVisible}
-        terminalDockVisible={terminalDockVisible}
+        // Canvas mode: every pane is its own tile, so the classic docked
+        // panel's visibility flags no longer mean "hide this region" — they'd
+        // just blank a tile's content with nothing left to un-hide it from
+        // (the TopBar buttons that used to control these are now disabled/
+        // repurposed for canvas mode, see TopBar.tsx). Force both true, same
+        // as the detached workspace-view canvas above.
+        toolPanelVisible
+        terminalDockVisible
         allSessions={sessions}
         worktrees={worktrees}
         projects={projects}
+        canvasToolbarVisible={canvasToolbarVisible}
       />
     ) : null;
 
@@ -342,12 +430,14 @@ export function Workspace() {
       ? "dashboard"
       : isDirectSession
         ? "direct-session"
-        : "workspace";
+        : isWorkspaceView
+          ? "workspace-view"
+          : "workspace";
 
   return (
     <PaneOutletProvider>
     <div className="workspace-route">
-      {!isFullWidthPane ? (
+      {!isFullWidthPane && !isWorkspaceView ? (
         isDirectSession ? (
           <QuickOpen
             api={api}
@@ -366,9 +456,9 @@ export function Workspace() {
             layoutMode={layoutMode}
             projects={projects}
             worktrees={worktrees}
-            sessions={sessions}
             directSession={directSession ?? undefined}
             directSessionProject={directSessionProject ?? undefined}
+            viewedWorkspaceName={viewedWorkspace?.name}
             isMobile={isMobile}
             onToggleLeftSidebar={() => {
               if (isMobile) setMobileSidebarOpen(!mobileSidebarOpen);
@@ -387,14 +477,22 @@ export function Workspace() {
             isMobile={isMobile}
             onWorktreeSelected={(wtId) => {
               if (isMobile) setMobileSidebarOpen(false);
-              if (isDashboard || isSettings || isDirectSession) navigate(`/worktree/${wtId}`);
+              if (isDashboard || isSettings || isDirectSession || isWorkspaceView) navigate(`/worktree/${wtId}`);
             }}
           />
         }
         dashboardPane={
           isDashboard ? (
             <DashboardPanel api={api} />
-          ) : isSettings ? <SettingsPanel api={api} /> : undefined
+          ) : isSettings ? (
+            <SettingsPanel api={api} />
+          ) : isWorkspaceView ? (
+            // Rendered via the `dashboardPane` slot (full-bleed, no classic
+            // agent/tools/terminal three-pane machinery) since this view has
+            // no single owning worktree to key that machinery's persisted
+            // sizes/visibility off of — see Layout.tsx's dashboard branch.
+            (detachedWorkspaceCanvas ?? <div className="workspace-canvas workspace-canvas--loading" />)
+          ) : undefined
         }
         leftColumnPx={leftColumnPx}
         leftSidebarCollapsed={leftSidebarCollapsed}
@@ -402,24 +500,32 @@ export function Workspace() {
         isMobile={isMobile}
         mobileSidebarOpen={mobileSidebarOpen}
         onMobileSidebarClose={() => setMobileSidebarOpen(false)}
-        {...(isFullWidthPane
-          ? {}
-          : isDirectSession
-            ? {
-                // Direct session: full worktree layout minus the agent tabs.
-                // Tool panel (Files) + terminal dock resolve to the project
-                // base dir (scope="project").
-                agentPane: directAgentPane,
-                toolPanel: directToolPanel,
-                terminalDock: directTerminalDock,
-              }
-            : {
-                agentPane,
-                toolPanel: worktreeToolPanel,
-                terminalDock,
-                workspaceCanvas,
-                paneHostLayer: worktreePaneHostLayer,
-              })}
+        {...(isWorkspaceView
+          ? // Detached workspace view: rendered via `dashboardPane` above, which
+            // doesn't read agentPane/toolPanel/terminalDock/workspaceCanvas at
+            // all (Layout.tsx returns early once `dashboardPane` is set) — the
+            // only prop that branch still needs from here is `paneHostLayer`,
+            // so the viewed doc's tiles have somewhere to portal their live
+            // panes into.
+            { paneHostLayer: detachedWorkspacePaneHostLayer }
+          : isFullWidthPane
+            ? {}
+            : isDirectSession
+              ? {
+                  // Direct session: full worktree layout minus the agent tabs.
+                  // Tool panel (Files) + terminal dock resolve to the project
+                  // base dir (scope="project").
+                  agentPane: directAgentPane,
+                  toolPanel: directToolPanel,
+                  terminalDock: directTerminalDock,
+                }
+              : {
+                  agentPane,
+                  toolPanel: worktreeToolPanel,
+                  terminalDock,
+                  workspaceCanvas,
+                  paneHostLayer: worktreePaneHostLayer,
+                })}
       />
     </div>
     </PaneOutletProvider>

--- a/web-ui/src/styles/chat.css
+++ b/web-ui/src/styles/chat.css
@@ -6,6 +6,45 @@
   min-height: 0;
   display: flex;
   flex-direction: column;
+  border: 2px solid transparent;
+  box-sizing: border-box;
+  transition: border-color 0.2s ease;
+}
+
+/* Colored rectangle around the pane, per session interaction state — same
+   color values as StatusDot's `.status-dot--*` rules (workspace.css) and
+   WorkspaceCanvas's `.workspace-canvas__tile--*` rules, so all three
+   surfaces (dot, workspace tile, single agent pane) stay in sync. Shared by
+   the classic single-agent-pane view and direct sessions — see
+   AgentPaneSlot.tsx for why this is the only "colored rectangle" surface
+   available in either case. */
+.agent-pane-slot--waiting_for_human {
+  border-color: #ef4444;
+}
+
+.agent-pane-slot--needs_review {
+  border-color: #b98cff;
+}
+
+.agent-pane-slot--working {
+  border-color: var(--accent);
+}
+
+.agent-pane-slot--idle {
+  border-color: var(--fg-muted, transparent);
+}
+
+.agent-pane-slot--done {
+  border-color: #22c55e;
+}
+
+.agent-pane-slot--exited {
+  border-color: #f59e0b;
+}
+
+.agent-pane-slot--spawning {
+  border-color: var(--border-default);
+  border-style: dashed;
 }
 .agent-pane-slot__terminal {
   min-height: 0;

--- a/web-ui/src/styles/workspace-canvas.css
+++ b/web-ui/src/styles/workspace-canvas.css
@@ -23,6 +23,21 @@
   flex-shrink: 0;
 }
 
+/* Portaled into TopBar's compact row (WORKSPACE_CANVAS_TOOLBAR_KEY) instead
+   of the canvas's own full-width row — drop the row chrome (border, padding,
+   space-between stretch) that only made sense at full width; sizes to
+   content like every other top-bar control. */
+.workspace-canvas__toolbar--portaled {
+  justify-content: flex-start;
+  gap: var(--space-3);
+  padding: 0;
+  border-bottom: none;
+}
+
+.workspace-canvas__toolbar--portaled .workspace-canvas__doc-name {
+  max-width: 160px;
+}
+
 .workspace-canvas__toolbar-left,
 .workspace-canvas__toolbar-right {
   display: flex;
@@ -44,22 +59,6 @@
 .workspace-canvas__doc-name--unsaved {
   color: var(--fg-muted);
   font-style: italic;
-}
-
-.workspace-canvas__ghost-btn {
-  appearance: none;
-  border: none;
-  background: transparent;
-  color: var(--fg-muted);
-  font-size: var(--font-size-xs);
-  padding: var(--space-1) var(--space-2);
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-}
-
-.workspace-canvas__ghost-btn:hover {
-  background: var(--bg-active);
-  color: var(--fg-primary);
 }
 
 .workspace-canvas__save-form {
@@ -160,9 +159,28 @@
   background: var(--bg-active);
 }
 
+/* Icon + label together, as one flex group on the left — kept separate from
+   the trailing kind-tag so `justify-content: space-between` on the parent
+   still pins the tag to the right regardless of label length. */
+.workspace-canvas__picker-item-main {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-canvas__picker-icon {
+  flex-shrink: 0;
+  color: var(--fg-muted);
+}
+
 .workspace-canvas__picker-kind {
   color: var(--fg-muted);
   font-size: var(--font-size-xs);
+  flex-shrink: 0;
 }
 
 /* Cross-context picker sections (saved workspaces only): project > worktree. */
@@ -173,6 +191,9 @@
 }
 
 .workspace-canvas__picker-heading {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
   font-size: var(--font-size-xs);
   color: var(--fg-primary);
   font-weight: 600;
@@ -180,15 +201,48 @@
 }
 
 .workspace-canvas__picker-subheading {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
   font-size: var(--font-size-xs);
   color: var(--fg-muted);
   padding: 0 var(--space-2) 2px var(--space-3);
+}
+
+/* Sessions/tools nested under a worktree subheading — indented to visually
+   read as children of it, one step deeper than the subheading's own indent,
+   with a vertical guide line (like a file tree) instead of bare whitespace
+   so the nesting reads clearly at a glance. */
+.workspace-canvas__picker-subitems {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  padding-left: var(--space-3);
+}
+
+.workspace-canvas__picker-indent-line {
+  position: absolute;
+  left: calc(var(--space-3) / 2);
+  top: 0;
+  bottom: var(--space-1);
+  width: 1px;
+  background: var(--border-subtle);
 }
 
 .workspace-canvas__picker-empty {
   color: var(--fg-muted);
   font-size: var(--font-size-xs);
   padding: var(--space-2);
+}
+
+/* Non-interactive hint, not a menu item — separated from real picker entries
+   with a divider rather than looking like one more (unclickable) row. */
+.workspace-canvas__picker-note {
+  color: var(--fg-faint);
+  font-size: var(--font-size-xs);
+  padding: var(--space-2);
+  border-top: var(--border-width) solid var(--border-subtle);
+  cursor: default;
 }
 
 .workspace-canvas__body {
@@ -279,6 +333,21 @@
 
 .workspace-canvas__free > .workspace-canvas__tile {
   position: absolute;
+}
+
+/* Click (not drag) a tile's title bar to expand it over the whole viewport —
+   same escape-the-container technique as the classic pane fullscreen
+   (`.pane-viewport-fullscreen`, workspace.css) so it works regardless of
+   free-mode vs tiled-mode or DOM nesting depth. `position: fixed` is set
+   inline (WorkspaceCanvas.tsx) since it must win over both
+   `.workspace-canvas__free > .workspace-canvas__tile`'s `position: absolute`
+   and tiled mode's flex sizing; this class only carries what inline styles
+   can't (z-index, border, radius reset — a fullscreen tile shouldn't look
+   like it's still "in" the grid). */
+.workspace-canvas__tile--fullscreen {
+  z-index: 200;
+  border-radius: 0;
+  border-width: 0;
 }
 
 /* Colored rectangle around the whole tile, per session interaction state —

--- a/web-ui/src/styles/workspace-canvas.css
+++ b/web-ui/src/styles/workspace-canvas.css
@@ -1,0 +1,430 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * WorkspaceCanvas — tiled/free-form canvas of live agent/terminal/tools
+ * panes for a worktree's "workspace" layoutMode. See
+ * components/layout/WorkspaceCanvas.tsx.
+ * ───────────────────────────────────────────────────────────────────────── */
+
+.workspace-canvas {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  background: var(--bg-primary);
+}
+
+.workspace-canvas__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-bottom: var(--border-width) solid var(--border-default);
+  flex-shrink: 0;
+}
+
+.workspace-canvas__toolbar-left,
+.workspace-canvas__toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+/* Which canvas is live: the saved workspace's name, or "Unsaved canvas". */
+.workspace-canvas__doc-name {
+  font-size: var(--font-size-xs);
+  color: var(--fg-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 220px;
+}
+
+.workspace-canvas__doc-name--unsaved {
+  color: var(--fg-muted);
+  font-style: italic;
+}
+
+.workspace-canvas__ghost-btn {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--fg-muted);
+  font-size: var(--font-size-xs);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.workspace-canvas__ghost-btn:hover {
+  background: var(--bg-active);
+  color: var(--fg-primary);
+}
+
+.workspace-canvas__save-form {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.workspace-canvas__save-input {
+  appearance: none;
+  background: var(--bg-primary);
+  border: var(--border-width) solid var(--border-default);
+  border-radius: var(--radius-sm);
+  color: var(--fg-primary);
+  font-size: var(--font-size-xs);
+  padding: var(--space-1) var(--space-2);
+  width: 160px;
+}
+
+.workspace-canvas__mode-toggle {
+  display: inline-flex;
+  border: var(--border-width) solid var(--border-default);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.workspace-canvas__mode-btn {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--fg-secondary);
+  font-size: var(--font-size-xs);
+  padding: var(--space-1) var(--space-3);
+  cursor: pointer;
+}
+
+.workspace-canvas__mode-btn + .workspace-canvas__mode-btn {
+  border-left: var(--border-width) solid var(--border-default);
+}
+
+.workspace-canvas__mode-btn--on {
+  background: var(--bg-active);
+  color: var(--fg-primary);
+}
+
+.workspace-canvas__add {
+  position: relative;
+}
+
+.workspace-canvas__add-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  appearance: none;
+  border: var(--border-width) solid var(--border-default);
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+  color: var(--fg-primary);
+  font-size: var(--font-size-xs);
+  padding: var(--space-1) var(--space-2);
+  cursor: pointer;
+}
+
+.workspace-canvas__picker {
+  position: absolute;
+  top: calc(100% + var(--space-1));
+  right: 0;
+  z-index: 20;
+  min-width: 200px;
+  max-height: 260px;
+  overflow-y: auto;
+  background: var(--bg-elevated, var(--bg-secondary));
+  border: var(--border-width) solid var(--border-default);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-md, 0 4px 16px rgba(0, 0, 0, 0.25));
+  display: flex;
+  flex-direction: column;
+  padding: var(--space-1);
+}
+
+.workspace-canvas__picker-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--fg-primary);
+  font-size: var(--font-size-xs);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  text-align: left;
+}
+
+.workspace-canvas__picker-item:hover {
+  background: var(--bg-active);
+}
+
+.workspace-canvas__picker-kind {
+  color: var(--fg-muted);
+  font-size: var(--font-size-xs);
+}
+
+/* Cross-context picker sections (saved workspaces only): project > worktree. */
+.workspace-canvas__picker-group {
+  border-top: var(--border-width) solid var(--border-default);
+  margin-top: var(--space-1);
+  padding-top: var(--space-1);
+}
+
+.workspace-canvas__picker-heading {
+  font-size: var(--font-size-xs);
+  color: var(--fg-primary);
+  font-weight: 600;
+  padding: var(--space-1) var(--space-2);
+}
+
+.workspace-canvas__picker-subheading {
+  font-size: var(--font-size-xs);
+  color: var(--fg-muted);
+  padding: 0 var(--space-2) 2px var(--space-3);
+}
+
+.workspace-canvas__picker-empty {
+  color: var(--fg-muted);
+  font-size: var(--font-size-xs);
+  padding: var(--space-2);
+}
+
+.workspace-canvas__body {
+  flex: 1;
+  min-height: 0;
+  position: relative;
+  overflow: hidden;
+}
+
+.workspace-canvas__empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--fg-muted);
+  font-size: var(--font-size-sm);
+}
+
+/* Free-form geometry: absolute-positioned, percent-based tiles. */
+.workspace-canvas__free {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+/* Tiled geometry: nested flexbox mirroring lib/tiling.ts's LayoutNode tree. */
+.workspace-canvas__tiled {
+  width: 100%;
+  height: 100%;
+  display: flex;
+}
+
+.workspace-canvas__split {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+}
+
+.workspace-canvas__split--row {
+  flex-direction: row;
+}
+
+.workspace-canvas__split--column {
+  flex-direction: column;
+}
+
+.workspace-canvas__split-item {
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+}
+
+.workspace-canvas__divider {
+  flex-shrink: 0;
+  background: var(--border-default);
+}
+
+.workspace-canvas__divider--row {
+  width: 4px;
+  cursor: col-resize;
+}
+
+.workspace-canvas__divider--column {
+  height: 4px;
+  cursor: row-resize;
+}
+
+.workspace-canvas__divider:hover {
+  background: var(--accent);
+}
+
+.workspace-canvas__tile {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  width: 100%;
+  height: 100%;
+  background: var(--bg-secondary);
+  border: 2px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  transition: border-color 0.2s ease;
+}
+
+.workspace-canvas__free > .workspace-canvas__tile {
+  position: absolute;
+}
+
+/* Colored rectangle around the whole tile, per session interaction state —
+   same color values as StatusDot's `.status-dot--*` rules (workspace.css)
+   so the two surfaces never drift apart. Panel/tools tiles carry no `status`
+   (WorkspaceCanvas only computes one for agent/terminal tiles), so they keep
+   the plain `--border-default` rule above — unset, not a color, on purpose. */
+.workspace-canvas__tile--waiting_for_human {
+  border-color: #ef4444;
+}
+
+.workspace-canvas__tile--needs_review {
+  border-color: #b98cff;
+}
+
+.workspace-canvas__tile--working {
+  border-color: var(--accent);
+}
+
+.workspace-canvas__tile--idle {
+  border-color: var(--fg-muted, var(--border-default));
+}
+
+.workspace-canvas__tile--done {
+  border-color: #22c55e;
+}
+
+.workspace-canvas__tile--exited {
+  border-color: #f59e0b;
+  opacity: 0.9;
+}
+
+.workspace-canvas__tile--spawning {
+  border-color: var(--border-default);
+  border-style: dashed;
+}
+
+.workspace-canvas__tile-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-2);
+  border-bottom: var(--border-width) solid var(--border-default);
+  background: var(--bg-tertiary, var(--bg-secondary));
+  flex-shrink: 0;
+  cursor: default;
+}
+
+.workspace-canvas__free .workspace-canvas__tile-header,
+.workspace-canvas__tiled .workspace-canvas__tile-header {
+  cursor: grab;
+}
+
+.workspace-canvas__free .workspace-canvas__tile-header:active,
+.workspace-canvas__tiled .workspace-canvas__tile-header:active {
+  cursor: grabbing;
+}
+
+/* The tile currently being dragged onto another tile's drop zone. */
+.workspace-canvas__tile--dragging {
+  opacity: 0.55;
+  outline: var(--border-width) dashed var(--accent);
+  outline-offset: -1px;
+}
+
+/* Drop-zone highlight: where the dragged tile would land on release.
+   Edge zones show the half of the target that the split would take;
+   the center zone covers the whole target (a position swap). */
+.workspace-canvas__drop-zone {
+  position: absolute;
+  z-index: 30;
+  pointer-events: none;
+  background: color-mix(in srgb, var(--accent) 28%, transparent);
+  border: 2px solid var(--accent);
+  border-radius: var(--radius-sm);
+  transition: left 60ms ease, top 60ms ease, width 60ms ease, height 60ms ease;
+}
+
+.workspace-canvas__drop-zone--center {
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  border-style: dashed;
+}
+
+.workspace-canvas__tile-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--font-size-xs);
+  color: var(--fg-primary);
+}
+
+.workspace-canvas__tile-close {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--fg-muted);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  border-radius: var(--radius-sm);
+}
+
+.workspace-canvas__tile-close:hover {
+  background: var(--bg-active);
+  color: var(--fg-primary);
+}
+
+.workspace-canvas__tile-body {
+  flex: 1;
+  min-height: 0;
+  position: relative;
+  display: flex;
+}
+
+.workspace-canvas__tile-hidden {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  color: var(--fg-muted);
+  font-size: var(--font-size-xs);
+  text-align: center;
+  padding: var(--space-2);
+}
+
+.workspace-canvas__tile-resize {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: 14px;
+  height: 14px;
+  cursor: nwse-resize;
+}
+
+.workspace-canvas__tile-resize::after {
+  content: "";
+  position: absolute;
+  right: 3px;
+  bottom: 3px;
+  width: 6px;
+  height: 6px;
+  border-right: 2px solid var(--fg-muted);
+  border-bottom: 2px solid var(--fg-muted);
+}

--- a/web-ui/src/styles/workspace.css
+++ b/web-ui/src/styles/workspace.css
@@ -2005,6 +2005,17 @@
   animation: spawning-pulse 1s ease-in-out infinite alternate;
 }
 
+/* waiting_for_human is the one non-negotiable color mapping (PRD R7/W7) —
+   always red, regardless of theme. needs_review is a distinct, less-urgent
+   violet so the two "needs attention" states never visually collide. */
+.status-dot--waiting_for_human {
+  color: #ef4444;
+}
+
+.status-dot--needs_review {
+  color: #b98cff;
+}
+
 .preview-body {
   flex: 1;
   overflow: auto;
@@ -4531,4 +4542,13 @@ a.dashboard-card.dashboard-card--session {
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * PaneHostLayer — permanently-mounted live panes (agent/terminal/tools).
+ * When no <PaneOutlet> currently claims a pane's key, PaneHostSlot renders
+ * it here instead of unmounting it, so its live PTY/stream stays alive.
+ * ───────────────────────────────────────────────────────────────────────── */
+.pane-holder--offscreen {
+  display: none;
 }

--- a/web-ui/src/styles/workspace.css
+++ b/web-ui/src/styles/workspace.css
@@ -321,6 +321,26 @@
   padding-left: var(--space-2);
 }
 
+/* The Workspaces section header's disclosure toggle (`.tree-row__project-expand`
+   reused here, not inside a `.tree-row--project` row like the per-project
+   ones) — `.sidebar-projects-heading`'s own `align-items: center` sizes it to
+   its own content instead of the full 32px heading row, leaving most of that
+   row unclickable and the chevron+label vertically centered against a
+   shorter box than the row appears to be. Stretch it to the full row height
+   so the whole heading row is the click target, and center its own content
+   within that taller box (`.tree-row__project-expand` already sets
+   `align-items: center`). */
+.sidebar-projects-heading .tree-row__project-expand {
+  align-self: stretch;
+  padding: 0 var(--space-1);
+  margin: 0 calc(var(--space-1) * -1);
+  border-radius: var(--radius-sm);
+}
+
+.sidebar-projects-heading .tree-row__project-expand:hover {
+  background: var(--bg-hover);
+}
+
 .sidebar-projects-heading__gutter {
   /* hidden — alignment handled by padding-left on the heading itself */
   display: none;
@@ -486,6 +506,15 @@
   width: 12px;
   height: 12px;
   flex-shrink: 0;
+  /* Center the chevron glyph itself within its fixed box — without this an
+     SVG icon's own intrinsic baseline can sit a px or two off from the
+     adjacent label text, most visible in the Workspaces section header
+     (`.sidebar-projects-heading .tree-row__project-expand` below), which —
+     unlike the per-project tree rows — has no `.tree-row` row chrome to
+     absorb the difference. */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .tree-row__chevron-spacer {
@@ -538,7 +567,9 @@
   min-width: 0;
   display: inline-flex;
   align-items: center;
-  gap: var(--space-1);
+  /* More breathing room than the default --space-1 (4px) — the folder icon
+     and project name were reading as too close together. */
+  gap: var(--space-2);
   margin: 0;
   padding: 0;
   border: none;
@@ -562,6 +593,11 @@
 }
 
 .tree-row__project-chevron {
+  /* Folder open/closed glyph is visually a touch bigger than the plain
+     chevron the base `.tree-row__chevron` box (12px) was sized for —
+     widen its own box slightly so the icon isn't clipped. */
+  width: 14px;
+  height: 14px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1201,13 +1237,17 @@
 }
 
 .top-bar {
+  border-bottom: var(--border-width) solid var(--border-default);
+  background: var(--bg-secondary);
+  flex-shrink: 0;
+}
+
+.top-bar__row {
   display: flex;
   align-items: center;
   gap: var(--space-2);
   padding: var(--space-2) var(--space-3);
-  border-bottom: var(--border-width) solid var(--border-default);
-  background: var(--bg-secondary);
-  flex-shrink: 0;
+  min-width: 0;
 }
 
 .top-bar__end {
@@ -1358,6 +1398,33 @@
   opacity: 0.3;
 }
 
+/* Canvas chip — the canvas-mode toggle and its toolbar-disclosure chevron,
+   merged into one pill so they read as a single control-with-a-dropdown
+   while staying two independently clickable <button>s (see TopBar.tsx).
+   Reuses `.top-bar__pane-btn` for the buttons themselves; this wrapper only
+   supplies the shared rounded ground and the hairline between them. */
+.top-bar__canvas-chip {
+  display: inline-flex;
+  align-items: center;
+  border-radius: var(--radius-sm);
+  background: var(--bg-hover);
+  overflow: hidden;
+}
+
+.top-bar__canvas-chip > .top-bar__pane-btn {
+  border-radius: 0;
+}
+
+.top-bar__canvas-chip > .top-bar__pane-btn + .top-bar__pane-btn {
+  border-left: var(--border-width) solid var(--border-default);
+}
+
+/* The chevron is a thin disclosure arrow, not a peer icon button — same
+   height so it aligns inside the chip, but narrower. */
+.top-bar__canvas-chip-chevron {
+  width: 21px;
+}
+
 .top-bar__actions {
   display: flex;
   align-items: center;
@@ -1429,7 +1496,7 @@
 }
 
 .left-sidebar .tree-row--project {
-  font-size: calc(var(--font-size-sm) + 2px);
+  font-size: calc(var(--font-size-sm) + 1px);
 }
 
 .left-sidebar--collapsed .tree-row.tree-row--worktree {


### PR DESCRIPTION
## Summary
- Adds the workspace-canvas tiling UI (agent-interaction-workspaces/04-workspaces): tiled/free-form panes, drag/resize, saved-workspace CRUD, cross-worktree tiles on saved docs, and `session:created` auto-insert via a new `spawnedFrom` session field + `vst ... --source-agent` CLI flag (daemon+cli).
- Reworks the canvas-mode top bar: the canvas toolbar (mode toggle, doc name, Save as workspace, Add tile) now renders as its own dedicated row in `WorkspaceCanvas`, shown/hidden via a chevron merged into a chip with the canvas-mode toggle; split-orientation/terminal-dock buttons are always rendered but disabled (not hidden) in canvas mode; the Tools button adds/removes a canvas tile instead of toggling docked-panel visibility.
- Fixes saved-workspace detachment: saving a canvas now creates the doc, navigates straight to its own `/workspaces/:id` route, and never binds the worktree back to it — a worktree's canvas is always its own scratch canvas. Removes the now-meaningless "Back to unsaved" button.
- Add-tile picker gets per-kind icons, a vertical indent guide, and a branch icon for worktree groups; fixes a breadcrumb/content-column misalignment exposed by moving the toolbar out of the top bar; sidebar project rows use a Folder/FolderOpen icon instead of a chevron.
- Records the `05-workspace-persistence` PRD/plan (daemon-side saved-workspace storage) — planning only, not implemented in this PR.

## Test plan
- [x] `pnpm -r typecheck` clean
- [x] `pnpm lint` (web-ui) — 0 errors, pre-existing warnings only
- [x] `cli` vitest suite — 663/663 passing (daemon + cli, via the `cli` package's symlinked `src/daemon`)
- [x] `web-ui` vitest suite — 390/390 passing
- [x] `pnpm -r build` — both packages build clean
- [x] Manually walked the canvas-mode flow in a running dev sandbox: canvas toggle, toolbar disclosure chevron, Add-tile picker (icons/indentation), Tools tile add/remove, save → detach → navigate to `/workspaces/:id`, reopening the worktree shows a fresh scratch canvas, breadcrumb/content alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)