### PR TITLE
fix(daemon,agy): switch agy JSON channel to --output-format stream-json

### DIFF
--- a/.vibekit/feature-plans/done/agy-stream-json/plan-agy-stream-json.md
+++ b/.vibekit/feature-plans/done/agy-stream-json/plan-agy-stream-json.md
@@ -1,0 +1,239 @@
+<!--
+RULES — read before writing or implementing:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. REQUIREMENTS: One crisp line each — no verbose descriptions
+3. CHECKLIST: Mark items [x] as you complete them — this is your persistent todo list
+4. READING TIME: Optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+# Plan: agy JSON channel — switch to `--output-format stream-json`
+
+> Replace agy's single-envelope `--output-format json` turn parsing with real per-step streaming (`--output-format stream-json`), matching the claude/cursor/opencode plugins' live event pattern.
+
+**Issue:** agy-stream-json
+**Branch:** `agy-stream-json`
+**Status:** Done
+
+**Reference files:**
+- Plugin: `daemon/src/agent-plugins/agy.ts`
+- Sibling patterns: `daemon/src/agent-plugins/claude.ts` (`parseClaudeStreamLine`), `daemon/src/agent-plugins/opencode.ts` (`parseOpencodeStreamLine`)
+- Types: `daemon/src/types.ts:44` (`NormalizedEventKind`), `:86` (`NormalizedEvent`)
+- Tests: `daemon/src/__tests__/agy.test.ts` (existing), `daemon/src/__tests__/claudeJson.test.ts` (pattern to mirror)
+- UI merge logic (why streamed deltas are safe): `web-ui/src/components/chat/MessageList.tsx:70-88`
+
+---
+
+## Problem
+
+- `agy.ts:435-440` spawns `agy --print=<msg> --output-format json`, which per the file's own doc comment (`agy.ts:41-45`, written at feature-inception in `075996a`) "does NOT stream per-event NDJSON."
+- That claim was never actually tested against `--output-format stream-json` — only against `json`. `agy models`/`--help` and hand-testing (this session) confirm `stream-json` is a distinct, real per-step NDJSON stream agy already supports.
+- Result: agy JSON-channel sessions render one opaque final blob instead of live text/tool-call visibility, unlike claude/cursor/opencode.
+
+## Out of Scope
+
+- `claude.ts` / `cursor.ts` / `opencode.ts` — untouched.
+- Human-gate / permission-prompt detection for agy (`ask_question`/`ask_permission` auto-skip in headless mode is a separate, already-answered question — not unlocked by this change).
+- TTY-mode chat-id capture (`--log-file` polling) — unrelated code path, untouched.
+- Changing `AGY_MODELS` list (unrelated drift noticed during hand-testing: live `agy` now also offers "Gemini 3.6 Flash" tiers not in the static list) — out of scope, file separately if wanted.
+
+## Concept
+
+- Swap `--output-format json` → `--output-format stream-json` in `runTurn` (`agy.ts:437-438`).
+- Replace `parseAgyResultLine` (single-envelope parser) with `parseAgyStreamLine`, a per-line NDJSON parser mirroring `parseClaudeStreamLine`/`parseOpencodeStreamLine`'s shape: pure function `(line, sessionId, state, fallbackModel) → NormalizedEvent[]`.
+- Success state: agy JSON-channel turns show live assistant text (streamed in chunks) and live tool-call cards (`run_command`, etc.) as they happen, not just a final answer — same as the other 3 CLIs.
+
+## Requirements
+
+| # | Requirement |
+|---|-------------|
+| 1 | `runTurn` spawns `agy --print=<msg> --output-format stream-json ...` |
+| 2 | `init` event → `session_init` (agentChatId, model from fallback — envelope carries none) |
+| 3 | `step_update` `step_type:"agent_response"` `text_delta` → `text` events, streamed per-chunk (both ACTIVE and DONE deltas) |
+| 4 | `step_update` `step_type:"tool"` → `tool_use` on first sight of a step (ACTIVE or DONE, guarded once), `tool_result` on DONE |
+| 5 | `result` event → `usage` + `result` (+ `error` on ERROR status) — same shape as today's final envelope handling |
+| 6 | `step_update` types with no useful payload (`user_input`, `unknown`, `checkpoint`, `error_message`) are dropped, not errored |
+| 7 | Malformed / non-JSON lines skipped (Decision 7 pattern, same as claude/opencode) |
+| 8 | No change to chat-id capture, restore, launch command (TTY mode), or model list |
+
+---
+
+## Research
+
+### Current single-envelope parsing
+
+- **File:** `daemon/src/agent-plugins/agy.ts:90-166` (`parseAgyResultLine`)
+- One line in, one final envelope out: `{conversation_id, status, response, error?, usage}` → fans out to `session_init, text, usage, result[, error]`.
+- Called once per output line in `runTurn`'s readline loop (`agy.ts:472-477`) — but agy only ever emits ONE such line in `json` mode, so this "loop" runs once.
+
+### Why `json` was chosen originally
+
+- `git log -p --follow -- daemon/src/agent-plugins/agy.ts` shows the plugin was authored from scratch in `075996a` ("feat(json-chat): JSON agent chat channel — core feature (P0-P4)").
+- The commit message's own summary states the *general* daemon design uses `--output-format stream-json` (or "closest per-CLI equivalent") for all 4 CLIs, and separately notes: "agy ... emits one final result envelope per turn instead" — i.e. the author asserted at commit time that agy has no streaming mode, without a recorded test of `stream-json` specifically.
+- No later commit (`bdd2479`, `51033cc`, `922888a`, `c76ae28`) revisits this decision — all are chat-id-capture / cwd-migration / prompt-length fixes, unrelated to output format.
+- **Conclusion:** not a documented limitation — an untested assumption. `stream-json` was simply never tried.
+
+### Live-verified `stream-json` event shapes (agy 1.1.12, hand-run this session)
+
+```jsonc
+// 1. init — always first (absent only on an immediate hard-fail, e.g. bad --model)
+{"event":"init","conversation_id":"<uuid>","init":{"cwd":"...","tools":[...],"permission_mode":"always-proceed"}}
+
+// 2. step_update — many per turn; conversation_id is NESTED here (unlike init/result)
+{"event":"step_update","step_update":{
+  "conversation_id":"<uuid>","step_index":0,"state":"DONE","step_type":"user_input"}}
+{"event":"step_update","step_update":{
+  "conversation_id":"<uuid>","step_index":1,"state":"DONE","step_type":"unknown","duration_seconds":0.001}}
+// agent_response: text streams in ACTIVE deltas, final delta + usage on DONE
+{"event":"step_update","step_update":{
+  "conversation_id":"<uuid>","step_index":2,"state":"ACTIVE","step_type":"agent_response","text_delta":"I'll run "}}
+{"event":"step_update","step_update":{
+  "conversation_id":"<uuid>","step_index":2,"state":"DONE","step_type":"agent_response","text_delta":"\n",
+  "duration_seconds":3.14,"usage":{"input_tokens":18668,"output_tokens":13,"thinking_tokens":0,"cache_read_tokens":0,"total_tokens":18681}}}
+// tool: ACTIVE carries the call (name+params), DONE carries the same + output
+{"event":"step_update","step_update":{
+  "conversation_id":"<uuid>","step_index":3,"state":"ACTIVE","step_type":"tool",
+  "tool_name":"run_command","tool_info":{"name":"run_command","parameters":{"CommandLine":"ls -la"}}}}
+{"event":"step_update","step_update":{
+  "conversation_id":"<uuid>","step_index":3,"state":"DONE","step_type":"tool","tool_name":"run_command",
+  "duration_seconds":0.76,"tool_info":{"name":"run_command","parameters":{"CommandLine":"ls -la"},"output":"total 8\r\n..."}}}
+{"event":"step_update","step_update":{
+  "conversation_id":"<uuid>","step_index":4,"state":"DONE","step_type":"checkpoint","duration_seconds":0.9,
+  "usage":{"input_tokens":109,"output_tokens":4,...}}}
+
+// 3. result — always last; conversation_id NESTED here too
+{"event":"result","result":{
+  "conversation_id":"<uuid>","status":"SUCCESS","response":"4\n","duration_seconds":3.88,"num_turns":1,
+  "usage":{"input_tokens":18772,"output_tokens":16,"thinking_tokens":0,"cache_read_tokens":0,"total_tokens":18788}}}
+
+// ERROR case (bad --model): NO init event at all, straight to result
+{"event":"result","result":{"conversation_id":"","status":"ERROR","response":"","error":"invalid model...","duration_seconds":0,"num_turns":0,"usage":{...all zero...}}}
+```
+
+- `conversation_id` location is inconsistent across event types: top-level on `init`, nested inside `step_update`/`result` on those.
+- `ask_question`/`ask_permission`-style human-gate tools surface as `step_type:"unknown"` with no `tool_name` (matches the task brief — confirmed live, no repro needed here; do not build gate detection around it).
+- No `error_message` `step_type` example was reproduced with a real tool failure this session — treat generically (dropped, Requirement 6) rather than invented.
+
+### Streamed-delta merge is already supported by the UI
+
+- **File:** `web-ui/src/components/chat/MessageList.tsx:70-79`
+- Consecutive `text` events with the same `turnId` are appended into one bubble (`last.text += ev.text`) — so emitting one `text` event per `text_delta` chunk (rather than accumulating in the plugin and emitting once) renders correctly and gives real incremental streaming, same mechanism opencode/claude rely on implicitly via their own per-block granularity.
+
+### Sibling pattern to mirror
+
+- **File:** `daemon/src/agent-plugins/opencode.ts:60-176` (`parseOpencodeStreamLine`)
+- Signature: `(line, sessionId, state) → NormalizedEvent[]`, `state` is a small mutable object threaded across calls in the `runTurn` readline loop (`opencode.ts:305,317-320`) to track `initEmitted` / `toolStarted: Set<string>` — same shape needed here (`tool_use` must fire once per step even though a tool step can arrive as ACTIVE-then-DONE or DONE-only).
+
+## Root Cause
+
+- The `json`-vs-`stream-json` choice was made once, in the original feature commit, based on an assumption ("agy does not stream") that was documented as fact but never tested against the actual `stream-json` flag value — only against `json`.
+
+---
+
+## Design Details
+
+### Key Decisions
+
+#### Decision 1: Per-step `state` object threaded through the readline loop, mirroring opencode
+
+- **Decision:** `parseAgyStreamLine(line, sessionId, state, fallbackModel)` where `state: { toolStarted: Set<string> }` tracks which `step_index`s already emitted `tool_use`, so a DONE-only or ACTIVE-then-DONE tool step never double-emits.
+- **Rationale:** matches `opencode.ts`'s `toolStarted` guard exactly (same double-emit risk: a terminal event may need to synthesize `tool_use` if the running one was never observed, e.g. turn resumed mid-tool).
+- **Where:** `daemon/src/agent-plugins/agy.ts` (new function, replaces `parseAgyResultLine`)
+
+```ts
+// toolId = String(step_index) — agy has no separate tool-call id, but step_index
+// is unique per turn and stable across the ACTIVE→DONE pair for the same tool call.
+const toolId = String(stepUpdate.step_index);
+if (!state.toolStarted.has(toolId)) {
+  state.toolStarted.add(toolId);
+  events.push(agyEvent(sessionId, "tool_use", {
+    toolName: stepUpdate.tool_name,
+    toolId,
+    toolInput: (stepUpdate.tool_info as any)?.parameters,
+  }));
+}
+if (stepUpdate.state === "DONE") {
+  const info = (stepUpdate.tool_info ?? {}) as Record<string, unknown>;
+  const raw = info.output ?? info.error;
+  events.push(agyEvent(sessionId, "tool_result", {
+    toolId,
+    toolResult: { content: typeof raw === "string" ? raw : raw != null ? JSON.stringify(raw) : undefined, isError: info.error !== undefined },
+  }));
+}
+```
+
+#### Decision 2: `text_delta` emitted per-chunk as `text` events (no in-plugin accumulation)
+
+- **Decision:** every non-empty `text_delta` on an `agent_response` step (ACTIVE or DONE state) becomes its own `text` NormalizedEvent immediately — the plugin does not buffer/join deltas itself.
+- **Rationale:** the daemon's transcript store + UI (`MessageList.tsx:70-79`) already merge consecutive same-turn `text` events into one bubble; buffering in the plugin would just delay the "real-time" visibility this migration exists to add. `turnId` stamping (needed for the merge) is handled by the core turn engine (`jsonAgent.ts`), not the plugin — plugin events don't set `turnId` today for agy or any other CLI (confirmed: no plugin sets `turnId` in claude.ts/opencode.ts either), so no new work needed there.
+- **Where:** `daemon/src/agent-plugins/agy.ts`, new parser's `agent_response` branch.
+
+#### Decision 3: `init` event → `session_init`; `result` event → `usage`+`result`(+`error`), same fields as today
+
+- **Decision:** keep the exact `usage`/`result`/`error` construction logic from `parseAgyResultLine` (`agy.ts:130-163`) verbatim, just re-triggered off the `result` event's `.result` sub-object instead of the whole (now single) line.
+- **Rationale:** no observed change in the `result` envelope's own shape between `json` and `stream-json` modes (only how many other events precede it) — reuse working code, don't redesign it.
+- **Where:** `daemon/src/agent-plugins/agy.ts`
+
+#### Decision 4: Unknown/no-payload `step_type`s dropped silently
+
+- **Decision:** `user_input`, `unknown`, `checkpoint`, `error_message` (and any future unrecognized `step_type`) produce zero events.
+- **Rationale:** none carry renderable content today (verified live — Research section); silently dropping matches Decision 7 in the original file (tolerate unexpected shapes, never throw) rather than inventing an unverified mapping.
+- **Where:** `daemon/src/agent-plugins/agy.ts`, default branch of the `step_type` switch.
+
+#### Decision 5: `runTurn` readline loop passes a fresh `state` per turn
+
+- **Decision:** `const state = { toolStarted: new Set<string>() }` declared once per `runTurn` call (same lifetime/scope as opencode's `state = { initEmitted: false }` at `opencode.ts:305`), passed to every `parseAgyStreamLine` call in that turn's loop.
+- **Rationale:** `toolStarted` must not leak across turns (step_index resets each turn) or across concurrent sessions (plugin functions are stateless between calls otherwise).
+- **Where:** `daemon/src/agent-plugins/agy.ts`, `runTurn` body (~`agy.ts:471-477`).
+
+---
+
+## Risks / Open Questions
+
+| # | Question | Notes |
+|---|----------|-------|
+| 1 | **Does `error_message` step_type ever carry renderable content?** | Not reproduced live this session. Dropped for now (Decision 4); revisit if a real repro surfaces a payload shape. |
+| 2 | **Could two tool steps share a `step_index` within one turn?** | Not observed — step_index increments monotonically per turn in every trace gathered. Guard (`toolStarted` Set) is defensive, not required by observed behavior. |
+| 3 | **Non-zero exit with partial NDJSON (e.g. process killed mid-stream)?** | Same handling as today: readline loop just stops, `runTurn`'s existing non-zero-exit-without-signal-abort → throw (`agy.ts:483-485`) is unchanged and still fires. |
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Streaming parser + runTurn switch
+
+- [x] **1.1** Add `parseAgyStreamLine(line, sessionId, state, fallbackModel): NormalizedEvent[]` in `agy.ts`, replacing `parseAgyResultLine` (Decisions 1-4).
+- [x] **1.2** Update `runTurn` (`agy.ts:435-477`): args → `--output-format stream-json`; declare per-turn `state`; readline loop calls `parseAgyStreamLine`.
+- [x] **1.3** Update file-header doc comment (`agy.ts:34-48`) to describe `stream-json` mode instead of the old single-envelope `json` mode.
+- [x] **1.4** Removed `parseAgyResultLine` entirely — its only importer was `daemon/src/__tests__/jsonPlugins.test.ts`, updated in place (no new file needed; deviates from the plan's original `agyStream.test.ts` — the sibling cursor/opencode agy parser tests already lived in `jsonPlugins.test.ts`, so the agy `describe` block there was replaced rather than forked into a new file).
+
+**Verify phase 1:**
+- [x] **1.T1** Unit — `daemon/src/__tests__/jsonPlugins.test.ts` (agy `describe` block replaced, not a new `agyStream.test.ts` — see 1.4): `init` event → `session_init` with `agentChatId`.
+- [x] **1.T2** Unit — `agent_response` `text_delta` (ACTIVE and DONE) → `text` events with correct text, one event per delta.
+- [x] **1.T3** Unit — `tool` step ACTIVE→DONE pair → one `tool_use` + one `tool_result`, no duplicate `tool_use`.
+- [x] **1.T4** Unit — `tool` step arriving DONE-only (no prior ACTIVE seen by parser, fresh `state`) → still emits both `tool_use` and `tool_result` (synthesized, guarded).
+- [x] **1.T5** Unit — `result` event (SUCCESS) → `usage` + `result` events with correct token sums.
+- [x] **1.T6** Unit — `result` event (ERROR, no prior `init`) → `usage` + `result` + `error` events, no `session_init` required.
+- [x] **1.T7** Unit — malformed/non-JSON line → `[]`, no throw.
+- [x] **1.T8** Unit — unrecognized `step_type` → `[]`.
+- [x] **1.T9** Regression — existing `daemon/src/__tests__/agy.test.ts` suite (chat-id capture, launch command, composeLaunchPrompt) still passes untouched — none of that code path changes. Confirmed: 10/10 pass, zero edits to that file.
+
+---
+
+### Phase 2 — Real-CLI verification
+
+- [x] **2.1** Hand-ran `agy --print="<msg>" --output-format stream-json --dangerously-skip-permissions` against a fresh scratch cwd (`/tmp/agytest`), piped real NDJSON output through the final `parseAgyStreamLine` via a `tsx` one-liner importing the actual plugin file — confirms the parser handles real output end-to-end, not just the fixtures in Research.
+- [x] **2.2** Hand-ran a `run_command`-invoking prompt (`echo hi`) — `tool_use`/`tool_result` events came out with correct `toolInput:{CommandLine:"echo hi"}` and `toolResult.content:"hi\r\n"`.
+
+**Verify phase 2:**
+- [x] **2.T1** Manual — piped real `agy` NDJSON output through `parseAgyStreamLine` line-by-line (`tsx` one-liner against `/tmp/agytest/real_agy_output.jsonl`) → event sequence matched exactly: `session_init → tool_use → tool_result → text → text → usage → result`.
+- [x] **2.T2** Automated — full repo test suite (`npx vitest run` from `cli/`, which symlinks `daemon/src`) green: 640/640 tests passed across 65 files (one pre-existing unrelated unhandled-rejection log line from `sessions.test.ts`'s intentional "failing spawn" test, not caused by this change).
+
+---
+
+## Files & Phase Impact
+
+| File | Status | Phase | Description / Contract Change |
+|------|--------|-------|-------------------------------|
+| `daemon/src/agent-plugins/agy.ts` | **Modified** | 1.1-1.4 | `--output-format json`→`stream-json`; `parseAgyResultLine`→`parseAgyStreamLine(line, sessionId, state: AgyStreamState, fallbackModel)` + new `createAgyStreamState()` helper |
+| `daemon/src/__tests__/jsonPlugins.test.ts` | **Modified** | 1.T1-1.T8 | Replaced the agy `describe` block with `parseAgyStreamLine` tests using real captured stream-json lines (deviates from plan's `agyStream.test.ts` — see 1.4) |
+| `daemon/src/__tests__/agy.test.ts` | **Unchanged** | 1.T9 | Regression check only — no edits |

--- a/daemon/src/__tests__/jsonPlugins.test.ts
+++ b/daemon/src/__tests__/jsonPlugins.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { parseCursorStreamLine } from "../agent-plugins/cursor.js";
 import { parseOpencodeStreamLine } from "../agent-plugins/opencode.js";
-import { parseAgyResultLine } from "../agent-plugins/agy.js";
+import { parseAgyStreamLine, createAgyStreamState } from "../agent-plugins/agy.js";
 
 /**
  * 3.T1 — per-plugin stream-json parsers map their CLI's native events into
@@ -299,99 +299,219 @@ describe("3.T1 — opencode parser", () => {
   });
 });
 
-describe("3.T1 — agy parser (live-captured 2026-07-15, agy 1.1.2)", () => {
-  // agy emits ONE final result envelope per turn (no streamed NDJSON); the
-  // parser fans it out into session_init → text → usage → result (+ error).
+describe("3.T1 — agy parser (live-captured 2026-08-13, agy 1.1.12, stream-json)", () => {
+  // agy streams real per-step NDJSON: init → many step_update → result. Lines
+  // below are copied verbatim from a real `agy --output-format stream-json` run.
 
-  it("maps a SUCCESS envelope → session_init, text, usage, result (real capture)", () => {
+  it("init event → session_init with agentChatId + fallback model", () => {
     const line = JSON.stringify({
-      conversation_id: "2ee537a2-ddad-42a4-a2cd-5c4dcc29f38c",
-      status: "SUCCESS",
-      response: "HELLO_AGY\n",
-      duration_seconds: 1.231695252,
-      num_turns: 1,
-      usage: { input_tokens: 16958, output_tokens: 8, thinking_tokens: 0, total_tokens: 16966 },
+      event: "init",
+      conversation_id: "a56a04cd-66b1-44cb-b538-90be2387c438",
+      init: { cwd: "/tmp/agytest", tools: ["run_command", "view_file"], permission_mode: "always-proceed" },
     });
-    const evs = parseAgyResultLine(line, SID, "Gemini 3.1 Pro (High)");
-    expect(evs.map((e) => e.kind)).toEqual(["session_init", "text", "usage", "result"]);
-    expect(evs.every((e) => e.provider === "agy")).toBe(true);
+    const evs = parseAgyStreamLine(line, SID, createAgyStreamState(), "Gemini 3.1 Pro (High)");
+    expect(evs).toHaveLength(1);
     expect(evs[0]).toMatchObject({
+      provider: "agy",
       kind: "session_init",
-      agentChatId: "2ee537a2-ddad-42a4-a2cd-5c4dcc29f38c",
+      agentChatId: "a56a04cd-66b1-44cb-b538-90be2387c438",
       model: "Gemini 3.1 Pro (High)",
     });
-    expect(evs[1]).toMatchObject({ kind: "text", role: "assistant", text: "HELLO_AGY\n" });
   });
 
-  it("reads agy usage token keys (input/output/total) and reports no cache/cost", () => {
+  it("agent_response text_delta (ACTIVE) → one text event per chunk", () => {
     const line = JSON.stringify({
-      conversation_id: "c1",
-      status: "SUCCESS",
-      response: "ok",
-      usage: { input_tokens: 16958, output_tokens: 8, thinking_tokens: 0, total_tokens: 16966 },
+      event: "step_update",
+      step_update: {
+        conversation_id: "beeaebcd-b396-4d7a-9fc3-a0c0ac83f1af",
+        step_index: 2,
+        state: "ACTIVE",
+        step_type: "agent_response",
+        text_delta: "I'll run both in parallel since they're independent!",
+      },
     });
-    const usageEv = parseAgyResultLine(line, SID, "Gemini 3.5 Flash (Low)").find((e) => e.kind === "usage");
-    expect(usageEv?.usage).toMatchObject({
-      inputTokens: 16958,
-      outputTokens: 8,
-      cacheReadTokens: 0,
-      cacheCreateTokens: 0,
-      totalTokens: 16966,
-      model: "Gemini 3.5 Flash (Low)",
-    });
-    expect(usageEv?.usage?.costUsd).toBeUndefined();
+    const evs = parseAgyStreamLine(line, SID, createAgyStreamState());
+    expect(evs).toEqual([
+      expect.objectContaining({
+        provider: "agy",
+        kind: "text",
+        role: "assistant",
+        text: "I'll run both in parallel since they're independent!",
+      }),
+    ]);
   });
 
-  it("maps an ERROR envelope → typed error event alongside result (real capture)", () => {
+  it("agent_response text_delta (DONE, carries usage) → text event; usage NOT surfaced as its own event", () => {
     const line = JSON.stringify({
-      conversation_id: "80fe5fd4-6973-43bc-bfff-38faae93082e",
-      status: "ERROR",
-      response: "readme.txt\n",
-      error:
-        "Permission denied for read_file(/home/gb/.gemini/antigravity-cli). Matches hardcoded system protection boundary rule.",
-      duration_seconds: 71.376995065,
-      num_turns: 2,
-      usage: { input_tokens: 147971, output_tokens: 7031, thinking_tokens: 5278, total_tokens: 155002 },
+      event: "step_update",
+      step_update: {
+        conversation_id: "beeaebcd-b396-4d7a-9fc3-a0c0ac83f1af",
+        step_index: 2,
+        state: "DONE",
+        step_type: "agent_response",
+        text_delta: "\n",
+        duration_seconds: 7.145,
+        usage: { input_tokens: 18684, output_tokens: 378, thinking_tokens: 0, cache_read_tokens: 0, total_tokens: 19062 },
+      },
     });
-    const evs = parseAgyResultLine(line, SID, "Gemini 3.5 Flash (Low)");
-    // status:ERROR with an `error` field emits a typed error event too, and the
-    // error text is also carried on the result.
-    expect(evs.map((e) => e.kind)).toEqual(["session_init", "text", "usage", "result", "error"]);
-    const capturedErr = evs.find((e) => e.kind === "error");
-    expect(capturedErr?.provider).toBe("agy");
-    expect(capturedErr?.text).toContain("Permission denied for read_file");
-    expect(evs.find((e) => e.kind === "result")?.text).toContain("hardcoded system protection");
-
-    // Minimal shape: partial response + short error.
-    const errLine = JSON.stringify({
-      conversation_id: "x",
-      status: "ERROR",
-      response: "partial",
-      error: "boom",
-    });
-    const errEvs = parseAgyResultLine(errLine, SID);
-    expect(errEvs.map((e) => e.kind)).toEqual(["session_init", "text", "usage", "result", "error"]);
-    const errEv = errEvs.find((e) => e.kind === "error");
-    expect(errEv).toMatchObject({ provider: "agy", kind: "error", text: "boom" });
-    expect(errEvs.find((e) => e.kind === "result")?.text).toBe("boom");
+    const evs = parseAgyStreamLine(line, SID, createAgyStreamState());
+    // Per-step usage is not the turn's final usage (Decision 3 — only the
+    // `result` event's usage becomes a `usage` NormalizedEvent).
+    expect(evs.map((e) => e.kind)).toEqual(["text"]);
+    expect(evs[0]?.text).toBe("\n");
   });
 
-  it("resumed turn carries the same conversation_id as agentChatId", () => {
+  it("empty text_delta emits nothing", () => {
     const line = JSON.stringify({
-      conversation_id: "b69873b6-6867-4830-ae40-fe84ff9707c8",
-      status: "SUCCESS",
-      response: "OK\n",
-      num_turns: 2,
-      usage: { input_tokens: 34061, output_tokens: 6, thinking_tokens: 0, total_tokens: 34067 },
+      event: "step_update",
+      step_update: { step_index: 4, state: "DONE", step_type: "agent_response", duration_seconds: 4.18 },
     });
-    const initEv = parseAgyResultLine(line, SID)[0];
-    expect(initEv).toMatchObject({ kind: "session_init", agentChatId: "b69873b6-6867-4830-ae40-fe84ff9707c8" });
+    expect(parseAgyStreamLine(line, SID, createAgyStreamState())).toEqual([]);
   });
 
-  it("skips malformed / non-result lines", () => {
-    expect(parseAgyResultLine("not json {{", SID)).toEqual([]);
-    expect(parseAgyResultLine("", SID)).toEqual([]);
-    // a stray JSON object without conversation_id/status is not our envelope.
-    expect(parseAgyResultLine(JSON.stringify({ hello: "world" }), SID)).toEqual([]);
+  it("tool step ACTIVE → tool_use, then DONE → tool_result (no duplicate tool_use)", () => {
+    const state = createAgyStreamState();
+    const activeLine = JSON.stringify({
+      event: "step_update",
+      step_update: {
+        conversation_id: "beeaebcd-b396-4d7a-9fc3-a0c0ac83f1af",
+        step_index: 3,
+        state: "ACTIVE",
+        step_type: "tool",
+        tool_name: "run_command",
+        tool_info: { name: "run_command", parameters: { CommandLine: "ls -la" } },
+      },
+    });
+    const activeEvs = parseAgyStreamLine(activeLine, SID, state);
+    expect(activeEvs).toHaveLength(1);
+    expect(activeEvs[0]).toMatchObject({
+      provider: "agy",
+      kind: "tool_use",
+      toolName: "run_command",
+      toolId: "3",
+      toolInput: { CommandLine: "ls -la" },
+    });
+
+    const doneLine = JSON.stringify({
+      event: "step_update",
+      step_update: {
+        conversation_id: "beeaebcd-b396-4d7a-9fc3-a0c0ac83f1af",
+        step_index: 3,
+        state: "DONE",
+        step_type: "tool",
+        tool_name: "run_command",
+        duration_seconds: 0.76,
+        tool_info: {
+          name: "run_command",
+          parameters: { CommandLine: "ls -la" },
+          output: "total 8\r\ndrwxr-xr-x  2 gb gb 4096 Jul 15 15:17 .\r\n",
+        },
+      },
+    });
+    const doneEvs = parseAgyStreamLine(doneLine, SID, state);
+    // Already emitted tool_use for step_index "3" — DONE must only add tool_result.
+    expect(doneEvs.map((e) => e.kind)).toEqual(["tool_result"]);
+    expect(doneEvs[0]).toMatchObject({
+      toolId: "3",
+      toolResult: { content: "total 8\r\ndrwxr-xr-x  2 gb gb 4096 Jul 15 15:17 .\r\n", isError: false },
+    });
+  });
+
+  it("tool step arriving DONE-only (fresh state, no prior ACTIVE seen) synthesizes both tool_use and tool_result", () => {
+    const doneLine = JSON.stringify({
+      event: "step_update",
+      step_update: {
+        step_index: 5,
+        state: "DONE",
+        step_type: "tool",
+        tool_name: "view_file",
+        tool_info: { name: "view_file", parameters: { AbsolutePath: "/tmp/x" }, output: "contents" },
+      },
+    });
+    const evs = parseAgyStreamLine(doneLine, SID, createAgyStreamState());
+    expect(evs.map((e) => e.kind)).toEqual(["tool_use", "tool_result"]);
+    expect(evs[0]).toMatchObject({ toolId: "5", toolName: "view_file", toolInput: { AbsolutePath: "/tmp/x" } });
+    expect(evs[1]).toMatchObject({ toolId: "5", toolResult: { content: "contents", isError: false } });
+  });
+
+  it("tool_info.error (not .output) → tool_result isError:true", () => {
+    const doneLine = JSON.stringify({
+      event: "step_update",
+      step_update: {
+        step_index: 3,
+        state: "DONE",
+        step_type: "tool",
+        tool_name: "run_command",
+        tool_info: { name: "run_command", parameters: {}, error: "permission denied" },
+      },
+    });
+    const evs = parseAgyStreamLine(doneLine, SID, createAgyStreamState());
+    const resultEv = evs.find((e) => e.kind === "tool_result");
+    expect(resultEv?.toolResult).toEqual({ content: "permission denied", isError: true });
+  });
+
+  it("no-payload step_types (user_input / unknown / checkpoint / error_message) are dropped", () => {
+    for (const step_type of ["user_input", "unknown", "checkpoint", "error_message"]) {
+      const line = JSON.stringify({ event: "step_update", step_update: { step_index: 0, state: "DONE", step_type } });
+      expect(parseAgyStreamLine(line, SID, createAgyStreamState())).toEqual([]);
+    }
+  });
+
+  it("result event (SUCCESS) → usage + result, no session_init (init already handled that)", () => {
+    const line = JSON.stringify({
+      event: "result",
+      result: {
+        conversation_id: "a56a04cd-66b1-44cb-b538-90be2387c438",
+        status: "SUCCESS",
+        response: "4\n",
+        duration_seconds: 3.88,
+        num_turns: 1,
+        usage: { input_tokens: 18772, output_tokens: 16, thinking_tokens: 0, cache_read_tokens: 0, total_tokens: 18788 },
+      },
+    });
+    const evs = parseAgyStreamLine(line, SID, createAgyStreamState(), "Gemini 3.1 Pro (High)");
+    expect(evs.map((e) => e.kind)).toEqual(["usage", "result"]);
+    expect(evs[0]).toMatchObject({
+      provider: "agy",
+      kind: "usage",
+      usage: {
+        inputTokens: 18772,
+        outputTokens: 16,
+        cacheReadTokens: 0,
+        cacheCreateTokens: 0,
+        totalTokens: 18788,
+        model: "Gemini 3.1 Pro (High)",
+      },
+    });
+    expect(evs[1]).toMatchObject({ kind: "result" });
+    expect(evs[1]?.usage?.totalTokens).toBe(18788);
+  });
+
+  it("result event (ERROR, no prior init — immediate hard-fail on bad --model) → usage + result + error", () => {
+    const line = JSON.stringify({
+      event: "result",
+      result: {
+        conversation_id: "",
+        status: "ERROR",
+        response: "",
+        error: 'invalid model selection (--model "totally-bogus-model"): model not recognized',
+        duration_seconds: 0,
+        num_turns: 0,
+        usage: { input_tokens: 0, output_tokens: 0, thinking_tokens: 0, cache_read_tokens: 0, total_tokens: 0 },
+      },
+    });
+    const evs = parseAgyStreamLine(line, SID, createAgyStreamState(), "totally-bogus-model");
+    expect(evs.map((e) => e.kind)).toEqual(["usage", "result", "error"]);
+    const errEv = evs.find((e) => e.kind === "error");
+    expect(errEv).toMatchObject({ provider: "agy", kind: "error" });
+    expect(errEv?.text).toContain("invalid model selection");
+    expect(evs.find((e) => e.kind === "result")?.text).toContain("invalid model selection");
+  });
+
+  it("skips malformed / non-JSON / unrecognized-event lines", () => {
+    expect(parseAgyStreamLine("not json {{", SID, createAgyStreamState())).toEqual([]);
+    expect(parseAgyStreamLine("", SID, createAgyStreamState())).toEqual([]);
+    expect(parseAgyStreamLine(JSON.stringify({ hello: "world" }), SID, createAgyStreamState())).toEqual([]);
+    expect(parseAgyStreamLine(JSON.stringify({ event: "something_future" }), SID, createAgyStreamState())).toEqual([]);
   });
 });

--- a/daemon/src/agent-plugins/agy.ts
+++ b/daemon/src/agent-plugins/agy.ts
@@ -31,20 +31,33 @@
  *                  (times out to null) and `refreshChatIdOnToggle` self-heals
  *                  once the user gets past the prompt and actually converses.
  *
- * JSON mode (verified live, agy 1.1.2):
+ * JSON mode (verified live, agy 1.1.12 — switched from `--output-format json`
+ * to `--output-format stream-json`; see json-agy-stream-json investigation):
  *   agy's `--print`/`-p`/`--prompt` is a STRING flag whose value IS the prompt.
- *   `agy --print=<msg> --output-format json [--model m] [--conversation <id>]
- *    --dangerously-skip-permissions` prints ONE final JSON envelope on stdout:
- *      { conversation_id, status:"SUCCESS"|"ERROR", response, error?,
- *        duration_seconds, num_turns,
- *        usage:{ input_tokens, output_tokens, thinking_tokens, total_tokens } }
- *   Unlike claude/cursor/opencode, agy does NOT stream per-event NDJSON — there
- *   are no live thinking/tool_use/tool_result events in print JSON. The whole
- *   turn resolves to a single result object at process exit, which the parser
- *   fans out into session_init + text + usage + result (+ error). Context resume
- *   via `--conversation` is verified stable (num_turns increments, recall works).
- *   agy reports no cache tokens and no cost, and the envelope carries no model
- *   name, so `model` is threaded in from the requested model.
+ *   `agy --print=<msg> --output-format stream-json [--model m]
+ *    [--conversation <id>] --dangerously-skip-permissions` emits real per-step
+ *    NDJSON on stdout, one JSON object per line:
+ *      {"event":"init", conversation_id, init:{cwd,tools,permission_mode}}
+ *      {"event":"step_update", step_update:{conversation_id, step_index,
+ *        state:"ACTIVE"|"DONE", step_type, text_delta?, tool_name?, tool_info?,
+ *        duration_seconds?, usage?}}
+ *      {"event":"result", result:{conversation_id, status:"SUCCESS"|"ERROR",
+ *        response, error?, duration_seconds, num_turns, usage}}
+ *   `init` is always first EXCEPT on an immediate hard-fail (e.g. unresolvable
+ *   `--model`), where the stream is just one `result` (status:"ERROR", no
+ *   conversation_id). `step_type:"agent_response"` streams the answer as
+ *   `text_delta` chunks (ACTIVE, then a final chunk + usage on DONE);
+ *   `step_type:"tool"` carries the call (`tool_name`/`tool_info.parameters`) on
+ *   ACTIVE and the same + `tool_info.output`/`.error` on DONE. Human-gate tools
+ *   (`ask_question`/`ask_permission`) auto-skip in headless/print mode and
+ *   surface as an anonymous `step_type:"unknown"` with no `tool_name` — not a
+ *   detectable gate signal (separate, already-answered question). Other
+ *   `step_type`s (`user_input`, `unknown`, `checkpoint`, `error_message`) carry
+ *   no renderable payload in any live capture and are dropped. `conversation_id`
+ *   is top-level on `init` but nested inside `step_update`/`result`. Context
+ *   resume via `--conversation` is verified stable (num_turns increments,
+ *   recall works). agy reports no cache tokens and no cost, and no event
+ *   carries a model name, so `model` is threaded in from the requested model.
  */
 
 import { promises as fs, mkdirSync, writeFileSync } from "node:fs";
@@ -78,18 +91,34 @@ function agyEvent(
   };
 }
 
+/** Per-turn mutable state threaded through `parseAgyStreamLine` calls in
+ *  `runTurn`'s readline loop — mirrors opencode's `toolStarted` guard
+ *  (`opencode.ts`'s `parseOpencodeStreamLine`). Must be a FRESH object per
+ *  turn (step_index resets every turn). */
+export interface AgyStreamState {
+  toolStarted: Set<string>;
+}
+
+export function createAgyStreamState(): AgyStreamState {
+  return { toolStarted: new Set() };
+}
+
 /**
- * Parse ONE agy `--output-format json` line — agy emits a SINGLE final result
- * envelope (not streamed NDJSON), so this maps that one object into the full
- * event sequence: session_init → text → usage → result (→ error). Exported for
- * unit testing (the plugin's private normalization boundary — Decision 3). The
- * envelope carries no model name, so `fallbackModel` (the requested model) fills
- * `usage.model`/`session_init.model`. Malformed / non-JSON lines are skipped
- * (Decision 7) — agy logs go to stderr/log-file, but tolerate any stray stdout.
+ * Parse ONE agy `--output-format stream-json` line into zero or more
+ * NormalizedEvents. Exported for unit testing (the plugin's private
+ * normalization boundary — Decision 3). agy streams real per-step NDJSON
+ * (`init` → many `step_update` → `result`, see the file-header doc comment for
+ * the full shape) — this is NOT a single-envelope parser (that was the old
+ * `--output-format json` behavior, retired in the stream-json migration).
+ * `fallbackModel` (the requested model) fills `model` on `session_init`/
+ * `usage`/`result` since no agy event ever carries a model name. Malformed /
+ * non-JSON lines are skipped (Decision 7) — agy logs go to stderr/log-file,
+ * but tolerate any stray stdout.
  */
-export function parseAgyResultLine(
+export function parseAgyStreamLine(
   line: string,
   sessionId: string,
+  state: AgyStreamState,
   fallbackModel?: string,
 ): NormalizedEvent[] {
   const trimmed = line.trim();
@@ -103,66 +132,117 @@ export function parseAgyResultLine(
     return []; // malformed — skip + tolerate
   }
 
-  // agy's result envelope is identified by conversation_id + status. Anything
-  // else on stdout (unexpected) is not our result line → skip.
-  const conversationId = typeof msg.conversation_id === "string" ? msg.conversation_id : undefined;
-  const status = typeof msg.status === "string" ? msg.status : undefined;
-  if (!conversationId && !status) return [];
-
-  const events: NormalizedEvent[] = [];
+  const event = typeof msg.event === "string" ? msg.event : undefined;
   const model = fallbackModel && fallbackModel.length ? fallbackModel : "";
-
-  // session_init — surface the conversation id so the core persists it as the
-  // agentChatId (reused via `--conversation` on the next turn, Decision 10).
-  events.push(
-    agyEvent(sessionId, "session_init", {
-      ...(conversationId ? { agentChatId: conversationId } : {}),
-      ...(model ? { model } : {}),
-    }),
-  );
-
-  // Assistant answer.
-  const response = typeof msg.response === "string" ? msg.response : "";
-  if (response) {
-    events.push(agyEvent(sessionId, "text", { role: "assistant", text: response }));
-  }
-
-  // Usage — agy reports no cache tokens and no cost; `total_tokens` is provided
-  // (input + output + thinking). thinking_tokens has no slot in UsageInfo (it is
-  // already summed into total_tokens by agy).
-  const usageRaw = (msg.usage ?? {}) as Record<string, unknown>;
   const num = (v: unknown): number => (typeof v === "number" ? v : 0);
-  const inputTokens = num(usageRaw.input_tokens);
-  const outputTokens = num(usageRaw.output_tokens);
-  const totalTokens = num(usageRaw.total_tokens) || inputTokens + outputTokens;
-  const usage = {
-    inputTokens,
-    outputTokens,
-    cacheReadTokens: 0,
-    cacheCreateTokens: 0,
-    totalTokens,
-    model,
-  };
-  events.push(agyEvent(sessionId, "usage", { usage, ...(model ? { model } : {}) }));
 
-  // Result — turn finished. On ERROR, carry the error text on the result too.
-  const errorText = typeof msg.error === "string" ? msg.error : undefined;
-  const isError = status === "ERROR" || errorText !== undefined;
-  events.push(
-    agyEvent(sessionId, "result", {
-      usage,
-      ...(model ? { model } : {}),
-      ...(isError && errorText ? { text: errorText } : {}),
-    }),
-  );
-
-  // A failed turn emits a typed `error` event alongside `result` (like claude /
-  // cursor) so the UI can distinguish it from a clean turn.
-  if (isError) {
-    events.push(agyEvent(sessionId, "error", { text: errorText ?? "agy turn failed" }));
+  if (event === "init") {
+    const conversationId = typeof msg.conversation_id === "string" ? msg.conversation_id : undefined;
+    return [
+      agyEvent(sessionId, "session_init", {
+        ...(conversationId ? { agentChatId: conversationId } : {}),
+        ...(model ? { model } : {}),
+      }),
+    ];
   }
 
-  return events;
+  if (event === "step_update") {
+    const step = (msg.step_update ?? {}) as Record<string, unknown>;
+    const stepType = typeof step.step_type === "string" ? step.step_type : undefined;
+    const stepState = typeof step.state === "string" ? step.state : undefined;
+    const events: NormalizedEvent[] = [];
+
+    if (stepType === "agent_response") {
+      const textDelta = typeof step.text_delta === "string" ? step.text_delta : "";
+      if (textDelta) {
+        events.push(agyEvent(sessionId, "text", { role: "assistant", text: textDelta }));
+      }
+      return events;
+    }
+
+    if (stepType === "tool") {
+      // No separate tool-call id in agy's protocol — step_index is unique per
+      // turn and stable across a tool's ACTIVE→DONE pair.
+      const toolId = typeof step.step_index === "number" ? String(step.step_index) : undefined;
+      const toolInfo = (step.tool_info ?? {}) as Record<string, unknown>;
+      const toolName = typeof step.tool_name === "string" ? step.tool_name : undefined;
+      if (toolId && !state.toolStarted.has(toolId)) {
+        state.toolStarted.add(toolId);
+        events.push(
+          agyEvent(sessionId, "tool_use", {
+            role: "assistant",
+            ...(toolName ? { toolName } : {}),
+            toolId,
+            toolInput: toolInfo.parameters,
+          }),
+        );
+      }
+      if (stepState === "DONE") {
+        const raw = toolInfo.output ?? toolInfo.error;
+        const contentStr =
+          typeof raw === "string" ? raw : raw != null ? JSON.stringify(raw) : undefined;
+        events.push(
+          agyEvent(sessionId, "tool_result", {
+            ...(toolId ? { toolId } : {}),
+            toolResult: {
+              ...(contentStr !== undefined ? { content: contentStr } : {}),
+              isError: toolInfo.error !== undefined,
+            },
+          }),
+        );
+      }
+      return events;
+    }
+
+    // user_input / unknown / checkpoint / error_message (and any future
+    // step_type) — no renderable payload observed live; drop (Decision 4).
+    return events;
+  }
+
+  if (event === "result") {
+    const result = (msg.result ?? {}) as Record<string, unknown>;
+    const status = typeof result.status === "string" ? result.status : undefined;
+    const events: NormalizedEvent[] = [];
+
+    // Usage — agy reports no cache tokens and no cost; `total_tokens` is
+    // provided (input + output + thinking). thinking_tokens has no slot in
+    // UsageInfo (already summed into total_tokens by agy).
+    const usageRaw = (result.usage ?? {}) as Record<string, unknown>;
+    const inputTokens = num(usageRaw.input_tokens);
+    const outputTokens = num(usageRaw.output_tokens);
+    const totalTokens = num(usageRaw.total_tokens) || inputTokens + outputTokens;
+    const usage = {
+      inputTokens,
+      outputTokens,
+      cacheReadTokens: 0,
+      cacheCreateTokens: 0,
+      totalTokens,
+      model,
+    };
+    events.push(agyEvent(sessionId, "usage", { usage, ...(model ? { model } : {}) }));
+
+    // Result — turn finished. On ERROR, carry the error text on the result too.
+    const errorText = typeof result.error === "string" ? result.error : undefined;
+    const isError = status === "ERROR" || errorText !== undefined;
+    events.push(
+      agyEvent(sessionId, "result", {
+        usage,
+        ...(model ? { model } : {}),
+        ...(isError && errorText ? { text: errorText } : {}),
+      }),
+    );
+
+    // A failed turn emits a typed `error` event alongside `result` (like claude
+    // / cursor) so the UI can distinguish it from a clean turn.
+    if (isError) {
+      events.push(agyEvent(sessionId, "error", { text: errorText ?? "agy turn failed" }));
+    }
+
+    return events;
+  }
+
+  // Unrecognized top-level event — tolerate any stray/future shape.
+  return [];
 }
 
 function sleep(ms: number): Promise<void> {
@@ -408,9 +488,10 @@ export function createAgyPlugin(): AgentPlugin {
 
     /**
      * Run ONE JSON-channel turn (Decision 2/3). Spawns `agy --print=<msg>
-     * --output-format json` and yields NormalizedEvents once the single result
-     * envelope arrives (agy does not stream). Own process group (detached) so a
-     * stuck turn is group-killed and never orphaned (Decision 13).
+     * --output-format stream-json` and yields NormalizedEvents live, as agy's
+     * per-step NDJSON arrives (see the file-header doc comment for the event
+     * shapes). Own process group (detached) so a stuck turn is group-killed and
+     * never orphaned (Decision 13).
      *
      * The message is passed as the VALUE of `--print` (agy's `--print` is a
      * string flag, NOT a boolean — a bare `--print` with the message on stdin or
@@ -435,7 +516,7 @@ export function createAgyPlugin(): AgentPlugin {
       const args = [
         `--print=${message}`,
         "--output-format",
-        "json",
+        "stream-json",
         "--dangerously-skip-permissions",
       ];
       if (ctx.model) args.push("--model", ctx.model);
@@ -468,10 +549,11 @@ export function createAgyPlugin(): AgentPlugin {
         child.on("close", (code) => resolve(code ?? 0));
       });
 
+      const state = createAgyStreamState();
       try {
         const rl = createInterface({ input: child.stdout!, crlfDelay: Infinity });
         for await (const line of rl) {
-          for (const ev of parseAgyResultLine(line, sessionId, ctx.model)) {
+          for (const ev of parseAgyStreamLine(line, sessionId, state, ctx.model)) {
             yield ev;
           }
         }


### PR DESCRIPTION
## Summary
- `agy.ts` spawned `agy --output-format json`, which resolves to a single opaque result envelope per turn — the plugin's own doc comment asserted agy "does NOT stream per-event NDJSON." That claim was never actually tested against `--output-format stream-json`; git history shows it was an assumption made at the original feature commit, not a verified limitation.
- Hand-testing the real `agy` CLI (v1.1.12) confirms `stream-json` is a genuine per-step NDJSON stream: `init` → many `step_update` (`agent_response` text deltas, `tool` calls with name/args/output) → final `result`.
- Replaces the single-envelope `parseAgyResultLine` with `parseAgyStreamLine`, mirroring `parseClaudeStreamLine`/`parseOpencodeStreamLine`'s pattern — agy JSON-channel sessions now show live streamed text and real-time tool_use/tool_result cards instead of one blob at the end, matching claude/cursor/opencode.

## Test plan
- [x] New unit tests in `daemon/src/__tests__/jsonPlugins.test.ts` against real captured stream-json lines (init, streamed text deltas, tool ACTIVE→DONE + DONE-only, dropped no-payload step types, success/error results, malformed input)
- [x] Existing `daemon/src/__tests__/agy.test.ts` regression suite (chat-id capture, launch, restore) passes untouched
- [x] Full repo suite: 640/640 tests green
- [x] Hand-ran the real `agy` CLI (plain turn + a `run_command`-invoking turn) and piped its real NDJSON output through the actual `parseAgyStreamLine` — confirmed correct event sequence end-to-end

Full investigation + design decisions: `.vibekit/feature-plans/done/agy-stream-json/plan-agy-stream-json.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)