### PR TITLE
fix(web-ui): sidebar kebab menu, canvas Add-tile dialog, new-agent shortcut

### DIFF
--- a/.vibekit/feature-plans/wip/sidebar-canvas-shortcuts/plan-sidebar-canvas-shortcuts.md
+++ b/.vibekit/feature-plans/wip/sidebar-canvas-shortcuts/plan-sidebar-canvas-shortcuts.md
@@ -1,0 +1,60 @@
+# Plan: sidebar-canvas-shortcuts
+
+Small bug-fix + small-feature bundle. No PRD (four self-contained, low-ambiguity changes).
+
+## Scope
+
+1. Pinned-item kebab (⋯) menu: vertical alignment + two-tap-to-open on touch.
+2. Canvas "Add tile" picker doesn't close on outside click.
+3. Canvas "Add tile" picker (own-worktree canvas only) gains a "New agent" entry that opens the same dialog as the tab bar's "+".
+4. Two new global shortcuts: new worktree in current project, new agent in current worktree.
+
+## Root causes (found during exploration)
+
+1. `web-ui/src/styles/workspace.css`:
+   - `.tree-row--worktree .wt-menu-trigger` (and the pinned/direct-session variants) are `opacity:0; pointer-events:none` until `:hover`/`:focus-within`. Touch devices have no hover — the first tap only synthesizes the row's hover state (making the button hit-testable); the second tap actually clicks it. Fix: `@media (hover: none)` override forcing the trigger always visible/interactive.
+   - `.pinned-row .wt-menu-trigger { top: 4px }` is an arbitrary offset that doesn't match `.pinned-row__leading`'s `padding-top: 5px` (the value chosen to align with the first text line). Fix: match it, `top: 5px`.
+2. `web-ui/src/components/layout/WorkspaceCanvas.tsx`: `pickerOpen` has no outside-click/Escape handler at all (unlike the sidebar's kebab menus, which use a deferred-`useEffect` + `document` click pattern). Fix: add the same pattern, scoped via `data-workspace-canvas-picker-trigger` / `data-workspace-canvas-picker-panel`.
+3. Same file: the picker only lists *existing* agent/terminal sessions (`addTile`), there's no "create a new agent" entry. `NewTabDialog` (`web-ui/src/components/dialogs/NewTabDialog.tsx`) is the dialog the tab bar's "+" already uses for this, for the same worktree. Fix: render it from `WorkspaceCanvas` too, gated to the non-detached (own-worktree) canvas, and auto-add the created session as a tile — this needs `NewTabDialog`'s `onCreated` to hand back the new session id (currently `() => void`), a small optional-arg widen.
+4. `web-ui/src/hooks/useWorkspaceKeyboardShortcuts.ts` is the one global `keydown` hook; `web-ui/src/routes/Workspace.tsx` is where "current project"/"current worktree" are already resolved and where `NewSessionDialog`/`NewTabDialog` can be rendered directly (both are plain controlled dialogs, no ambient state needed). `Ctrl/Cmd+N` and `Ctrl/Cmd+Shift+N` are OS/browser-reserved (new window / new incognito window) and cannot be `preventDefault()`-ed from a web page — using them would silently fail. Use `Ctrl/Cmd+Alt+N` (new worktree) and `Ctrl/Cmd+Shift+A` (new agent) instead, mnemonic and unreserved.
+
+## Checklist
+
+- [x] 1a. `workspace.css`: add `@media (hover: none)` override making `.tree-row--worktree .wt-menu-trigger` / `.tree-row--direct-session.pinned-row .wt-menu-trigger` always `opacity:1; pointer-events:auto`.
+- [x] 1b. `workspace.css`: `.pinned-row .wt-menu-trigger { top: 4px }` → `top: 5px` (match `.pinned-row__leading`).
+- [x] 2. `WorkspaceCanvas.tsx`: add deferred outside-click + Escape close effect for `pickerOpen`, mirroring `LeftSidebar.tsx`'s pattern; add matching `data-workspace-canvas-picker-trigger` / `data-workspace-canvas-picker-panel` attributes.
+- [x] 3a. `NewTabDialog.tsx`: widen `onCreated?: () => void` → `onCreated?: (sessionId: string) => void`, pass `sess.id` at both call sites inside `submit()`.
+- [x] 3b. `WorkspaceCanvas.tsx`: import `NewTabDialog`, add `newAgentOpen` state, render a "New agent" picker entry (own-worktree canvas only, i.e. `!isDetachedView`) above the existing agent list, and render `<NewTabDialog>` with `onCreated={(id) => { addTile("agent", id); setNewAgentOpen(false); }}`. Adjust `pickerEmpty` so the "everything's on the canvas" message doesn't show when New Agent is available.
+- [x] 4a. `NewTabDialog.tsx` call site check / `TabsStrip.tsx`: no change needed (extra callback arg is backward compatible).
+- [x] 4b. `Workspace.tsx`: resolve current project + worktree (reuse the existing `worktrees.find`/`projects.find` pattern at lines ~74-77), add local state for a worktree-scoped `NewSessionDialog` and worktree-scoped `NewTabDialog`, pass two new callbacks into `useWorkspaceKeyboardShortcuts`.
+- [x] 4c. `useWorkspaceKeyboardShortcuts.ts`: accept the two new callbacks, add `Ctrl/Cmd+Alt+N` → new worktree, `Ctrl/Cmd+Shift+A` → new agent, guarded by the existing `inEditable` check and only when a project/worktree is actually active.
+
+## Verification
+
+- `npx tsc --noEmit` (or the project's existing typecheck script) in `web-ui/`.
+- `npm run build` in `web-ui/` (or equivalent) to catch JSX/type errors the above doesn't.
+- Manual code-reading pass over the diff for the two CSS fixes (no live device available in this environment) — call this out explicitly as unverified-in-browser in the report.
+
+## Follow-up round (post-review, post-PR)
+
+Opus subagent review of the above surfaced 7 real issues (Alt+N dead-key on Mac, id-chip/trigger
+overlap on touch, invisible-session edge case for the agent shortcut in canvas mode, stale dialog
+state across worktree switches, keydown-listener churn, picker not closing under the new "New
+agent" item, and an inaccurate code comment) — all fixed, then verified against the live dev
+sandbox with Playwright screenshots (the pinned-row centering fix in particular needed a second
+pass: the first attempt was still visibly off-center).
+
+Then two more rounds of user feedback, folded into the same commit (single-commit PR):
+
+- [x] 5. Shortcut rework: `Alt+N` (bare, no ⌘/Ctrl) → new agent in current worktree; `Alt+Shift+N`
+      → new worktree in current project. Replaces the earlier `Ctrl/Cmd+Alt+N` / `Ctrl/Cmd+Shift+A`
+      pair per user preference. `useWorkspaceKeyboardShortcuts.ts`: moved the Alt+N handling above
+      the `mod` (⌘/Ctrl) gate so it fires independent of it; kept `e.code === "KeyN"` for the
+      Mac-dead-key fix.
+- [x] 6. Agent tile "⋯" popup menu in canvas/workspace mode (`WorkspaceCanvas.tsx`,
+      `workspace-canvas.css`): a kebab button left of each agent tile's existing close ("remove
+      from canvas") button, opening a `menu-pop` (same component class TabsStrip's right-click
+      menu uses) with Reset / Reset with handoff / Terminate. Terminate mirrors the tab bar's "×"
+      close (`ConfirmDialog` → `api.deleteSession`) and additionally removes the tile from this
+      canvas (the tab bar has no canvas to reconcile against). Gated to `tile.kind === "agent"`
+      tiles only — terminal/tools tiles unaffected.

--- a/.vibekit/feature-plans/wip/sidebar-canvas-shortcuts/report.md
+++ b/.vibekit/feature-plans/wip/sidebar-canvas-shortcuts/report.md
@@ -1,0 +1,64 @@
+# /sdlc report — sidebar-canvas-shortcuts
+
+**Scope:** small bug-bundle + small-feature. Plan → implement, no PRD (low ambiguity). Grew across
+three rounds: initial implementation, an Opus subagent review pass with fixes, then two rounds of
+direct user feedback (shortcut rework + a canvas-tile actions menu) — all folded into one commit.
+**Plan:** `plan-sidebar-canvas-shortcuts.md` (checklist fully `[x]`, including the follow-up round).
+
+## What was implemented
+
+1. **Pinned-item ⋯ menu, vertical alignment** (`workspace.css`) — the hardcoded `top: 4px` override
+   read as visibly off-center against the two-line pinned row (confirmed with Playwright
+   screenshots against a live dev sandbox). Removed the override entirely — it now inherits the
+   same `top:50%; translateY(-50%)` centering every other `.wt-menu-trigger` uses.
+2. **Pinned-item ⋯ menu, two taps to open** (`workspace.css`) — root cause: `.wt-menu-trigger` is
+   `opacity:0; pointer-events:none` until `:hover`/`:focus-within`, and touch has no hover — the
+   first tap only synthesized the row's hover state, the second tap actually hit the button. Added
+   `@media (hover: none)` forcing it always visible/interactive; also hides the id chip the same
+   way `:hover` already does, so the two don't render on top of each other on touch.
+3. **Canvas "Add tile" picker not closing on outside tap** (`WorkspaceCanvas.tsx`) — added the same
+   deferred `document`-click + Escape effect the sidebar's kebab menus already use.
+4. **"New agent" entry in the canvas picker** (`WorkspaceCanvas.tsx`, `NewTabDialog.tsx`) — opens
+   the exact same `NewTabDialog` the tab bar's "+" uses (own-worktree canvases only) and
+   auto-places the created session as a tile; closes the picker when opened.
+5. **Keyboard shortcuts, reworked twice**: `Alt+N` → new agent in current worktree (no-op in canvas
+   mode, where the picker's own "New agent" already covers it — avoids creating an orphaned,
+   unplaced session); `Alt+Shift+N` → new worktree in current project. Bare Alt combos per user
+   preference, not `Ctrl+N`/`Ctrl+Shift+N` (OS/browser-chrome-reserved, can't be
+   `preventDefault()`-ed) — matched on `e.code` so Option+N's Mac dead-key behavior doesn't break it.
+6. **Agent tile "⋯" menu in canvas/workspace mode** (`WorkspaceCanvas.tsx`,
+   `workspace-canvas.css`) — a kebab button left of each agent tile's close button, opening the
+   same actions as the agent tab bar's right-click menu (Reset, Reset with handoff), plus a
+   Terminate action equivalent to the tab bar's "×" close (`ConfirmDialog` → `deleteSession`, and
+   also removes the tile from canvas). Agent tiles only — terminal/tools tiles unaffected.
+
+## Review + fixes (Opus subagent pass on the first round)
+
+7 findings, all fixed: Alt+N wouldn't fire on Mac (dead key) → matched on `e.code`; forcing the
+trigger visible on touch would overlap the id chip → hid the chip too; the new-agent shortcut
+could create an invisible session in canvas mode → suppressed there; shortcut-dialog open state
+could survive a worktree switch → reset on `activeWorktreeId` change; the keydown listener churned
+every render → stabilized callbacks with `useCallback`; the picker stayed open behind the new
+"New agent" dialog → now closes it; a CSS comment's stated rationale was wrong → caught while
+fixing it, which led to re-deriving the alignment fix from a live screenshot instead (see #1 above).
+
+## Verification
+
+- `npx tsc -b --noEmit` — clean, twice (post-review and post-follow-up).
+- `npm run build` (vite) — clean, twice.
+- `npx vitest run` — **404/404 tests pass** (60 files), unchanged across all rounds.
+- `npm run lint` — could not run; root `eslint.config.mjs` needs root-level deps (`@eslint/js`) not
+  installed in this environment. Pre-existing environment gap, unrelated to this diff.
+- **Visually verified against a live dev sandbox** (`scripts/dev-sandbox.sh up vs-48`, hot-reloading
+  this worktree) with Playwright screenshots: pinned-row kebab centering (before/after), the canvas
+  tile "⋯" menu opening with the three expected items, the Terminate confirm dialog matching the
+  tab bar's copy, `Alt+Shift+N` opening the New Session dialog, and `Alt+N` correctly no-op'ing in
+  canvas mode.
+- Not verified: real touch-device tap behavior (no touch hardware in this environment) — the fix is
+  code-reasoned from the CSS cascade, not physically tapped.
+
+## Diff / PR
+
+Single commit, amended across all rounds per request. Pushed to `dialog-canvas-shortcut`, PR
+[#56](https://github.com/fastestdevalive/vibe-station/pull/56) (opened under the `fastestdevalive`
+account, per this repo's collaborator requirement).

--- a/web-ui/src/components/dialogs/NewTabDialog.tsx
+++ b/web-ui/src/components/dialogs/NewTabDialog.tsx
@@ -11,7 +11,7 @@ interface NewTabDialogProps {
   onClose: () => void;
   api: ApiInstance;
   worktreeId: string;
-  onCreated?: () => void;
+  onCreated?: (sessionId: string) => void;
 }
 
 /** Create a new agent session. Terminals use NewTerminalDialog. */
@@ -59,6 +59,7 @@ export function NewTabDialog({
   const isJson = channel === "json";
 
   async function submit() {
+    let sessionId: string;
     if (isJson) {
       // JSON path: create the session idle (prompt included only so the
       // daemon can derive the auto name/initialPrompt from it —
@@ -74,6 +75,7 @@ export function NewTabDialog({
         skipAutoTurn: true,
       });
       await sendJsonFirstTurn(api, sess.id, prompt, files);
+      sessionId = sess.id;
     } else {
       // KNOWN RACE: unlike the JSON path above, the daemon spawns the CLI
       // with `prompt` baked into argv fire-and-forget as soon as this route
@@ -94,8 +96,9 @@ export function NewTabDialog({
       if (files.length > 0) {
         await api.uploadAttachments(sess.id, files);
       }
+      sessionId = sess.id;
     }
-    onCreated?.();
+    onCreated?.(sessionId);
     onClose();
   }
 

--- a/web-ui/src/components/layout/DashboardPanel.test.tsx
+++ b/web-ui/src/components/layout/DashboardPanel.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, beforeEach } from "vitest";
 import type { ReactNode } from "react";
@@ -37,7 +38,7 @@ describe("DashboardPanel", () => {
     });
   });
 
-  it("renders working, idle, and finished sections", async () => {
+  it("renders working and waiting-for-user sections, with finished hidden until toggled", async () => {
     const api = createMockApi();
     render(
       <MemoryRouter>
@@ -50,7 +51,12 @@ describe("DashboardPanel", () => {
       expect(screen.getAllByText(/Proj A/i).length).toBeGreaterThan(0);
     });
     expect(screen.getByText("working")).toBeInTheDocument();
-    expect(screen.getByText("idle")).toBeInTheDocument();
+    // wt-3's idle session buckets under "waiting for user", not "finished".
+    expect(screen.getByText("waiting for user")).toBeInTheDocument();
+    // wt-2's "done" session is finished — hidden by default.
+    expect(screen.queryByText("finished")).toBeNull();
+
+    await userEvent.click(screen.getByRole("checkbox", { name: /show finished/i }));
     expect(screen.getByText("finished")).toBeInTheDocument();
   });
 
@@ -79,7 +85,7 @@ describe("DashboardPanel", () => {
       // Bucket hides entirely when empty — old section refs would point at stale detached DOM.
       expect(screen.queryByText("working")).toBeNull();
     });
-    const idleSection = screen.getByText("idle").closest("section");
+    const idleSection = screen.getByText("waiting for user").closest("section");
     expect(idleSection).not.toBeNull();
     await waitFor(() => {
       expect(within(idleSection!).getByRole("link", { name: /Proj A/i })).toHaveAttribute(

--- a/web-ui/src/components/layout/DashboardPanel.tsx
+++ b/web-ui/src/components/layout/DashboardPanel.tsx
@@ -16,13 +16,26 @@ interface DashboardPanelProps {
   api: ApiInstance;
 }
 
-function bucketForRollup(r: WorktreeRolledUpStatus): "working" | "idle" | "finished" {
+/**
+ * Dashboard buckets, coarser than the full `WorktreeRolledUpStatus` set:
+ *  - "working": actively running, or not started yet (`spawning`).
+ *  - "waiting": stopped and needs a human — either explicitly flagged
+ *    (`waiting_for_human`) or just idle after finishing a turn (`idle`).
+ *    Idle deliberately lives here, NOT in "finished" — an idle worktree is
+ *    still open work waiting on the user, not done.
+ *  - "pr": the review poller found an open PR for this session (`needs_review`).
+ *  - "finished": actually done or exited (or no recognizable state at all) —
+ *    hidden by default behind the "Show finished" checkbox.
+ */
+function bucketForRollup(r: WorktreeRolledUpStatus): "working" | "waiting" | "pr" | "finished" {
   if (r === "working" || r === "spawning") return "working";
-  if (r === "idle") return "idle";
+  if (r === "waiting_for_human" || r === "idle") return "waiting";
+  if (r === "needs_review") return "pr";
   return "finished";
 }
 
 const DASHBOARD_VIEW_KEY = "dashboard:view";
+const DASHBOARD_SHOW_FINISHED_KEY = "dashboard:showFinished";
 
 export function DashboardPanel({ api }: DashboardPanelProps) {
   const [health, setHealth] = useState<HealthResponse | null>(null);
@@ -70,6 +83,22 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
     }
   }, [dashboardView]);
 
+  const [showFinished, setShowFinished] = useState(() => {
+    try {
+      return localStorage.getItem(DASHBOARD_SHOW_FINISHED_KEY) === "true";
+    } catch {
+      return false;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(DASHBOARD_SHOW_FINISHED_KEY, String(showFinished));
+    } catch {
+      /* ignore */
+    }
+  }, [showFinished]);
+
   // Subscribe to live session output for every session in the store so the
   // rollup updates in real time. The set of ids comes from the central store
   // (single source of truth) — no local fetch, no local listeners.
@@ -93,9 +122,10 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
    *  back to the REST session's `state` field. */
   const sessionStates = useWorkspaceStore((s) => s.sessionStates);
 
-  const { working, idle, finished } = useMemo(() => {
+  const { working, waiting, pr, finished } = useMemo(() => {
     const wtsWorking: Worktree[] = [];
-    const wtsIdle: Worktree[] = [];
+    const wtsWaiting: Worktree[] = [];
+    const wtsPr: Worktree[] = [];
     const wtsFinished: Worktree[] = [];
     for (const wt of worktrees) {
       if (hiddenProjectIds.has(wt.projectId)) continue;
@@ -104,10 +134,11 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
       const rolled = worktreeRolledUpStatus(agentSessions, sessionStates);
       const b = bucketForRollup(rolled);
       if (b === "working") wtsWorking.push(wt);
-      else if (b === "idle") wtsIdle.push(wt);
+      else if (b === "waiting") wtsWaiting.push(wt);
+      else if (b === "pr") wtsPr.push(wt);
       else wtsFinished.push(wt);
     }
-    return { working: wtsWorking, idle: wtsIdle, finished: wtsFinished };
+    return { working: wtsWorking, waiting: wtsWaiting, pr: wtsPr, finished: wtsFinished };
   }, [worktrees, sessions, sessionStates, hiddenProjectIds]);
 
   const daemonOk = connState === "online";
@@ -184,17 +215,27 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
                   : "daemon unreachable"}
             </span>
           </div>
-          {!isMobile ? (
-            <button
-              type="button"
-              className="icon-btn dashboard-header__view-toggle"
-              aria-label={toggleViewLabel}
-              title={toggleViewLabel}
-              onClick={() => setDashboardView((v) => (v === "list" ? "kanban" : "list"))}
-            >
-              {dashboardView === "list" ? <Columns3 size={18} /> : <LayoutList size={18} />}
-            </button>
-          ) : null}
+          <div className="dashboard-header__actions">
+            <label className="dashboard-header__show-finished">
+              <input
+                type="checkbox"
+                checked={showFinished}
+                onChange={(e) => setShowFinished(e.target.checked)}
+              />
+              Show finished
+            </label>
+            {!isMobile ? (
+              <button
+                type="button"
+                className="icon-btn dashboard-header__view-toggle"
+                aria-label={toggleViewLabel}
+                title={toggleViewLabel}
+                onClick={() => setDashboardView((v) => (v === "list" ? "kanban" : "list"))}
+              >
+                {dashboardView === "list" ? <Columns3 size={18} /> : <LayoutList size={18} />}
+              </button>
+            ) : null}
+          </div>
         </div>
 
         {/* On mobile always render the list layout — kanban columns don't work on narrow screens */}
@@ -207,26 +248,33 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
               </section>
             ) : null}
 
-            {idle.length > 0 ? (
+            {waiting.length > 0 ? (
               <section className="dashboard-section">
-                <div className="dashboard-section__label">idle</div>
-                <div className="dashboard-card-list">{idle.map((wt) => renderWorktreeCard(wt))}</div>
+                <div className="dashboard-section__label">waiting for user</div>
+                <div className="dashboard-card-list">{waiting.map((wt) => renderWorktreeCard(wt))}</div>
               </section>
             ) : null}
 
-            {finished.length > 0 ? (
+            {pr.length > 0 ? (
+              <section className="dashboard-section">
+                <div className="dashboard-section__label">pr created</div>
+                <div className="dashboard-card-list">{pr.map((wt) => renderWorktreeCard(wt))}</div>
+              </section>
+            ) : null}
+
+            {showFinished && finished.length > 0 ? (
               <section className="dashboard-section">
                 <div className="dashboard-section__label">finished</div>
                 <div className="dashboard-card-list">{finished.map((wt) => renderWorktreeCard(wt))}</div>
               </section>
             ) : null}
 
-            {working.length === 0 && idle.length === 0 && finished.length === 0 ? (
+            {working.length === 0 && waiting.length === 0 && pr.length === 0 && (!showFinished || finished.length === 0) ? (
               <p className="dashboard-empty">No agent worktrees yet. Add a project with the CLI.</p>
             ) : null}
           </>
         ) : (
-          <div className="dashboard-kanban">
+          <div className={`dashboard-kanban${showFinished ? " dashboard-kanban--with-finished" : ""}`}>
             <div className="dashboard-kanban__col">
               <div className="dashboard-kanban__col-header">
                 Working <span className="dashboard-kanban__col-count">({working.length})</span>
@@ -235,16 +283,24 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
             </div>
             <div className="dashboard-kanban__col">
               <div className="dashboard-kanban__col-header">
-                Idle <span className="dashboard-kanban__col-count">({idle.length})</span>
+                Waiting for User <span className="dashboard-kanban__col-count">({waiting.length})</span>
               </div>
-              <div className="dashboard-card-list">{idle.map((wt) => renderWorktreeCard(wt))}</div>
+              <div className="dashboard-card-list">{waiting.map((wt) => renderWorktreeCard(wt))}</div>
             </div>
             <div className="dashboard-kanban__col">
               <div className="dashboard-kanban__col-header">
-                Finished <span className="dashboard-kanban__col-count">({finished.length})</span>
+                PR Created <span className="dashboard-kanban__col-count">({pr.length})</span>
               </div>
-              <div className="dashboard-card-list">{finished.map((wt) => renderWorktreeCard(wt))}</div>
+              <div className="dashboard-card-list">{pr.map((wt) => renderWorktreeCard(wt))}</div>
             </div>
+            {showFinished ? (
+              <div className="dashboard-kanban__col">
+                <div className="dashboard-kanban__col-header">
+                  Finished <span className="dashboard-kanban__col-count">({finished.length})</span>
+                </div>
+                <div className="dashboard-card-list">{finished.map((wt) => renderWorktreeCard(wt))}</div>
+              </div>
+            ) : null}
           </div>
         )}
 

--- a/web-ui/src/components/layout/WorkspaceCanvas.tsx
+++ b/web-ui/src/components/layout/WorkspaceCanvas.tsx
@@ -2,7 +2,7 @@ import "@/styles/workspace-canvas.css";
 import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { useNavigate } from "react-router-dom";
-import { Bot, Check, FolderOpen, GitBranch, Minimize2, PanelRight, Plus, Save, SquareTerminal, X } from "lucide-react";
+import { Bot, Check, FolderOpen, GitBranch, Minimize2, MoreVertical, PanelRight, Plus, Save, SquareTerminal, X } from "lucide-react";
 import type { Project, Session, Worktree } from "@/api/types";
 import {
   buildBalancedTree,
@@ -29,6 +29,9 @@ import { StatusDot } from "@/components/layout/StatusDot";
 import { sessionStatus } from "@/lib/worktreeStatus";
 import { sessionLabel } from "@/lib/sessionLabel";
 import { randomId } from "@/lib/uuid";
+import { api } from "@/api";
+import { NewTabDialog } from "@/components/dialogs/NewTabDialog";
+import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
 
 interface WorkspaceCanvasProps {
   /**
@@ -152,6 +155,15 @@ export function WorkspaceCanvas({
   const splitRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
   const [pickerOpen, setPickerOpen] = useState(false);
+  const [newAgentOpen, setNewAgentOpen] = useState(false);
+  // Agent tile "⋯" popup — same actions as the agent tab bar's right-click
+  // menu (Reset / Reset with handoff) plus Terminate (mirrors the tab bar's
+  // "×" close). Only one tile's menu can be open at a time, mirroring
+  // TabsStrip's `resetMenu`.
+  const [tileMenu, setTileMenu] = useState<{ tileId: string; x: number; y: number } | null>(null);
+  const [resetTarget, setResetTarget] = useState<Session | null>(null);
+  const [resetHandoff, setResetHandoff] = useState(false);
+  const [terminateTarget, setTerminateTarget] = useState<{ tileId: string; session: Session } | null>(null);
   const [savePromptOpen, setSavePromptOpen] = useState(false);
   const [saveName, setSaveName] = useState("");
   const [draggingTileId, setDraggingTileId] = useState<string | null>(null);
@@ -174,6 +186,61 @@ export function WorkspaceCanvas({
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [fullscreenTileId]);
+
+  /** Close-on-outside must attach after the opening click finishes (same tap
+   *  would otherwise immediately close the picker it just opened) — same
+   *  deferred pattern as the sidebar's kebab menus (LeftSidebar.tsx). */
+  useEffect(() => {
+    if (!pickerOpen) return undefined;
+    let removeListeners: (() => void) | undefined;
+    const timer = window.setTimeout(() => {
+      function onDocClick(ev: MouseEvent) {
+        const t = ev.target as HTMLElement;
+        if (t.closest("[data-workspace-canvas-picker-panel]") || t.closest("[data-workspace-canvas-picker-trigger]")) return;
+        setPickerOpen(false);
+      }
+      function onKey(ev: KeyboardEvent) {
+        if (ev.key === "Escape") setPickerOpen(false);
+      }
+      document.addEventListener("click", onDocClick);
+      document.addEventListener("keydown", onKey);
+      removeListeners = () => {
+        document.removeEventListener("click", onDocClick);
+        document.removeEventListener("keydown", onKey);
+      };
+    }, 0);
+    return () => {
+      window.clearTimeout(timer);
+      removeListeners?.();
+    };
+  }, [pickerOpen]);
+
+  /** Same deferred close-on-outside pattern as the picker above and
+   *  TabsStrip's `resetMenu` (portaled panel → tag it, check `closest`). */
+  useEffect(() => {
+    if (!tileMenu) return undefined;
+    let removeListeners: (() => void) | undefined;
+    const timer = window.setTimeout(() => {
+      function onDocClick(ev: MouseEvent) {
+        const t = ev.target as HTMLElement;
+        if (t.closest("[data-workspace-canvas-tile-menu-panel]")) return;
+        setTileMenu(null);
+      }
+      function onKey(ev: KeyboardEvent) {
+        if (ev.key === "Escape") setTileMenu(null);
+      }
+      document.addEventListener("click", onDocClick);
+      document.addEventListener("keydown", onKey);
+      removeListeners = () => {
+        document.removeEventListener("click", onDocClick);
+        document.removeEventListener("keydown", onKey);
+      };
+    }, 0);
+    return () => {
+      window.clearTimeout(timer);
+      removeListeners?.();
+    };
+  }, [tileMenu]);
 
   /** Read the CURRENT canvas straight from the store (drag handlers, post-mount). */
   function readCanvas(): CanvasGeometry | null {
@@ -304,7 +371,11 @@ export function WorkspaceCanvas({
         }))
         .filter((group) => group.worktrees.length > 0);
 
+  // Own-worktree canvases always offer "New agent" (below), so the picker is
+  // never truly empty there — only the detached workspace view (no New Agent
+  // entry, see the picker JSX) can hit the empty state.
   const pickerEmpty =
+    isDetachedView &&
     availableAgents.length === 0 &&
     availableTerminals.length === 0 &&
     !canAddTools &&
@@ -680,6 +751,24 @@ export function WorkspaceCanvas({
         >
           {status ? <StatusDot status={status} /> : null}
           <span className="workspace-canvas__tile-label" title={label}>{label}</span>
+          {tile.kind === "agent" && session ? (
+            <button
+              type="button"
+              className="workspace-canvas__tile-menu-trigger"
+              aria-label={`${label} actions`}
+              title="Agent actions"
+              aria-expanded={tileMenu?.tileId === tile.id}
+              onMouseDown={(e) => e.stopPropagation()}
+              onClick={(e) => {
+                e.stopPropagation();
+                setTileMenu((prev) =>
+                  prev?.tileId === tile.id ? null : { tileId: tile.id, x: e.clientX, y: e.clientY },
+                );
+              }}
+            >
+              <MoreVertical size={13} />
+            </button>
+          ) : null}
           {/* Fullscreen: swap "remove tile" for "exit fullscreen" — clicking
               the header already exits fullscreen too (same toggle), this is
               just a second, more discoverable affordance for it. Removing a
@@ -863,6 +952,7 @@ export function WorkspaceCanvas({
           <div className="workspace-canvas__add">
             <button
               type="button"
+              data-workspace-canvas-picker-trigger
               className="workspace-canvas__add-btn"
               onClick={() => setPickerOpen((v) => !v)}
               aria-expanded={pickerOpen}
@@ -870,9 +960,24 @@ export function WorkspaceCanvas({
               <Plus size={14} /> Add tile
             </button>
             {pickerOpen ? (
-              <div className="workspace-canvas__picker" role="menu">
+              <div className="workspace-canvas__picker" role="menu" data-workspace-canvas-picker-panel>
                 {pickerEmpty ? (
                   <div className="workspace-canvas__picker-empty">Everything's already on the canvas</div>
+                ) : null}
+                {!isDetachedView ? (
+                  <button
+                    type="button"
+                    className="workspace-canvas__picker-item"
+                    onClick={() => {
+                      setNewAgentOpen(true);
+                      setPickerOpen(false);
+                    }}
+                  >
+                    <span className="workspace-canvas__picker-item-main">
+                      <Plus size={13} className="workspace-canvas__picker-icon" />
+                      New agent
+                    </span>
+                  </button>
                 ) : null}
                 {availableAgents.map((s) => (
                   <button
@@ -983,6 +1088,10 @@ export function WorkspaceCanvas({
       </div>
   );
 
+  const tileMenuTile = tileMenu ? (cv.tiles.find((t) => t.id === tileMenu.tileId) ?? null) : null;
+  const tileMenuSession = tileMenuTile?.sessionId ? (sessionById.get(tileMenuTile.sessionId) ?? null) : null;
+  const tileMenuLabel = tileMenuSession ? sessionLabel(tileMenuSession) : "";
+
   return (
     <div className="workspace-canvas">
       {canvasToolbarVisible
@@ -990,6 +1099,110 @@ export function WorkspaceCanvas({
           ? createPortal(toolbarNode, toolbarPortalEl)
           : toolbarNode
         : null}
+      {!isDetachedView ? (
+        <NewTabDialog
+          open={newAgentOpen}
+          api={api}
+          worktreeId={worktreeId}
+          onClose={() => setNewAgentOpen(false)}
+          onCreated={(sessionId) => addTile("agent", sessionId)}
+        />
+      ) : null}
+      {tileMenu && tileMenuSession
+        ? createPortal(
+            <div
+              className="menu-pop"
+              data-workspace-canvas-tile-menu-panel
+              role="menu"
+              aria-label="Agent actions"
+              style={{
+                position: "fixed",
+                top: tileMenu.y + 6,
+                left: Math.max(
+                  8,
+                  Math.min(tileMenu.x, typeof window !== "undefined" ? window.innerWidth - 178 : 8),
+                ),
+                minWidth: 150,
+                zIndex: 4000,
+              }}
+            >
+              <button
+                type="button"
+                role="menuitem"
+                className="menu-pop__item"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setResetTarget(tileMenuSession);
+                  setResetHandoff(false);
+                  setTileMenu(null);
+                }}
+              >
+                Reset
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                className="menu-pop__item"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setResetTarget(tileMenuSession);
+                  setResetHandoff(true);
+                  setTileMenu(null);
+                }}
+              >
+                Reset with handoff
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                className="menu-pop__item menu-pop__item--danger"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (tileMenuTile) setTerminateTarget({ tileId: tileMenuTile.id, session: tileMenuSession });
+                  setTileMenu(null);
+                }}
+              >
+                Terminate
+              </button>
+            </div>,
+            document.body,
+          )
+        : null}
+      <ConfirmDialog
+        open={!!resetTarget}
+        title={resetHandoff ? "Reset with handoff" : "Reset session"}
+        message="Resetting ends the current chat and starts a fresh session in its place. This can't be undone."
+        confirmLabel="Reset"
+        onCancel={() => setResetTarget(null)}
+        onConfirm={() => {
+          const target = resetTarget;
+          const handoff = resetHandoff;
+          setResetTarget(null);
+          if (target) {
+            void api.resetSession(target.id, { handoff }).catch(() => {
+              /* surface errors later */
+            });
+          }
+        }}
+      />
+      {/* Mirrors the agent tab bar's "×" close — same confirm copy, same
+          `deleteSession` call. Also drops the tile from THIS canvas (the tab
+          bar has no canvas to reconcile) so a terminated session doesn't
+          linger as a dead tile. */}
+      <ConfirmDialog
+        open={!!terminateTarget}
+        title="Close agent"
+        message="Close this agent session?"
+        confirmLabel="Close"
+        onCancel={() => setTerminateTarget(null)}
+        onConfirm={() => {
+          const target = terminateTarget;
+          setTerminateTarget(null);
+          if (target) {
+            void api.deleteSession(target.session.id).then(() => removeTile(target.tileId));
+          }
+        }}
+      />
       <div className="workspace-canvas__body" ref={canvasBodyRef}>
         {cv.tiles.length === 0 ? (
           <div className="workspace-canvas__empty">

--- a/web-ui/src/hooks/useWorkspaceKeyboardShortcuts.ts
+++ b/web-ui/src/hooks/useWorkspaceKeyboardShortcuts.ts
@@ -3,7 +3,13 @@ import { useWorkspaceStore } from "@/hooks/useStore";
 
 /**
  * ⌘/Ctrl+Shift+F/P → Files/Preview tool tab; ⌘/Ctrl+Shift+Z → terminal dock;
- * ⌘/Ctrl+P quick-open files.
+ * ⌘/Ctrl+P quick-open files; Alt+N → new agent in the current worktree;
+ * Alt+Shift+N → new worktree in the current project.
+ *
+ * The new-agent/new-worktree shortcuts deliberately use bare Alt (no ⌘/Ctrl)
+ * combos, not Ctrl+N/Ctrl+Shift+N — those are reserved by the OS/browser
+ * chrome (new window, new incognito window) and can't be `preventDefault()`-ed
+ * from a page.
  *
  * `canvasMode`: in workspace-canvas mode the terminal dock's visibility flag
  * no longer means anything (every terminal is its own tile, forced-visible —
@@ -16,6 +22,8 @@ export function useWorkspaceKeyboardShortcuts(
   setQuickOpen: (v: boolean | ((p: boolean) => boolean)) => void,
   enabled = true,
   canvasMode = false,
+  onNewWorktree?: () => void,
+  onNewAgent?: () => void,
 ) {
   useEffect(() => {
     if (!enabled) return;
@@ -24,9 +32,6 @@ export function useWorkspaceKeyboardShortcuts(
     const toggleTerminalDock = useWorkspaceStore.getState().toggleTerminalDock;
 
     const onKey = (e: KeyboardEvent) => {
-      const mod = e.metaKey || e.ctrlKey;
-      if (!mod) return;
-
       const t = e.target as HTMLElement | null;
       const inEditable =
         t &&
@@ -35,7 +40,32 @@ export function useWorkspaceKeyboardShortcuts(
           t.tagName === "SELECT" ||
           t.isContentEditable);
 
-      if (!e.shiftKey && e.key.toLowerCase() === "p") {
+      // Alt+N / Alt+Shift+N — independent of ⌘/Ctrl, and of the `mod` gate
+      // below. `e.code` (physical key), not `e.key`: Option+N is a dead key
+      // on the US Mac layout ("Dead"/"˜" instead of "n") — `code` stays
+      // layout-independent so this still fires there.
+      if (e.altKey && !e.metaKey && !e.ctrlKey && e.code === "KeyN") {
+        if (inEditable) return;
+        if (e.shiftKey) {
+          if (onNewWorktree) {
+            e.preventDefault();
+            onNewWorktree();
+          }
+        } else if (onNewAgent && !canvasMode) {
+          // In canvas mode every worktree already exposes an equivalent "New
+          // agent" entry in the Add-tile picker, which also places the
+          // created session as a tile — this global shortcut has no canvas to
+          // place into, so defer to that instead of creating an orphaned session.
+          e.preventDefault();
+          onNewAgent();
+        }
+        return;
+      }
+
+      const mod = e.metaKey || e.ctrlKey;
+      if (!mod) return;
+
+      if (!e.shiftKey && !e.altKey && e.key.toLowerCase() === "p") {
         e.preventDefault();
         setQuickOpen((open) => !open);
         return;
@@ -60,5 +90,5 @@ export function useWorkspaceKeyboardShortcuts(
 
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [setQuickOpen, enabled, canvasMode]);
+  }, [setQuickOpen, enabled, canvasMode, onNewWorktree, onNewAgent]);
 }

--- a/web-ui/src/routes/Workspace.tsx
+++ b/web-ui/src/routes/Workspace.tsx
@@ -23,6 +23,8 @@ import { useWorkspaceUrlSync } from "@/hooks/useWorkspaceUrlSync";
 import { useWorkspaceKeyboardShortcuts } from "@/hooks/useWorkspaceKeyboardShortcuts";
 import { sessionLabel } from "@/lib/sessionLabel";
 import { QuickOpen } from "@/components/dialogs/QuickOpen";
+import { NewSessionDialog } from "@/components/dialogs/NewSessionDialog";
+import { NewTabDialog } from "@/components/dialogs/NewTabDialog";
 
 export function Workspace() {
   const location = useLocation();
@@ -62,6 +64,12 @@ export function Workspace() {
   const { layoutMode: paneLayoutMode, canvasToolbarVisible } = useLayout();
 
   const [quickOpen, setQuickOpen] = useState(false);
+  // Keyboard-shortcut-triggered dialogs (Alt+N, Alt+Shift+N below) —
+  // reuse the same dialogs the sidebar's "+" (new worktree) and the tab bar's
+  // "+" (new agent) already open, just driven from here since this is where
+  // "current project"/"current worktree" are already resolved.
+  const [shortcutNewWorktreeOpen, setShortcutNewWorktreeOpen] = useState(false);
+  const [shortcutNewAgentOpen, setShortcutNewAgentOpen] = useState(false);
 
   const isMobile = useMediaQuery("(max-width: 768px)");
 
@@ -86,6 +94,32 @@ export function Workspace() {
     return workspaceDocs[params.workspaceId] ?? null;
   }, [isWorkspaceView, params.workspaceId, workspaceDocs]);
 
+  // Current worktree + its owning project, for the new-worktree/new-agent
+  // shortcuts below — same lookup pattern as `directSessionProject` above.
+  const activeWorktree = useMemo(
+    () => worktrees.find((w) => w.id === activeWorktreeId) ?? null,
+    [worktrees, activeWorktreeId],
+  );
+  const activeWorktreeProject = useMemo(
+    () => (activeWorktree ? (projects.find((p) => p.id === activeWorktree.projectId) ?? null) : null),
+    [activeWorktree, projects],
+  );
+
+  // The dialogs these open are scoped to `activeWorktree`/`activeWorktreeProject`
+  // (below) — reset if either goes away (e.g. switching to a direct session)
+  // so a dialog left open doesn't silently reappear scoped to whatever
+  // worktree/project the user lands on next.
+  useEffect(() => {
+    setShortcutNewWorktreeOpen(false);
+    setShortcutNewAgentOpen(false);
+  }, [activeWorktreeId]);
+
+  // Stable identities so `useWorkspaceKeyboardShortcuts`'s effect (keyed on
+  // these) doesn't tear down and re-add its `keydown` listener on every
+  // unrelated re-render of this route.
+  const openNewWorktreeShortcut = useCallback(() => setShortcutNewWorktreeOpen(true), []);
+  const openNewAgentShortcut = useCallback(() => setShortcutNewAgentOpen(true), []);
+
   useWorkspaceUrlSync(bundleLoaded, worktrees, sessions);
   // Quick Open + pane shortcuts work in both worktree and direct-session modes
   // (direct sessions browse the project base dir); only full-width panes (and
@@ -95,6 +129,8 @@ export function Workspace() {
     setQuickOpen,
     !isFullWidthPane && !isWorkspaceView,
     paneLayoutMode === "workspace",
+    activeWorktreeProject ? openNewWorktreeShortcut : undefined,
+    activeWorktree ? openNewAgentShortcut : undefined,
   );
 
   // Clear worktree context when entering direct session mode (mutual exclusion)
@@ -449,6 +485,25 @@ export function Workspace() {
         ) : (
           <QuickOpen api={api} worktreeId={activeWorktreeId} open={quickOpen} onClose={() => setQuickOpen(false)} />
         )
+      ) : null}
+      {activeWorktreeProject ? (
+        <NewSessionDialog
+          open={shortcutNewWorktreeOpen}
+          projectId={activeWorktreeProject.id}
+          projectName={activeWorktreeProject.name}
+          api={api}
+          onClose={() => setShortcutNewWorktreeOpen(false)}
+          onCreated={() => { /* store stays current via worktree:created WS event */ }}
+        />
+      ) : null}
+      {activeWorktree ? (
+        <NewTabDialog
+          open={shortcutNewAgentOpen}
+          api={api}
+          worktreeId={activeWorktree.id}
+          onClose={() => setShortcutNewAgentOpen(false)}
+          onCreated={() => { /* store stays current via session:created WS event */ }}
+        />
       ) : null}
       <Layout
         topBar={

--- a/web-ui/src/styles/workspace-canvas.css
+++ b/web-ui/src/styles/workspace-canvas.css
@@ -441,7 +441,8 @@
   color: var(--fg-primary);
 }
 
-.workspace-canvas__tile-close {
+.workspace-canvas__tile-close,
+.workspace-canvas__tile-menu-trigger {
   appearance: none;
   border: none;
   background: transparent;
@@ -454,7 +455,9 @@
   border-radius: var(--radius-sm);
 }
 
-.workspace-canvas__tile-close:hover {
+.workspace-canvas__tile-close:hover,
+.workspace-canvas__tile-menu-trigger:hover,
+.workspace-canvas__tile-menu-trigger[aria-expanded="true"] {
   background: var(--bg-active);
   color: var(--fg-primary);
 }

--- a/web-ui/src/styles/workspace.css
+++ b/web-ui/src/styles/workspace.css
@@ -1025,13 +1025,14 @@
   padding-top: 4px;
 }
 
-/* Defeat the inherited `top:50%; translateY(-50%)` on `.wt-menu-trigger` so the
- * ⋯ button sits at the top-right of the pinned row, next to the id chip, not
- * floating between branch and subheader. */
-.pinned-row .wt-menu-trigger {
-  top: 4px;
-  transform: none;
-}
+/* Previously overrode `.wt-menu-trigger`'s inherited `top:50%; translateY(-50%)`
+ * with a hardcoded `top: 4px` to pin the button to the top-right, next to the
+ * id chip — but visual testing showed that reads as noticeably OFF-center
+ * against the two-line pinned row (it lands near the second line, not
+ * centered), which is exactly the "not center aligned" complaint. Just
+ * inherit the base centering instead: vertically centered in the row like
+ * every other `.wt-menu-trigger` (worktree rows, direct-session rows). No
+ * override needed here anymore. */
 
 /* The `.pinned-row` resets for indent/height/alignment (above) are single-class
  * (0,1,0) and were silently defeated by the later, higher-specificity
@@ -1061,6 +1062,29 @@
 .tree-row--direct-session.pinned-row .wt-menu-trigger[aria-expanded="true"] {
   opacity: 1;
   pointer-events: auto;
+}
+
+/* Touch devices have no `:hover` — the reveal-on-hover rules above left the
+ * ⋯ trigger `pointer-events: none` at rest, so the first tap only landed on
+ * the row underneath (synthesizing a hover-like state) and only the SECOND
+ * tap actually hit the button. Keep it always interactive when hover isn't
+ * available. Selectors + specificity mirror the rules above exactly so this
+ * wins the cascade for every `.wt-menu-trigger` variant (plain worktree rows,
+ * pinned worktree rows, pinned direct-session rows). */
+@media (hover: none) {
+  .tree-row--worktree .wt-menu-trigger,
+  .tree-row--direct-session.pinned-row .wt-menu-trigger {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  /* The trigger and the id chip share the same trailing slot (see
+     `.tree-row--worktree:hover .wt-row__id` above) — now that the trigger is
+     always shown here, hide the chip the same way hover already does, so the
+     two don't render on top of each other. */
+  .tree-row--worktree .wt-row__id {
+    opacity: 0;
+  }
 }
 
 /* Direct sessions read italic in the project tree (`.direct-session__label`);

--- a/web-ui/src/styles/workspace.css
+++ b/web-ui/src/styles/workspace.css
@@ -3319,8 +3319,26 @@ textarea.input {
   border-bottom: var(--border-width) solid var(--border-default);
 }
 
-.dashboard-header__view-toggle {
+.dashboard-header__actions {
   margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-shrink: 0;
+}
+
+.dashboard-header__show-finished {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: var(--font-size-xs);
+  color: var(--fg-muted);
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.dashboard-header__view-toggle {
   flex-shrink: 0;
 }
 
@@ -3472,6 +3490,12 @@ a.dashboard-card.dashboard-card--session {
   gap: var(--space-3);
   align-items: start;
   width: 100%;
+}
+
+/* Show finished" adds a 4th column — without this the 4th `__col` still
+   wraps onto its own row under the fixed 3-column track above. */
+.dashboard-kanban--with-finished {
+  grid-template-columns: repeat(4, 1fr);
 }
 
 .dashboard-kanban__col {


### PR DESCRIPTION
## Summary
- Pinned-item ⋯ menu: fixed off-center placement (now vertically centered like every other `.wt-menu-trigger` — confirmed with live-sandbox screenshots) and a two-tap-to-open bug on touch devices (the trigger was `opacity:0`/`pointer-events:none` until `:hover`, with no touch fallback — added `@media (hover: none)`, and hid the id chip the same way `:hover` already does so the two don't overlap on touch).
- Canvas "Add tile" picker: now closes on outside click/Escape, and gained a "New agent" entry (own-worktree canvases) that opens the same dialog as the tab bar's "+" and auto-places the created session as a tile.
- Keyboard shortcuts: `Alt+N` → new agent in current worktree (no-op in canvas mode, where the picker's own "New agent" already covers it); `Alt+Shift+N` → new worktree in current project. Bare Alt combos, not `Ctrl+N`/`Ctrl+Shift+N` (OS/browser-reserved, can't be intercepted from a page); matched on `e.code` so Option+N's Mac dead-key behavior doesn't break it.
- Agent tiles in canvas/workspace mode get a "⋯" popup menu (left of the existing close button) with the same actions as the agent tab bar's right-click menu — Reset, Reset with handoff — plus a Terminate action equivalent to the tab bar's "×" close.
- **New (separate commit):** reworked the dashboard's home-page buckets from Working/Idle/Finished to **Working**, **Waiting for User** (waiting_for_human + idle — an idle worktree is still open work waiting on you, not done), and **PR created** (needs_review). Finished (done/exited) is now opt-in behind a "Show finished" checkbox next to the layout toggle, off by default, persisted like the layout choice.

Reviewed by an Opus subagent pass on the first round; all 7 findings addressed (Alt+N key detection on Mac dead-key layouts, id-chip/trigger overlap on touch, an invisible-session edge case for the shortcut in canvas mode, stale dialog-open state across worktree switches, keydown-listener churn, picker not closing when opening the New Agent dialog, an inaccurate code comment that led to re-deriving the alignment fix from a live screenshot).

## Test plan
- [x] `tsc -b --noEmit` clean
- [x] `npm run build` clean
- [x] `npx vitest run` — 404/404 tests pass
- [x] Visually verified against a live dev sandbox with Playwright: kebab-menu centering, canvas tile "⋯" menu + Terminate confirm dialog, `Alt+Shift+N`/`Alt+N` behavior, and the new dashboard buckets (list + kanban, with/without "Show finished")
- [ ] Manual touch-device check of the two-tap fix (not available in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)