### PR TITLE
fix(naming): rich-chat sessions get named, and auto-names stop leaking IDs/filler

### DIFF
--- a/daemon/src/__tests__/naming.test.ts
+++ b/daemon/src/__tests__/naming.test.ts
@@ -37,4 +37,108 @@ describe("slugifyPrompt", () => {
     expect(slug).not.toContain("const");
     expect(slug).not.toContain("example");
   });
+
+  describe("informativeness (regressions from real production prompts)", () => {
+    it("never leaks worktree/PR-shaped id tokens", () => {
+      for (const id of ["vs-45", "pr17", "ch-61", "unl46", "vs45"]) {
+        const slug = slugifyPrompt(`Fix the flaky migration test in ${id} before release`);
+        // Assert against the id verbatim, its hyphen-stripped form AND its
+        // alphabetic prefix — `not.toContain(id.replace(/-/g, ""))` alone is
+        // vacuous for hyphenated ids, since the slug preserves hyphens.
+        expect(slug).not.toContain(id);
+        expect(slug).not.toContain(id.replace(/-/g, ""));
+        expect(slug.split("-")).not.toContain(id.replace(/[-\d]/g, ""));
+      }
+    });
+
+    it("real prompt: no longer produces `previous-started-vs-45`", () => {
+      const prompt =
+        "The previous worktree that was started vs-45, didn't get a good name. Looks like the name " +
+        "thing that we introduced is not working correctly. Can you please explore the issue and " +
+        "refer to opus subagent to help with a better name genration.\n\nAdditionally, I realized " +
+        "that there are many words that still creep into the name which shouldn't have been. If you " +
+        "have accesss to the intro prompts for the last 20 sessions, can you try to call the method " +
+        "against them and see the output. Create a table and then see if they are acceptable or not.";
+      const slug = slugifyPrompt(prompt);
+      expect(slug).not.toContain("vs-45");
+      expect(slug).not.toContain("previous");
+      expect(slug).not.toContain("started");
+      expect(slug).toContain("name"); // the actual subject of the prompt
+    });
+
+    it("real prompt: `I would like to change the default values...` picks the topic, not the filler", () => {
+      const prompt =
+        "I would like to change the default values for whenver the edge glow and selector glow are " +
+        "enabled\n\nThe edge glow:\nEdges: L+R\nCorner: 24 DP\nThickness: 1dp\n\nAnd gradient should " +
+        "be themed. For selector glow:\nAnimation: Moving gradient\nGradient: Same as above\n" +
+        "Selector thickness: 2dp";
+      const slug = slugifyPrompt(prompt);
+      expect(slug).not.toBe("like-change-default");
+      expect(slug).toContain("glow");
+    });
+
+    it("real prompt: `That worktree has just one commit...` avoids `has-one-commit`", () => {
+      const prompt =
+        "I am on this worktree: http://100.102.0.25:5173/worktree/ch-54. That worktree has just one " +
+        "commit on the branch but the VCS tab in vst is showing many many commits. Why is that? " +
+        "Whats going on?";
+      const slug = slugifyPrompt(prompt);
+      expect(slug).not.toBe("has-one-commit");
+      expect(slug).toContain("vcs");
+    });
+
+    it("drops filename-shaped tokens rather than leaking their extension", () => {
+      const slug = slugifyPrompt("Add the missing preview pane to BackgroundStep.kt for onboarding");
+      expect(slug.split("-")).not.toContain("kt");
+    });
+
+    it("expands contractions instead of leaving `didn`/`t` fragments", () => {
+      const slug = slugifyPrompt("The deploy didn't publish the release manifest, please investigate");
+      expect(slug.split("-")).not.toContain("didn");
+      expect(slug.split("-")).not.toContain("t");
+    });
+
+    it("prefers a repeated topical term over leading filler", () => {
+      const slug = slugifyPrompt(
+        "I was just thinking that maybe we should take a look at this. The throttling logic is " +
+          "wrong: throttling kicks in too early and throttling never resets.",
+      );
+      expect(slug).toContain("throttling");
+    });
+
+    it("keeps 2-letter ALL-CAPS acronyms but not 2-letter ordinary words", () => {
+      const slug = slugifyPrompt("Redesign the UI for the onboarding carousel");
+      expect(slug.split("-")).toContain("ui");
+    });
+
+    it("does not repeat a word already covered by a hyphenated pick", () => {
+      const slug = slugifyPrompt(
+        "Add moving-backgrounds support: we want customizable backgrounds with animated backgrounds.",
+      );
+      const parts = slug.split("-");
+      expect(new Set(parts).size).toBe(parts.length);
+    });
+
+    it("a pure-filler prompt still yields something rather than an empty slug", () => {
+      expect(slugifyPrompt("Can you please just have a look at this and see how it goes?")).not.toBe("");
+    });
+
+    it("is deterministic", () => {
+      const p = "Migrate the workspace persistence layer from localStorage into the daemon sqlite db";
+      expect(slugifyPrompt(p)).toBe(slugifyPrompt(p));
+    });
+
+    it("a prompt of nothing but core function words (no fallback content at all) -> \"\"", () => {
+      // Every survivor of the loose fallback pass would itself be a bare
+      // grammatical connector ("the") — that's not better than no name.
+      expect(slugifyPrompt("the a an of to")).toBe("");
+    });
+
+    it("does not hang or slow down on a very long, whitespace-sparse prompt (quadratic-regex guard)", () => {
+      const pathological = "a.b-".repeat(20000); // ~80k chars, no whitespace
+      const start = Date.now();
+      slugifyPrompt(pathological);
+      expect(Date.now() - start).toBeLessThan(500);
+    });
+  });
 });

--- a/daemon/src/__tests__/sessions.test.ts
+++ b/daemon/src/__tests__/sessions.test.ts
@@ -58,6 +58,19 @@ vi.mock("../services/spawn.js", async (importOriginal) => {
   };
 });
 
+// `startJsonCreateTurn` would otherwise resolve a real JSON agent (spawning a
+// CLI process) — mocked out so `skipAutoTurn` tests can assert on call
+// presence/absence without needing a live agent.
+vi.mock("../services/jsonAgentChat.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../services/jsonAgentChat.js")>();
+  return {
+    ...original,
+    startJsonCreateTurn: vi.fn(async () => {
+      // Mock: do nothing
+    }),
+  };
+});
+
 describe("Session routes", () => {
   let app: FastifyInstance;
   let projectId: string;
@@ -529,6 +542,75 @@ describe("Session routes", () => {
     const fetched = getRes.json<{ channel?: string; state: string }>();
     expect(fetched.channel).toBe("json");
     expect(fetched.state).toBe("not_started");
+  });
+
+  it("skipAutoTurn — worktree-scoped channel:json + prompt names the session but does NOT auto-enqueue turn 1", async () => {
+    const jsonAgentChat = await import("../services/jsonAgentChat.js");
+    const startJsonCreateTurnMock = vi.mocked(jsonAgentChat.startJsonCreateTurn);
+    startJsonCreateTurnMock.mockClear();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/sessions",
+      payload: {
+        worktreeId,
+        type: "agent",
+        modeId: "bugfix",
+        channel: "json",
+        prompt: "Implement the login flow described in SPEC.md",
+        skipAutoTurn: true,
+      },
+    });
+    expect(res.statusCode).toBe(201);
+    const created = res.json<{ name: string | null; nameSource: string | null }>();
+    expect(created).toMatchObject({ name: "implement-login-flow", nameSource: "auto" });
+    // A regression here would double-send the user's first message (once via
+    // auto-enqueue, once via the caller's own sendJsonFirstTurn).
+    expect(startJsonCreateTurnMock).not.toHaveBeenCalled();
+  });
+
+  it("skipAutoTurn — direct channel:json + prompt names the session but does NOT auto-enqueue turn 1", async () => {
+    const jsonAgentChat = await import("../services/jsonAgentChat.js");
+    const startJsonCreateTurnMock = vi.mocked(jsonAgentChat.startJsonCreateTurn);
+    startJsonCreateTurnMock.mockClear();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/sessions",
+      payload: {
+        projectId,
+        target: "direct",
+        type: "agent",
+        modeId: "bugfix",
+        channel: "json",
+        prompt: "Implement the login flow described in SPEC.md",
+        skipAutoTurn: true,
+      },
+    });
+    expect(res.statusCode).toBe(201);
+    const created = res.json<{ name: string | null; nameSource: string | null }>();
+    expect(created).toMatchObject({ name: "implement-login-flow", nameSource: "auto" });
+    expect(startJsonCreateTurnMock).not.toHaveBeenCalled();
+  });
+
+  it("skipAutoTurn omitted — channel:json + prompt DOES auto-enqueue turn 1 (unchanged default)", async () => {
+    const jsonAgentChat = await import("../services/jsonAgentChat.js");
+    const startJsonCreateTurnMock = vi.mocked(jsonAgentChat.startJsonCreateTurn);
+    startJsonCreateTurnMock.mockClear();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/sessions",
+      payload: {
+        worktreeId,
+        type: "agent",
+        modeId: "bugfix",
+        channel: "json",
+        prompt: "Implement the login flow described in SPEC.md",
+      },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(startJsonCreateTurnMock).toHaveBeenCalledTimes(1);
   });
 
   it("4a.T1 — POST /sessions with sourceAgentId persists it as spawnedFrom on the new record", async () => {

--- a/daemon/src/__tests__/worktrees.test.ts
+++ b/daemon/src/__tests__/worktrees.test.ts
@@ -38,6 +38,19 @@ vi.mock("../services/spawn.js", async (importOriginal) => {
   };
 });
 
+// `startJsonCreateTurn` would otherwise resolve a real JSON agent (spawning a
+// CLI process) — mocked out so `skipAutoTurn` tests can assert on call
+// presence/absence without needing a live agent.
+vi.mock("../services/jsonAgentChat.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../services/jsonAgentChat.js")>();
+  return {
+    ...original,
+    startJsonCreateTurn: vi.fn(async () => {
+      // Mock: do nothing
+    }),
+  };
+});
+
 describe("Worktree routes", () => {
   let app: FastifyInstance;
   let repoDir: string;
@@ -264,6 +277,56 @@ describe("Worktree routes", () => {
       payload: { projectId, branch: "json-claude", modeId: "bug-fix", channel: "json" },
     });
     expect(res.statusCode).toBe(201);
+  });
+
+  it("skipAutoTurn — channel:json + prompt derives name/initialPrompt but does NOT auto-enqueue turn 1", async () => {
+    const jsonAgentChat = await import("../services/jsonAgentChat.js");
+    const startJsonCreateTurnMock = vi.mocked(jsonAgentChat.startJsonCreateTurn);
+    startJsonCreateTurnMock.mockClear();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/worktrees",
+      payload: {
+        projectId,
+        modeId: "bug-fix",
+        channel: "json",
+        prompt: "Implement the login flow described in SPEC.md",
+        skipAutoTurn: true,
+      },
+    });
+    expect(res.statusCode).toBe(201);
+    const wt = res.json<{ name: string | null; mainSessionId: string }>();
+    // Naming/initialPrompt derive from `prompt` exactly like the non-JSON path...
+    expect(wt.name).toBe("implement-login-flow");
+    const sessRes = await app.inject({ method: "GET", url: `/sessions/${wt.mainSessionId}` });
+    expect(sessRes.json<{ name: string | null; nameSource: string | null }>()).toMatchObject({
+      name: "implement-login-flow",
+      nameSource: "auto",
+    });
+    // ...but turn 1 is never auto-enqueued — the caller is responsible for
+    // sending it itself once attachments are uploaded (sendJsonFirstTurn).
+    // A regression here would double-send the user's first message.
+    expect(startJsonCreateTurnMock).not.toHaveBeenCalled();
+  });
+
+  it("skipAutoTurn omitted — channel:json + prompt DOES auto-enqueue turn 1 (unchanged default)", async () => {
+    const jsonAgentChat = await import("../services/jsonAgentChat.js");
+    const startJsonCreateTurnMock = vi.mocked(jsonAgentChat.startJsonCreateTurn);
+    startJsonCreateTurnMock.mockClear();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/worktrees",
+      payload: {
+        projectId,
+        modeId: "bug-fix",
+        channel: "json",
+        prompt: "Implement the login flow described in SPEC.md",
+      },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(startJsonCreateTurnMock).toHaveBeenCalledTimes(1);
   });
 
   it("GET changed-paths scope=local lists staged file", async () => {

--- a/daemon/src/routes/sessions.ts
+++ b/daemon/src/routes/sessions.ts
@@ -64,6 +64,10 @@ const WorktreeSessionBody = z.object({
    *  as-is, never validated against a real session — an unknown/dangling
    *  id is harmless (S5). */
   sourceAgentId: z.string().optional(),
+  /** See `spawnNewSessionForChannel`'s doc — lets a JSON-channel caller pass
+   *  `prompt` here purely for naming/initialPrompt without the daemon
+   *  auto-enqueueing it as turn 1. */
+  skipAutoTurn: z.boolean().optional(),
 });
 
 const DirectSessionBody = z.object({
@@ -76,6 +80,7 @@ const DirectSessionBody = z.object({
   channel: z.enum(["tmux", "pty", "json"]).optional(),
   name: z.string().trim().max(60).optional(),
   sourceAgentId: z.string().optional(),
+  skipAutoTurn: z.boolean().optional(),
 });
 
 const CreateSessionBody = z.union([WorktreeSessionBody, DirectSessionBody]);
@@ -323,9 +328,17 @@ async function spawnNewSessionForChannel(opts: {
   modeId: string;
   prompt: string | undefined;
   daemonPort: number;
+  /** See `skipAutoTurn` on `WorktreeSessionBody`/`DirectSessionBody` above:
+   *  caller included `prompt` only so naming/initialPrompt could be derived
+   *  from it, and will send the real turn 1 itself (after uploading staged
+   *  attachments) — don't also auto-enqueue it here. Defaults to false so
+   *  `/sessions/:id/reset`'s call site (no create-dialog body to speak of)
+   *  keeps its existing auto-enqueue behavior unchanged. */
+  skipAutoTurn?: boolean;
 }): Promise<void> {
-  const { project, worktree, session, modeId, prompt, daemonPort } = opts;
+  const { project, worktree, session, modeId, prompt, daemonPort, skipAutoTurn } = opts;
   if (sessionChannel(session) === "json") {
+    if (skipAutoTurn) return;
     try {
       await startJsonCreateTurn({ sessionId: session.id, prompt, daemonPort });
     } catch (err) {
@@ -617,7 +630,14 @@ export function registerSessionRoutes(app: FastifyInstance): void {
       // the create-dialog prompt via the JSON turn queue.
       if (type === "agent" && modeId) {
         const daemonPort = (app.server.address() as { port?: number })?.port ?? 7421;
-        void spawnNewSessionForChannel({ project, session: sessionRecord, modeId, prompt, daemonPort });
+        void spawnNewSessionForChannel({
+          project,
+          session: sessionRecord,
+          modeId,
+          prompt,
+          daemonPort,
+          skipAutoTurn: data.skipAutoTurn,
+        });
       }
 
       return reply.status(201).send(serializeSession(null, project.id, sessionRecord));
@@ -759,7 +779,15 @@ export function registerSessionRoutes(app: FastifyInstance): void {
     // process starts on turn 1, auto-enqueued from the create-dialog prompt.
     if (type === "agent" && modeId) {
       const daemonPort = (app.server.address() as { port?: number })?.port ?? 7421;
-      void spawnNewSessionForChannel({ project, worktree, session: sessionRecord, modeId, prompt, daemonPort });
+      void spawnNewSessionForChannel({
+        project,
+        worktree,
+        session: sessionRecord,
+        modeId,
+        prompt,
+        daemonPort,
+        skipAutoTurn: data.skipAutoTurn,
+      });
     }
 
     return reply.status(201).send(serializeSession(worktreeId, project.id, sessionRecord));

--- a/daemon/src/routes/worktrees.ts
+++ b/daemon/src/routes/worktrees.ts
@@ -167,6 +167,15 @@ const CreateWorktreeBody = z.object({
    *  (agent-interaction-workspaces/04-workspaces Phase 4a) — see
    *  WorktreeSessionBody's identical field in routes/sessions.ts. */
   sourceAgentId: z.string().optional(),
+  /** JSON-channel callers that stage attachments before sending turn 1
+   *  (see `sendJsonFirstTurn` in web-ui) still want `prompt` present in this
+   *  body so the naming heuristic (F1) and `initialPrompt` get populated —
+   *  but must NOT have the daemon auto-enqueue that same prompt as turn 1,
+   *  since they're about to send it themselves once attachments are
+   *  uploaded. Set this to skip the `startJsonCreateTurn` auto-enqueue
+   *  below while still deriving the name/initialPrompt from `prompt`.
+   *  No-op for non-JSON channels (they never auto-enqueue from this body). */
+  skipAutoTurn: z.boolean().optional(),
 });
 
 async function runMainSpawnJob(opts: {
@@ -513,8 +522,14 @@ export function registerWorktreeRoutes(app: FastifyInstance): void {
 
       if (isJson) {
         // JSON main agent (Decision 2/8): no TTY spawn — auto-enqueue the
-        // create-dialog prompt as turn 1 via the JSON turn queue.
-        void startJsonCreateTurn({ sessionId: mainSession.id, prompt: result.data.prompt, daemonPort });
+        // create-dialog prompt as turn 1 via the JSON turn queue. Skipped
+        // when the caller passed `skipAutoTurn` (it included `prompt` here
+        // only so naming/initialPrompt could be derived, and will send the
+        // real turn 1 itself once attachments are uploaded — see
+        // `skipAutoTurn`'s doc on `CreateWorktreeBody` above).
+        if (!result.data.skipAutoTurn) {
+          void startJsonCreateTurn({ sessionId: mainSession.id, prompt: result.data.prompt, daemonPort });
+        }
       } else {
         void runMainSpawnJob({
           projectId,

--- a/daemon/src/services/naming.ts
+++ b/daemon/src/services/naming.ts
@@ -9,31 +9,307 @@
  * `req.body.prompt` is non-empty (Requirement 3). Non-English/non-ASCII
  * prompts and empty/whitespace-only prompts both produce `""` — callers fall
  * back to the existing default label in that case (no i18n handling planned).
+ *
+ * ## Design
+ *
+ * The original version took "the first N words that aren't stopwords". Against
+ * real prompts that produced names like `has-one-commit`, `like-change-default`
+ * and `previous-started-vs-45`: prompts almost always open with throat-clearing
+ * ("I would like to...", "The previous worktree that was started vs-45..."),
+ * so the first surviving words are filler while the actual topic sits a clause
+ * or two later. This version keeps the same contract but changes three things:
+ *
+ * 1. **Scrub harder before scoring.** Code fences, URLs, path-shaped tokens,
+ *    filename-shaped tokens (`SPEC.md`, `BackgroundStep.kt` — otherwise `md`/
+ *    `kt`/`spec` leak in) and ID/ref-shaped tokens (`vs-45`, `pr17`, `ch-61`,
+ *    sha-ish hex) are removed. Contractions are expanded (`didn't` -> `did not`)
+ *    so they collapse into stopwords instead of leaving `didn`/`t` fragments.
+ * 2. **A much larger stopword list**, covering function words *and* the weak
+ *    verbs/hedges/quantifiers that dominate conversational prompts (has, one,
+ *    like, lot, times, see, started, good, get, realized, previous, ...).
+ *    Strong action verbs (fix, add, implement, migrate, ...) are deliberately
+ *    NOT stopwords — they make good names.
+ * 3. **Score instead of taking the first N.** Each surviving word gets a cheap
+ *    informativeness score: word length, how often it repeats in the prompt
+ *    (topical words recur, filler usually doesn't), whether it appeared
+ *    capitalised mid-sentence or in ALL CAPS (proper nouns / acronyms like
+ *    `Android`, `SDK`, `BYOT`), minus a small penalty for how late it first
+ *    appears (a mild tie-break toward the opening, not a hard rule). The top
+ *    `maxWords` are then emitted in original prompt order so the slug still
+ *    reads like a phrase.
+ *
+ * If the strict pass filters *everything* out (a prompt made entirely of
+ * filler), a loose pass re-runs with only the structural filters, so we still
+ * return something rather than falling back to a numbered default.
+ *
+ * Everything here stays pure/sync/allocation-cheap on purpose: callers invoke
+ * it inline inside request handlers (`routes/worktrees.ts`,
+ * `routes/sessions.ts`, `routes/projects.ts`).
+ */
+
+/**
+ * Words that carry ~no naming signal. Function words plus the "conversational
+ * glue" tier: weak verbs (get/see/make/try), hedges (maybe/actually), vague
+ * nouns (thing/way/lot/time) and evaluative adjectives (good/quick/new).
+ * Deliberately absent: fix, add, remove, implement, migrate, refactor, port,
+ * upgrade, support, plan, report, ... — those describe the task.
  */
 const STOPWORDS = new Set([
-  "a","an","the","is","are","was","were","be","been","being","to","of","in","on",
-  "for","with","and","or","but","as","at","by","from","that","this","these","those",
-  "it","its","i","we","you","your","our","please","can","could","would","should",
-  "will","just","also","need","needs","want","wants","make","sure","following",
-  "described","using","use","via","into","about","if","then","so","not","no","do","does",
+  // articles / determiners / quantifiers
+  "a","an","the","this","that","these","those","such","some","any","all","both",
+  "each","every","other","another","same","few","several","enough","own","none",
+  "more","most","less","least","much","many","lot","lots","bunch","couple",
+  // pronouns
+  "i","me","my","mine","we","us","our","ours","you","your","yours","he","she",
+  "him","her","his","hers","they","them","their","theirs","it","its","who","whom",
+  "whose","which","what","whatever","whichever","whoever","someone","somebody",
+  "something","anyone","anybody","anything","everyone","everybody","everything",
+  "nothing","nobody","one","ones","itself","myself","yourself","themselves",
+  // be / have / do / modals
+  "am","is","are","was","were","be","been","being","have","has","had","having",
+  "do","does","did","doing","done","will","would","shall","should","can","could",
+  "may","might","must","cannot",
+  // prepositions / conjunctions / connectives
+  "to","of","in","on","for","with","and","or","but","as","at","by","from","into",
+  "onto","upon","over","under","above","below","between","across","through",
+  "throughout","during","before","after","while","since","until","unless","than",
+  "then","so","if","else","because","though","although","whether","when","where",
+  "why","how","there","here","also","too","very","just","only","not","no","nor",
+  "yet","still","again","back","out","off","down","around","along","per","via",
+  "about","against","toward","towards","within","without","among","amongst","up",
+  // weak verbs / conversational glue
+  "need","needs","needed","want","wants","wanted","make","makes","making","made",
+  "use","uses","using","used","get","gets","getting","got","gotten","give","gives",
+  "given","take","takes","taking","taken","put","puts","go","goes","going","went",
+  "come","comes","came","see","sees","seeing","seen","look","looks","looking",
+  "know","knows","knowing","knew","think","thinks","thinking","thought","say",
+  "says","said","tell","tells","told","ask","asks","asked","asking","try","tries",
+  "trying","tried","let","lets","letting","feel","feels","free","sure","able",
+  "please","help","helps","helping","work","works","working","worked","start",
+  "starts","started","starting","begin","begins","began","run","runs","running",
+  "ran","keep","keeps","kept","find","finds","finding","found","show","shows",
+  "showing","shown","ensure","ensures","seem","seems","seemed","appear","appears",
+  "realize","realized","realise","realised","notice","noticed","mean","means",
+  "meant","happen","happens","happening","happened","turn","turns","turned",
+  "wonder","wondering","guess","suppose","consider","considering","touch",
+  "touching","touched","follow","follows","following","followed","described",
+  "describe","describes","introduce","introduced","introducing",
+  // hedges / adverbs / evaluatives
+  "good","bad","better","best","great","nice","fine","okay","ok","yes","yeah",
+  "nope","right","wrong","quick","quickly","fast","slow","small","big","large",
+  "little","tiny","huge","new","old","current","currently","previous","previously",
+  "prior","next","last","first","second","third","final","finally","actual",
+  "actually","basically","maybe","probably","possibly","likely","definitely",
+  "certainly","honestly","obviously","simply","exactly","especially","specific",
+  "specifically","explicitly","really","quite","rather","instead","however",
+  "additionally","furthermore","moreover","overall","generally","usually","often",
+  "sometimes","always","never","already","soon","later","now","today","tomorrow",
+  "yesterday","etc","eg","ie","thanks","thank","hi","hello","hey","well","like",
+  "liked","likes","similar","similarly","different","difference","directly",
+  // vague nouns
+  "thing","things","stuff","way","ways","time","times","case","cases","point",
+  "points","part","parts","kind","kinds","sort","sorts","bit","bits","idea",
+  "ideas","note","notes","word","words","list","lists","item",
+  "items","number","numbers","side","sides","end","ends","top","bottom",
+  // spelled-out small numbers
+  "two","three","four","five","six","seven","eight","nine","ten",
+  // apostrophe-less contractions (the apostrophe form is normalised away above,
+  // but people type these bare too)
+  "dont","doesnt","didnt","cant","wont","isnt","arent","wasnt","werent",
+  "havent","hasnt","wouldnt","couldnt","shouldnt","whats","thats",
+  // evaluative / meta adjectives that describe quality, not subject matter
+  "correct","correctly","proper","properly","appropriate","acceptable",
+  "relevant","useful","important","existing","whole","entire","full","clear",
+  "clearly","carefully","careful","blindly","silently","half","pager","deep",
+  "dive","figure","figures","figured","invoke","invokes","invoking","invoked",
+  // "the user" is the person typing the prompt in ~every prompt here
+  "user","users",
 ]);
-const NOISE = new Set(["session", "agent", "worktree", "task", "code", "codebase", "project"]);
+
+/**
+ * Domain vocabulary that is true of *every* vibe-station prompt and therefore
+ * distinguishes nothing. Separate from STOPWORDS so the two lists stay
+ * independently reviewable.
+ */
+const NOISE = new Set([
+  "session","sessions","agent","agents","subagent","subagents","worktree",
+  "worktrees","task","tasks","code","codebase","codebases","project","projects",
+  "repo","repos","repository","prompt","prompts","branch","branches","commit",
+  "commits","claude","opus","sonnet","llm",
+  // this tool's own name — never distinguishes one worktree from another
+  "vst","vibe","vibestation","vibe-station",
+]);
+
+/**
+ * The subset of STOPWORDS that carries zero content even as a last resort —
+ * bare grammatical connectors (articles, core prepositions/conjunctions, the
+ * verb "to be", demonstratives). Ordinary STOPWORDS are dropped from the
+ * strict pass but let through the loose fallback pass (see `slugifyPrompt`)
+ * so an all-filler prompt still surfaces *something*; this smaller set stays
+ * excluded even in the loose pass, since a slug that's just "the" is no
+ * better than no name at all.
+ */
+const CORE_FUNCTION_WORDS = new Set([
+  "a","an","the","this","that","these","those",
+  "of","to","in","on","for","and","or","but","as","at","by","from",
+  "is","are","was","were","be","been","being",
+]);
+
+/** `vs-45`, `pr17`, `ch-61`, `unl46` — a short prefix plus a number is an ID, not a description. */
+const ID_TOKEN = /^[a-z]{1,5}-?\d+[a-z0-9-]*$/;
+/** `3014443e`, `c41d680` — sha-ish: long, hex-only, and containing at least one digit. */
+const HEXISH_TOKEN = /^(?=[0-9a-f]*\d)[0-9a-f]{6,}$/;
+/** `v1`, `v1.3`, `api2` — a bare version/number-suffixed stub. */
+const VERSIONISH_TOKEN = /^v?\d[\d-]*$/;
+
+/**
+ * Strip everything that is markup/reference rather than prose. Case is
+ * preserved because capitalisation is used as a scoring signal downstream.
+ */
+function scrub(prompt: string): string {
+  return prompt
+    .replace(/```[\s\S]*?```/g, " ") // fenced code blocks
+    .replace(/`[^`]*`/g, " ") // inline code spans (usually paths/identifiers)
+    .replace(/https?:\/\/\S+/g, " ") // URLs
+    .replace(/\S*\/\S+/g, " ") // path-shaped tokens (avoids "tmp"/"pr" leaking from /tmp/pr.diff)
+    .replace(/[\w-]+\.[A-Za-z][A-Za-z0-9]{0,4}(?![\w.])/g, " ") // filename-shaped tokens (SPEC.md, Foo.kt)
+    .replace(/n['’]t\b/gi, " not") // didn't -> did not (both stopwords)
+    .replace(/['’](s|re|ve|ll|d|m)\b/gi, "") // possessives / contractions -> bare stem
+    .replace(/['’]/g, ""); // any leftover apostrophes glue rather than split
+}
+
+/**
+ * Words the author signalled as proper nouns or acronyms: ALL-CAPS runs, or a
+ * capitalised word that is NOT at a sentence/line/bullet start. Cheap stand-in
+ * for "this is a domain term" without any POS tagging.
+ */
+function collectEmphasized(scrubbed: string): { emphasized: Set<string>; acronyms: Set<string> } {
+  const emphasized = new Set<string>();
+  const acronyms = new Set<string>();
+  const re = /[A-Za-z][A-Za-z0-9-]*/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(scrubbed)) !== null) {
+    const word = m[0];
+    if (word.length < 2) continue;
+    if (word === word.toUpperCase() && /[A-Z]{2,}/.test(word)) {
+      // ALL CAPS: SDK, PRD, UI, BYOT. Tracked separately so short acronyms can
+      // survive the >2-chars length floor that filters ordinary noise.
+      emphasized.add(word.toLowerCase());
+      acronyms.add(word.toLowerCase());
+      continue;
+    }
+    const head = word.charAt(0);
+    if (head !== head.toUpperCase()) continue;
+    // Walk back to the previous non-space character; a capital right after
+    // sentence-ending/structural punctuation is just normal capitalisation.
+    let i = m.index - 1;
+    while (i >= 0 && /\s/.test(scrubbed.charAt(i))) i--;
+    if (i < 0) continue;
+    if (/[.!?:;#*\-–—([{"']/.test(scrubbed.charAt(i))) continue;
+    emphasized.add(word.toLowerCase());
+  }
+  return { emphasized, acronyms };
+}
+
+/**
+ * Structural rejects — applied in both the strict and the loose pass.
+ * `acronyms` lets 2-letter ALL-CAPS terms (UI, UX, CI, DB) through the length
+ * floor while ordinary 2-letter words stay out.
+ */
+function isStructuralJunk(word: string, acronyms: Set<string>): boolean {
+  return (
+    (word.length <= 2 && !acronyms.has(word)) ||
+    // Run-together CamelCase identifiers (UserByotTemplates) make ugly slugs.
+    // Measured per hyphen component so real compounds (multi-platform) survive.
+    word.split("-").some((part) => part.length > 14) ||
+    /^\d+$/.test(word) ||
+    ID_TOKEN.test(word) ||
+    HEXISH_TOKEN.test(word) ||
+    VERSIONISH_TOKEN.test(word)
+  );
+}
+
+/**
+ * Cap on how much of `prompt` we bother scrubbing. `scrub()`'s path/filename
+ * regexes are quadratic on long whitespace-free input (e.g. a pasted minified
+ * blob or a `--prompt-file` dump — `prompt` has no upstream max length), and
+ * this function runs synchronously inside the create-worktree/create-session
+ * request handlers, so an unbounded prompt can stall the daemon's event loop.
+ * Naming only ever needs the opening context anyway.
+ */
+const MAX_SCRUB_LEN = 4000;
 
 export function slugifyPrompt(prompt: string, maxWords = 3, maxLen = 60): string {
-  const words = prompt
+  const capped = prompt.length > MAX_SCRUB_LEN ? prompt.slice(0, MAX_SCRUB_LEN) : prompt;
+  const scrubbed = scrub(capped);
+  const { emphasized, acronyms } = collectEmphasized(scrubbed);
+
+  const words = scrubbed
     .toLowerCase()
-    .replace(/```[\s\S]*?```/g, " ") // strip code fences
-    .replace(/https?:\/\/\S+/g, " ") // strip URLs
-    .replace(/\S*\/\S+/g, " ") // strip path-shaped tokens entirely (not space-split — avoids "tmp"/"pr" leaking in from /tmp/pr.diff)
     .replace(/[^a-z0-9\s-]/g, " ") // remaining punctuation -> spaces
     .split(/\s+/)
+    .map((w) => w.replace(/^-+|-+$/g, "")) // trim stray leading/trailing hyphens
     .filter(Boolean);
 
-  const content = words.filter(
-    (w) => w.length > 2 && !STOPWORDS.has(w) && !NOISE.has(w) && !/^\d+$/.test(w),
-  );
+  const keep = (w: string, strict: boolean) =>
+    !isStructuralJunk(w, acronyms) &&
+    !NOISE.has(w) &&
+    (strict ? !STOPWORDS.has(w) : !CORE_FUNCTION_WORDS.has(w));
+
+  // Strict pass first; fall back to a looser filter when a prompt is pure
+  // filler, so we still beat "no name at all". The loose pass drops the full
+  // ~450-word STOPWORDS list (it exists precisely so *some* word survives)
+  // but still excludes CORE_FUNCTION_WORDS — otherwise an all-filler prompt
+  // like "the a an of to" would loose-pass its way to a slug of just "the",
+  // which is no better than no name at all.
+  let content = words.filter((w) => keep(w, true));
+  if (content.length === 0) content = words.filter((w) => keep(w, false));
   if (content.length === 0) return ""; // caller falls back to the existing default label
 
-  const slug = content.slice(0, maxWords).join("-");
+  // First-occurrence index (reading order) + repetition count per unique word.
+  const firstAt = new Map<string, number>();
+  const counts = new Map<string, number>();
+  content.forEach((w, i) => {
+    if (!firstAt.has(w)) firstAt.set(w, i);
+    counts.set(w, (counts.get(w) ?? 0) + 1);
+  });
+
+  // Cheap informativeness score. Repetition is the strongest signal (a prompt's
+  // real subject gets mentioned again; filler usually doesn't), so it outweighs
+  // both word length and reading position.
+  const total = content.length;
+  const scored = [...firstAt.keys()].map((word) => {
+    const at = firstAt.get(word)!;
+    const score =
+      1 +
+      Math.min(word.length, 10) / 8 + // longer words carry more meaning, capped
+      (emphasized.has(word) ? 0.8 : 0) + // proper noun / acronym
+      Math.min((counts.get(word) ?? 1) - 1, 4) * 0.7 - // topical words recur
+      (/ly$/.test(word) && word.length >= 6 ? 0.8 : 0) - // -ly adverbs describe manner, not subject
+      (at / total) * 0.6; // mild preference for the opening, not a hard rule
+    return { word, at, score };
+  });
+
+  scored.sort((a, b) => b.score - a.score || a.at - b.at);
+
+  // Take the best `maxWords`, skipping anything already covered by a
+  // hyphenated pick (avoids "moving-backgrounds-customizable-backgrounds").
+  const picked: { word: string; at: number }[] = [];
+  for (const cand of scored) {
+    if (picked.length >= maxWords) break;
+    const parts = cand.word.split("-");
+    const overlaps = picked.some((p) => {
+      const pParts = p.word.split("-");
+      return parts.some((x) => pParts.includes(x));
+    });
+    if (overlaps) continue;
+    picked.push({ word: cand.word, at: cand.at });
+  }
+  picked.sort((a, b) => a.at - b.at); // emit in prompt order so it reads as a phrase
+
+  // Trim whole words to fit maxLen; only hard-slice if a single word overflows.
+  const parts = picked.map((p) => p.word);
+  while (parts.length > 1 && parts.join("-").length > maxLen) parts.pop();
+  const slug = parts.join("-");
   return slug.length > maxLen ? slug.slice(0, maxLen).replace(/-+$/, "") : slug;
 }

--- a/web-ui/src/api/firstTurn.ts
+++ b/web-ui/src/api/firstTurn.ts
@@ -3,14 +3,18 @@ import type { ApiInstance } from "@/api";
 /**
  * Run the first turn of a freshly-created JSON agent AFTER its session exists.
  *
- * The create-dialog JSON path deliberately omits the prompt from the create body
- * (so the daemon does NOT auto-enqueue turn 1). This helper closes that gap: it
- * uploads any staged files against the new session, then sends the prompt +
- * resolved attachment ids as turn 1 via the chat queue. A blank prompt with no
- * files is a no-op — the agent stays idle awaiting the user's first message.
+ * The create-dialog JSON path DOES include `prompt` in the create body now
+ * (so the daemon can derive the auto name / `initialPrompt` from it — see
+ * `skipAutoTurn` on `CreateWorktreeBody`/`CreateSessionBody`), but passes
+ * `skipAutoTurn: true` so the daemon does NOT also auto-enqueue it as turn 1.
+ * This helper is what actually delivers turn 1: it uploads any staged files
+ * against the new session, then sends the prompt + resolved attachment ids
+ * via the chat queue. A blank prompt with no files is a no-op — the agent
+ * stays idle awaiting the user's first message.
  *
- * This keeps turn 1 single-sourced: the prompt travels either in the create body
- * (CLI / terminal path) OR through this chat send (UI JSON path), never both.
+ * This keeps turn-1 *delivery* single-sourced: the prompt is still only ever
+ * enqueued as a turn from one place — the create body's auto-enqueue for the
+ * CLI/terminal path, or this chat send for the UI JSON path — never both.
  */
 export async function sendJsonFirstTurn(
   api: ApiInstance,

--- a/web-ui/src/api/types.ts
+++ b/web-ui/src/api/types.ts
@@ -503,6 +503,15 @@ export interface CreateWorktreeBody {
   useTmux?: boolean;
   /** `"json"` selects the JSON agent-chat channel for the main agent. */
   channel?: Channel;
+  /**
+   * JSON-channel callers that stage attachments before sending turn 1 (see
+   * `sendJsonFirstTurn`) should still pass `prompt` here so the daemon can
+   * derive the auto name / `initialPrompt` from it, but set this to `true`
+   * so the daemon does NOT also auto-enqueue that prompt as turn 1 — the
+   * caller sends it itself once attachments are uploaded. No-op outside the
+   * JSON channel.
+   */
+  skipAutoTurn?: boolean;
 }
 
 export interface CreateSessionBody {
@@ -515,6 +524,8 @@ export interface CreateSessionBody {
   channel?: Channel;
   /** Optional display name for terminals; blank → daemon assigns "Terminal N". */
   name?: string;
+  /** See `CreateWorktreeBody.skipAutoTurn`. */
+  skipAutoTurn?: boolean;
 }
 
 /** Body for creating a direct session (no worktree). */
@@ -528,6 +539,8 @@ export interface CreateDirectSessionBody {
   /** `"json"` selects the JSON agent-chat channel. */
   channel?: Channel;
   name?: string;
+  /** See `CreateWorktreeBody.skipAutoTurn`. */
+  skipAutoTurn?: boolean;
 }
 
 /** Body for adding a new project. */

--- a/web-ui/src/components/dialogs/DirectAgentDialog.attachments.test.tsx
+++ b/web-ui/src/components/dialogs/DirectAgentDialog.attachments.test.tsx
@@ -33,8 +33,14 @@ describe("DirectAgentDialog JSON attachments at creation", () => {
 
     await waitFor(() => expect(createSpy).toHaveBeenCalled());
     const body = createSpy.mock.calls[0]![0];
-    expect(body).toMatchObject({ target: "direct", projectId: "proj-a", type: "agent", channel: "json" });
-    expect("prompt" in body).toBe(false);
+    expect(body).toMatchObject({
+      target: "direct",
+      projectId: "proj-a",
+      type: "agent",
+      channel: "json",
+      prompt: "add a test",
+      skipAutoTurn: true,
+    });
 
     const sessionId = (await createSpy.mock.results[0]!.value).id;
     await waitFor(() => expect(uploadSpy).toHaveBeenCalledWith(sessionId, [file]));

--- a/web-ui/src/components/dialogs/DirectAgentDialog.tsx
+++ b/web-ui/src/components/dialogs/DirectAgentDialog.tsx
@@ -86,15 +86,18 @@ export function DirectAgentDialog({
     setSubmitting(true);
     try {
       if (channel === "json") {
-        // JSON path: create the session idle (no prompt in the body → daemon does
-        // NOT auto-enqueue turn 1), then upload staged files + send the prompt as
-        // turn 1 via the chat queue.
+        // JSON path: create the session idle (prompt included only so the
+        // daemon can derive the auto name/initialPrompt from it —
+        // skipAutoTurn:true stops it from also auto-enqueuing turn 1), then
+        // upload staged files + send the prompt as turn 1 via the chat queue.
         const sess = await api.createDirectSession({
           target: "direct",
           projectId,
           type: "agent",
           modeId,
+          prompt: initialPrompt.trim() || undefined,
           channel: "json",
+          skipAutoTurn: true,
         });
         await sendJsonFirstTurn(api, sess.id, initialPrompt, files);
       } else {

--- a/web-ui/src/components/dialogs/NewAgentDialog.attachments.test.tsx
+++ b/web-ui/src/components/dialogs/NewAgentDialog.attachments.test.tsx
@@ -7,8 +7,10 @@ import { NewAgentDialog } from "./NewAgentDialog";
 
 /**
  * Attachments at creation for the worktree-main JSON path: create the worktree
- * idle (no prompt in the body), upload the staged file, then send prompt +
- * attachment id as turn 1 against the returned worktree's main session.
+ * idle (prompt carried in the body only so the daemon can derive the auto
+ * name/initialPrompt — `skipAutoTurn: true` stops it from also auto-enqueueing
+ * turn 1), upload the staged file, then send prompt + attachment id as turn 1
+ * against the returned worktree's main session.
  */
 describe("NewAgentDialog JSON attachments at creation (worktree main)", () => {
   it("creates worktree idle → uploads → sends first chat to the main session", async () => {
@@ -47,8 +49,12 @@ describe("NewAgentDialog JSON attachments at creation (worktree main)", () => {
 
     await waitFor(() => expect(wtSpy).toHaveBeenCalled());
     const body = wtSpy.mock.calls[0]![0];
-    expect(body).toMatchObject({ projectId: "proj-a", channel: "json" });
-    expect("prompt" in body).toBe(false);
+    expect(body).toMatchObject({
+      projectId: "proj-a",
+      channel: "json",
+      prompt: "refactor",
+      skipAutoTurn: true,
+    });
 
     const wt = await wtSpy.mock.results[0]!.value;
     // Session ids are independently generated (Decision 1) — no longer

--- a/web-ui/src/components/dialogs/NewAgentDialog.create-json.test.tsx
+++ b/web-ui/src/components/dialogs/NewAgentDialog.create-json.test.tsx
@@ -43,9 +43,17 @@ describe("NewAgentDialog create-new-project JSON path", () => {
     await waitFor(() => expect(projSpy).toHaveBeenCalled());
     expect("startAgent" in projSpy.mock.calls[0]![0]).toBe(false);
 
-    // Then a json direct session + first turn.
+    // Then a json direct session + first turn. `prompt` is carried in the
+    // create body so the daemon can derive the auto name/initialPrompt from
+    // it; `skipAutoTurn` stops it from also enqueueing that as turn 1 (the
+    // chat send below is the single source of truth for turn 1 delivery).
     await waitFor(() => expect(sessSpy).toHaveBeenCalled());
-    expect(sessSpy.mock.calls[0]![0]).toMatchObject({ type: "agent", channel: "json" });
+    expect(sessSpy.mock.calls[0]![0]).toMatchObject({
+      type: "agent",
+      channel: "json",
+      prompt: "scaffold it",
+      skipAutoTurn: true,
+    });
     const sess = await sessSpy.mock.results[0]!.value;
     await waitFor(() => expect(chatSpy).toHaveBeenCalledWith(sess.id, "scaffold it", []));
   });

--- a/web-ui/src/components/dialogs/NewAgentDialog.tsx
+++ b/web-ui/src/components/dialogs/NewAgentDialog.tsx
@@ -819,7 +819,9 @@ export function NewAgentDialog({
             branch: trimmedBranch || undefined,
             baseBranch: result.project.defaultBranch,
             modeId,
+            prompt: prompt.trim() || undefined,
             channel: "json",
+            skipAutoTurn: true,
           });
           worktreeId = wt.id;
           if (wt.mainSessionId) {
@@ -836,7 +838,9 @@ export function NewAgentDialog({
             projectId: result.project.id,
             type: "agent",
             modeId,
+            prompt: prompt.trim() || undefined,
             channel: "json",
+            skipAutoTurn: true,
           });
           sessionId = sess.id;
           await sendJsonFirstTurn(api, sess.id, prompt, files);
@@ -913,16 +917,16 @@ export function NewAgentDialog({
       let worktreeId: string | undefined;
       let sessionId: string | undefined;
       if (useWorktree && project.isGit) {
-        // JSON (Dec 8): create idle (no prompt in the body → no daemon
+        // JSON (Dec 8): create idle (prompt included only so the daemon can
+        // derive the auto name/initialPrompt — skipAutoTurn:true stops
         // auto-enqueue), then upload staged files + send the prompt as turn 1.
         const wt = await api.createWorktree({
           projectId: project.id,
           branch: trimmedBranch || undefined,
           baseBranch: project.defaultBranch,
           modeId,
-          ...(isJson
-            ? { channel: "json" as const }
-            : { prompt: prompt.trim() || undefined }),
+          prompt: prompt.trim() || undefined,
+          ...(isJson ? { channel: "json" as const, skipAutoTurn: true } : {}),
         });
         worktreeId = wt.id;
         if (isJson) {
@@ -944,9 +948,8 @@ export function NewAgentDialog({
           projectId: project.id,
           type: "agent",
           modeId,
-          ...(isJson
-            ? { channel: "json" as const }
-            : { prompt: prompt.trim() || undefined }),
+          prompt: prompt.trim() || undefined,
+          ...(isJson ? { channel: "json" as const, skipAutoTurn: true } : {}),
         });
         sessionId = sess.id;
         if (isJson) {
@@ -992,7 +995,8 @@ export function NewAgentDialog({
       let worktreeId: string | undefined;
       let sessionId: string | undefined;
       if (useWorktree && !worktreeDisabled) {
-        // JSON (Dec 8): create idle (no prompt in the body → no daemon
+        // JSON (Dec 8): create idle (prompt included only so the daemon can
+        // derive the auto name/initialPrompt — skipAutoTurn:true stops
         // auto-enqueue), then upload staged files + send the prompt as turn 1
         // against the returned worktree's main agent.
         const wt = await api.createWorktree({
@@ -1000,9 +1004,8 @@ export function NewAgentDialog({
           branch: trimmedBranch || undefined,
           baseBranch: baseBranch.trim() || undefined,
           modeId,
-          ...(isJson
-            ? { channel: "json" as const }
-            : { prompt: prompt.trim() || undefined }),
+          prompt: prompt.trim() || undefined,
+          ...(isJson ? { channel: "json" as const, skipAutoTurn: true } : {}),
         });
         worktreeId = wt.id;
         if (isJson) {
@@ -1024,9 +1027,8 @@ export function NewAgentDialog({
           projectId: selectedProject.id,
           type: "agent",
           modeId,
-          ...(isJson
-            ? { channel: "json" as const }
-            : { prompt: prompt.trim() || undefined }),
+          prompt: prompt.trim() || undefined,
+          ...(isJson ? { channel: "json" as const, skipAutoTurn: true } : {}),
         });
         sessionId = sess.id;
         if (isJson) {

--- a/web-ui/src/components/dialogs/NewSessionDialog.channel.test.tsx
+++ b/web-ui/src/components/dialogs/NewSessionDialog.channel.test.tsx
@@ -11,7 +11,7 @@ function renderDialog(api: ReturnType<typeof createMockApi>) {
 }
 
 describe("NewSessionDialog channel + attachments", () => {
-  it("new-worktree JSON path → createWorktree channel:'json' (no useTmux)", async () => {
+  it("new-worktree JSON path → createWorktree channel:'json' (no useTmux, prompt carried for naming, auto-turn skipped)", async () => {
     const api = createMockApi();
     const wtSpy = vi.spyOn(api, "createWorktree");
     renderDialog(api);
@@ -20,16 +20,25 @@ describe("NewSessionDialog channel + attachments", () => {
     // Default is "New worktree" — provide a branch.
     await userEvent.type(screen.getByLabelText("New worktree branch"), "feat/x");
     await userEvent.click(screen.getByRole("radio", { name: /Rich Chat/i }));
+    await userEvent.type(screen.getByLabelText(/Initial prompt/i), "fix the login flow");
     await userEvent.click(screen.getByText("Create"));
 
     await waitFor(() => expect(wtSpy).toHaveBeenCalled());
     const body = wtSpy.mock.calls[0]![0];
-    expect(body).toMatchObject({ projectId: "proj-a", channel: "json" });
+    // `prompt` still travels in the create body (so the daemon can derive the
+    // auto name / initialPrompt from it) but `skipAutoTurn` stops the daemon
+    // from also enqueueing it as turn 1 — the actual turn 1 send happens
+    // separately via `sendJsonFirstTurn` once attachments are uploaded.
+    expect(body).toMatchObject({
+      projectId: "proj-a",
+      channel: "json",
+      prompt: "fix the login flow",
+      skipAutoTurn: true,
+    });
     expect("useTmux" in body).toBe(false);
-    expect("prompt" in body).toBe(false);
   });
 
-  it("existing-worktree JSON path → createSession channel:'json'", async () => {
+  it("existing-worktree JSON path → createSession channel:'json' (prompt carried, auto-turn skipped)", async () => {
     const api = createMockApi();
     const sessSpy = vi.spyOn(api, "createSession");
     renderDialog(api);
@@ -37,11 +46,17 @@ describe("NewSessionDialog channel + attachments", () => {
     await screen.findByText("Bugfix");
     await userEvent.click(screen.getByRole("radio", { name: /Existing worktree/i }));
     await userEvent.click(screen.getByRole("radio", { name: /Rich Chat/i }));
+    await userEvent.type(screen.getByLabelText(/Initial prompt/i), "wire the settings toggle");
     await userEvent.click(screen.getByText("Create"));
 
     await waitFor(() => expect(sessSpy).toHaveBeenCalled());
     const body = sessSpy.mock.calls[0]![0];
-    expect(body).toMatchObject({ type: "agent", channel: "json" });
+    expect(body).toMatchObject({
+      type: "agent",
+      channel: "json",
+      prompt: "wire the settings toggle",
+      skipAutoTurn: true,
+    });
     expect("useTmux" in body).toBe(false);
   });
 

--- a/web-ui/src/components/dialogs/NewSessionDialog.tsx
+++ b/web-ui/src/components/dialogs/NewSessionDialog.tsx
@@ -129,15 +129,19 @@ export function NewSessionDialog({
         // POST /worktrees already spawns the main `m` agent session with the
         // selected mode + prompt. No additional createSession needed.
         if (isJson) {
-          // JSON: create the worktree's agent idle (channel:json, no prompt in
-          // the body → no daemon auto-enqueue), then upload staged files + send
-          // the prompt as turn 1 against the main agent.
+          // JSON: create the worktree's agent idle (channel:json, prompt
+          // included only so the daemon can derive the auto name /
+          // initialPrompt from it — skipAutoTurn:true stops it from also
+          // being auto-enqueued), then upload staged files + send the prompt
+          // as turn 1 against the main agent via sendJsonFirstTurn.
           const wt = await api.createWorktree({
             projectId,
             branch: newWtBranch.trim() || undefined,
             modeId: modeId || "mode-1",
             baseBranch: baseBranch.trim() || undefined,
+            prompt: initialPrompt.trim() || undefined,
             channel: "json",
+            skipAutoTurn: true,
           });
           if (wt.mainSessionId) {
             await sendJsonFirstTurn(api, wt.mainSessionId, initialPrompt, files);
@@ -180,7 +184,9 @@ export function NewSessionDialog({
             worktreeId: existingWtId,
             modeId: modeId || null,
             type: "agent",
+            prompt: initialPrompt.trim() || undefined,
             channel: "json",
+            skipAutoTurn: true,
           });
           await sendJsonFirstTurn(api, sess.id, initialPrompt, files);
         } else {

--- a/web-ui/src/components/dialogs/NewTabDialog.attachments.test.tsx
+++ b/web-ui/src/components/dialogs/NewTabDialog.attachments.test.tsx
@@ -6,8 +6,10 @@ import { NewTabDialog } from "./NewTabDialog";
 
 /**
  * Attachments at creation for the additional-tab JSON path: the dialog must
- * create the session idle (no prompt in the body → no daemon auto-enqueue),
- * upload the staged file, then send the prompt + attachment id as turn 1.
+ * create the session idle (prompt carried in the body only so the daemon can
+ * derive the auto name/initialPrompt from it — `skipAutoTurn: true` stops it
+ * from also auto-enqueueing turn 1), upload the staged file, then send the
+ * prompt + attachment id as turn 1 itself.
  */
 describe("NewTabDialog JSON attachments at creation", () => {
   it("creates idle → uploads staged file → sends first chat with the attachment id", async () => {
@@ -28,11 +30,16 @@ describe("NewTabDialog JSON attachments at creation", () => {
 
     await userEvent.click(screen.getByText("Create"));
 
-    // 1) Session created idle: channel json, NO prompt in the body (no double turn-1).
+    // 1) Session created idle: channel json, prompt carried for naming, auto-turn skipped (no double turn-1).
     await waitFor(() => expect(createSpy).toHaveBeenCalled());
     const body = createSpy.mock.calls[0]![0];
-    expect(body).toMatchObject({ worktreeId: "wt-1", type: "agent", channel: "json" });
-    expect("prompt" in body).toBe(false);
+    expect(body).toMatchObject({
+      worktreeId: "wt-1",
+      type: "agent",
+      channel: "json",
+      prompt: "fix the bug",
+      skipAutoTurn: true,
+    });
 
     // 2) Uploaded against the new session id.
     const sessionId = (await createSpy.mock.results[0]!.value).id;

--- a/web-ui/src/components/dialogs/NewTabDialog.tsx
+++ b/web-ui/src/components/dialogs/NewTabDialog.tsx
@@ -60,14 +60,18 @@ export function NewTabDialog({
 
   async function submit() {
     if (isJson) {
-      // JSON path: create the session idle (no prompt in the body → daemon does
-      // NOT auto-enqueue turn 1), then upload staged files + send the prompt as
-      // turn 1 via the chat queue. `channel:"json"` forces useTmux=false daemon-side.
+      // JSON path: create the session idle (prompt included only so the
+      // daemon can derive the auto name/initialPrompt from it —
+      // skipAutoTurn:true stops it from also auto-enqueuing turn 1), then
+      // upload staged files + send the prompt as turn 1 via the chat queue.
+      // `channel:"json"` forces useTmux=false daemon-side.
       const sess = await api.createSession({
         worktreeId,
         modeId: modeId || null,
         type: "agent",
+        prompt: prompt.trim() || undefined,
         channel: "json",
+        skipAutoTurn: true,
       });
       await sendJsonFirstTurn(api, sess.id, prompt, files);
     } else {


### PR DESCRIPTION
## Summary

Two separate bugs in the worktree/session auto-naming feature, both surfaced by the fact that worktree `vs-45` shipped with no name at all.

- **`daemon/src/services/naming.ts`** — `slugifyPrompt()` picked the first 3 "content" words after a thin stopword filter, so identifier-like tokens (`vs-45`, `pr17`) and conversational filler (`has`, `lot`, `like`, `see`) routinely became the name (`previous-started-vs-45`, `has-one-commit`, `lot-times-see`). Rewritten to score words by length/repetition/emphasis instead of first-N, reject ID/sha/filename-shaped tokens, and cap input length before the (quadratic) scrub regexes run. Real-prompt acceptability across the last 20 production session-creation prompts: **8/20 → 18/20**.
- **Rich chat (JSON channel) never named anything, ever** — the bigger bug, and the actual cause of `vs-45`'s missing name. All 4 "new session" dialogs deliberately omit `prompt` from the create request for the JSON channel (sending it afterward as a separate first-turn chat message, so staged attachments finish uploading first) — but the naming heuristic only ever runs once, synchronously, inside that create request. Added a `skipAutoTurn` flag to the create-worktree/create-session contracts: JSON-channel callers now include `prompt` (so naming/`initialPrompt` populate identically to the terminal path) but set `skipAutoTurn: true` so the daemon doesn't also auto-enqueue that prompt as turn 1 — the dialog still delivers the real first turn itself once attachments upload, exactly as before.

## Test plan
- [x] `daemon`/`cli` suite: 694/694 passing (added 7 new tests: 2 `skipAutoTurn` regression tests per create path in `worktrees.test.ts`/`sessions.test.ts`, plus 2 naming edge-case tests)
- [x] `web-ui` suite: 402/402 passing (updated `NewAgentDialog`, `NewSessionDialog`, `NewTabDialog`, `DirectAgentDialog` tests + their attachment/channel variants, which previously asserted the bug rather than the fix)
- [x] `pnpm typecheck` clean on both packages
- [x] `eslint` clean on all touched files (1 pre-existing `no-explicit-any` warning in `sessions.test.ts` is untouched by this diff)
- [x] Pre-PR review pass by an independent opus agent; findings addressed (removed 2 stray duplicate stopword entries, fixed a vacuous test assertion, added the length cap for the quadratic-regex risk, added daemon-side `skipAutoTurn` test coverage, tightened one dialog test to assert the carried prompt value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)