### PR TITLE
fix(web-ui): make Aa −/+ font zoom work in Rich Chat, not just tmux terminal

### DIFF
--- a/web-ui/src/components/layout/ChatPane.test.tsx
+++ b/web-ui/src/components/layout/ChatPane.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { createMockApi } from "@/api/mock";
 import type { NormalizedEvent, Session, SessionMeta } from "@/api/types";
+import { useWorkspaceStore } from "@/hooks/useStore";
 import { ChatPane } from "./ChatPane";
 
 function meta(sessionId: string, extra: Partial<SessionMeta> = {}): SessionMeta {
@@ -106,6 +107,21 @@ describe("ChatPane (4.T2)", () => {
     ).toBeTruthy();
     expect(screen.queryByRole("textbox", { name: /message/i })).toBeNull();
     expect(screen.queryByRole("button", { name: /send message/i })).toBeNull();
+  });
+
+  it("scales its --font-size-* CSS variables with the shared terminalFontScale (Aa −/+ control)", async () => {
+    const api = createMockApi();
+    useWorkspaceStore.setState({ terminalFontScale: 1.2 });
+    try {
+      const { container } = render(<ChatPane api={api} session={jsonSession("js-zoom")} visible />);
+      await screen.findByText("Start chatting");
+      const pane = container.querySelector(".chat-pane") as HTMLElement;
+      // Base --font-size-sm is 12px; at 1.2x scale it should round to 14px.
+      expect(pane.style.getPropertyValue("--font-size-sm")).toBe("14px");
+      expect(pane.style.getPropertyValue("--font-size-base")).toBe("17px");
+    } finally {
+      useWorkspaceStore.setState({ terminalFontScale: 1 });
+    }
   });
 
   it("a non-archived session still renders the live composer", async () => {

--- a/web-ui/src/components/layout/ChatPane.tsx
+++ b/web-ui/src/components/layout/ChatPane.tsx
@@ -1,11 +1,28 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState, type CSSProperties } from "react";
 import type { ApiInstance } from "@/api";
 import type { Attachment, Session } from "@/api/types";
 import { useChat } from "@/hooks/useChat";
+import { useWorkspaceStore } from "@/hooks/useStore";
 import { MessageList } from "@/components/chat/MessageList";
 import { QueuedTray, type QueuedTrayRow } from "@/components/chat/QueuedTray";
 import { Composer } from "@/components/chat/Composer";
 import { StatusBar } from "@/components/chat/StatusBar";
+
+// Desktop bases for the --font-size-* tokens (tokens.css), scaled by the same
+// PaneTools "Aa −/+" control that zooms TerminalPane's xterm font (14 * scale
+// there). Chat's font-size rules read the shared --font-size-* custom
+// properties, which are otherwise fixed, app-wide tokens — overriding them
+// here (inline style) scopes the zoom to just this pane's subtree instead of
+// resizing the whole app.
+const CHAT_FONT_BASE_PX: Record<string, number> = {
+  "--font-size-xs": 11,
+  "--font-size-sm": 12,
+  "--font-size-base": 14,
+  "--font-size-lg": 16,
+  "--font-size-xl": 18,
+  "--font-size-2xl": 22,
+  "--font-size-3xl": 28,
+};
 
 interface ChatPaneProps {
   api: ApiInstance;
@@ -26,6 +43,15 @@ export function ChatPane({ api, session, visible }: ChatPaneProps) {
   const isJson = session?.channel === "json";
   const sessionId = session?.id ?? null;
   const enabled = visible && isJson && !!sessionId;
+
+  const terminalFontScale = useWorkspaceStore((s) => s.terminalFontScale);
+  const chatFontVars = useMemo(() => {
+    const vars: Record<string, string> = {};
+    for (const [name, base] of Object.entries(CHAT_FONT_BASE_PX)) {
+      vars[name] = `${Math.round(base * terminalFontScale)}px`;
+    }
+    return vars as CSSProperties;
+  }, [terminalFontScale]);
 
   const {
     events,
@@ -151,11 +177,11 @@ export function ChatPane({ api, session, visible }: ChatPaneProps) {
   // Keep the pane mounted even when hidden (Decision 14) — the terminal beside it
   // must never remount. `hidden` also stops the offscreen list from scrolling.
   if (!enabled) {
-    return <div className="chat-pane chat-pane--hidden" aria-hidden hidden />;
+    return <div className="chat-pane chat-pane--hidden" aria-hidden hidden style={chatFontVars} />;
   }
 
   return (
-    <div className="chat-pane">
+    <div className="chat-pane" style={chatFontVars}>
       <div className="chat-pane__body">
         {loading ? (
           <div className="chat-pane__state">

--- a/web-ui/src/components/layout/PaneTools.tsx
+++ b/web-ui/src/components/layout/PaneTools.tsx
@@ -9,13 +9,17 @@ interface PaneToolsProps {
 }
 
 /**
- * Terminal-zoom (`Aa −/+`) + fullscreen toggle, shared between `TabsStrip`
+ * Agent font-zoom (`Aa −/+`) + fullscreen toggle, shared between `TabsStrip`
  * (worktree agent/terminal tabs, direct-session terminal dock) and any pane
  * that renders a `TerminalPane` without a surrounding tab list — e.g. a
  * direct session's single agent, which intentionally has no `TabsStrip`
  * ("single agent, no tabs") but still needs these controls above its
  * terminal. Extracted out of `TabsStrip` so the controls aren't lost when
  * the tab list itself is legitimately skipped.
+ *
+ * The zoom scale (`terminalFontScale`) drives both TerminalPane's xterm
+ * fontSize AND ChatPane's font-size CSS variables — one control zooms
+ * whichever agent view (tmux terminal or Rich Chat) is currently visible.
  */
 export function PaneTools({ fsTarget, onCloseDock }: PaneToolsProps) {
   const bumpTerminalFont = useWorkspaceStore((s) => s.bumpTerminalFont);
@@ -25,12 +29,12 @@ export function PaneTools({ fsTarget, onCloseDock }: PaneToolsProps) {
 
   return (
     <div className="tabs-strip__tools">
-      <div className="tabs-strip__zoom" aria-label="Terminal zoom">
+      <div className="tabs-strip__zoom" aria-label="Agent font zoom">
         <span className="tabs-strip__zoom-label">Aa</span>
         <button
           type="button"
           className="tab tab--icon"
-          aria-label="Decrease terminal font"
+          aria-label="Decrease agent font"
           onClick={() => bumpTerminalFont(-0.05)}
         >
           <Minus size={11} />
@@ -38,7 +42,7 @@ export function PaneTools({ fsTarget, onCloseDock }: PaneToolsProps) {
         <button
           type="button"
           className="tab tab--icon"
-          aria-label="Increase terminal font"
+          aria-label="Increase agent font"
           onClick={() => bumpTerminalFont(0.05)}
         >
           <Plus size={11} />


### PR DESCRIPTION
## Summary
- The `Aa −/+` zoom control only ever drove `TerminalPane`'s xterm `fontSize`; `ChatPane` (Rich Chat) reads the app-wide `--font-size-*` tokens directly, so the buttons had no visible effect while viewing a Rich Chat (json channel) agent.
- `ChatPane` now overrides the `--font-size-*` custom properties inline on its root, scaled the same way `TerminalPane` scales its base-14 font — scoped to just the chat subtree so the rest of the app's UI is unaffected.
- Relabeled the control's aria-labels ("Terminal zoom" → "Agent font zoom") since it now zooms whichever agent view (tmux terminal or Rich Chat) is visible.

## Test plan
- [x] `pnpm --filter @vibestation/web typecheck`
- [x] `pnpm --filter @vibestation/web test -- --run` (403 tests pass, including new ChatPane font-scale test)
- [x] `pnpm lint` (no new warnings/errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)