### PR TITLE
fix(web-ui): tool-call grouping stays consistent across empty thinking events

### DIFF
--- a/web-ui/src/components/chat/MessageList.test.tsx
+++ b/web-ui/src/components/chat/MessageList.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import type { NormalizedEvent } from "@/api/types";
-import { MessageList, groupEvents } from "./MessageList";
+import { MessageList, groupEvents, mergeToolRuns } from "./MessageList";
 
 function userEvent(turnId: string, text: string, edited = false): NormalizedEvent {
   return {
@@ -101,6 +101,38 @@ describe("MessageList queued-turn filtering (tray relocation)", () => {
     expect(screen.queryByText("now running")).toBeNull();
     rerender(<MessageList events={[userEvent("t1", "now running")]} pending={[]} hiddenTurnIds={new Set()} />);
     expect(screen.getByText("now running")).toBeTruthy();
+  });
+});
+
+function toolItem(id: string, turnId: string) {
+  return { type: "tool" as const, id, toolName: "Bash", turnId, toolInput: { command: "echo" } };
+}
+function thinkingItem(id: string, turnId: string, text: string) {
+  return { type: "thinking" as const, id, turnId, text };
+}
+
+describe("mergeToolRuns", () => {
+  it("wraps even a lone tool call in a toolRun (consistent new-style rendering)", () => {
+    const out = mergeToolRuns([toolItem("a", "t1")]);
+    expect(out).toEqual([{ type: "toolRun", id: "a", tools: [toolItem("a", "t1")] }]);
+  });
+
+  it("does not let an empty/signature-only thinking event split an otherwise-contiguous tool run", () => {
+    const out = mergeToolRuns([
+      toolItem("a", "t1"),
+      thinkingItem("th", "t1", ""),
+      toolItem("b", "t1"),
+    ]);
+    expect(out).toEqual([{ type: "toolRun", id: "a", tools: [toolItem("a", "t1"), toolItem("b", "t1")] }]);
+  });
+
+  it("still splits the run when the thinking event carries real content", () => {
+    const out = mergeToolRuns([
+      toolItem("a", "t1"),
+      thinkingItem("th", "t1", "reasoning about next step"),
+      toolItem("b", "t1"),
+    ]);
+    expect(out.map((i) => i.type)).toEqual(["toolRun", "thinking", "toolRun"]);
   });
 });
 

--- a/web-ui/src/components/chat/MessageList.tsx
+++ b/web-ui/src/components/chat/MessageList.tsx
@@ -5,8 +5,6 @@ import type { PendingTurn } from "@/hooks/useChat";
 import { TextMessage } from "./TextMessage";
 import { QueuedTurnEditor } from "./QueuedTurnEditor";
 import { ThinkingBlock } from "./ThinkingBlock";
-import { ToolUseCard } from "./ToolUseCard";
-import { ToolResultCard } from "./ToolResultCard";
 import { ToolRunSummary } from "./ToolRunSummary";
 import { ErrorCard } from "./ErrorCard";
 import type { ToolCallEntry } from "./toolFormat";
@@ -21,26 +19,32 @@ type RenderItem =
   | { type: "status"; id: string; text: string };
 
 /**
- * A run of 2+ consecutive `tool` items (no text/thinking/user message, and no
- * turn boundary, between them) collapses into one `toolRun` item — rendered
- * as a single integrated, borderless summary line (e.g. "Read 1 file, ran 2
- * shell commands") instead of N separately-bordered tool cards, matching
- * Claude Code's native terminal transcript. A lone tool call keeps rendering
- * as an individual `tool` item (unchanged today's look).
+ * Consecutive `tool` items (no text/user message, and no turn boundary,
+ * between them) collapse into one `toolRun` item — rendered as a single
+ * integrated, borderless summary line (e.g. "Read 1 file, ran 2 shell
+ * commands") instead of separately-bordered tool cards, matching Claude
+ * Code's native terminal transcript. Even a lone tool call becomes a
+ * (single-entry) `toolRun` so its look is consistent regardless of whether
+ * anything ran alongside it.
+ *
+ * An empty/signature-only `thinking` item (no text — a redacted or
+ * signature-only reasoning block, common between near-every tool call in
+ * some sessions) carries no information, so it's transparent to an
+ * in-progress run: it's dropped rather than splitting one logical burst of
+ * tool calls into several single-tool runs.
  */
 export function mergeToolRuns(items: RenderItem[]): RenderItem[] {
   const out: RenderItem[] = [];
   let run: Extract<RenderItem, { type: "tool" }>[] = [];
   const flushRun = () => {
     if (run.length === 0) return;
-    if (run.length === 1) {
-      out.push(run[0]!);
-    } else {
-      out.push({ type: "toolRun", id: run[0]!.id, tools: [...run] });
-    }
+    out.push(run.length === 1 ? { type: "toolRun", id: run[0]!.id, tools: [run[0]!] } : { type: "toolRun", id: run[0]!.id, tools: [...run] });
     run = [];
   };
   for (const item of items) {
+    if (item.type === "thinking" && item.text.trim().length === 0 && run.length > 0) {
+      continue;
+    }
     // A run never spans a turn boundary — two tool calls from different
     // turns just happening to be adjacent (nothing else rendered between
     // them) shouldn't visually merge into one group.
@@ -349,24 +353,6 @@ export function MessageList({
             break;
           case "thinking":
             node = <ThinkingBlock key={key} text={item.text} />;
-            break;
-          case "tool":
-            node = (
-              <div key={key} className="chat-tool-group">
-                <ToolUseCard
-                  toolName={item.toolName}
-                  toolInput={item.toolInput}
-                  running={!item.result && turnActive && i === items.length - 1}
-                />
-                {item.result ? (
-                  <ToolResultCard
-                    toolName={item.toolName}
-                    content={item.result.content}
-                    isError={item.result.isError}
-                  />
-                ) : null}
-              </div>
-            );
             break;
           case "toolRun":
             // "Live" means this run is the trailing item of an active turn —

--- a/web-ui/src/components/chat/ThinkingBlock.tsx
+++ b/web-ui/src/components/chat/ThinkingBlock.tsx
@@ -7,9 +7,21 @@ interface ThinkingBlockProps {
   defaultOpen?: boolean;
 }
 
-/** Collapsible dim "Thinking…" reasoning block (Decision 9). */
+/** Collapsible dim "Thinking…" reasoning block (Decision 9). Signature-only /
+ *  redacted thinking events carry no text — those render as a plain label with
+ *  no chevron, since there's nothing to expand. */
 export function ThinkingBlock({ text, defaultOpen = false }: ThinkingBlockProps) {
   const [open, setOpen] = useState(defaultOpen);
+  const hasContent = text.trim().length > 0;
+  if (!hasContent) {
+    return (
+      <div className="chat-thinking">
+        <span className="chat-thinking__toggle chat-thinking__toggle--static">
+          <span className="chat-thinking__label">Thinking…</span>
+        </span>
+      </div>
+    );
+  }
   return (
     <div className="chat-thinking">
       <button

--- a/web-ui/src/components/chat/ToolRunSummary.tsx
+++ b/web-ui/src/components/chat/ToolRunSummary.tsx
@@ -151,7 +151,11 @@ function ToolRunEntryRow({ tool, running }: { tool: ToolCallEntry; running: bool
  * element, not a separate card pair.
  */
 export function ToolRunSummary({ tools, live }: ToolRunSummaryProps) {
-  const [open, setOpen] = useState(() => !!live);
+  // A singleton run's summary line is a generic phrase ("Ran 1 shell
+  // command") — start it expanded so the actual tool name + inline args
+  // (in the entry row below) are visible without a click, matching what a
+  // lone tool call used to show directly.
+  const [open, setOpen] = useState(() => !!live || tools.length === 1);
   const hasError = tools.some((t) => t.result?.isError);
   const hasPending = live && tools.some((t) => !t.result);
 

--- a/web-ui/src/styles/chat.css
+++ b/web-ui/src/styles/chat.css
@@ -343,6 +343,9 @@
   font-family: inherit;
   font-size: inherit;
 }
+.chat-thinking__toggle--static {
+  cursor: default;
+}
 .chat-thinking__body {
   border-left: var(--border-width-2) solid var(--border-subtle);
   padding-left: var(--space-3);
@@ -352,11 +355,6 @@
 
 /* ── Tool cards ───────────────────────────────────────────────────────────── */
 
-.chat-tool-group {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
-}
 .chat-tool-card {
   border: var(--border-width) solid var(--border-subtle);
   border-radius: var(--radius-md);


### PR DESCRIPTION
## Summary
- Empty/signature-only `thinking` events (text `""`) were breaking `mergeToolRuns`'s adjacency check, splitting otherwise-contiguous tool-call bursts into singletons — this is why some sessions (e.g. Direct chats, which interleave these between nearly every tool call) kept showing the old ungrouped, bordered per-call UI even after the grouping redesign landed. These events are now transparent to an in-progress run.
- Singleton tool calls now also render through `ToolRunSummary` instead of falling back to the old `ToolUseCard`/`ToolResultCard` pair, for visual consistency regardless of run length; defaults to expanded so the tool name/args stay visible without an extra click (matching what the old card always showed inline).
- A `thinking` block with no real content no longer shows a clickable chevron — there's nothing to expand.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run` — 402/402 passing (3 new tests covering the run-merging fix)
- [ ] Manual check in a live Direct session that a burst of tool calls collapses into one summary line

🤖 Generated with [Claude Code](https://claude.com/claude-code)