### PR TITLE
fix(daemon,web-ui): dashboard bucket fixes — mixed-session working, PR merged retention

### DIFF
--- a/.vibekit/feature-plans/wip/dashboard-bucket-fixes/plan-dashboard-bucket-fixes.md
+++ b/.vibekit/feature-plans/wip/dashboard-bucket-fixes/plan-dashboard-bucket-fixes.md
@@ -1,0 +1,61 @@
+# Plan: dashboard-bucket-fixes
+
+Small bug-fix bundle, no PRD. Found via investigation (opus subagent), see summary below.
+
+## Scope
+
+1. **Mixed-session worktree hides live "Working" activity.** A worktree with one `waiting_for_human`
+   session and one genuinely `working` session doesn't show in the dashboard's "Working" bucket,
+   because `worktreeRolledUpStatus` picks a single winner by rank (`waiting_for_human`=8 beats
+   `working`=6). Also: archived sessions aren't excluded from the bucketing scan, so a handed-off/
+   archived session stuck in `waiting_for_human` can poison a worktree's bucket too.
+2. **Merging a PR silently loses the "this had a PR" signal.** `prPoller.ts`'s `fallbackStateFor()`
+   reverts the session to `idle`/`working` on merge — indistinguishable from a worktree that never
+   had a PR. Dashboard should keep showing "PR created" for a worktree whose PR merged, until a
+   *new* reviewable PR appears on the same branch.
+
+## Root causes / design (from investigation)
+
+1. `web-ui/src/lib/worktreeStatus.ts`'s rank table and `worktreeRolledUpStatus` are correct AS
+   WRITTEN — no propagation bug, no off-by-one. The issue is purely that `DashboardPanel.tsx`'s
+   bucket loop (`web-ui/src/components/layout/DashboardPanel.tsx:96-112`) uses that single-winner
+   rollup as-is for its Working/Waiting/PR/Finished split, when the "Working" bucket's actual intent
+   ("is there live activity here right now") is better served by "ANY agent session live-working",
+   not "the single highest-ranked session across the whole worktree". Fix is bucket-layer only —
+   `worktreeStatus.ts`/`StatusDot` stay untouched (still correct for single-session displays: the
+   worktree card's own status dot, sidebar rows, canvas tile borders).
+2. "PR merged" is never persisted anywhere today — `prPoller.ts` derives `needs_review` fresh every
+   60s tick and forgets it the instant the PR closes. `PrInfo.merged` (`daemon/src/services/
+   github.ts:17-24`) already carries the fact live but it's discarded. Chosen fix (investigation's
+   "Option 2", lowest risk): persist a small worktree-level `prMergedAt` timestamp, mirroring the
+   existing `pinnedAt` field's exact plumbing (SQLite column + migration-safe `addColumnIfMissing`,
+   row mapper, INSERT, WS broadcast via the existing passthrough `worktree:updated` event — no
+   protocol schema change needed, `WorktreeUpdatedEvent.worktree` is `z.record(z.string(),
+   z.unknown())`). No new `SessionState` value, no change to `needs_review`'s own lifecycle.
+
+## Checklist
+
+### Daemon (issue 2 — retain "PR created" through a merge)
+
+- [x] 1. `daemon/src/types.ts`: add `prMergedAt?: string;` to `WorktreeRecord`, doc comment mirroring `pinnedAt`.
+- [x] 2. `daemon/src/services/dbSchema.ts`: `addColumnIfMissing(db, "worktrees", "prMergedAt", "TEXT");`
+- [x] 3. `daemon/src/state/sqliteRowMappers.ts`: add `prMergedAt: string | null` to `WorktreeRow`; `rowToWorktree`/`worktreeToRow` mirror `pinnedAt`'s present-if-non-null pattern.
+- [x] 4. `daemon/src/state/project-store.ts`: add `prMergedAt` to the `INSERT INTO worktrees` column list + `VALUES` placeholder in `writeProjectFull`.
+- [x] 5. `daemon/src/routes/worktrees.ts`: export `serializeWorktree`; add `prMergedAt: w.prMergedAt ?? null,`.
+- [x] 6. `daemon/src/services/prPoller.ts`: `pollWorktree` gains a `currentPrMergedAt` param (passed from `pollAllPrs` as `worktree.prMergedAt`); add `setWorktreePrMergedAt(projectId, worktreeId, value)` helper (mutateProject + broadcastAll, mirrors the `/pin` route's pattern). On the reviewable branch, clear `prMergedAt` if set (new PR cycle). On the not-reviewable branch, if `pr?.merged === true` and `currentPrMergedAt == null`, set it to `new Date().toISOString()` before falling back to `working`/`idle`. A closed-without-merge or vanished PR must NOT set it.
+- [x] 7. `daemon/src/__tests__/prPoller.test.ts`: new cases — merged PR sets `prMergedAt`; closed-without-merge does NOT; a fresh open+non-draft PR on the same branch clears a previously-set `prMergedAt`.
+
+### Web-ui (both issues)
+
+- [x] 8. `web-ui/src/api/types.ts`: add `prMergedAt: string | null;` to `Worktree`, doc comment mirroring `pinnedAt`.
+- [x] 9. `web-ui/src/components/layout/DashboardPanel.tsx`:
+  - Exclude `s.archivedAt != null` from the agent-session list used for bucketing (not just for `worktreeRolledUpStatus`'s own callers elsewhere — scoped to this component only).
+  - Bucket a worktree into "Working" if ANY (non-archived) agent session's live state (`sessionStates[s.id] ?? s.state`) is `working` or `not_started`, taking priority over the rollup-driven bucket.
+  - Bucket a worktree with `wt.prMergedAt` set into "PR created", taking priority over the session-state-driven bucket (but still losing to the "Working" check above — a worktree that's actively working again after merge should read as Working, not stuck showing a stale PR badge).
+- [x] 10. `web-ui/src/components/layout/DashboardPanel.test.tsx`: new/updated cases for the "any session working" bucket rule and the archived-session exclusion. (`prMergedAt` daemon-persistence itself is covered by the daemon test above; the mock API's `Worktree` fixtures don't need a new PR-merge scenario for this small pass — the bucket-priority logic is a one-line conditional, verified by code review + the daemon-side test.)
+
+## Verification
+
+- Daemon: `npm test` (vitest) in `daemon/`, specifically `prPoller.test.ts`.
+- Web-ui: `npx tsc -b --noEmit`, `npm run build`, `npx vitest run`.
+- Manual: none available (no live daemon+GitHub in this environment) — daemon logic verified via the mocked `github.js` test harness already in place.

--- a/.vibekit/feature-plans/wip/dashboard-bucket-fixes/report.md
+++ b/.vibekit/feature-plans/wip/dashboard-bucket-fixes/report.md
@@ -1,0 +1,63 @@
+# /sdlc report — dashboard-bucket-fixes
+
+**Scope:** small bug-fix bundle, no PRD. Investigated by an Opus subagent, then plan → implement.
+
+## Issues
+
+1. **Mixed-session worktree hides live activity.** A worktree with one `waiting_for_human`
+   session and one genuinely `working` session didn't show under "Working" — confirmed as a
+   rollup/ranking design issue, not a propagation bug: `worktreeRolledUpStatus` picks a single
+   winning status per worktree by rank (`waiting_for_human`=8 beats `working`=6), which is correct
+   for single-session displays (status dots, sidebar) but wrong for the dashboard's "is anything
+   live here" bucket. Also found: archived sessions weren't excluded from bucketing, so a
+   handed-off session stuck in `waiting_for_human` could poison a worktree's bucket too.
+2. **Merging a PR silently loses the "PR created" signal.** `prPoller.ts` derives `needs_review`
+   fresh every 60s tick and forgets it the instant the PR closes — a merged worktree looks
+   identical to one that never had a PR. `PrInfo.merged` already carries the fact live but was
+   discarded.
+
+## What was implemented
+
+- **Daemon** (`prPoller.ts` + a `pinnedAt`-style plumbing addition — `types.ts`, `dbSchema.ts`,
+  `sqliteRowMappers.ts`, `project-store.ts`, `worktrees.ts`): a new `WorktreeRecord.prMergedAt`
+  timestamp, set when the poller sees `pr.merged === true` while the session was `needs_review`
+  (never on a plain close-without-merge), broadcast over the existing passthrough
+  `worktree:updated` WS event (no protocol schema change needed). Cleared the moment a fresh
+  open+non-draft PR appears on the same branch. SQLite migration is the existing
+  `addColumnIfMissing` idempotent `ALTER TABLE` helper — verified against the live dev sandbox's
+  pre-existing database, which booted and migrated cleanly.
+- **Web-ui** (`DashboardPanel.tsx`): the bucket loop now (a) excludes archived sessions from the
+  agent-session scan, (b) buckets a worktree as "Working" if ANY non-archived session is live
+  `working`/`not_started`, taking priority over the single-winner rollup, and (c) buckets a
+  worktree with `prMergedAt` set into "PR created" (unless something's actively working, which
+  wins). `worktreeStatus.ts` and `StatusDot` are untouched — still correct for single-session
+  displays elsewhere.
+
+## Verification
+
+- Daemon (`cli/` — `daemon/` is symlinked in): `npx vitest run` — **697/697 pass** (69 files),
+  including 13/13 in `prPoller.test.ts` (10 pre-existing + 3 new: merge stamps `prMergedAt`,
+  close-without-merge doesn't, a fresh PR clears a stale one). `tsc -b --noEmit` clean.
+  One pre-existing flaky timing test (`handoff.test.ts`) failed once under parallel load and
+  passed in isolation and on a full-suite rerun — confirmed unrelated to this change.
+- Web-ui: `tsc -b --noEmit` clean, `npm run build` clean, `npx vitest run` — **406/406 pass**
+  (60 files), including 2 new `DashboardPanel.test.tsx` cases (sibling-working overrides
+  waiting_for_human; archived session excluded from bucketing).
+- `npm run lint` (root, now runnable — installed root deps as a side effect) — 0 errors; fixed one
+  unrelated warning (unused `tileMenuLabel`) left over from earlier work in `WorkspaceCanvas.tsx`.
+- **Live-verified the risky part**: rebuilt and restarted the `vs-48` dev sandbox against its
+  existing (pre-migration) SQLite database — daemon booted clean, no schema errors, dashboard
+  rendered correctly with the new "Waiting for User" bucket. (Caught and reverted a near-miss
+  mid-verification: ran `docker compose` directly without the per-worktree env vars first, which
+  almost bound the shared `vst-dev-data`/`vst-dev-projects` volumes instead of `vst-dev-data-vs-48`
+  — port conflict stopped it before any actual attach; no data was touched, redid it correctly via
+  `scripts/dev-sandbox.sh`.)
+- Not verified live: an actual GitHub PR merge (no live PR/GitHub token in this environment) — the
+  daemon-side logic is covered by the mocked-`github.js` test harness already in place for
+  `prPoller.ts`.
+
+## Not committed yet
+
+11 files changed (7 daemon, 4 web-ui) plus the plan/report — awaiting confirmation to commit and
+push (single commit, per your earlier "separate commit in the same PR" preference, though this PR
+is already merged — let me know if you want this on a fresh branch/PR instead).

--- a/daemon/src/__tests__/prPoller.test.ts
+++ b/daemon/src/__tests__/prPoller.test.ts
@@ -95,6 +95,55 @@ describe("PR poller behavior", () => {
     return getProject("proj-pr")!.worktrees[0]!.sessions[0]!.lifecycle.state;
   }
 
+  async function getCurrentPrMergedAt(): Promise<string | undefined> {
+    const { getProject } = await import("../state/project-store.js");
+    return getProject("proj-pr")!.worktrees[0]!.prMergedAt;
+  }
+
+  /** Same as `seedProject`, plus a pre-existing `prMergedAt` on the worktree
+   *  — for the "clear on fresh PR" test below. */
+  async function seedProjectWithMergedAt(
+    initialState: LifecycleState,
+    prMergedAt: string,
+  ): Promise<void> {
+    const { _clearStoreForTest, addProject } = await import("../state/project-store.js");
+    _clearStoreForTest();
+    const record: ProjectRecord = {
+      id: "proj-pr",
+      absolutePath: join(tempDir, "repo"),
+      prefix: "pfx",
+      isGit: true,
+      defaultBranch: "main",
+      createdAt: new Date().toISOString(),
+      directSessions: [],
+      worktrees: [
+        {
+          id: "wt-pr",
+          branch: "feature-branch",
+          baseBranch: "main",
+          baseSha: "a".repeat(40),
+          createdAt: new Date().toISOString(),
+          prMergedAt,
+          sessions: [
+            {
+              id: "sess-pr",
+              slot: "m",
+              isMain: true,
+              type: "agent",
+              modeId: "mode",
+              tmuxName: "pane-pr",
+              lifecycle: {
+                state: initialState,
+                lastTransitionAt: new Date().toISOString(),
+              },
+            },
+          ],
+        },
+      ],
+    };
+    await addProject(record);
+  }
+
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), "vst-prpoller-test-"));
     await mkdir(join(tempDir, "projects", "proj-pr"), { recursive: true });
@@ -165,6 +214,23 @@ describe("PR poller behavior", () => {
     expect(await getCurrentState()).toBe("idle");
   });
 
+  it("dashboard-bucket-fixes — a merged PR also stamps the worktree's prMergedAt", async () => {
+    await seedProject("needs_review");
+    github.fetchPrForBranch.mockResolvedValue({
+      number: 7,
+      url: "https://github.com/acme/widgets/pull/7",
+      title: "Add widget",
+      state: "closed",
+      merged: true,
+      draft: false,
+      author: "octocat",
+    });
+
+    await pollAllPrs();
+
+    expect(await getCurrentPrMergedAt()).toBeDefined();
+  });
+
   it("a closed-without-merge PR also transitions the session out of needs_review", async () => {
     await seedProject("needs_review");
     github.fetchPrForBranch.mockResolvedValue({
@@ -180,6 +246,41 @@ describe("PR poller behavior", () => {
     await pollAllPrs();
 
     expect(await getCurrentState()).toBe("idle");
+  });
+
+  it("dashboard-bucket-fixes — a closed-without-merge PR does NOT stamp prMergedAt", async () => {
+    await seedProject("needs_review");
+    github.fetchPrForBranch.mockResolvedValue({
+      number: 9,
+      url: "https://github.com/acme/widgets/pull/9",
+      title: "Abandoned",
+      state: "closed",
+      merged: false,
+      draft: false,
+      author: "octocat",
+    });
+
+    await pollAllPrs();
+
+    expect(await getCurrentPrMergedAt()).toBeUndefined();
+  });
+
+  it("dashboard-bucket-fixes — a fresh open+non-draft PR on the same branch clears a previously-set prMergedAt", async () => {
+    await seedProjectWithMergedAt("idle", "2024-01-01T00:00:00.000Z");
+    github.fetchPrForBranch.mockResolvedValue({
+      number: 12,
+      url: "https://github.com/acme/widgets/pull/12",
+      title: "Round two",
+      state: "open",
+      merged: false,
+      draft: false,
+      author: "octocat",
+    });
+
+    await pollAllPrs();
+
+    expect(await getCurrentState()).toBe("needs_review");
+    expect(await getCurrentPrMergedAt()).toBeUndefined();
   });
 
   it("no PR at all transitions the session out of needs_review", async () => {

--- a/daemon/src/routes/worktrees.ts
+++ b/daemon/src/routes/worktrees.ts
@@ -125,7 +125,7 @@ function parseBranchNameStatus(stdout: string): { path: string; status: string }
 }
 
 /** Map internal WorktreeRecord to API shape (adds projectId, drops nested sessions). */
-function serializeWorktree(projectId: string, w: WorktreeRecord) {
+export function serializeWorktree(projectId: string, w: WorktreeRecord) {
   return {
     id: w.id,
     projectId,
@@ -137,6 +137,9 @@ function serializeWorktree(projectId: string, w: WorktreeRecord) {
     createdAt: w.createdAt,
     // Always emit pinnedAt so the client doesn't have to special-case undefined.
     pinnedAt: w.pinnedAt ?? null,
+    // Same rationale — set by prPoller.ts when this worktree's PR is seen
+    // merged, so the dashboard can keep crediting "PR created" through it.
+    prMergedAt: w.prMergedAt ?? null,
     sortOrder: w.sortOrder,
     // Id of the worktree's main agent session (isMain === true — replaces the
     // old slot==="m" check, Decision 1). Lets the create-dialog JSON path

--- a/daemon/src/services/dbSchema.ts
+++ b/daemon/src/services/dbSchema.ts
@@ -108,6 +108,12 @@ export function ensureSchema(db: Database): void {
   // leaving a dangling id is harmless (Research: the client-side workspace
   // tile scan simply won't find a match, S5).
   addColumnIfMissing(db, "sessions", "spawnedFrom", "TEXT");
+  // prMergedAt (dashboard-bucket-fixes) — ISO8601 timestamp remembering that
+  // this worktree's PR was seen merged, so the dashboard can keep crediting
+  // "PR created" instead of reading as idle/working again once the poller
+  // falls the session back out of needs_review. NULL until a merge is seen;
+  // cleared once a fresh open+non-draft PR appears on the same branch.
+  addColumnIfMissing(db, "worktrees", "prMergedAt", "TEXT");
 }
 
 /** Add `column` to `table` via `ALTER TABLE` if `PRAGMA table_info` shows it's absent. */

--- a/daemon/src/services/prPoller.ts
+++ b/daemon/src/services/prPoller.ts
@@ -18,12 +18,14 @@
  * ever touches a `needs_review` session).
  */
 
-import { getAllProjects } from "../state/project-store.js";
+import { getAllProjects, mutateProject } from "../state/project-store.js";
 import { getRemoteUrl, parseGithubRepo, fetchPrForBranch } from "./github.js";
 import { persistLifecycleState } from "./lifecycle.js";
 import { jsonAgentRegistry } from "../state/jsonAgentRegistry.js";
 import { sessionChannel } from "./channel.js";
-import type { SessionRecord } from "../types.js";
+import { broadcastAll } from "../broadcaster.js";
+import { serializeWorktree } from "../routes/worktrees.js";
+import type { SessionRecord, WorktreeRecord } from "../types.js";
 
 /**
  * 60s (Decision 3b): >= github.ts's own 30s cache TTL (polling faster is
@@ -60,12 +62,46 @@ function fallbackStateFor(session: SessionRecord): "working" | "idle" {
   return "idle";
 }
 
+/**
+ * Set/clear `WorktreeRecord.prMergedAt` (dashboard-bucket-fixes) and
+ * broadcast the change — same mutate-then-broadcast shape as the `/pin`
+ * route (`routes/worktrees.ts`), just triggered by the poller instead of a
+ * user action. `null` drops the field entirely rather than persisting an
+ * explicit null, matching `pinnedAt`'s own unset convention.
+ */
+async function setWorktreePrMergedAt(
+  projectId: string,
+  worktreeId: string,
+  value: string | null,
+): Promise<void> {
+  let updated: WorktreeRecord | undefined;
+  await mutateProject(projectId, (p) => ({
+    ...p,
+    worktrees: p.worktrees.map((w) => {
+      if (w.id !== worktreeId) return w;
+      if (value == null) {
+        const { prMergedAt: _drop, ...rest } = w;
+        void _drop;
+        updated = rest;
+        return rest;
+      }
+      const next = { ...w, prMergedAt: value };
+      updated = next;
+      return next;
+    }),
+  }));
+  if (updated) {
+    broadcastAll({ type: "worktree:updated", worktree: serializeWorktree(projectId, updated) });
+  }
+}
+
 async function pollWorktree(
   projectId: string,
   projectAbsolutePath: string,
   worktreeId: string,
   branch: string,
   mainSession: SessionRecord | undefined,
+  currentPrMergedAt: string | undefined,
 ): Promise<void> {
   if (!mainSession) return; // No agent session to attribute needs_review to.
   // Terminal state — same as lifecycle.ts's own terminal-state early return.
@@ -82,12 +118,23 @@ async function pollWorktree(
     if (mainSession.lifecycle.state !== "needs_review") {
       await persistLifecycleState(projectId, worktreeId, mainSession.id, "needs_review");
     }
+    // A fresh reviewable PR on this branch is a new review cycle — any
+    // earlier merge we remembered no longer applies.
+    if (currentPrMergedAt != null) {
+      await setWorktreePrMergedAt(projectId, worktreeId, null);
+    }
     return;
   }
 
   // PR merged/closed/gone — only act if WE are the one holding this session
   // in needs_review; anything else (done/exited, handled above) wins as-is.
   if (mainSession.lifecycle.state === "needs_review") {
+    // Distinguish "merged" (worth remembering — dashboard-bucket-fixes) from
+    // "closed without merging" / "gone entirely": only a genuine merge sets
+    // prMergedAt. `pr` can be null here (PR deleted/branch gone).
+    if (pr?.merged && currentPrMergedAt == null) {
+      await setWorktreePrMergedAt(projectId, worktreeId, new Date().toISOString());
+    }
     await persistLifecycleState(projectId, worktreeId, mainSession.id, fallbackStateFor(mainSession));
   }
 }
@@ -118,6 +165,7 @@ export async function pollAllPrs(): Promise<void> {
           worktree.id,
           worktree.branch,
           mainSession,
+          worktree.prMergedAt,
         ).catch((err) => {
           console.error(`[prPoller] Poll error for worktree ${worktree.id}:`, err);
         });

--- a/daemon/src/state/project-store.ts
+++ b/daemon/src/state/project-store.ts
@@ -250,8 +250,8 @@ function writeProjectFull(record: ProjectRecord): void {
     db.prepare("DELETE FROM worktrees WHERE projectId = ?").run(p.id);
 
     const insertWorktree = db.prepare(
-      `INSERT INTO worktrees (id, projectId, name, branch, baseBranch, baseSha, createdAt, pinnedAt, sortOrder, terminalSeq, agentSeq, branchIsPlaceholder)
-       VALUES (@id, @projectId, @name, @branch, @baseBranch, @baseSha, @createdAt, @pinnedAt, @sortOrder, @terminalSeq, @agentSeq, @branchIsPlaceholder)`,
+      `INSERT INTO worktrees (id, projectId, name, branch, baseBranch, baseSha, createdAt, pinnedAt, prMergedAt, sortOrder, terminalSeq, agentSeq, branchIsPlaceholder)
+       VALUES (@id, @projectId, @name, @branch, @baseBranch, @baseSha, @createdAt, @pinnedAt, @prMergedAt, @sortOrder, @terminalSeq, @agentSeq, @branchIsPlaceholder)`,
     );
     const insertSession = db.prepare(
       `INSERT INTO sessions (id, worktreeId, projectId, isMain, sortOrder, type, modeId, name, nameSource, tmuxName, useTmux, channel, state, reason, lastTransitionAt, transcriptKind, transcriptPath, agentChatId, modelOverride, pinnedAt, initialPrompt, archivedAt, handoffSummary, spawnedFrom)

--- a/daemon/src/state/sqliteRowMappers.ts
+++ b/daemon/src/state/sqliteRowMappers.ts
@@ -130,6 +130,7 @@ export interface WorktreeRow {
   baseSha: string | null;
   createdAt: string;
   pinnedAt: string | null;
+  prMergedAt: string | null;
   sortOrder: number;
   terminalSeq: number;
   agentSeq: number;
@@ -146,6 +147,7 @@ export function rowToWorktree(row: WorktreeRow, sessions: SessionRecord[]): Work
     baseSha: row.baseSha ?? "",
     createdAt: row.createdAt,
     ...(row.pinnedAt != null ? { pinnedAt: row.pinnedAt } : {}),
+    ...(row.prMergedAt != null ? { prMergedAt: row.prMergedAt } : {}),
     sortOrder: row.sortOrder,
     terminalSeq: row.terminalSeq,
     agentSeq: row.agentSeq,
@@ -163,6 +165,7 @@ export function worktreeToRow(w: WorktreeRecord, projectId: string): WorktreeRow
     baseSha: w.baseSha ?? null,
     createdAt: w.createdAt,
     pinnedAt: w.pinnedAt ?? null,
+    prMergedAt: w.prMergedAt ?? null,
     sortOrder: w.sortOrder ?? 0,
     terminalSeq: w.terminalSeq ?? 0,
     agentSeq: w.agentSeq ?? 0,

--- a/daemon/src/types.ts
+++ b/daemon/src/types.ts
@@ -290,6 +290,16 @@ export interface WorktreeRecord {
    * (newest pinned first), so we don't need a separate sort field.
    */
   pinnedAt?: string; // ISO8601
+  /**
+   * When set, this worktree's PR was seen merged by `prPoller.ts` while its
+   * main session was `needs_review` — kept around (distinct from a PR that
+   * was merely closed without merging) so the dashboard can keep crediting
+   * "PR created" instead of silently reading as idle/working again. Cleared
+   * the moment `prPoller.ts` finds a fresh open, non-draft PR on the same
+   * branch (a new review cycle has started). Absent / undefined ≡ no
+   * remembered merge.
+   */
+  prMergedAt?: string; // ISO8601
   /** Fractional display-order rank among a project's worktrees (F9 — reordering itself is Part 03). */
   sortOrder: number;
   /**

--- a/web-ui/src/api/types.ts
+++ b/web-ui/src/api/types.ts
@@ -36,6 +36,15 @@ export interface Worktree {
    * default sort order (newest first).
    */
   pinnedAt: string | null;
+  /**
+   * ISO8601 timestamp set by the daemon's PR poller when this worktree's PR
+   * was seen merged while its main session was `needs_review` — lets the
+   * dashboard keep crediting "PR created" instead of reading as idle/working
+   * again once the poller falls the session back out of `needs_review`.
+   * Cleared once a fresh open, non-draft PR appears on the same branch.
+   * Optional for legacy/test fixtures predating this field (same as `sortOrder` below).
+   */
+  prMergedAt?: string | null;
   /** Fractional display-order rank among a project's worktrees (F9). Optional for legacy/test fixtures predating this field. */
   sortOrder?: number;
   /**

--- a/web-ui/src/components/layout/DashboardPanel.test.tsx
+++ b/web-ui/src/components/layout/DashboardPanel.test.tsx
@@ -95,6 +95,62 @@ describe("DashboardPanel", () => {
     });
   });
 
+  it("dashboard-bucket-fixes — a sibling session actively working keeps the worktree bucketed as working, even if another session is waiting_for_human", async () => {
+    const api = createMockApi();
+    render(
+      <MemoryRouter>
+        <Harness api={api}>
+          <DashboardPanel api={api} />
+        </Harness>
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getAllByText(/Proj A/i).length).toBeGreaterThan(0);
+    });
+
+    // wt-1: sess-main stays "working"; sess-agent2 flips to waiting_for_human
+    // (rank 8, would normally outrank "working" rank 6 in the single-winner
+    // rollup) — the worktree must still read as "working" because SOME
+    // session is actively working right now.
+    api.__test.emit({ type: "session:state", sessionId: "sess-agent2", state: "waiting_for_human" });
+
+    await waitFor(() => {
+      const workingSection = screen.getByText("working").closest("section");
+      expect(workingSection).not.toBeNull();
+      expect(within(workingSection!).getByRole("link", { name: /Proj A/i })).toHaveAttribute(
+        "href",
+        "/worktree/wt-1",
+      );
+    });
+  });
+
+  it("dashboard-bucket-fixes — excludes an archived session from bucketing", async () => {
+    const api = createMockApi();
+    render(
+      <MemoryRouter>
+        <Harness api={api}>
+          <DashboardPanel api={api} />
+        </Harness>
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(document.querySelector('a[href="/worktree/wt-3"]')).not.toBeNull();
+    });
+
+    // wt-3's only agent session (idle) gets archived — with no non-archived
+    // agent sessions left, the worktree must drop out of every bucket
+    // entirely rather than keep poisoning "waiting for user".
+    api.__test.emit({
+      type: "session:updated",
+      sessionId: "sess-wt3-main",
+      archivedAt: new Date().toISOString(),
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector('a[href="/worktree/wt-3"]')).toBeNull();
+    });
+  });
+
   it("excludes a hidden project's worktree cards and its project card", async () => {
     const api = createMockApi();
     render(

--- a/web-ui/src/components/layout/DashboardPanel.tsx
+++ b/web-ui/src/components/layout/DashboardPanel.tsx
@@ -129,14 +129,39 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
     const wtsFinished: Worktree[] = [];
     for (const wt of worktrees) {
       if (hiddenProjectIds.has(wt.projectId)) continue;
-      const agentSessions = sessions.filter((s) => s.worktreeId === wt.id && s.type === "agent");
+      // Archived (handed-off/reset) sessions are excluded from bucketing —
+      // one stuck in `waiting_for_human` shouldn't poison this worktree's
+      // bucket the way a live session's state should.
+      const agentSessions = sessions.filter(
+        (s) => s.worktreeId === wt.id && s.type === "agent" && s.archivedAt == null,
+      );
       if (agentSessions.length === 0) continue;
+      // "Working" means "is there live activity here right now" — ANY
+      // session actively working takes priority over the rollup's single
+      // highest-ranked status, which would otherwise let one session's
+      // `waiting_for_human` (rank 8) hide a SIBLING session's `working`
+      // (rank 6) for the whole worktree.
+      const hasLiveActivity = agentSessions.some((s) => {
+        const st = sessionStates[s.id] ?? s.state;
+        return st === "working" || st === "not_started";
+      });
+      if (hasLiveActivity) {
+        wtsWorking.push(wt);
+        continue;
+      }
+      // A remembered PR merge (see prPoller.ts) keeps reading as "PR
+      // created" instead of silently falling back to idle/waiting — as long
+      // as nothing here is actively working (checked above).
+      if (wt.prMergedAt) {
+        wtsPr.push(wt);
+        continue;
+      }
       const rolled = worktreeRolledUpStatus(agentSessions, sessionStates);
       const b = bucketForRollup(rolled);
-      if (b === "working") wtsWorking.push(wt);
-      else if (b === "waiting") wtsWaiting.push(wt);
+      if (b === "waiting") wtsWaiting.push(wt);
       else if (b === "pr") wtsPr.push(wt);
-      else wtsFinished.push(wt);
+      else if (b === "finished") wtsFinished.push(wt);
+      else wtsWorking.push(wt); // defensive — hasLiveActivity already covers "working"
     }
     return { working: wtsWorking, waiting: wtsWaiting, pr: wtsPr, finished: wtsFinished };
   }, [worktrees, sessions, sessionStates, hiddenProjectIds]);

--- a/web-ui/src/components/layout/WorkspaceCanvas.tsx
+++ b/web-ui/src/components/layout/WorkspaceCanvas.tsx
@@ -1090,7 +1090,6 @@ export function WorkspaceCanvas({
 
   const tileMenuTile = tileMenu ? (cv.tiles.find((t) => t.id === tileMenu.tileId) ?? null) : null;
   const tileMenuSession = tileMenuTile?.sessionId ? (sessionById.get(tileMenuTile.sessionId) ?? null) : null;
-  const tileMenuLabel = tileMenuSession ? sessionLabel(tileMenuSession) : "";
 
   return (
     <div className="workspace-canvas">


### PR DESCRIPTION
## Summary
Two dashboard bugs, investigated via an Opus subagent before fixing:

1. **A worktree with a `waiting_for_human` session and a sibling genuinely-`working` session didn't show under "Working"** — `worktreeRolledUpStatus`'s single-winner rank (`waiting_for_human`=8 beats `working`=6) is correct for single-session displays (status dots, sidebar) but wrong for the dashboard's "is anything live here" bucket. Fixed at the `DashboardPanel` bucket layer only — a worktree now buckets as Working if ANY non-archived agent session is live `working`/`not_started`. Also excludes archived sessions from bucketing entirely (a handed-off session stuck in `waiting_for_human` was poisoning its worktree's bucket).
2. **Merging a PR silently lost the "PR created" signal** — `prPoller.ts` derives `needs_review` fresh every 60s tick and forgets it the instant the PR closes, so a merged worktree looked identical to one that never had a PR. Adds a small worktree-level `prMergedAt` timestamp (mirrors the existing `pinnedAt` field's exact plumbing — SQLite column via the existing `addColumnIfMissing` migration helper, row mapper, WS broadcast over the existing passthrough `worktree:updated` event, no protocol schema change), set only on a genuine merge (never a plain close-without-merge), cleared once a fresh open+non-draft PR appears on the same branch.

## Test plan
- [x] Daemon (`cli/`): `tsc -b --noEmit` clean, `npx vitest run` — 697/697 pass, including 13/13 in `prPoller.test.ts` (10 pre-existing + 3 new)
- [x] Web-ui: `tsc -b --noEmit` clean, `npm run build` clean, `npx vitest run` — 406/406 pass, including 2 new `DashboardPanel.test.tsx` cases
- [x] `npm run lint` — 0 errors
- [x] Live-verified the risky part: rebuilt + restarted the `vs-48` dev sandbox against its existing (pre-migration) SQLite database — daemon booted clean, no schema errors, dashboard rendered correctly
- [ ] Not verified live: an actual GitHub PR merge (no live PR/GitHub token in this environment) — covered by the mocked-`github.js` daemon test harness instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)