### PR TITLE
fix(web-ui): make chat message text respond to the Aa font zoom too

### DIFF
--- a/web-ui/src/components/layout/ChatPane.test.tsx
+++ b/web-ui/src/components/layout/ChatPane.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { render, screen, within, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
@@ -122,6 +124,18 @@ describe("ChatPane (4.T2)", () => {
     } finally {
       useWorkspaceStore.setState({ terminalFontScale: 1 });
     }
+  });
+
+  it("`.chat-pane` re-declares font-size from the scaled token, so inherited text zooms too", () => {
+    // jsdom resolves neither stylesheets nor var(), so the *rendered* size of a
+    // message bubble can't be asserted here. The regression guarded instead is
+    // structural: without this declaration, `body`'s font-size (computed from
+    // the UNSCALED root token) inherits into every element that doesn't read a
+    // --font-size-* var itself — user messages and assistant markdown — and
+    // only tool cards / the composer follow the zoom.
+    const css = readFileSync(resolve(process.cwd(), "src/styles/chat.css"), "utf8");
+    const block = /\.chat-pane \{([^}]*)\}/.exec(css)?.[1] ?? "";
+    expect(block).toMatch(/font-size:\s*var\(--font-size-base\)/);
   });
 
   it("a non-archived session still renders the live composer", async () => {

--- a/web-ui/src/styles/chat.css
+++ b/web-ui/src/styles/chat.css
@@ -154,6 +154,15 @@
   background: var(--bg-primary);
   color: var(--fg-primary);
   font-family: var(--font-sans);
+  /* Re-resolve the base text size HERE, from this subtree's (possibly zoomed)
+     --font-size-base — ChatPane overrides the --font-size-* tokens inline for
+     the "Aa −/+" control. `body` already sets font-size: var(--font-size-base)
+     (global.css), but that computed at the root with the UNSCALED token, and
+     font-size itself inherits as a computed px value — so without this rule
+     everything that just inherits (message bubbles, markdown prose) stays at
+     the unzoomed size while rules that read var(--font-size-*) directly
+     (tool cards, composer) scale. */
+  font-size: var(--font-size-base);
   /* Positioning context for the json→terminal channel toggle overlay (item 4) —
      mirrors `.agent-pane-slot__terminal` on the tty→json side. */
   position: relative;
@@ -312,6 +321,14 @@
 }
 .chat-pane .workspace-markdown-preview > :first-child { margin-top: 0; }
 .chat-pane .workspace-markdown-preview > :last-child { margin-bottom: 0; }
+
+/* Code-block chrome (lang label + Copy) is hardcoded to 11px in workspace.css,
+   so it wouldn't follow the "Aa −/+" zoom like the code it labels. Same scope
+   rule as above: only inside the chat pane. */
+.chat-pane .workspace-md-code-block-header,
+.chat-pane .workspace-md-code-block-copy {
+  font-size: var(--font-size-xs);
+}
 
 /* ── Markdown segments (prose + inline mermaid diagrams) ───────────────────── */
 


### PR DESCRIPTION
## Summary
- Follow-up to #54: after that fix shipped, tool-use cards and the composer scaled with the "Aa −/+" zoom control, but the user's own sent messages and full assistant response text did not.
- Root cause: those elements never declare their own `font-size`, so they inherit the computed (unscaled) size from `body { font-size: var(--font-size-base) }` — a `font-size` inherits as an already-resolved px value, not a live `var()` reference, so ChatPane's inline override of `--font-size-*` never reached them.
- Fix: `.chat-pane` now re-declares `font-size: var(--font-size-base)`, re-resolving the base size inside the (possibly zoomed) subtree so everything that merely inherits — user bubbles, assistant markdown, headings/inline code (`em`-relative), thinking prose, diff views (`font-size: inherit`) — scales proportionally. Also fixes the code-block header/copy button chrome, which was hardcoded to `11px` in `workspace.css` and didn't follow the zoom of the code it labels.
- Scope stays limited to `.chat-pane`; nothing outside Rich Chat is touched, and at the default scale (1.0) computed sizes are unchanged.

## Test plan
- [x] `pnpm --filter @vibestation/web typecheck`
- [x] `pnpm --filter @vibestation/web test -- --run` (404 tests pass, including a new structural regression test since jsdom can't resolve `var()`/stylesheets to assert computed size directly)
- [x] `pnpm lint` (no new warnings/errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)