### PR TITLE
feat(web-ui): show direct agent sessions on the dashboard and in the Add-tile picker

### DIFF
--- a/.vibekit/feature-plans/wip/direct-agents-dashboard-tile/plan-direct-agents-dashboard-tile.md
+++ b/.vibekit/feature-plans/wip/direct-agents-dashboard-tile/plan-direct-agents-dashboard-tile.md
@@ -1,0 +1,72 @@
+# Plan: direct-agents-dashboard-tile
+
+Small feature bundle, no PRD — both parts confirmed architecturally additive by investigation.
+
+## Scope
+
+1. Direct agent sessions (no worktree, project-scoped) don't appear on the dashboard home page —
+   only worktrees are bucketed. Add them into the same Working/Waiting for User/PR created/Finished
+   buckets, alongside worktrees.
+2. The canvas "Add tile" picker's cross-context section (saved workspaces only) offers other
+   worktrees' sessions but never direct sessions. Add them per project, same section.
+
+## Findings (investigation)
+
+- Direct sessions live in the same flat `sessions` array (`useServerStore`), identified by
+  `worktreeId == null && projectId` set. No store changes needed.
+- `sessionStatus(state)` (`lib/worktreeStatus.ts:34`) is purely state-driven, no worktree
+  dependency — reusable as-is for a single direct session's bucket status.
+- `/session/:directSessionId` route already exists (`App.tsx`), and `Workspace.tsx` already derives
+  active direct-session context from the URL alone — a dashboard card needs only a plain `<Link>`,
+  no store action on click (confirmed by mirroring `LeftSidebar.tsx`'s existing direct-session row,
+  which does the same).
+- `TileSpec.worktreeId` staying `undefined` for a direct-session tile is safe: `paneKeyForTile`
+  never reads worktreeId for agent/terminal tiles (pure `${kind}:${sessionId}`), and
+  `renderTileChrome`'s label logic already branches on `session.worktreeId` (not `tile.worktreeId`)
+  for the worktree-segment of the label — a direct session's tile already renders correctly as
+  `"Project > SessionLabel"` with zero changes, per a comment already in the code anticipating
+  exactly this case.
+- The cross-context picker is saved-workspace-only by explicit design (`!isSaved` guard,
+  `WorkspaceCanvas.tsx:353`) — direct sessions are added to that same scope, not the transient
+  per-worktree scratch canvas (architectural limit, not a new one introduced here).
+
+## Explicit scope decisions
+
+- No "dismiss" affordance on a direct-session dashboard card (worktree cards get one for
+  done/exited, backed by `api.dismissWorktree` — deleting a direct session outright is a more
+  destructive, different action not needed for a visibility-only fix).
+- No PR-poller changes — `prPoller.ts` only ever polls worktrees; a direct session's `needs_review`
+  bucket is dead code today (never actually set) but harmless to leave wired for forward-compat.
+- Direct-session card secondary line shows `"direct"` (mirrors the sidebar's own "direct" badge)
+  in place of a worktree's short id, since there's no id-chip equivalent.
+
+## Checklist
+
+- [x] 1. `DashboardPanel.tsx`: introduce a `DashboardItem` union (`{kind:"worktree", worktree}` |
+      `{kind:"direct", session}`), change the 4 bucket arrays to hold `DashboardItem[]`.
+- [x] 2. Extend the bucketing loop to also scan `sessions` for `type === "agent" && worktreeId == null
+      && archivedAt == null && projectId not hidden`, bucket via `sessionStatus`.
+- [x] 3. Generalize `renderWorktreeCard` → `renderDashboardItem`, switching on `item.kind`; direct
+      case renders a `Link to="/session/:id"` card (dot, `sessionLabel`, "direct", project name),
+      no dismiss button.
+- [x] 4. Update the list/kanban render call sites (`.map((wt) => renderWorktreeCard(wt))` →
+      `.map((item) => renderDashboardItem(item))`).
+- [x] 5. `WorkspaceCanvas.tsx`: add a `directSessions` array to each `otherContextGroups` project
+      entry (same project, `worktreeId == null`, not already placed), include in the group's
+      non-empty filter.
+- [x] 6. Render the group's `directSessions` in the picker JSX, sibling to the worktree subheadings
+      (own "Direct" subheading, same item-button styling, `addTile(s.type, s.id)` — no
+      `tileWorktreeId`, matching the own-worktree call pattern).
+- [x] 7. `DashboardPanel.test.tsx` / `WorkspaceCanvas.test.tsx`: added a direct-session dashboard
+      bucketing test and a picker cross-context test (asserts the tile lands with the right
+      sessionId and no worktreeId).
+
+## Verification
+
+- `npx tsc -b --noEmit`, `npm run build`, `npx vitest run` (web-ui) — all clean, 406/406 tests
+  (404 baseline + 2 new).
+- Live: dev sandbox (vs-48) — created a real direct session via `POST /sessions`, confirmed it
+  shows on the dashboard under "Working" linking to `/session/:id`, confirmed the session page
+  itself renders correctly, then saved a worktree's canvas as a workspace and confirmed "Doc audit
+  agent" appears under a "Direct" subheading in the Add-tile picker and tiles in correctly labeled
+  "northstar-api > Doc audit agent".

--- a/.vibekit/feature-plans/wip/direct-agents-dashboard-tile/report.md
+++ b/.vibekit/feature-plans/wip/direct-agents-dashboard-tile/report.md
@@ -1,0 +1,50 @@
+# /sdlc report — direct-agents-dashboard-tile
+
+**Scope:** small feature bundle, no PRD — investigation confirmed both parts are purely additive,
+no architecture changes needed.
+
+## What was implemented
+
+1. **Dashboard visibility** (`DashboardPanel.tsx`) — direct (worktree-less) agent sessions now
+   bucket into the same Working/Waiting for User/PR created/Finished sections as worktrees. Added
+   a `DashboardItem` union (`{kind:"worktree"}` | `{kind:"direct"}`) so the existing bucket arrays
+   and render function could hold both kinds without duplicating the list/kanban layout code. A
+   direct session's card links to `/session/:id` (the route and its URL-driven context derivation
+   already existed — no routing change), shows `sessionLabel(s)`, a `"direct"` secondary tag
+   (mirrors the sidebar's own badge), and the owning project's name. No dismiss button (that's a
+   worktree-only, less-destructive "untrack but keep files" action; deleting a direct session
+   outright is a different, more destructive operation, out of scope for a visibility fix).
+2. **Add-tile picker** (`WorkspaceCanvas.tsx`) — the cross-context picker (saved workspaces only,
+   by existing design) now lists each project's direct sessions under their own "Direct"
+   subheading, alongside the existing per-worktree session groups. Confirmed via investigation
+   that `TileSpec.worktreeId` staying `undefined` for a direct-session tile is already handled
+   correctly by existing code — `paneKeyForTile` never reads it for agent/terminal tiles, and the
+   tile label logic already branches on `session.worktreeId` (not `tile.worktreeId`), so a direct
+   session's tile renders as `"Project > SessionLabel"` with zero other changes required.
+
+## Explicit scope decisions
+
+- No PR-poller changes — `prPoller.ts` only polls worktrees, so a direct session's `needs_review`
+  bucket is unreachable in practice today; left wired for forward-compatibility, not worth
+  expanding poller scope for this fix.
+- Cross-context tile addition stays saved-workspace-only, matching the picker's existing
+  architecture (the transient per-worktree scratch canvas's `PaneHostLayer` scope is deliberately
+  limited to that one worktree — not touched).
+
+## Verification
+
+- `npx tsc -b --noEmit`, `npm run build`, `npx vitest run` — all clean. **406/406 tests** (404
+  baseline + 2 new: a dashboard-bucketing test for a direct session, and a picker test asserting
+  the tile lands with the correct `sessionId` and no `worktreeId`).
+- `npm run lint` — 0 errors (2 pre-existing unrelated warnings on `main`, one of which — an unused
+  `tileMenuLabel` in `WorkspaceCanvas.tsx` — is already fixed on the still-open PR #58).
+- **Live-verified end to end** against the running `vs-48` dev sandbox: created a real direct
+  session via `POST /sessions`, confirmed it appears on the dashboard under "Working" and links to
+  a working `/session/:id` page; saved a worktree's canvas as a workspace and confirmed the direct
+  session appears under a "Direct" subheading in the Add-tile picker, and that clicking it adds a
+  correctly-labeled tile ("northstar-api > Doc audit agent") to the canvas.
+
+## Diff / PR
+
+Branched fresh off `main` (not off the two other still-open PRs, to keep this independent).
+4 files changed (2 source, 2 test) + plan/report. Not yet committed — awaiting confirmation.

--- a/web-ui/src/components/layout/DashboardPanel.test.tsx
+++ b/web-ui/src/components/layout/DashboardPanel.test.tsx
@@ -60,6 +60,48 @@ describe("DashboardPanel", () => {
     expect(screen.getByText("finished")).toBeInTheDocument();
   });
 
+  it("dashboard-direct-agents — shows a direct (worktree-less) agent session, bucketed and linking to /session/:id", async () => {
+    const api = createMockApi();
+    render(
+      <MemoryRouter>
+        <Harness api={api}>
+          <DashboardPanel api={api} />
+        </Harness>
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getAllByText(/Proj A/i).length).toBeGreaterThan(0);
+    });
+
+    api.__test.emit({
+      type: "session:created",
+      sessionId: "sess-direct-1",
+      worktreeId: null,
+      projectId: "proj-a",
+      sessionType: "agent",
+      snapshot: {
+        id: "sess-direct-1",
+        worktreeId: null,
+        projectId: "proj-a",
+        modeId: "mode-1",
+        type: "agent",
+        name: "My Direct Agent",
+        isMain: false,
+        state: "working",
+        lifecycleState: "working",
+        tmuxName: "sess-direct-1",
+        createdAt: new Date().toISOString(),
+      },
+    });
+
+    await waitFor(() => {
+      const workingSection = screen.getByText("working").closest("section");
+      expect(workingSection).not.toBeNull();
+      const link = within(workingSection!).getByRole("link", { name: /My Direct Agent/i });
+      expect(link).toHaveAttribute("href", "/session/sess-direct-1");
+    });
+  });
+
   it("updates worktree row bucket when session:state fires", async () => {
     const api = createMockApi();
     render(

--- a/web-ui/src/components/layout/DashboardPanel.tsx
+++ b/web-ui/src/components/layout/DashboardPanel.tsx
@@ -4,17 +4,22 @@ import { Link } from "react-router-dom";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 import type { ApiInstance } from "@/api";
 import type { ConnectionState } from "@/api/client";
-import type { HealthResponse, Worktree } from "@/api/types";
+import type { HealthResponse, Session, Worktree } from "@/api/types";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
 import { StatusDot } from "@/components/layout/StatusDot";
 import { useSubscription } from "@/hooks/useSubscription";
 import { useWorkspaceStore } from "@/hooks/useStore";
 import { useServerStore } from "@/hooks/useServerStore";
-import { type WorktreeRolledUpStatus, worktreeRolledUpStatus } from "@/lib/worktreeStatus";
+import { type WorktreeRolledUpStatus, sessionStatus, worktreeRolledUpStatus } from "@/lib/worktreeStatus";
+import { sessionLabel } from "@/lib/sessionLabel";
 
 interface DashboardPanelProps {
   api: ApiInstance;
 }
+
+/** A dashboard card is either a worktree or a direct (worktree-less) agent
+ *  session — both bucket into the same Working/Waiting/PR/Finished sections. */
+type DashboardItem = { kind: "worktree"; worktree: Worktree } | { kind: "direct"; session: Session };
 
 /**
  * Dashboard buckets, coarser than the full `WorktreeRolledUpStatus` set:
@@ -123,10 +128,10 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
   const sessionStates = useWorkspaceStore((s) => s.sessionStates);
 
   const { working, waiting, pr, finished } = useMemo(() => {
-    const wtsWorking: Worktree[] = [];
-    const wtsWaiting: Worktree[] = [];
-    const wtsPr: Worktree[] = [];
-    const wtsFinished: Worktree[] = [];
+    const wtsWorking: DashboardItem[] = [];
+    const wtsWaiting: DashboardItem[] = [];
+    const wtsPr: DashboardItem[] = [];
+    const wtsFinished: DashboardItem[] = [];
     for (const wt of worktrees) {
       if (hiddenProjectIds.has(wt.projectId)) continue;
       // Archived (handed-off/reset) sessions are excluded from bucketing —
@@ -145,31 +150,70 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
         const st = sessionStates[s.id] ?? s.state;
         return st === "working" || st === "not_started";
       });
+      const wtItem: DashboardItem = { kind: "worktree", worktree: wt };
       if (hasLiveActivity) {
-        wtsWorking.push(wt);
+        wtsWorking.push(wtItem);
         continue;
       }
       // A remembered PR merge (see prPoller.ts) keeps reading as "PR
       // created" instead of silently falling back to idle/waiting — as long
       // as nothing here is actively working (checked above).
       if (wt.prMergedAt) {
-        wtsPr.push(wt);
+        wtsPr.push(wtItem);
         continue;
       }
       const rolled = worktreeRolledUpStatus(agentSessions, sessionStates);
       const b = bucketForRollup(rolled);
-      if (b === "waiting") wtsWaiting.push(wt);
-      else if (b === "pr") wtsPr.push(wt);
-      else if (b === "finished") wtsFinished.push(wt);
-      else wtsWorking.push(wt); // defensive — hasLiveActivity already covers "working"
+      if (b === "waiting") wtsWaiting.push(wtItem);
+      else if (b === "pr") wtsPr.push(wtItem);
+      else if (b === "finished") wtsFinished.push(wtItem);
+      else wtsWorking.push(wtItem); // defensive — hasLiveActivity already covers "working"
+    }
+    // Direct (worktree-less) agent sessions bucket the same way, one card per
+    // session — there's no rollup to do since there's only ever one session
+    // per card here.
+    for (const s of sessions) {
+      if (s.type !== "agent" || s.worktreeId != null || s.archivedAt != null) continue;
+      if (!s.projectId || hiddenProjectIds.has(s.projectId)) continue;
+      const item: DashboardItem = { kind: "direct", session: s };
+      // No sibling sessions to prioritize over (one session = one card here),
+      // so — unlike the worktree loop above — a plain rollup is sufficient.
+      const b = bucketForRollup(sessionStatus(sessionStates[s.id] ?? s.state));
+      if (b === "working") wtsWorking.push(item);
+      else if (b === "waiting") wtsWaiting.push(item);
+      else if (b === "pr") wtsPr.push(item);
+      else wtsFinished.push(item);
     }
     return { working: wtsWorking, waiting: wtsWaiting, pr: wtsPr, finished: wtsFinished };
   }, [worktrees, sessions, sessionStates, hiddenProjectIds]);
 
   const daemonOk = connState === "online";
 
-  const renderWorktreeCard = useCallback(
-    (wt: Worktree) => {
+  const renderDashboardItem = useCallback(
+    (item: DashboardItem) => {
+      if (item.kind === "direct") {
+        const s = item.session;
+        const status = sessionStatus(sessionStates[s.id] ?? s.state);
+        const proj = projectById[s.projectId];
+        return (
+          <div key={s.id} className="dashboard-card-shell">
+            <Link
+              to={`/session/${s.id}`}
+              className="dashboard-card dashboard-card--session dashboard-card--worktree"
+            >
+              <span className="dashboard-card__dot dashboard-card__dot--status">
+                <StatusDot status={status} />
+              </span>
+              <span className="dashboard-card__session-main">
+                <span className="dashboard-card__primary">{sessionLabel(s)}</span>
+                <span className="dashboard-card__branch">direct</span>
+              </span>
+              <span className="dashboard-card__secondary">{proj?.name ?? ""}</span>
+            </Link>
+          </div>
+        );
+      }
+      const wt = item.worktree;
       const agentSessions = sessions.filter((s) => s.worktreeId === wt.id && s.type === "agent");
       const rolled = worktreeRolledUpStatus(agentSessions, sessionStates);
       const sessionsForWt = sessions.filter((s) => s.worktreeId === wt.id);
@@ -269,28 +313,28 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
             {working.length > 0 ? (
               <section className="dashboard-section">
                 <div className="dashboard-section__label">working</div>
-                <div className="dashboard-card-list">{working.map((wt) => renderWorktreeCard(wt))}</div>
+                <div className="dashboard-card-list">{working.map((item) => renderDashboardItem(item))}</div>
               </section>
             ) : null}
 
             {waiting.length > 0 ? (
               <section className="dashboard-section">
                 <div className="dashboard-section__label">waiting for user</div>
-                <div className="dashboard-card-list">{waiting.map((wt) => renderWorktreeCard(wt))}</div>
+                <div className="dashboard-card-list">{waiting.map((item) => renderDashboardItem(item))}</div>
               </section>
             ) : null}
 
             {pr.length > 0 ? (
               <section className="dashboard-section">
                 <div className="dashboard-section__label">pr created</div>
-                <div className="dashboard-card-list">{pr.map((wt) => renderWorktreeCard(wt))}</div>
+                <div className="dashboard-card-list">{pr.map((item) => renderDashboardItem(item))}</div>
               </section>
             ) : null}
 
             {showFinished && finished.length > 0 ? (
               <section className="dashboard-section">
                 <div className="dashboard-section__label">finished</div>
-                <div className="dashboard-card-list">{finished.map((wt) => renderWorktreeCard(wt))}</div>
+                <div className="dashboard-card-list">{finished.map((item) => renderDashboardItem(item))}</div>
               </section>
             ) : null}
 
@@ -304,26 +348,26 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
               <div className="dashboard-kanban__col-header">
                 Working <span className="dashboard-kanban__col-count">({working.length})</span>
               </div>
-              <div className="dashboard-card-list">{working.map((wt) => renderWorktreeCard(wt))}</div>
+              <div className="dashboard-card-list">{working.map((item) => renderDashboardItem(item))}</div>
             </div>
             <div className="dashboard-kanban__col">
               <div className="dashboard-kanban__col-header">
                 Waiting for User <span className="dashboard-kanban__col-count">({waiting.length})</span>
               </div>
-              <div className="dashboard-card-list">{waiting.map((wt) => renderWorktreeCard(wt))}</div>
+              <div className="dashboard-card-list">{waiting.map((item) => renderDashboardItem(item))}</div>
             </div>
             <div className="dashboard-kanban__col">
               <div className="dashboard-kanban__col-header">
                 PR Created <span className="dashboard-kanban__col-count">({pr.length})</span>
               </div>
-              <div className="dashboard-card-list">{pr.map((wt) => renderWorktreeCard(wt))}</div>
+              <div className="dashboard-card-list">{pr.map((item) => renderDashboardItem(item))}</div>
             </div>
             {showFinished ? (
               <div className="dashboard-kanban__col">
                 <div className="dashboard-kanban__col-header">
                   Finished <span className="dashboard-kanban__col-count">({finished.length})</span>
                 </div>
-                <div className="dashboard-card-list">{finished.map((wt) => renderWorktreeCard(wt))}</div>
+                <div className="dashboard-card-list">{finished.map((item) => renderDashboardItem(item))}</div>
               </div>
             ) : null}
           </div>

--- a/web-ui/src/components/layout/WorkspaceCanvas.test.tsx
+++ b/web-ui/src/components/layout/WorkspaceCanvas.test.tsx
@@ -134,6 +134,69 @@ describe("WorkspaceCanvas - Add tile picker cross-worktree note", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("offers a project's direct sessions in the cross-context picker (saved workspace), addable with no worktreeId", async () => {
+    const user = userEvent.setup();
+    const docId = "doc-1";
+    const canvas: CanvasGeometry = { mode: "free", tiles: [], tree: null, freeRects: {} };
+    useWorkspaceStore.setState({
+      workspaceDocs: { [docId]: { id: docId, name: "Doc", contextKey: W1, ...canvas } },
+    });
+    const project = {
+      id: "proj-a",
+      name: "Proj A",
+      path: "/home/dev/proj-a",
+      prefix: "pa",
+      isGit: true,
+      createdAt: new Date().toISOString(),
+      hidden: false,
+    };
+    const directSession = {
+      id: "sess-direct-1",
+      worktreeId: null,
+      projectId: "proj-a",
+      modeId: "mode-1",
+      type: "agent" as const,
+      name: "My Direct Agent",
+      isMain: false,
+      state: "idle" as const,
+      lifecycleState: "idle" as const,
+      tmuxName: "sess-direct-1",
+      createdAt: new Date().toISOString(),
+    };
+    render(
+      <MemoryRouter>
+        <PaneOutletProvider>
+          <WorkspaceCanvas
+            worktreeId={W1}
+            agentSessions={[]}
+            terminalSessions={[]}
+            hasTools
+            toolPanelVisible
+            terminalDockVisible
+            allSessions={[directSession]}
+            worktrees={[]}
+            projects={[project]}
+            canvasToolbarVisible
+            detachedWorkspaceId={docId}
+          />
+        </PaneOutletProvider>
+      </MemoryRouter>,
+    );
+    await user.click(screen.getByText("Add tile"));
+    expect(screen.getByText("Direct")).toBeInTheDocument();
+    const item = screen.getByText("My Direct Agent");
+    expect(item).toBeInTheDocument();
+
+    await user.click(item);
+
+    // Tile landed with the direct session's id and no worktreeId (undefined —
+    // it's not scoped to any other worktree, matching an own-worktree tile).
+    const doc = useWorkspaceStore.getState().workspaceDocs[docId];
+    expect(doc?.tiles).toHaveLength(1);
+    expect(doc?.tiles[0]).toMatchObject({ kind: "agent", sessionId: "sess-direct-1" });
+    expect(doc?.tiles[0]?.worktreeId).toBeUndefined();
+  });
+
   it("a worktree's classic canvas never binds to a saved doc even if a stale activeWorkspaceId is present (regression)", async () => {
     const user = userEvent.setup();
     const docId = "doc-1";

--- a/web-ui/src/components/layout/WorkspaceCanvas.tsx
+++ b/web-ui/src/components/layout/WorkspaceCanvas.tsx
@@ -368,8 +368,18 @@ export function WorkspaceCanvas({
               canAddTools: !placedToolWorktrees.has(w.id),
             }))
             .filter((entry) => entry.sessions.length > 0 || entry.canAddTools),
+          // Direct (worktree-less) sessions of the SAME project — no
+          // worktree to nest under, so they get their own subheading instead
+          // of a `{worktree, sessions}` entry above.
+          directSessions: allSessions.filter(
+            (s) =>
+              s.projectId === project.id &&
+              s.worktreeId == null &&
+              (s.type === "agent" || s.type === "terminal") &&
+              !placedSessionIds.has(s.id),
+          ),
         }))
-        .filter((group) => group.worktrees.length > 0);
+        .filter((group) => group.worktrees.length > 0 || group.directSessions.length > 0);
 
   // Own-worktree canvases always offer "New agent" (below), so the picker is
   // never truly empty there — only the detached workspace view (no New Agent
@@ -1069,6 +1079,32 @@ export function WorkspaceCanvas({
                         </div>
                       </div>
                     ))}
+                    {group.directSessions.length > 0 ? (
+                      <div>
+                        <div className="workspace-canvas__picker-subheading">Direct</div>
+                        <div className="workspace-canvas__picker-subitems">
+                          <span className="workspace-canvas__picker-indent-line" aria-hidden />
+                          {group.directSessions.map((s) => (
+                            <button
+                              key={s.id}
+                              type="button"
+                              className="workspace-canvas__picker-item"
+                              onClick={() => addTile(s.type as TileKind, s.id)}
+                            >
+                              <span className="workspace-canvas__picker-item-main">
+                                {s.type === "agent" ? (
+                                  <Bot size={13} className="workspace-canvas__picker-icon" />
+                                ) : (
+                                  <SquareTerminal size={13} className="workspace-canvas__picker-icon" />
+                                )}
+                                {sessionLabel(s)}
+                              </span>
+                              <span className="workspace-canvas__picker-kind">{s.type}</span>
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                    ) : null}
                   </div>
                 ))}
                 {/* Unsaved (transient) canvases only ever offer THIS worktree's


### PR DESCRIPTION
## Summary
Direct (worktree-less) agent sessions were invisible outside the sidebar. Investigated both gaps before implementing (see plan for the full architecture writeup) — confirmed both are purely additive, no type/pane-key changes needed.

- **Dashboard**: direct sessions now bucket into the same Working/Waiting for User/PR created/Finished sections as worktrees, one card per session, linking to `/session/:id`.
- **Add-tile picker**: the saved-workspace-only cross-context section now lists each project's direct sessions under a "Direct" subheading, addable as tiles just like other worktrees' sessions.

## Test plan
- [x] `tsc -b --noEmit` clean
- [x] `npm run build` clean
- [x] `npx vitest run` — 406/406 pass (404 baseline + 2 new)
- [x] `npm run lint` — 0 errors
- [x] Live-verified against the dev sandbox: created a real direct session, confirmed it shows on the dashboard and links correctly, saved a workspace and confirmed the session tiles in correctly labeled

🤖 Generated with [Claude Code](https://claude.com/claude-code)