### PR TITLE
Rich Chat: collapse consecutive tool calls into a merged, borderless run

### DIFF
--- a/web-ui/src/components/chat/MessageList.tsx
+++ b/web-ui/src/components/chat/MessageList.tsx
@@ -7,15 +7,54 @@ import { QueuedTurnEditor } from "./QueuedTurnEditor";
 import { ThinkingBlock } from "./ThinkingBlock";
 import { ToolUseCard } from "./ToolUseCard";
 import { ToolResultCard } from "./ToolResultCard";
+import { ToolRunSummary } from "./ToolRunSummary";
 import { ErrorCard } from "./ErrorCard";
+import type { ToolCallEntry } from "./toolFormat";
 
 type RenderItem =
   | { type: "user"; id: string; text: string; attachments?: Attachment[]; turnId?: string; cancelled?: boolean }
   | { type: "assistant"; id: string; text: string; turnId?: string }
   | { type: "thinking"; id: string; text: string; turnId?: string }
-  | { type: "tool"; id: string; toolName: string; toolInput?: unknown; result?: { content?: string; isError?: boolean } }
+  | ({ type: "tool" } & ToolCallEntry)
+  | { type: "toolRun"; id: string; tools: ToolCallEntry[] }
   | { type: "error"; id: string; text: string }
   | { type: "status"; id: string; text: string };
+
+/**
+ * A run of 2+ consecutive `tool` items (no text/thinking/user message, and no
+ * turn boundary, between them) collapses into one `toolRun` item — rendered
+ * as a single integrated, borderless summary line (e.g. "Read 1 file, ran 2
+ * shell commands") instead of N separately-bordered tool cards, matching
+ * Claude Code's native terminal transcript. A lone tool call keeps rendering
+ * as an individual `tool` item (unchanged today's look).
+ */
+export function mergeToolRuns(items: RenderItem[]): RenderItem[] {
+  const out: RenderItem[] = [];
+  let run: Extract<RenderItem, { type: "tool" }>[] = [];
+  const flushRun = () => {
+    if (run.length === 0) return;
+    if (run.length === 1) {
+      out.push(run[0]!);
+    } else {
+      out.push({ type: "toolRun", id: run[0]!.id, tools: [...run] });
+    }
+    run = [];
+  };
+  for (const item of items) {
+    // A run never spans a turn boundary — two tool calls from different
+    // turns just happening to be adjacent (nothing else rendered between
+    // them) shouldn't visually merge into one group.
+    if (item.type === "tool" && (run.length === 0 || run[run.length - 1]!.turnId === item.turnId)) {
+      run.push(item);
+    } else {
+      flushRun();
+      if (item.type === "tool") run.push(item);
+      else out.push(item);
+    }
+  }
+  flushRun();
+  return out;
+}
 
 /**
  * Fold the flat normalized-event stream into renderable items: consecutive
@@ -90,7 +129,7 @@ export function groupEvents(events: NormalizedEvent[]): RenderItem[] {
         break;
       }
       case "tool_use": {
-        items.push({ type: "tool", id: ev.id, toolName: ev.toolName ?? "tool", toolInput: ev.toolInput });
+        items.push({ type: "tool", id: ev.id, toolName: ev.toolName ?? "tool", toolInput: ev.toolInput, turnId: ev.turnId });
         if (ev.toolId) toolIndexById.set(ev.toolId, items.length - 1);
         break;
       }
@@ -101,7 +140,7 @@ export function groupEvents(events: NormalizedEvent[]): RenderItem[] {
         if (target && target.type === "tool") {
           target.result = result;
         } else {
-          items.push({ type: "tool", id: ev.id, toolName: ev.toolName ?? "tool", result });
+          items.push({ type: "tool", id: ev.id, toolName: ev.toolName ?? "tool", result, turnId: ev.turnId });
         }
         break;
       }
@@ -192,13 +231,13 @@ export function MessageList({
   const grouped = useMemo(() => groupEvents(events), [events]);
   // Queued / editing user turns render in the tray above the composer, not in
   // the log. Filter after grouping so the A7 edited-turn dedupe still applies.
-  const items = useMemo(
-    () =>
+  const items = useMemo(() => {
+    const filtered =
       hiddenTurnIds && hiddenTurnIds.size > 0
         ? grouped.filter((it) => it.type !== "user" || !it.turnId || !hiddenTurnIds.has(it.turnId))
-        : grouped,
-    [grouped, hiddenTurnIds],
-  );
+        : grouped;
+    return mergeToolRuns(filtered);
+  }, [grouped, hiddenTurnIds]);
   const bottomRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -328,6 +367,13 @@ export function MessageList({
                 ) : null}
               </div>
             );
+            break;
+          case "toolRun":
+            // "Live" means this run is the trailing item of an active turn —
+            // any tool inside it still missing a result is genuinely running
+            // (turns can fire several tool calls before results land), not
+            // just the last one in the run.
+            node = <ToolRunSummary key={key} tools={item.tools} live={!!turnActive && i === items.length - 1} />;
             break;
           case "error":
             node = <ErrorCard key={key} text={item.text} onRetry={onRetry} />;

--- a/web-ui/src/components/chat/ToolResultCard.tsx
+++ b/web-ui/src/components/chat/ToolResultCard.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { DiffView } from "@/components/preview/DiffView";
+import { capForDisplay, looksLikeUnifiedDiff } from "./toolFormat";
 
 interface ToolResultCardProps {
   toolName?: string;
@@ -7,27 +8,9 @@ interface ToolResultCardProps {
   isError?: boolean;
 }
 
-/** Heuristic: does this look like a unified diff (edit-tool output)? */
-export function looksLikeUnifiedDiff(text: string): boolean {
-  if (!text) return false;
-  if (/^diff --git /m.test(text)) return true;
-  // A hunk header plus at least one +/- line is a strong signal.
-  return /^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@/m.test(text) && /^[+-]/m.test(text);
-}
-
-/**
- * Client-side mirror of the server's `TOOL_RESULT_MAX_BYTES` cap
- * (`daemon/src/services/toolResultCap.ts`). Defense-in-depth only — the
- * server caps both write paths (live turns + at-rest import backfill), so
- * this guard mainly protects against a stale cached transcript fetched
- * before the one-time backfill migration ran.
- */
-const CLIENT_TOOL_RESULT_MAX_CHARS = 20_000;
-
-function capForDisplay(text: string): string {
-  if (text.length <= CLIENT_TOOL_RESULT_MAX_CHARS) return text;
-  return `(tool result omitted — ${text.length} chars)`;
-}
+// Re-exported for existing callers/tests — canonical implementation now
+// lives in toolFormat.ts (shared with ToolRunSummary's merged rows).
+export { looksLikeUnifiedDiff };
 
 /**
  * Tool output attached to a tool card. Collapsible; unified diffs render via the

--- a/web-ui/src/components/chat/ToolRunSummary.tsx
+++ b/web-ui/src/components/chat/ToolRunSummary.tsx
@@ -1,0 +1,183 @@
+import { useState } from "react";
+import { DiffView } from "@/components/preview/DiffView";
+import {
+  capForDisplay,
+  looksLikeUnifiedDiff,
+  prettyToolInput,
+  summarizeToolInput,
+  type ToolCallEntry,
+} from "./toolFormat";
+
+interface ToolRunSummaryProps {
+  tools: ToolCallEntry[];
+  /** True while this run is the trailing item of an active turn — any tool
+   *  inside it still missing a result is genuinely in flight (a turn can fire
+   *  several tool calls before results land, not just the last one). */
+  live?: boolean;
+}
+
+// Tool names that describe the same kind of action fold into one bucket so
+// the summary doesn't read e.g. "searched 1 time, searched 2 times" for a
+// Grep + Glob mix.
+const TOOL_ALIASES: Record<string, string> = {
+  grep: "search",
+  glob: "search",
+  multiedit: "edit",
+};
+
+// Order in which phrases appear when several kinds of tools ran in the same
+// burst (mirrors Claude Code's own ordering, e.g. "Read 1 file, ran 1 shell
+// command").
+const PHRASE_ORDER = ["read", "write", "edit", "bash", "search"];
+const PHRASE_FNS: Record<string, (n: number) => string> = {
+  read: (n) => `read ${n} file${n === 1 ? "" : "s"}`,
+  write: (n) => `wrote ${n} file${n === 1 ? "" : "s"}`,
+  edit: (n) => `edited ${n} file${n === 1 ? "" : "s"}`,
+  bash: (n) => `ran ${n} shell command${n === 1 ? "" : "s"}`,
+  search: (n) => `searched ${n} time${n === 1 ? "" : "s"}`,
+};
+
+function summarizeGroup(tools: ToolCallEntry[]): string {
+  const counts = new Map<string, number>();
+  // Bucket key -> the first original-cased tool name seen for it, so an
+  // unrecognized tool (e.g. "TodoWrite") falls back to its real name instead
+  // of a lowercased one ("used TodoWrite 2 times", not "used todowrite...").
+  const displayName = new Map<string, string>();
+  for (const t of tools) {
+    const raw = t.toolName.toLowerCase();
+    const key = TOOL_ALIASES[raw] ?? raw;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+    if (!displayName.has(key)) displayName.set(key, t.toolName);
+  }
+  const seen = new Set<string>();
+  const parts: string[] = [];
+  const pushKey = (key: string) => {
+    if (seen.has(key)) return;
+    seen.add(key);
+    const n = counts.get(key);
+    if (!n) return;
+    const fn = PHRASE_FNS[key];
+    parts.push(fn ? fn(n) : `used ${displayName.get(key) ?? key} ${n} time${n === 1 ? "" : "s"}`);
+  };
+  for (const key of PHRASE_ORDER) pushKey(key);
+  for (const key of counts.keys()) pushKey(key);
+  const text = parts.join(", ");
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+/**
+ * One tool call inside an expanded run: a single borderless row (icon + name
+ * + inline input) — the call and its result are ONE element, not two. A
+ * small chevron toggles the merged detail (pretty input + result/diff) only
+ * when there's more to show than the inline summary. While running, a
+ * spinner replaces the chevron in place of a separate "result" row; once
+ * done, a quiet checkmark marks completion when there's no detail to expand
+ * into (an empty-output Bash call, say) so it doesn't read as still pending.
+ */
+function ToolRunEntryRow({ tool, running }: { tool: ToolCallEntry; running: boolean }) {
+  const [open, setOpen] = useState(false);
+  const inline = summarizeToolInput(tool.toolInput);
+  const pretty = prettyToolInput(tool.toolInput);
+  const hasInputBody = tool.toolInput != null && pretty !== "undefined";
+  const result = tool.result;
+  const resultText = result?.content ? capForDisplay(result.content) : "";
+  const hasResultBody = resultText.length > 0;
+  const isError = !!result?.isError;
+  const isDiff = !isError && hasResultBody && looksLikeUnifiedDiff(resultText);
+  const hasBody = hasInputBody || hasResultBody;
+
+  return (
+    <div className={`chat-tool-entry${isError ? " chat-tool-entry--error" : ""}`}>
+      <button
+        type="button"
+        className="chat-tool-entry__header"
+        aria-expanded={hasBody ? open : undefined}
+        disabled={!hasBody}
+        onClick={() => hasBody && setOpen((v) => !v)}
+      >
+        {hasBody ? (
+          <span className="chat-tool-entry__caret" aria-hidden>
+            {open ? "▾" : "▸"}
+          </span>
+        ) : (
+          <span className="chat-tool-entry__caret chat-tool-entry__caret--spacer" aria-hidden />
+        )}
+        <span className="chat-tool-entry__icon" aria-hidden>
+          {isError ? "⚠" : "🔧"}
+        </span>
+        <span className="chat-tool-entry__name">{tool.toolName}</span>
+        {inline ? <code className="chat-tool-entry__inline">{inline}</code> : null}
+        <span className="chat-tool-entry__status">
+          {running ? (
+            <span className="chat-spinner" aria-label="running" />
+          ) : !hasBody && result ? (
+            <span className="chat-tool-entry__done" aria-hidden>
+              ✓
+            </span>
+          ) : null}
+        </span>
+      </button>
+      {open && hasBody ? (
+        <div className="chat-tool-entry__body">
+          {hasInputBody ? (
+            <pre className="chat-tool-entry__pre">
+              <code>{pretty}</code>
+            </pre>
+          ) : null}
+          {hasResultBody ? (
+            isDiff ? (
+              <DiffView diffText={resultText} />
+            ) : (
+              <pre className="chat-tool-entry__pre">
+                <code>{resultText}</code>
+              </pre>
+            )
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * A run of consecutive tool calls (no text/thinking between them) collapses
+ * into one integrated, borderless summary line — matching Claude Code's
+ * native terminal transcript (e.g. "Read 1 file, ran 1 shell command")
+ * instead of stacking N separately-bordered cards. Collapsed by default,
+ * EXCEPT while the run is still live (Change: starts expanded so the user
+ * doesn't lose sight of in-progress tool calls mid-turn) — expands into a
+ * list of merged, borderless per-tool rows (see ToolRunEntryRow) indented
+ * under the summary line; each tool's call and result render as ONE
+ * element, not a separate card pair.
+ */
+export function ToolRunSummary({ tools, live }: ToolRunSummaryProps) {
+  const [open, setOpen] = useState(() => !!live);
+  const hasError = tools.some((t) => t.result?.isError);
+  const hasPending = live && tools.some((t) => !t.result);
+
+  return (
+    <div className="chat-tool-run">
+      <button
+        type="button"
+        className="chat-tool-run__summary"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span className="chat-tool-run__caret" aria-hidden>
+          {open ? "▾" : "▸"}
+        </span>
+        <span className={`chat-tool-run__text${hasError ? " chat-tool-run__text--error" : ""}`}>
+          {summarizeGroup(tools)}
+        </span>
+        {hasPending ? <span className="chat-spinner" aria-label="running" /> : null}
+      </button>
+      {open ? (
+        <div className="chat-tool-run__body">
+          {tools.map((t) => (
+            <ToolRunEntryRow key={t.id} tool={t} running={!!live && !t.result} />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web-ui/src/components/chat/ToolUseCard.tsx
+++ b/web-ui/src/components/chat/ToolUseCard.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { prettyToolInput, summarizeToolInput } from "./toolFormat";
 
 interface ToolUseCardProps {
   toolName: string;
@@ -7,30 +8,11 @@ interface ToolUseCardProps {
   running?: boolean;
 }
 
-function summarize(input: unknown): string {
-  if (input == null) return "";
-  if (typeof input === "string") return input;
-  if (typeof input === "object") {
-    const obj = input as Record<string, unknown>;
-    // Common single-value tool inputs render inline (command / path / pattern).
-    for (const key of ["command", "cmd", "path", "file_path", "filePath", "pattern", "query"]) {
-      if (typeof obj[key] === "string") return obj[key] as string;
-    }
-  }
-  return "";
-}
-
 /** A tool invocation: name + input (collapsible pretty JSON) + running spinner. */
 export function ToolUseCard({ toolName, toolInput, running }: ToolUseCardProps) {
   const [open, setOpen] = useState(false);
-  const inline = summarize(toolInput);
-  const pretty = (() => {
-    try {
-      return JSON.stringify(toolInput, null, 2);
-    } catch {
-      return String(toolInput);
-    }
-  })();
+  const inline = summarizeToolInput(toolInput);
+  const pretty = prettyToolInput(toolInput);
   const hasBody = toolInput != null && pretty !== "undefined";
 
   return (

--- a/web-ui/src/components/chat/toolFormat.ts
+++ b/web-ui/src/components/chat/toolFormat.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared formatting helpers for rendering tool_use / tool_result payloads in
+ * chat. Used by the standalone ToolUseCard/ToolResultCard pair (a lone tool
+ * call) and by ToolRunSummary's merged per-tool rows (a run of consecutive
+ * tool calls) — kept in one place so both stay in sync.
+ */
+
+/** One tool_use (+ its tool_result, once it arrives) as rendered in chat —
+ *  shared shape between MessageList's `RenderItem` and ToolRunSummary's
+ *  per-tool rows so the two don't declare the same type twice. */
+export interface ToolCallEntry {
+  id: string;
+  toolName: string;
+  toolInput?: unknown;
+  /** Present once the matching tool_result event has arrived. */
+  result?: { content?: string; isError?: boolean };
+  /** The turn this tool call belongs to — used to stop a run of consecutive
+   *  tool calls from merging across a turn boundary. */
+  turnId?: string;
+}
+
+/** Common single-value tool inputs render inline (command / path / pattern). */
+export function summarizeToolInput(input: unknown): string {
+  if (input == null) return "";
+  if (typeof input === "string") return input;
+  if (typeof input === "object") {
+    const obj = input as Record<string, unknown>;
+    for (const key of ["command", "cmd", "path", "file_path", "filePath", "pattern", "query"]) {
+      if (typeof obj[key] === "string") return obj[key] as string;
+    }
+  }
+  return "";
+}
+
+export function prettyToolInput(input: unknown): string {
+  try {
+    return JSON.stringify(input, null, 2);
+  } catch {
+    return String(input);
+  }
+}
+
+/** Heuristic: does this look like a unified diff (edit-tool output)? */
+export function looksLikeUnifiedDiff(text: string): boolean {
+  if (!text) return false;
+  if (/^diff --git /m.test(text)) return true;
+  // A hunk header plus at least one +/- line is a strong signal.
+  return /^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@/m.test(text) && /^[+-]/m.test(text);
+}
+
+/**
+ * Client-side mirror of the server's `TOOL_RESULT_MAX_BYTES` cap
+ * (`daemon/src/services/toolResultCap.ts`). Defense-in-depth only — the
+ * server caps both write paths (live turns + at-rest import backfill), so
+ * this guard mainly protects against a stale cached transcript fetched
+ * before the one-time backfill migration ran.
+ */
+export const CLIENT_TOOL_RESULT_MAX_CHARS = 20_000;
+
+export function capForDisplay(text: string): string {
+  if (text.length <= CLIENT_TOOL_RESULT_MAX_CHARS) return text;
+  return `(tool result omitted — ${text.length} chars)`;
+}

--- a/web-ui/src/styles/chat.css
+++ b/web-ui/src/styles/chat.css
@@ -373,6 +373,116 @@
   word-break: break-word;
 }
 
+/* ── Tool run summary (collapsed consecutive tool calls) ─────────────────────
+   A run of 2+ consecutive tool calls collapses into one integrated,
+   borderless line (e.g. "Read 1 file, ran 1 shell command") instead of
+   stacking N bordered cards — mirrors Claude Code's native terminal look. */
+
+.chat-tool-run__summary {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-1) 0;
+  background: none;
+  border: none;
+  color: var(--fg-muted);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: var(--font-size-sm);
+  text-align: left;
+}
+.chat-tool-run__summary:hover {
+  color: var(--fg-secondary);
+}
+.chat-tool-run__caret {
+  flex-shrink: 0;
+}
+.chat-tool-run__text--error {
+  color: var(--destructive);
+}
+.chat-tool-run__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin-left: var(--space-3);
+  padding-top: var(--space-1);
+}
+
+/* A single tool call inside an expanded run: borderless, integrated row —
+   the call and its result are ONE element (no separate "X result" card). A
+   small chevron only appears when there's detail beyond the inline summary
+   (pretty input JSON and/or the result/diff). */
+.chat-tool-entry {
+  font-size: var(--font-size-sm);
+}
+.chat-tool-entry__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-1) 0;
+  background: none;
+  border: none;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  text-align: left;
+}
+.chat-tool-entry--error .chat-tool-entry__header {
+  color: var(--destructive);
+}
+.chat-tool-entry__caret {
+  flex-shrink: 0;
+  width: 1em;
+  color: var(--fg-muted);
+}
+.chat-tool-entry__caret--spacer {
+  visibility: hidden;
+}
+.chat-tool-entry__name {
+  font-weight: var(--font-weight-medium);
+  flex-shrink: 0;
+}
+.chat-tool-entry__inline {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--fg-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+}
+.chat-tool-entry__status {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+.chat-tool-entry__done {
+  color: var(--fg-muted);
+}
+.chat-tool-entry__body {
+  margin-left: calc(1em + var(--space-2));
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+.chat-tool-entry__pre {
+  margin: 0;
+  padding: var(--space-1) var(--space-2);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--fg-secondary);
+  background: var(--bg-secondary);
+  border-radius: var(--radius-sm);
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 /* ── Error card ───────────────────────────────────────────────────────────── */
 
 .chat-error-card {


### PR DESCRIPTION
## Summary
- A run of 2+ consecutive tool calls (Bash/Read/Edit/... with no assistant text/thinking between them) now collapses into one integrated summary line (e.g. "Read 1 file, ran 1 shell command"), collapsed by default, flush with the surrounding message text — only its expanded detail is indented. A lone tool call is unaffected.
- Expanding a run shows each tool as a single merged, borderless row (call + result combined, own small chevron) instead of separate "X" / "X result" cards. A tool still awaiting its result shows a spinner instead of a pending card, and a run stays expanded by default while it's still live so in-progress tool calls aren't hidden mid-turn.
- Runs never merge across a turn boundary; phrase-building dedupes aliased tool names (Grep/Glob → "searched", MultiEdit → "edited") while preserving original casing for unrecognized tools.
- Extracted shared tool-formatting helpers (`toolFormat.ts`) so the existing `ToolUseCard`/`ToolResultCard` pair and the new merged rows stay in sync instead of duplicating logic.

## Test plan
- [x] `tsc -b` clean
- [x] `eslint` clean on touched files
- [x] `vitest run src/components/chat` — 57/57 passing (incl. pre-existing `ToolResultCard.test.tsx` after the shared-helper refactor)
- [x] Manual visual review via a static before/after preview built from the real `chat.css`/component markup

🤖 Generated with [Claude Code](https://claude.com/claude-code)