### PR TITLE
fix(daemon,web-ui): PR detection had never worked — two-axis status indicators

### DIFF
--- a/.vibekit/feature-plans/wip/pr-status-axis/.sdlc-state.yaml
+++ b/.vibekit/feature-plans/wip/pr-status-axis/.sdlc-state.yaml
@@ -1,0 +1,19 @@
+feature: pr-status-axis
+worktree: /home/gb/.vibe-station/projects/vibe-station/worktrees/vs-49
+master:
+  prd: skipped        # chain was `plan-implement` — prd not in scope
+  plan: complete
+current_subfeature: root
+subfeatures:
+  - id: root
+    origin: planned
+    mode: implementing
+    phase_chain: [plan, implement, verify, review]   # extended by user at the plan gate
+    last_completed: null
+    awaiting_phase: null
+    awaiting_artifact: null
+    review:
+      iterations: 2          # max_iterations reached — escalated to user
+      round_1: 12 blocking, all fixed
+      round_2: 5 blocking, all fixed, NOT re-reviewed
+      escalation: user chose proceed-to-implement

--- a/.vibekit/feature-plans/wip/pr-status-axis/plan-pr-status-axis.md
+++ b/.vibekit/feature-plans/wip/pr-status-axis/plan-pr-status-axis.md
@@ -256,7 +256,7 @@ export function resolveStatusClass(
 > Supersedes D14 and parts of 3.1/3.4/4.8. Requested after seeing Phase 1–4 in the sandbox.
 
 - [x] **5.1** `tokens.css`: `--status-working` 🟡 `#eab308`/`#a16207` (new); `--pr-open` yellow→🔵 blue `#3b82f6`/`#1d4ed8`; `--pr-merged` 🟢 unchanged; `--status-waiting` 🔴 unchanged. Both theme blocks.
-- [x] **5.2** `statusColor.ts` `resolveStatusClass`: precedence becomes `working|not_started` → `pr=merged` → `pr=open` → `waiting_for_human` → `idle` → `null`. **`done`/`exited` always return `null`** (neutral).
+- [x] **5.2** `statusColor.ts` `resolveStatusClass`: precedence becomes `working|not_started` → `pr=merged` → `pr=open` → `waiting_for_human` → `idle` → `null`. **`done`/`exited` always return `null`** (neutral). _Superseded by D21 (done/exited inherit PR colour) and B2 (spawning/not_started wins over PR, checked ahead of the PR branches, not folded into `working`) — see `docs/STATUS-INDICATORS.md`._
 - [x] **5.3** CSS: add `--working` border rules to `workspace-canvas.css` + `chat.css` (re-broadens what `6f020b6` scoped down — deliberate, user-requested). Recolour `--pr-open` rules to blue.
 - [x] **5.4** **Branch-keyed PR (D20):** add `prBranch` to `PrStatus` + a `prBranch` SQLite column (`dbSchema.ts`, `sqliteRowMappers.ts`, `project-store.ts` INSERT list, `serializeSession`, `protocol.ts`, web-ui `PrStatus`). `prPoller` records the branch it queried.
 - [x] **5.5** `statusColor.ts`: `worktreePrStatus(sessions, currentBranch)` returns `null` when `pr.prBranch !== currentBranch` — stale PR colour never renders. Update both call sites (`WorkspaceCanvas`, `DashboardPanel`, `LeftSidebar`).
@@ -265,7 +265,7 @@ export function resolveStatusClass(
 - [x] **5.8** **One indicator, not two (user request 2026-08-17):** the primary marker is the existing `●` dot from `StatusDot`, recoloured by `resolveStatusClass` — yellow (working), blue (PR open), green (PR merged). `waiting_for_human` keeps its shape-distinct red `!`; `idle` `○`, `done` `✓`, `exited` `×` stay neutral.
 - [x] **5.9** **Retire `PrBadge` from the sidebar, canvas tiles and dashboard cards** — the coloured dot replaces it. Keep `PrBadge.tsx` + its test only if the VCS panel adopts it; otherwise delete both files and their imports. Simpler than maintaining two indicators per row.
   - Trade-off accepted: blue/green/yellow dots differ by colour alone. Mitigation — `aria-label` and `title` already carry the state name, and `waiting_for_human` (the urgent one) stays shape-distinct.
-- [x] **5.T1** Unit — `resolveStatusClass`: `working`+`pr=open` → `"working"`; `waiting_for_human`+`pr=open` → `"pr-open"`; `idle`+`pr=open` → `"pr-open"`; `done`+`pr=merged` → `null`; `waiting_for_human`+no PR → `"waiting_for_human"`.
+- [x] **5.T1** Unit — `resolveStatusClass`: `working`+`pr=open` → `"working"`; `waiting_for_human`+`pr=open` → `"pr-open"`; `idle`+`pr=open` → `"pr-open"`; `done`+`pr=merged` → `null`; `waiting_for_human`+no PR → `"waiting_for_human"`. _`done`+`pr=merged` → `null` superseded by D21 (now `"pr-merged"`) — see `statusColor.test.ts`'s D21 cases._
 - [x] **5.T2** Unit — `worktreePrStatus`: returns `null` when `prBranch` ≠ current branch; returns the status when equal.
 - [x] **5.T3** Unit — `bucketForRollup`: `done`+`pr=merged` → `"finished"` (D19 regression — the previously-wrong case).
 - [x] **5.T4** Integration — `prBranch` round-trips through `project-store` (same INSERT-column trap as 2.T5).
@@ -312,3 +312,23 @@ export function resolveStatusClass(
 | `web-ui/src/lib/statusColor.test.ts` | **New** | 3.T1–3.T2 | Unit — precedence + rollup |
 | `web-ui/src/components/layout/PrBadge.test.tsx` | **New** | 3.T3 | Unit — rendering + a11y labels |
 | `web-ui/src/components/layout/DashboardPanel.test.tsx` | Modified | 4.T1–4.T6 | Two-axis bucketing coverage |
+
+### Phase 6 — Agents as the dashboard unit (amendment, 2026-08-17)
+> User decision: a worktree is normally single-agent; multi-agent is rare (large features /
+> parallel work). That removes the PR-duplication objection to per-agent cards, and deletes the
+> lossy rollup that caused `966b676`'s hidden-working-sibling bug.
+
+- [x] **6.1** `DashboardPanel.tsx`: replace the `DashboardItem` union with **one card per non-archived agent session** — worktree-attached and direct alike. Drops the two card types and the `kind: "worktree" | "direct"` special-casing.
+- [x] **6.2** Bucket per session via `bucketForRollup(sessionStatus(liveState), pr)` — **delete the `hasLiveActivity` short-circuit** and the `worktreeRolledUpStatus` call from this file; both existed only to paper over the rollup.
+- [x] **6.3** PR per session = `session.pr`, branch-guarded against its worktree's `branch` (direct sessions have no worktree → no PR).
+- [x] **6.4** **Dropped by user decision (2026-08-17), not implemented.** No multi-agent PR guard: every non-archived agent session's card shows its own PR colour/bucket independently, with no `isMain` special-casing in `DashboardPanel.tsx`. Same-branch duplication across sibling sessions is expected/intended ("it's fine for 2 agents to transition through states together"). `worktreePrStatus()`'s `isMain` preference is unchanged and still used by the sidebar/canvas rollup — only the dashboard dropped the guard.
+- [x] **6.5** Card content: agent/session name as the title, with worktree + branch as the subtitle so worktree context isn't lost. Link to `/session/:id` for direct sessions, `/worktree/:id` for worktree-attached (preserve existing nav).
+- [x] **6.6** Split the Waiting column: `waiting_for_human` → **"Needs you"** (red), `idle` → **"Idle"**. Fixes the observed "in Waiting with no red exclamation" confusion. Idle is shown by default (not hidden behind "Show finished") — idle is open work, not done.
+- [x] **6.7** Update `docs/STATUS-INDICATORS.md` (bucket table + § Per-session vs per-worktree, which no longer applies to the dashboard) and the AGENTS.md trigger list if bucket names changed.
+- [x] **6.T1** Unit — `bucketForRollup`: unchanged semantics, plus the new `idle` → `"idle"` bucket; `waiting_for_human` → `"needs-you"`.
+- [x] **6.T2** Integration — a worktree with 2 agent sessions renders 2 cards; **both** carry the PR colour/bucket when both match the branch (6.4 dropped — no `isMain` guard).
+- [x] **6.T3** Integration — a direct (worktree-less) agent session renders one card and buckets by its own state.
+- [x] **6.T4** Regression — archived sessions (`archivedAt != null`) still produce no card.
+- [x] **6.T5** Regression — a `working` session and a `waiting_for_human` session in the same worktree now appear as two separate cards in two columns (the `966b676` bug becomes structurally impossible).
+
+**Verify phase 6:** `pnpm typecheck` + `pnpm lint` clean; both suites green; sandbox at :5184 shows one card per agent across five columns.

--- a/.vibekit/feature-plans/wip/pr-status-axis/plan-pr-status-axis.md
+++ b/.vibekit/feature-plans/wip/pr-status-axis/plan-pr-status-axis.md
@@ -1,0 +1,314 @@
+<!--
+RULES — read before writing or implementing:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. REQUIREMENTS: One crisp line each — no verbose descriptions
+3. CHECKLIST: Mark items [x] as you complete them — this is your persistent todo list
+4. READING TIME: Optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+# Plan: PR status axis — fix dead PR detection + two-axis status UI
+
+**Issue:** — · **Branch:** `pr-created-state` · **Status:** wip · **PRD:** none (chain was `plan-implement`)
+**Research:** `.vibekit/reports/2026-08-16-pr-detection-broken-root-cause-and-fix.md` — **authoritative**; D1–D16 are locked, do not re-litigate.
+
+> **Phase-ordering invariant:** `needs_review` stays in every type union until **Phase 4**, which removes it everywhere atomically. Phases 1–3 are additive so `pnpm typecheck` passes at the end of each. Do not delete a union member early.
+
+## Problem
+- PR detection is 100% dead — **0 of 269 sessions have ever reached `needs_review`** since the feature shipped in `4ada68d`.
+- Root cause: `parseGithubRepo` (`daemon/src/services/github.ts:46-56`) requires a literal `github.com` host; 103 of 147 worktrees use SSH host aliases → `prPoller.ts:112` silently returns, no log.
+- Two more silent failures stack behind it: no credentials (private repos → 404) and per-worktree polling (147 req/tick = 8,820/hr, over the 5,000/hr authed cap).
+- Every failure returns the same `null` as "no PR exists" — which is why this hid for weeks.
+- `needs_review` conflates two orthogonal facts (agent activity vs PR existence) into one enum slot with three uncoordinated writers.
+
+## Concept
+- Split status into two axes: **lifecycle** (agent activity) and **PR** (VCS outcome), each with its own indicator.
+- PR open → **yellow**; PR merged → **green**; both derived live from the worktree's *current branch*, so a branch change re-derives naturally and merged-green persists until the worktree is removed.
+
+## Requirements
+| # | Requirement |
+|---|-------------|
+| R1 | PR detection works for SSH host aliases (`git@github-<user>:owner/repo`) |
+| R2 | Both GitHub accounts (`techwithnidhi`, `fastestdevalive`) work simultaneously |
+| R3 | ≤2 GitHub API requests per poll tick regardless of worktree count |
+| R4 | "Couldn't check" is never treated as "no PR" — state holds on transient failure |
+| R5 | `needs_review` removed from `LifecycleState`; PR status on an orthogonal field |
+| R6 | PR open renders yellow, merged green, on border + badge |
+| R7 | `waiting_for_human` (red) is never masked by PR color |
+| R8 | Status colors are per-theme CSS tokens, defined once |
+| R9 | Docker dev sandbox makes zero network calls and zero log lines |
+| R10 | Records persisted with `needs_review` still load |
+
+## Research
+- **State model:** `LifecycleState` `daemon/src/types.ts:8-15`; UI mirror `SessionState` `web-ui/src/api/types.ts:74-81`; rollup + rank `web-ui/src/lib/worktreeStatus.ts:3-11,17-26,34-53,62-92`.
+- **Poller:** `daemon/src/services/prPoller.ts` — `pollWorktree:98-140`, `pollAllPrs:143-175`, interval `:38`, `setWorktreePrMergedAt:72-96`.
+- **Transport:** `github.ts` — header `:1-11`, `getRemoteUrl:28-37`, `parseGithubRepo:46-56`, cache `:58-68` (TTL `:67`), `fetchPrForBranch:77-89`, `fetchPrForBranchUncached:98-140`. Error paths all `return null` (`:116,127,137-139`).
+- **Route consumer:** `daemon/src/routes/worktrees.ts:20` (import), `:1168-1172` (`GET /worktrees/:id/pr`); test `daemon/src/__tests__/worktrees.test.ts:872-889`.
+- **Session persistence:** `serializeSession` `daemon/src/routes/sessions.ts:374`; `INSERT INTO sessions` explicit column list `daemon/src/state/project-store.ts:257-258`; `rowToSession` `sqliteRowMappers.ts:45`. Existing session columns are **camelCase** (`spawnedFrom`, `lastTransitionAt`).
+- **`needs_review` — all 14 code sites:** `daemon/src/ws/protocol.ts:209-217,218-226,253-261` (3 zod enums); `daemon/src/__tests__/protocol.test.ts:21-29`; `daemon/src/__tests__/prPoller.test.ts:165,179,182,199-213,234-235,282,286-287`; `web-ui/src/components/dev/DevStatePanel.tsx:17-25`; `web-ui/src/lib/worktreeStatus.test.ts:54,61-67`; `worktreeStatus.ts:3-11,17-26,34-53`; `StatusDot.tsx:5`; `DashboardPanel.tsx:38`. **`lifecycle.ts` has ZERO occurrences** — do not touch it.
+- **Comment-only mentions to scrub:** `daemon/src/main.ts:174`; `prPoller.ts:9-18,52`; `dbSchema.ts:114`; `web-ui/src/api/types.ts:41-43,68-72`; `useStore.ts:172`; `LeftSidebar.tsx:143`; `workspace.css:2121-2123`; `workspace-canvas.css:399-408,417-421`; `chat.css:14-24`.
+- **`prMergedAt` inventory:** `types.ts:302`; `dbSchema.ts:116`; `sqliteRowMappers.ts:133,150,168`; `project-store.ts:253-254`; `prPoller.ts:66,72-96,104,123-125,132-137,168`; `routes/worktrees.ts:142`; `web-ui/src/api/types.ts:47`; `DashboardPanel.tsx:161-164`; tests `prPoller.test.ts:98-101,103-108,126,217,251,268`.
+- **Colors:** only 2 of 8 states have a dot color — `waiting_for_human` `#ef4444` (`workspace.css:2125`), `needs_review` `#b98cff` (`:2129`). Only 2 have a border — `#ef4444` + `var(--success)` (`workspace-canvas.css:410,414`; `chat.css:26,30`). **`needs_review` is split-brain: violet dot, green border.** Unrelated `#ef4444` at `workspace.css:4525` (diff stats) — leave it.
+- **Non-color cues retained:** `tile--exited{opacity:.9}` (`workspace-canvas.css:422-424`), `tile--spawning{border-style:dashed}` (`:426-428`).
+- **Canvas status sites (NOT the drag-drop lines):** `WorkspaceCanvas.tsx:161` (`showAgentStatusBorders`), `:419` (`worktreeRolledUpStatus`), `:813-815` (`sessionStatus`), `:846-848` (tile class), `:867` (`<StatusDot>`).
+- **VCS panel PR colors:** `workspace.css:3857,3897` (open `#4ade80`), `:3861` (merged `#a78bfa`), `:3865` (closed `#f87171`).
+- **Tokens:** `tokens.css` dark `:73-106`, light `:108-140`. `--success` `#16a34a` (`:100,133`), `--accent` `#6e78c7`/`#5c64b5` (`:74,109`). No `--status-*` family exists.
+- **Env:** `gh` **not** in `dev.Dockerfile:21-24`; `ssh` not either. Sandbox repos are `git init` with no remotes (`scripts/demo-seed.sh:44,765`). `~/.config/gh/hosts.yml` holds plaintext `oauth_token` per user.
+- **Tests:** vitest. Daemon compiles under `cli` via symlink `cli/src/daemon -> ../../daemon/src` (`preserveSymlinks: true`) — so `daemon/src/__tests__/x.ts` **is** `cli/src/daemon/__tests__/x.ts`, one file, two paths. `prPoller.test.ts:33-37` factory-mocks the whole `github.js` module. **`daemon/src/__tests__/github.test.ts` already exists** (200+ lines, `describe("parseGithubRepo") :16-41`, `toBeNull()` assertions `:105,110,115,177-200`).
+
+## Architecture
+
+```mermaid
+flowchart TB
+  subgraph daemon
+    RU["getRemoteUrl<br/>git remote get-url"] --> RGR["resolveGithubRemote<br/>relaxed regex + ~/.ssh/config"]
+    RGR -->|"host, owner, repo"| AUTH["githubAuth<br/>env → hosts.yml → gh (opportunistic)"]
+    AUTH -->|"token per account"| GQL["fetchPrsForBranches<br/>1 aliased GraphQL query per ACCOUNT"]
+    GQL -->|PrLookupResult| PP["prPoller 10s"]
+    PP -->|"session.pr ONLY"| STORE[(SQLite sessions)]
+    LC["lifecycle poller 1s"] -->|"session.lifecycle ONLY"| STORE
+    STORE --> SER["serializeSession"]
+  end
+  SER -->|"WS session:updated"| UI
+  subgraph UI["web-ui"]
+    WPS["worktreePrStatus(sessions)"] --> RSC["resolveStatusClass(lifecycle, pr)"]
+    RSC --> TILE["tile / pane border"]
+    WPS --> PB["PrBadge (lucide)"]
+    PB --> SIDE["sidebar rows"]
+    PB --> DASH["dashboard cards"]
+  end
+```
+
+- **Key invariant:** `prPoller` writes **only** `session.pr`; `lifecycle.ts` writes **only** `session.lifecycle`. This is what removes the clobber race (D5/D6).
+
+## Design Details
+
+### CUJs
+| # | Flow | Expected |
+|---|------|----------|
+| C1 | Agent opens a PR on its branch → next 10s tick | Tile border turns yellow; `PrBadge` shows `GitPullRequestArrow`; dashboard card moves to PR column |
+| C2 | PR merges | Border turns green, badge → `GitMerge`; card stays in PR column until the worktree is removed |
+| C3 | Agent needs input while its PR is open | Border is **red** (`waiting_for_human` wins, R7); yellow PR badge still visible |
+| C4 | *(error)* GitHub returns 403 rate-limited | `session.pr` keeps its previous `state`; `error` set; border unchanged; one throttled warn |
+| C5 | *(error)* Worktree has no git remote (Docker sandbox) | `not_github` cached; zero network calls; zero log lines (R9) |
+| C6 | Branch is re-pointed to a new branch with no PR | `pr.state` → `none`; border reverts to lifecycle color |
+
+### Data model
+| Field | Type | Constraint | Where |
+|---|---|---|---|
+| `LifecycleState` | `not_started\|working\|idle\|waiting_for_human\|done\|exited` | `needs_review` removed **in Phase 4** | `daemon/src/types.ts:8-15` |
+| `SessionRecord.pr` | `PrStatus \| undefined` | optional; absent ≡ never checked | `daemon/src/types.ts` |
+| `PrStatus.state` | `none\|draft\|open\|merged\|closed` | required | — |
+| `PrStatus.number` | `number \| undefined` | present iff a PR exists | — |
+| `PrStatus.url` | `string \| undefined` | present iff a PR exists | — |
+| `PrStatus.checkedAt` | ISO8601 string | required | — |
+| `PrStatus.error` | `string \| undefined` | set on `error`/`no_credentials` | — |
+| `sessions.prState/prNumber/prUrl/prCheckedAt` | TEXT/INTEGER/TEXT/TEXT | nullable; **camelCase** to match `spawnedFrom` | `dbSchema.ts` |
+| `WorktreeRecord.prMergedAt` | — | **deleted** | superseded by D5 |
+
+- **Migration:** additive columns via `addColumnIfMissing`. Removing `prMergedAt` drops only the `addColumnIfMissing` call — the column stays orphaned on existing DBs (SQLite has no cheap `DROP COLUMN`); that is the accepted rollback posture.
+- **Back-compat (R10):** a row/manifest with `lifecycle.state === "needs_review"` maps to `idle` + `pr:{state:"open"}` in `rowToSession` (`sqliteRowMappers.ts:45`). The three zod enums in `protocol.ts` **keep** `"needs_review"` as an accepted input value (never emitted) so legacy clients/records don't fail validation.
+
+### System boundaries — daemon ↔ web-ui
+| Boundary | Contract |
+|---|---|
+| REST | `GET /sessions/:id` and every session-bearing route return `serializeSession` output, now including `pr?: {state, number?, url?, checkedAt, error?}` — `daemon/src/routes/sessions.ts:374` |
+| WS | Existing `session:updated` carries the whole serialized session; add `pr` to its zod schema in `daemon/src/ws/protocol.ts`. **No new event type.** |
+| REST | `GET /worktrees/:id/pr` → `200 {kind:"pr",pr:PrInfo}` · `200 {kind:"no_pr"}` · `200 {kind:"not_github"}` · `503 {kind:"error",reason,message}` · `503 {kind:"no_credentials"}` |
+| Source of truth | daemon; client never derives `pr`, only renders it |
+
+```ts
+// daemon/src/services/github.ts — exported surface (mockable exactly like today)
+export async function getRemoteUrl(repoPath: string): Promise<string | null>;
+export async function resolveGithubRemote(remoteUrl: string):
+  Promise<{ host: string; owner: string; repo: string } | null>;   // replaces parseGithubRepo, now async
+export async function fetchPrForBranch(owner: string, repo: string, branch: string):
+  Promise<PrLookupResult>;
+export async function fetchPrsForBranches(
+  entries: Array<{ owner: string; repo: string; branch: string }>,
+): Promise<Map<string, PrLookupResult>>;                            // key `${owner}/${repo}#${branch}`
+export function _clearPrCacheForTest(): void;
+
+export type PrLookupResult =
+  | { kind: "pr"; pr: PrInfo }
+  | { kind: "no_pr" }
+  | { kind: "not_github" }
+  | { kind: "no_credentials" }
+  | { kind: "error"; reason: "network"|"rate_limited"|"auth"|"api"; message: string; retryAfterMs?: number };
+```
+
+| `PrLookupResult` | `session.pr` write | Lifecycle | Log |
+|---|---|---|---|
+| `pr` open non-draft | `{state:"open"}` | untouched | none |
+| `pr` draft/merged/closed | matching `state` | untouched | none |
+| `no_pr` | `{state:"none"}` | untouched | none |
+| `not_github` | untouched | untouched | none, ever (cached per worktree) |
+| `no_credentials` | `error` set, `state` **held** | untouched | `warn` once per daemon lifetime |
+| `error` | `error` set, `state` **held** | untouched | `warn` throttled 10min per reason |
+
+```ts
+// web-ui/src/lib/statusColor.ts — returns a CSS CLASS SUFFIX (matches existing
+// `workspace-canvas__tile--${x}` / `agent-pane-slot--${x}` convention), never a hex or var().
+export function worktreePrStatus(sessions: Session[]): PrStatus | null;   // isMain session's pr, else null
+export function resolveStatusClass(
+  lifecycle: WorktreeRolledUpStatus,   // rolled-up, NOT raw SessionState
+  pr: PrStatus | null,
+): string | null;                      // "waiting_for_human" | "pr-merged" | "pr-open" | lifecycle | null
+```
+- Precedence (K6/D12): `waiting_for_human` → `pr=merged` → `pr=open` → lifecycle → `null`.
+
+### Key decisions
+| # | Decision | Where |
+|---|---|---|
+| K1 | No `gh` binary — GraphQL over `fetch`, creds from `hosts.yml` (D2/D3) | `daemon/src/services/githubAuth.ts` (new) |
+| K2 | SSH alias resolved by parsing `~/.ssh/config` in TS, never `ssh -G` (D4) | `github.ts` |
+| K3 | Account→repo by probe, cached in-memory (D4b) | `github.ts` |
+| K4 | One aliased GraphQL query per account per tick (D1) | `github.ts` |
+| K5 | Poller holds state on non-definitive results (D8) | `prPoller.ts` |
+| K6 | Border precedence via `resolveStatusClass` (D12) | `web-ui/src/lib/statusColor.ts` |
+| K7 | Lifecycle keeps text glyphs; PR axis uses lucide (D16) | `PrBadge.tsx` |
+| K8 | Poll 60s→10s **and** cache TTL 30s→5s, else the cache defeats the interval | `prPoller.ts:38`, `github.ts:67` |
+| K9 | PR is per-session but rendered per-worktree → `worktreePrStatus` reads the **`isMain`** session (matches `prPoller.ts:161`) | `statusColor.ts` |
+
+## Risks / Open Questions
+| # | Question | Notes |
+|---|----------|-------|
+| 1 | `hosts.yml` keyring storage (no plaintext token) | Fallback chain step 4 covers it; only this host inspected |
+| 2 | `~/.ssh/config` `Include` / `Match` blocks | Parser handles one `Include` level, no `Match`; falls back to `/^github[-.]/i` |
+| 3 | Daemon restart required to see any of this | Running binary predates even `966b676` |
+
+---
+
+## Implementation Phases
+
+### Phase 1 — GitHub transport (daemon, additive)
+- [x] **1.1** New `daemon/src/services/githubAuth.ts`: `listAccounts(): Promise<Array<{login,token}>>` — env `GH_TOKEN_<LOGIN>` → `GITHUB_TOKEN`/`GH_TOKEN` → `~/.config/gh/hosts.yml` `users.<login>.oauth_token` → `gh auth token --user X` only if `gh` on PATH. Never throws; `[]` when nothing found.
+- [x] **1.2** `github.ts`: add `PrInfo` + `PrLookupResult`; add async `resolveGithubRemote` (relaxed regex capturing any host → `~/.ssh/config` `HostName` → `/^github[-.]/i` heuristic → `null`). Cache parsed ssh-config by mtime. **Keep `parseGithubRepo` exported** until Phase 4.
+- [x] **1.3** `github.ts`: implement `fetchPrsForBranches` — group by resolved account, one aliased GraphQL query per account (`repoN: repository(owner:,name:){ pullRequests(headRefName:, last:1, orderBy:{field:CREATED_AT,direction:DESC}){ nodes{ number url title state isDraft merged author{login} } } }`). Read GraphQL `errors[]` per alias; `NOT_FOUND` → probe other accounts, cache `owner→account`.
+- [x] **1.4** `github.ts`: rewrite `fetchPrForBranch` as a single-entry wrapper over `fetchPrsForBranches`; return type becomes `PrLookupResult`; cache TTL `:67` 30s→5s (K8); never cache `error`.
+- [x] **1.5** `daemon/src/routes/worktrees.ts:20,1168-1172`: migrate `GET /worktrees/:id/pr` to `resolveGithubRemote` + `PrLookupResult`, mapping each `kind` to the HTTP shapes in § System boundaries.
+- [x] **1.6** Replace the `github.ts:1-11` header comment per D2 (config-file dependency, not binary; ssh-config parsed not invoked).
+- [x] **1.7** **Required for Phase 1 to typecheck** — `prPoller.ts:114-137` still consumes the old `PrInfo | null` shape (`.state`/`.draft`/`.merged`). Adapt it minimally: `kind:"pr"` → existing behaviour, every other `kind` → early return. Full rewrite lands in 2.6.
+- [x] **1.8** Web-ui consumer of the changed route — `web-ui/src/api/client.ts:606-613` casts `{pr: PrInfo|null}` via unchecked `parseJson`, so a stale shape **typechecks green and silently blanks the PR banner**. Switch on `kind`; mirror `PrLookupResult` into `web-ui/src/api/types.ts`. Check `VcsPanel.tsx:36,49,173,276-281` still renders.
+- [x] **1.T1** Unit — `resolveGithubRemote`: `git@github-x:o/r.git` → `{host:"github-x",owner:"o",repo:"r"}`; `git@gitlab.com:o/r.git` → `null`; strips `.git`; handles `https://` and `ssh://`.
+- [x] **1.T2** Unit — `listAccounts`: env wins over `hosts.yml`; `[]` when neither exists (no throw).
+- [x] **1.T3** Unit — `fetchPrsForBranches`: a response with one `NOT_FOUND` alias still returns sibling results.
+- [x] **1.T4** Unit — error mapping: non-2xx → `{kind:"error",reason:"api"}`; 403 + rate-limit headers → `reason:"rate_limited"` + `retryAfterMs`; no accounts → `{kind:"no_credentials"}`.
+- [x] **1.T5** Regression — rewrite existing `daemon/src/__tests__/github.test.ts`: `describe("parseGithubRepo") :16-41` → `resolveGithubRemote`; convert the **5** `toBeNull()` assertions (`:39,55,105,110,115`) to `{kind:"no_pr"}`/`{kind:"error"}`; update the 3 cache tests at `:173-204` (`toHaveBeenCalledTimes`) for the 30s→5s TTL.
+- [x] **1.T6** Regression — `daemon/src/__tests__/worktrees.test.ts`: `:865-870` asserts `{pr: null}` → `{kind:"not_github"}`; `:872-889` spy returns `PrLookupResult`.
+
+**Verify phase 1:** `pnpm --filter @vibestation/cli test` green; `pnpm typecheck` clean (both packages).
+
+### Phase 2 — `session.pr` + poller (daemon, additive)
+- [x] **2.1** `types.ts`: add `PrStatus` interface + `SessionRecord.pr?: PrStatus`. **Do not touch `LifecycleState` yet.**
+- [x] **2.2** `dbSchema.ts`: `addColumnIfMissing(db,"sessions","prState"|"prNumber"|"prUrl"|"prCheckedAt", …)` (camelCase, matching `spawnedFrom`).
+- [x] **2.3** `sqliteRowMappers.ts`: add the 4 keys to `SessionRow`, `rowToSession` (`:45`), `sessionToRow`. **And** extend the explicit `INSERT INTO sessions` column list + `VALUES` at `project-store.ts:257-258` — omitting this silently drops every write.
+- [x] **2.4** `routes/sessions.ts:374` `serializeSession`: emit `pr`. Add `pr` to the session shape in `daemon/src/ws/protocol.ts`.
+- [x] **2.5** Delete `prMergedAt`: `types.ts:295,302` (doc comment + field), `dbSchema.ts:111-116` (comment block **and** the `addColumnIfMissing` call), `sqliteRowMappers.ts:133,150,168`, `project-store.ts:253-254`, `routes/worktrees.ts:142`, `prPoller.ts:66,72-96,104,123-125,132-137,168`.
+- [x] **2.6** `prPoller.ts`: rewrite `pollAllPrs` to collect all worktrees → one `fetchPrsForBranches` call → apply the per-variant table. `pollWorktree` writes **only** `session.pr`; remove every `persistLifecycleState` call. Interval `:38` → `10_000`.
+- [x] **2.7** `prPoller.ts`: add the D10 startup self-check log — per project, resolvable? credentialed? Replace `warnedNoToken` with the `no_credentials` once-per-lifetime warn.
+- [x] **2.T1** Unit — `{kind:"error"}` leaves `session.pr.state` **and** lifecycle unchanged (R4 — the latent bug being fixed).
+- [x] **2.T2** Unit — open non-draft → `pr.state==="open"`; merged → `"merged"`; `not_github` → no write, no log.
+- [x] **2.T3** Unit — one tick, 3 worktrees, 2 accounts → exactly 2 batch queries (R3).
+- [x] **2.T4** Unit — `getRemoteUrl` returns `null` → zero `fetch` calls, zero log lines (R9/C5).
+- [x] **2.T5** Integration — `prState` survives a write→read round-trip through `project-store` (guards the 2.3 INSERT trap).
+- [x] **2.T6** Regression — rewrite **all 11** `prPoller.test.ts` cases (`:165,179,182,199-213,217,234-235,251,268,282,286-287`) as `pr.state` assertions; drop `getCurrentPrMergedAt`/`seedProjectWithMergedAt` helpers (`:98-108,126`); update the mock factory (`:33-37`) to `{getRemoteUrl, resolveGithubRemote, fetchPrsForBranches, fetchPrForBranch, _clearPrCacheForTest}`.
+
+**Verify phase 2:** `pnpm --filter @vibestation/cli test` green; `pnpm typecheck` clean; `grep -rn "prMergedAt" daemon/ web-ui/src` → **only** `web-ui/src/api/types.ts:47` and `DashboardPanel.tsx:161` (both removed in Phase 4).
+
+### Phase 3 — Tokens, badge, borders (web-ui, additive)
+- [x] **3.1** `tokens.css`: add `--status-waiting`, `--pr-open`, `--pr-merged`, `--pr-draft`, `--pr-closed` to **both** blocks (dark `:73-106`, light `:108-140`). D14 values: open `#eab308`/`#a16207`, merged `#22c55e`/`#15803d`, draft `#8a8a8a`/`#737373`, closed `#6b6b6b`/`#737373`, waiting `#ef4444`/`#dc2626`.
+- [x] **3.2** Replace `#ef4444` with `var(--status-waiting)` at `workspace.css:2125`, `workspace-canvas.css:410`, `chat.css:26`. **Leave `workspace.css:4525`** (diff stats, unrelated). Add `.workspace-canvas__tile--pr-open`/`--pr-merged` and `.agent-pane-slot--pr-open`/`--pr-merged` rules.
+- [x] **3.3** `web-ui/src/api/types.ts`: add `PrStatus` + `Session.pr?: PrStatus`. **Do not remove `needs_review` yet.**
+- [x] **3.4** New `web-ui/src/lib/statusColor.ts`: `worktreePrStatus` + `resolveStatusClass` per the § System boundaries signatures. Pure, no React.
+- [x] **3.5** New `web-ui/src/components/layout/PrBadge.tsx`: lucide `GitPullRequestArrow`/`GitMerge`/`GitPullRequestDraft`/`GitPullRequestClosed`, 14px `strokeWidth={2.5}`, colored by the matching token, `aria-label` per state, `null` when `state==="none"`.
+- [x] **3.6** `WorkspaceCanvas.tsx:846-848` (tile class) + `:867` (`<StatusDot>`): derive the class via `resolveStatusClass`; render `PrBadge` beside `StatusDot`. `AgentPaneSlot.tsx:57-60` receives a **single** `session?: Session` (`AgentPaneSlotProps:10-14`), not a list — so call `resolveStatusClass(sessionStatus(session.state), session.pr ?? null)` there, **not** `worktreePrStatus`.
+- [x] **3.T1** Unit — `resolveStatusClass`: `waiting_for_human` + `pr=open` → `"waiting_for_human"` (R7); `done` + `pr=merged` → `"pr-merged"`; `working` + `pr=none` → `"working"`; `pr=draft`/`closed` never win.
+- [x] **3.T2** Unit — `worktreePrStatus`: returns the `isMain` session's `pr`; `null` when no main session.
+- [x] **3.T3** Unit — `PrBadge`: `null` for `none`; correct `aria-label` for the other 4.
+- [x] **3.T4** Regression — `exited` opacity + `spawning` dashed cues still apply (`workspace-canvas.css:422-428`).
+
+**Verify phase 3:** `pnpm --filter @vibestation/web test` green; `pnpm typecheck` clean.
+
+### Phase 4 — Remove `needs_review` atomically + dashboard/sidebar
+> Every edit below lands in one phase because the union member cannot be removed piecemeal without breaking `typecheck`.
+- [x] **4.1** `daemon/src/types.ts:8-15`: remove `needs_review` from `LifecycleState`.
+- [x] **4.2** `daemon/src/ws/protocol.ts:209-217,218-226,253-261`: keep `"needs_review"` as an **accepted input** in all three zod enums (never emitted) per the back-compat rule; add a comment saying so.
+- [x] **4.3** `sqliteRowMappers.ts:45` `rowToSession`: map a persisted `needs_review` → `idle` + `pr:{state:"open"}` (R10).
+- [x] **4.4** `web-ui/src/api/types.ts`: remove `needs_review` from `SessionState:74-81`; delete `prMergedAt:47`; scrub comments `:41-43,68-72`.
+- [x] **4.5** `worktreeStatus.ts:3-11,17-26,34-53,79`: remove from union, `rank`, `sessionStatus`, and the `else if (st === "needs_review")` branch inside `worktreeRolledUpStatus:62-92`.
+- [x] **4.5b** `github.ts`: delete the now-unused `parseGithubRepo` export (kept through Phases 1–3 for compatibility).
+- [x] **4.6** `StatusDot.tsx:5`: remove the `◆` entry. `workspace.css:2128-2130`: delete `.status-dot--needs_review`. `workspace-canvas.css:413-415` + `chat.css:29-31`: delete `--needs_review` border rules.
+- [x] **4.7** `web-ui/src/components/dev/DevStatePanel.tsx:17-25`: remove `"needs_review"` from `STATES`.
+- [x] **4.8** `DashboardPanel.tsx:24-40`: `bucketForRollup(rollup, pr)` — `pr.state==="open"||"merged"` → `"pr"`, checked **after** the `hasLiveActivity` short-circuit (`:144-157`), **before** the rollup. Delete the `prMergedAt` short-circuit (`:161-164`). Render `PrBadge` on worktree cards (`:216+`) and direct-session cards (`:194-215`).
+- [x] **4.9** `LeftSidebar.tsx:938-940,1064-1068,1467-1469,1616-1620`: render `PrBadge` beside `StatusDot` at all four sites.
+- [x] **4.10** Recolor **all six** VCS PR color sites in `workspace.css` — icons `:3857` `#4ade80`→`var(--pr-open)`, `:3861` `#a78bfa`→`var(--pr-merged)`, `:3865` `#f87171`→`var(--pr-closed)`; badges `:3897`→`var(--pr-open)`, `:3902`→`var(--pr-merged)`, `:3907`→`var(--pr-closed)`. Missing the badge trio leaves icon and badge different colors. `.vcs-pr--draft` already uses `var(--fg-muted)` — leave it.
+- [x] **4.11** Scrub remaining `needs_review` comments: `daemon/src/main.ts:174`, `prPoller.ts:9-18,52`, `dbSchema.ts:114`, `useStore.ts:172`, `LeftSidebar.tsx:143`, `workspace.css:2121-2123`, `workspace-canvas.css:399-408,417-421`, `chat.css:14-24`. **`prPoller.ts:13-18`'s claim that "nothing else ever touches a `needs_review` session" is factually wrong** — `lifecycle.ts:205-222,295-303` moves it out within ~1s; correct the text, don't just delete it.
+- [x] **4.T1** Unit — `bucketForRollup`: `done` + `pr=merged` → `"pr"` not `"finished"`; `working` + `pr=open` → `"working"` (live activity wins).
+- [x] **4.T2** Integration — `DashboardPanel`: a worktree whose PR merges stays in the PR column across a `session:updated` event (replaces deleted `prMergedAt` coverage).
+- [x] **4.T3** Integration — `daemon/src/__tests__/protocol.test.ts:21-29`: a legacy `session:state` carrying `"needs_review"` still parses (R10).
+- [x] **4.T4** Integration — a session row persisted with `needs_review` loads as `idle` + `pr.state==="open"` (R10).
+- [x] **4.T5** Regression — `web-ui/src/lib/worktreeStatus.test.ts:54,61-67`: rewrite the two `needs_review` cases against the new union.
+- [x] **4.T6** Regression — `DashboardPanel`: an `archivedAt`-set session in `waiting_for_human` does **not** place its worktree in the Waiting bucket (`:137-142`); a direct session (`worktreeId == null`) with `pr.state==="open"` lands in the PR bucket (`:172-186`).
+
+**Verify phase 4:** `pnpm ci` green (typecheck + lint + all tests); `grep -rn "needs_review" daemon/src web-ui/src` returns **only** `protocol.ts` (accepted-input enums + comment) and `sqliteRowMappers.ts` (back-compat map).
+
+### Phase 5 — Recolour + rebucket per D17–D20 (amendment, 2026-08-17)
+> Supersedes D14 and parts of 3.1/3.4/4.8. Requested after seeing Phase 1–4 in the sandbox.
+
+- [x] **5.1** `tokens.css`: `--status-working` 🟡 `#eab308`/`#a16207` (new); `--pr-open` yellow→🔵 blue `#3b82f6`/`#1d4ed8`; `--pr-merged` 🟢 unchanged; `--status-waiting` 🔴 unchanged. Both theme blocks.
+- [x] **5.2** `statusColor.ts` `resolveStatusClass`: precedence becomes `working|not_started` → `pr=merged` → `pr=open` → `waiting_for_human` → `idle` → `null`. **`done`/`exited` always return `null`** (neutral).
+- [x] **5.3** CSS: add `--working` border rules to `workspace-canvas.css` + `chat.css` (re-broadens what `6f020b6` scoped down — deliberate, user-requested). Recolour `--pr-open` rules to blue.
+- [x] **5.4** **Branch-keyed PR (D20):** add `prBranch` to `PrStatus` + a `prBranch` SQLite column (`dbSchema.ts`, `sqliteRowMappers.ts`, `project-store.ts` INSERT list, `serializeSession`, `protocol.ts`, web-ui `PrStatus`). `prPoller` records the branch it queried.
+- [x] **5.5** `statusColor.ts`: `worktreePrStatus(sessions, currentBranch)` returns `null` when `pr.prBranch !== currentBranch` — stale PR colour never renders. Update both call sites (`WorkspaceCanvas`, `DashboardPanel`, `LeftSidebar`).
+- [x] **5.6** `DashboardPanel.tsx` `bucketForRollup`: `done`/`exited` → **Finished always**, checked FIRST, before live-activity and before PR (D19). Then live activity → Working; then branch-matched `pr=open|merged` → PR; then `waiting_for_human`/`idle` → Waiting.
+- [x] **5.7** VCS panel: recolour `.vcs-pr--open` foreground **and** background to blue (`workspace.css:3857,3897,3892-3904`).
+- [x] **5.8** **One indicator, not two (user request 2026-08-17):** the primary marker is the existing `●` dot from `StatusDot`, recoloured by `resolveStatusClass` — yellow (working), blue (PR open), green (PR merged). `waiting_for_human` keeps its shape-distinct red `!`; `idle` `○`, `done` `✓`, `exited` `×` stay neutral.
+- [x] **5.9** **Retire `PrBadge` from the sidebar, canvas tiles and dashboard cards** — the coloured dot replaces it. Keep `PrBadge.tsx` + its test only if the VCS panel adopts it; otherwise delete both files and their imports. Simpler than maintaining two indicators per row.
+  - Trade-off accepted: blue/green/yellow dots differ by colour alone. Mitigation — `aria-label` and `title` already carry the state name, and `waiting_for_human` (the urgent one) stays shape-distinct.
+- [x] **5.T1** Unit — `resolveStatusClass`: `working`+`pr=open` → `"working"`; `waiting_for_human`+`pr=open` → `"pr-open"`; `idle`+`pr=open` → `"pr-open"`; `done`+`pr=merged` → `null`; `waiting_for_human`+no PR → `"waiting_for_human"`.
+- [x] **5.T2** Unit — `worktreePrStatus`: returns `null` when `prBranch` ≠ current branch; returns the status when equal.
+- [x] **5.T3** Unit — `bucketForRollup`: `done`+`pr=merged` → `"finished"` (D19 regression — the previously-wrong case).
+- [x] **5.T4** Integration — `prBranch` round-trips through `project-store` (same INSERT-column trap as 2.T5).
+- [x] **5.T5** Unit — `StatusDot`: renders `●` with the `pr-open` class for `waiting_for_human`+`pr=open`; `title`/`aria-label` names the state so it isn't colour-only.
+
+**Verify phase 5:** `pnpm typecheck` + `pnpm lint` clean; both suites green; sandbox at `localhost:5184` shows yellow/red/blue/green per the D18 table.
+
+## Files & Phase Impact
+| File | Status | Phase | Description / Contract Change |
+|------|--------|-------|-------------------------------|
+| `daemon/src/services/githubAuth.ts` | **New** | 1.1 | Contract: `listAccounts(): Promise<Array<{login,token}>>` · Owns: token cache |
+| `daemon/src/services/github.ts` | Modified | 1.2–1.4, 1.6 | Contract: `resolveGithubRemote`, `fetchPrsForBranches`, `PrLookupResult` · Owns: PR + ssh-config + owner→account caches |
+| `daemon/src/routes/worktrees.ts` | Modified | 1.5, 2.5 | `GET /:id/pr` → `PrLookupResult` HTTP mapping; `prMergedAt` removed |
+| `web-ui/src/api/client.ts` | Modified | 1.8 | `getPr` switches on `kind` — unchecked `parseJson` cast means a stale shape typechecks green (`:606-613`) |
+| `web-ui/src/components/tools/VcsPanel.tsx` | Modified | 1.8 | Consume the `kind`-tagged result (`:36,49,173,276-281`) |
+| `daemon/src/__tests__/github.test.ts` | **Modified** | 1.T1–1.T5 | Existing file — rewrite `parseGithubRepo` block, convert `toBeNull()` assertions |
+| `daemon/src/__tests__/worktrees.test.ts` | Modified | 1.T6 | `fetchPrForBranch` spy returns `PrLookupResult` |
+| `daemon/src/types.ts` | Modified | 2.1, 2.5, 4.1 | `PrStatus` + `SessionRecord.pr`; `prMergedAt` deleted; `LifecycleState` loses `needs_review` (Phase 4) |
+| `daemon/src/services/dbSchema.ts` | Modified | 2.2, 2.5, 4.11 | 4 `pr*` session columns; drop `prMergedAt` add |
+| `daemon/src/state/sqliteRowMappers.ts` | Modified | 2.3, 2.5, 4.3 | Map `pr*`; remove `prMergedAt`; back-compat `needs_review` → `idle`+`pr.open` |
+| `daemon/src/state/project-store.ts` | Modified | 2.3, 2.5 | Extend `INSERT INTO sessions` column list `:257-258`; drop `prMergedAt` `:253-254` |
+| `daemon/src/routes/sessions.ts` | Modified | 2.4 | `serializeSession` emits `pr` |
+| `daemon/src/ws/protocol.ts` | Modified | 2.4, 4.2 | Session shape gains `pr`; 3 zod enums keep `needs_review` as accepted input |
+| `daemon/src/services/prPoller.ts` | Modified | 2.5–2.7, 4.11 | Contract: writes only `session.pr`; batch lookup; 10s interval; self-check log |
+| `daemon/src/__tests__/prPoller.test.ts` | Modified | 2.T1–2.T6 | Mock surface updated; all 11 cases → `pr.state` |
+| `daemon/src/__tests__/protocol.test.ts` | Modified | 4.T3 | Legacy `needs_review` still parses |
+| `daemon/src/main.ts` | Modified | 4.11 | Comment scrub |
+| `web-ui/src/api/types.ts` | Modified | 3.3, 4.4 | `PrStatus` + `Session.pr`; `SessionState` loses `needs_review`; `prMergedAt` deleted |
+| `web-ui/src/styles/tokens.css` | Modified | 3.1 | 5 new tokens in both theme blocks |
+| `web-ui/src/styles/workspace.css` | Modified | 3.2, 4.6, 4.10, 4.11 | Tokenize `#ef4444`; delete `needs_review` dot; recolor 4 `.vcs-pr--*` |
+| `web-ui/src/styles/workspace-canvas.css` | Modified | 3.2, 4.6, 4.11 | Tokenize; add `--pr-open`/`--pr-merged`; delete `--needs_review` |
+| `web-ui/src/styles/chat.css` | Modified | 3.2, 4.6, 4.11 | Same |
+| `web-ui/src/lib/statusColor.ts` | **New** | 3.4 | Contract: `worktreePrStatus(sessions)`, `resolveStatusClass(lifecycle, pr)` → class suffix · Owns: nothing (pure) |
+| `web-ui/src/components/layout/PrBadge.tsx` | **New** | 3.5 | Contract: `<PrBadge pr={PrStatus|null} />`, `null` when `none` |
+| `web-ui/src/components/layout/WorkspaceCanvas.tsx` | Modified | 3.6 | Tile class via `resolveStatusClass` (`:846-848`); `PrBadge` at `:867` |
+| `web-ui/src/components/layout/AgentPaneSlot.tsx` | Modified | 3.6 | Border via `resolveStatusClass` |
+| `web-ui/src/components/layout/StatusDot.tsx` | Modified | 4.6 | Drop `needs_review` glyph |
+| `web-ui/src/lib/worktreeStatus.ts` | Modified | 4.5 | Union + rank + `sessionStatus` lose `needs_review` |
+| `web-ui/src/lib/worktreeStatus.test.ts` | Modified | 4.T5 | Rewrite 2 `needs_review` cases |
+| `web-ui/src/components/dev/DevStatePanel.tsx` | Modified | 4.7 | Remove from `STATES` |
+| `web-ui/src/components/layout/DashboardPanel.tsx` | Modified | 4.8 | `bucketForRollup(rollup, pr)`; `prMergedAt` short-circuit deleted; `PrBadge` on cards |
+| `web-ui/src/components/layout/LeftSidebar.tsx` | Modified | 4.9, 4.11 | `PrBadge` at 4 sites |
+| `web-ui/src/hooks/useStore.ts` | Modified | 4.11 | Comment scrub |
+| `web-ui/src/lib/statusColor.test.ts` | **New** | 3.T1–3.T2 | Unit — precedence + rollup |
+| `web-ui/src/components/layout/PrBadge.test.tsx` | **New** | 3.T3 | Unit — rendering + a11y labels |
+| `web-ui/src/components/layout/DashboardPanel.test.tsx` | Modified | 4.T1–4.T6 | Two-axis bucketing coverage |

--- a/.vibekit/reports/2026-08-16-pr-detection-broken-root-cause-and-fix.md
+++ b/.vibekit/reports/2026-08-16-pr-detection-broken-root-cause-and-fix.md
@@ -1,0 +1,147 @@
+<!--
+RULES — read before writing this report:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. ANSWER FIRST: the finding goes at the top, before any evidence
+3. EVERY CLAIM CITED: file:line, a command + its output, or a screenshot
+4. READING TIME: optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+# Report: PR detection is dead — root cause + locked fix
+
+**Date:** 2026-08-16 · **Commit:** `2e513789443acf41eaa6691078ab9f71f39ee327` · **Scope:** `daemon/src/services/{github,prPoller,lifecycle}.ts`, `vibe-station.db`, live daemon logs · **Method:** log forensics + sqlite + live `gh`/GraphQL probes
+
+## Answer
+- **No session has ever reached `needs_review`** — 0 of 269 in the DB, despite the feature shipping in `4ada68d`. ch-62 is not a one-off.
+- Root cause is **read-side and silent**: `parseGithubRepo` (`github.ts:47-51`) demands a literal `github.com` host, but 103 of 147 worktrees use SSH host aliases (`git@github-techwithnidhi:...`) → returns `null` → `prPoller.ts:71` `if (!gh) return;` — those worktrees are **never polled at all**, with no log line.
+- Two more blockers stack behind it: **no `GITHUB_TOKEN`** (private repos → 404) and the **60 req/hr unauthenticated limit permanently exhausted** by the 44 parseable worktrees.
+- All three failure modes return the same `null` as "no PR exists" — which is why this stayed invisible for weeks.
+- **Not** a state-clobber race: `/sessions/:id/done` was never called for ch-62 and it never exited. It sat in **Waiting** the whole time PR #84 was open (00:17→04:58Z) and is still alive there.
+
+## Evidence
+| Claim | Source |
+|-------|--------|
+| Regex requires literal `github.com` | `daemon/src/services/github.ts:47-51` |
+| ch-62 remote is an SSH alias; both regexes reject it | `$ git -C .../ch-62 remote get-url origin` → `git@github-techwithnidhi:techwithnidhi/console-home.git`; `.test()` → `false`, `false` |
+| Unresolvable repo ⇒ silent skip, no log | `daemon/src/services/prPoller.ts:71` |
+| Zero `needs_review` ever | `$ sqlite3 vibe-station.db "select state,count(*) from sessions group by state;"` → `done\|168  exited\|42  waiting_for_human\|31  working\|28` |
+| PR #84 open + non-draft for 4h41m | `$ gh pr list --state all` → `#84 open, isDraft:false`, merged `04:58:27Z` |
+| ch-62 alive, never `done`/`exited`; `/done` never called | DB `state='waiting_for_human'`; grep of daemon log → no hits for `ch-62-a-116f9454/done` |
+| No token in daemon env | `/proc/1831796/environ` → zero `*TOKEN` vars |
+| Rate limit exhausted | `$ curl api.github.com/rate_limit` → `core:{limit:60, remaining:0}`; unauth pulls → 403 |
+| Failures indistinguishable from "no PR" | `github.ts:113,116,137-139` (`return null`) |
+| Two GitHub accounts in play | `$ gh auth status` → `techwithnidhi` (active) + `fastestdevalive` |
+| Live daemon predates dashboard-bucket fixes | pid 1831796 built Aug 15 16:34 PDT; `966b676` landed Aug 16 14:14 PDT |
+
+## State glossary
+
+`LifecycleState` — `daemon/src/types.ts:8-15`
+
+| State | Meaning | Set by | Terminal? | Live count |
+|---|---|---|---|---|
+| `not_started` | Record exists, agent not spawned | session create | no | 0 |
+| `working` | Pane output changing | lifecycle poller, 1s | no | 28 |
+| `idle` | Alive, output quiet, no prompt | lifecycle poller, 1s | no | 0 |
+| `waiting_for_human` | Alive, agent prompting for input | lifecycle poller, 1s | no | 31 |
+| `needs_review` | **"PR Created"** — open, non-draft PR | PR poller only, 60s (`prPoller.ts:79-84`) | no | **0 — never occupied** |
+| `done` | User marked complete | `POST /sessions/:id/done` (`routes/sessions.ts:974-998`) | **yes** | 168 |
+| `exited` | Process/tmux gone | `markSessionExited` (`lifecycle.ts:317-348`) | **yes** | 42 |
+
+- Terminal ⇒ both pollers skip forever (`lifecycle.ts:144`, `prPoller.ts:72`) — a PR opened after that is never detected.
+- Only the worktree's `isMain` session can be `needs_review` (`prPoller.ts:114`).
+- Dashboard buckets (`DashboardPanel.tsx:19-35`): `working|spawning`→Working · `waiting_for_human|idle`→Waiting · `needs_review`→PR · rest→Finished (hidden by default).
+
+## Decisions locked
+
+> Settled 2026-08-16 via discussion + live probes. Input to the detailed plan — **not implemented**.
+
+| # | Decision | Rationale / evidence |
+|---|---|---|
+| D1 | **One GraphQL request per GitHub *account*** — alias N repos into one query | Verified: 2-repo aliased query returned both, `rateLimit.cost: 1` of 5000. 10 repos → 2 req/tick |
+| D2 | **No `gh` binary dependency.** Transport is `fetch` + GraphQL; credentials come from gh's *data file* `~/.config/gh/hosts.yml` (`users.<login>.oauth_token`), env first, `gh auth token --user X` only opportunistically when `gh` happens to be on PATH | `gh` is **not** in `dev.Dockerfile:21-24`, and `github.ts:1-11` documents avoiding the binary. Reading its config file keeps that constraint while still supporting two accounts. `gh auth switch` **banned** — mutates `hosts.yml` globally, races |
+| D3 | **Credential chain:** `GH_TOKEN_<LOGIN>` → `GITHUB_TOKEN`/`GH_TOKEN` → `hosts.yml` → `gh auth token` (if on PATH) → `no_credentials` | Verified: this host's `hosts.yml` holds 3 plaintext `oauth_token`s. Keyring storage is the only gap, and step 4 covers it |
+| D4 | **Replace `parseGithubRepo` with async `resolveGithubRemote`** — relaxed regex captures any host, then resolves SSH aliases by **parsing `~/.ssh/config` in TS** (never `ssh -G`; that binary isn't in the image either). Fallback heuristic: alias matching `/^github[-.]/i` | Its regex is the primary root cause. Verified `ssh -G github-techwithnidhi` → `hostname github.com`, and all 103 real aliases match the heuristic |
+| D4b | **Account→repo discovery by probe, cached** — order candidates by login-substring-of-alias, then login===owner; probe `repository(owner,name){id}` until one succeeds | Two accounts means the right token per repo can't be known statically; ~1 extra point per new owner, once |
+| D5 | **`needs_review` leaves `LifecycleState`; PR status becomes orthogonal `session.pr`** | Kills the 3-writer clobber by construction; closes both latent write-side bugs (unguarded `/done`, PR-blind `exited`) for free |
+| D6 | **Keep two pollers** — local tmux ~free @1s vs network billed | The defect was the shared *write target* (D5), never the two timers |
+| D7 | **Poll interval 60s → 10s**; no on-push trigger needed | 2 req/tick @10s = 720 pts/hr = 14% of 5000 |
+| D8 | **Typed `PrLookupResult` union** — `pr \| no_pr \| not_github \| no_credentials \| error{network\|rate_limited\|auth\|api}`. On `error`/`no_credentials` the poller **holds** current lifecycle state; only a definitive `no_pr` exits `needs_review` | The single `null` return is why this hid for weeks. Also fixes a latent bug: a transient fetch failure today kicks a session *out* of `needs_review` |
+| D9 | **Read GraphQL `errors[]` per alias; ignore `gh` exit code** | Verified: bad repo → `"bad": null` + `errors[{type:"NOT_FOUND"}]`, siblings still return data; `gh` exits non-zero anyway |
+| D10 | **Startup self-check log** — per project: resolvable? authed? | "Silently dead for 103 worktrees" must be visible day 1 |
+
+### UI decisions (D11–D16)
+
+| # | Decision | Rationale |
+|---|---|---|
+| D11 | **Two axes, two indicators** — lifecycle `StatusDot` + a separate PR badge when `pr !== none`. Never a combined glyph | Mirrors D5's orthogonality; a merged PR on a `done` session must show both facts |
+| D12 | **Rectangle border = single color, strict precedence**: `waiting_for_human` (red) → `pr=merged` (green) → `pr=open` (yellow) → lifecycle color | "Agent blocked on YOU" must never be masked by PR state; draft/closed PRs never drive the border |
+| D13 | **Borders stay scoped to few states** — `6f020b6` already removed border color from working/idle/done/exited; keep it that way, add only the PR axis | A border on every state made the colored ones meaningless (`workspace-canvas.css:399-408`). No grey-ing work needed — it's already done |
+| ~~D14~~ | ~~PR open = yellow, merged = green~~ | **SUPERSEDED by D17** — yellow was reassigned to `working` |
+| **D17** | **Four-colour scheme (2026-08-17, user-specified):** `working` 🟡 yellow · `waiting_for_human` 🔴 red · `pr=open` 🔵 blue · `pr=merged` 🟢 green. Per-theme tokens | Yellow reads as "in progress", blue as "up for review". Blue is free now that `working` isn't the blue-purple accent |
+| **D18** | **Precedence:** `working` → `pr=merged` → `pr=open` → `waiting_for_human` → `idle` → `done`/`exited` | Active work is the freshest signal; a PR beats waiting because the agent idles at its prompt right after opening one, so red would otherwise mask blue permanently |
+| **D19** | **`done`/`exited` are terminal and always bucket to Finished, regardless of PR state** | `done` is a deliberate manual user action meaning finished. Reverses the earlier "done + merged → PR bucket" idea |
+| **D20** | **Blue/green are keyed to the *branch*, not the worktree** — persist `prBranch` and render the PR colour only when it matches the worktree's current branch | Without it, a branch switch shows a stale PR colour until the next 10s tick |
+| D14b | **Fix the `needs_review` split-brain** — currently violet `#b98cff` in `StatusDot` (`workspace.css:2129`) but green `var(--success)` on borders (`workspace-canvas.css:414`, `chat.css:30`) | Two surfaces disagree today; the PR axis replaces both, so the divergence disappears rather than needing a reconciliation |
+| D15 | **Tokenize all status colors in `tokens.css`; delete hard-coded hexes from `chat.css`, `workspace.css`, `workspace-canvas.css`** | Today the same values are duplicated in 3 files with comments begging them not to drift; per-theme values are impossible without tokens |
+| D16 | **Lifecycle keeps text glyphs; PR axis uses lucide-react** (`GitPullRequestArrow`, `GitMerge`, `GitPullRequestDraft`, `GitPullRequestClosed`) | `lucide-react@^0.468.0` already a dependency; git iconography is shape-distinct at 14px, so states never rely on color alone |
+
+**Color table (superseded — see D17/D18 above for the live scheme):**
+
+| Axis | State | Dark | Light | Glyph/icon |
+|---|---|---|---|---|
+| lifecycle | spawning | `#525252` dashed | `#a3a3a3` dashed | `◐` pulse |
+| lifecycle | working | `--accent` #6e78c7 | `--accent` #5c64b5 | `●` |
+| lifecycle | idle | `#6b6b6b` | `#737373` | `○` |
+| lifecycle | waiting_for_human | `#ef4444` | `#dc2626` | `!` |
+| lifecycle | done | `#8a8a8a` | `#525252` | `✓` |
+| lifecycle | exited | `#525252` | `#a3a3a3` | `×` |
+| **PR** | **open** | **`#eab308`** | **`#a16207`** | `GitPullRequestArrow` |
+| **PR** | **merged** | **`#22c55e`** | **`#15803d`** | `GitMerge` |
+| PR | draft | `#8a8a8a` | `#737373` | `GitPullRequestDraft` |
+| PR | closed | `#6b6b6b` | `#737373` | `GitPullRequestClosed` |
+
+- `needs_review` violet `#b98cff` + `◆` glyph are **deleted** with the enum value.
+- Merged-green persists until the worktree is removed; it re-derives on branch change because PR lookup is keyed to the current branch — **no `mergedAt` timestamp or expiry needed**.
+- Sidebar rows + dashboard cards have **no rectangle today** — adding the PR badge there is new UI, not a recolor.
+- VCS panel's existing "PR open" green `#4ade80` (`workspace.css:3857,3897`) **must move to yellow** or it contradicts the new semantics.
+- Contrast: all chosen colors ≥3:1 for non-text UI except `spawning`/`exited` (~2.2–2.5:1), **intentionally** de-emphasized — glyph + dashed style carry that information.
+
+**Rejected:**
+
+| Rejected | Why |
+|---|---|
+| **Shelling out to the `gh` binary** (earlier D3) | Not in `dev.Dockerfile:21-24`; `github.ts:1-11` documents the deliberate decision to avoid it. Superseded by D2 — depend on its *config file*, not the binary |
+| Adding `gh` to `dev.Dockerfile` | Needs the GitHub apt keyring + repo lines; and the sandbox seeds `git init` repos with **no remotes** (`demo-seed.sh:44,765`), so PR detection is inherently a no-op there — the dependency would buy nothing |
+| `ssh -G <alias>` for host resolution | `ssh` is not in the image either; parse `~/.ssh/config` in TS instead |
+| **`prMergedAt`** (shipped in `966b676`) | Superseded by D5 — `pr.state === "merged"` derives live from the current branch, so retention is free. Removes a SQLite column, row mapper, route field, and 3 tests |
+| Single global search query (`gh search prs`) | Two accounts → no one token sees both; search index lags seconds-to-minutes; `author:@me` misses teammate PRs |
+| "Just set `GITHUB_TOKEN`" | Single-account assumption — a `techwithnidhi` token 404s on `fastestdevalive` private repos, reproducing the exact silent failure |
+| Per-repo REST (10 req/tick) | Superseded by D1 — GraphQL does it in 2 |
+| Merging the two pollers | 1s would hammer GitHub; 60s would make the UI feel dead |
+
+## Budget math
+| Design | Req/tick | Cost/hr @60s | % of 5000 |
+|---|---|---|---|
+| Today (per-worktree REST) | 147 | 8,820 | **176% — blows even the authed limit** |
+| GraphQL per-account (D1) | **2** | **120** | **2.4%** |
+| GraphQL per-account @10s (D7) | 2 | 720 | 14% |
+
+## Resolved since first draft
+| Was open | Resolution |
+|---|---|
+| Is `gh` on the daemon's PATH? | `/usr/bin/gh` v2.88.1, both accounts authed — but **moot**: D2 dropped the binary dependency |
+| Reconcile with `966b676` | It was on `origin/main`, not this branch; branch rebased (4 commits). `prMergedAt` **superseded** by D5 |
+| Should a merged PR retain the PR bucket? | Yes — green persists until the worktree is removed, derived live from the current branch |
+| Docker sandbox impact | None — seeded repos have no remotes, so lookups short-circuit at `not_github` with zero calls and zero logs |
+
+## Not checked
+- Migration for persisted manifests/SQLite rows already carrying `needs_review` — D5 is a breaking change to on-disk records; the back-compat read is designed but unwritten.
+- Whether `hosts.yml` keyring-storage (no plaintext `oauth_token`) occurs on any machine this runs on — only this host was inspected, and it stores plaintext.
+- `~/.ssh/config` `Include` directives beyond one level, and `Match` blocks — the TS parser handles neither.
+- No runtime repro of the fix; every decision above is unimplemented.
+
+## Follow-ups
+| # | Question | Why it matters |
+|---|----------|-----------------|
+| 1 | Does any UI besides the dashboard read `needs_review`? | D5 breaks persisted records — needs a back-compat read |
+| 2 | Restart the daemon after landing | The running binary (built Aug 15 16:34) predates even `966b676` |
+| 3 | Should `GET /worktrees/:id/pr` (VCS tab) share the poller's cache? | It currently does its own lookup; D1's batch cache could serve it |

--- a/.vibekit/reports/2026-08-16-pr-detection-broken-root-cause-and-fix.md
+++ b/.vibekit/reports/2026-08-16-pr-detection-broken-root-cause-and-fix.md
@@ -63,7 +63,7 @@ RULES — read before writing this report:
 | D4b | **Account→repo discovery by probe, cached** — order candidates by login-substring-of-alias, then login===owner; probe `repository(owner,name){id}` until one succeeds | Two accounts means the right token per repo can't be known statically; ~1 extra point per new owner, once |
 | D5 | **`needs_review` leaves `LifecycleState`; PR status becomes orthogonal `session.pr`** | Kills the 3-writer clobber by construction; closes both latent write-side bugs (unguarded `/done`, PR-blind `exited`) for free |
 | D6 | **Keep two pollers** — local tmux ~free @1s vs network billed | The defect was the shared *write target* (D5), never the two timers |
-| D7 | **Poll interval 60s → 10s**; no on-push trigger needed | 2 req/tick @10s = 720 pts/hr = 14% of 5000 |
+| D7 | **Poll interval 60s → 30s** (was briefly 10s); no on-push trigger needed | 2 req/tick @30s = 240 pts/hr = ~5% of 5000 |
 | D8 | **Typed `PrLookupResult` union** — `pr \| no_pr \| not_github \| no_credentials \| error{network\|rate_limited\|auth\|api}`. On `error`/`no_credentials` the poller **holds** current lifecycle state; only a definitive `no_pr` exits `needs_review` | The single `null` return is why this hid for weeks. Also fixes a latent bug: a transient fetch failure today kicks a session *out* of `needs_review` |
 | D9 | **Read GraphQL `errors[]` per alias; ignore `gh` exit code** | Verified: bad repo → `"bad": null` + `errors[{type:"NOT_FOUND"}]`, siblings still return data; `gh` exits non-zero anyway |
 | D10 | **Startup self-check log** — per project: resolvable? authed? | "Silently dead for 103 worktrees" must be visible day 1 |
@@ -79,7 +79,7 @@ RULES — read before writing this report:
 | **D17** | **Four-colour scheme (2026-08-17, user-specified):** `working` 🟡 yellow · `waiting_for_human` 🔴 red · `pr=open` 🔵 blue · `pr=merged` 🟢 green. Per-theme tokens | Yellow reads as "in progress", blue as "up for review". Blue is free now that `working` isn't the blue-purple accent |
 | **D18** | **Precedence:** `working` → `pr=merged` → `pr=open` → `waiting_for_human` → `idle` → `done`/`exited` | Active work is the freshest signal; a PR beats waiting because the agent idles at its prompt right after opening one, so red would otherwise mask blue permanently |
 | **D19** | **`done`/`exited` are terminal and always bucket to Finished, regardless of PR state** | `done` is a deliberate manual user action meaning finished. Reverses the earlier "done + merged → PR bucket" idea |
-| **D20** | **Blue/green are keyed to the *branch*, not the worktree** — persist `prBranch` and render the PR colour only when it matches the worktree's current branch | Without it, a branch switch shows a stale PR colour until the next 10s tick |
+| **D20** | **Blue/green are keyed to the *branch*, not the worktree** — persist `prBranch` and render the PR colour only when it matches the worktree's current branch | Without it, a branch switch shows a stale PR colour until the next 30s tick |
 | D14b | **Fix the `needs_review` split-brain** — currently violet `#b98cff` in `StatusDot` (`workspace.css:2129`) but green `var(--success)` on borders (`workspace-canvas.css:414`, `chat.css:30`) | Two surfaces disagree today; the PR axis replaces both, so the divergence disappears rather than needing a reconciliation |
 | D15 | **Tokenize all status colors in `tokens.css`; delete hard-coded hexes from `chat.css`, `workspace.css`, `workspace-canvas.css`** | Today the same values are duplicated in 3 files with comments begging them not to drift; per-theme values are impossible without tokens |
 | D16 | **Lifecycle keeps text glyphs; PR axis uses lucide-react** (`GitPullRequestArrow`, `GitMerge`, `GitPullRequestDraft`, `GitPullRequestClosed`) | `lucide-react@^0.468.0` already a dependency; git iconography is shape-distinct at 14px, so states never rely on color alone |
@@ -123,7 +123,7 @@ RULES — read before writing this report:
 |---|---|---|---|
 | Today (per-worktree REST) | 147 | 8,820 | **176% — blows even the authed limit** |
 | GraphQL per-account (D1) | **2** | **120** | **2.4%** |
-| GraphQL per-account @10s (D7) | 2 | 720 | 14% |
+| GraphQL per-account @30s (D7) | 2 | 240 | ~5% |
 
 ## Resolved since first draft
 | Was open | Resolution |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,59 @@ The lock is scoped to one `WSConnection`. Two browser tabs legitimately hold two
 
 ---
 
+## Status indicators — `docs/STATUS-INDICATORS.md` is the source of truth, keep it in sync
+
+**Canonical matrix:** [`docs/STATUS-INDICATORS.md`](docs/STATUS-INDICATORS.md) — every
+lifecycle × PR combination, its dot colour, its glyph, and its dashboard bucket.
+
+### The invariant
+
+Session status is **two orthogonal axes**, never one enum:
+
+| Axis | Field | Written by, exclusively |
+|------|-------|------------------------|
+| Lifecycle (is the agent busy?) | `session.lifecycle.state` | `daemon/src/services/lifecycle.ts`, 1s poll |
+| PR (what happened to the branch?) | `session.pr` | `daemon/src/services/prPoller.ts`, 10s poll |
+
+Each poller writes **only** its own field. They previously shared one `LifecycleState` slot
+(`needs_review`) with three uncoordinated writers, which raced and silently destroyed the
+"PR created" signal — that is why the axes are split. Do not add a cross-write, and do not
+collapse them back into one enum.
+
+### Rule: a status change is a two-file change
+
+Touching **any** of these means updating `docs/STATUS-INDICATORS.md`'s matrix **in the same commit**:
+
+- `web-ui/src/lib/statusColor.ts` — `resolveStatusClass` / `worktreePrStatus`
+- `web-ui/src/components/layout/DashboardPanel.tsx` — `bucketForRollup`
+- `web-ui/src/components/layout/StatusDot.tsx` — glyphs
+- `web-ui/src/styles/tokens.css` — `--status-*` / `--pr-*` tokens
+- `LifecycleState` (`daemon/src/types.ts`) or `PrStatus` — adding/removing a value
+- `daemon/src/services/prPoller.ts` — which PR states map to which `pr.state`
+
+A PR that changes behaviour without changing the matrix should be sent back.
+
+### What to watch for
+
+- **Colour and bucket deliberately disagree for `done`/`exited`** — the dot keeps the PR colour
+  (blue/green) so you can see the branch landed, but the card stays in **Finished**, because
+  `done` is an explicit manual user action. This is intentional; don't "fix" it into agreement.
+- **`idle` buckets to Waiting, not Finished** — so the Waiting column mixes 🔴 `waiting_for_human`
+  (agent needs you) with neutral `○` `idle` (nothing happening). Known and intentional.
+- **`working` beats PR; PR beats `waiting_for_human`.** The second one is easy to get backwards:
+  an agent idles at its prompt right after opening a PR, so if red won you would almost never
+  see blue — which was the original bug's symptom all over again.
+- **Never render a PR colour without checking `pr.prBranch === worktree.branch`.** The PR is a
+  property of the branch, not the worktree; after a branch switch a stale PR must colour nothing.
+- **`draft` and `closed` are informational only** — they never drive colour or bucket.
+- **No bare hexes.** Status colours are per-theme tokens in `tokens.css`; a single hex fails
+  light-mode contrast. Non-colour cues (`spawning` dashed, `exited` dimmed) must survive recolours.
+- **Testing:** Ctrl+Shift+D opens the dev state simulator, which drives both axes with no daemon.
+  Prefer it over injecting SQLite rows — a container restart kills tmux, the lifecycle poller
+  then marks every session `exited`, and `exited` is terminal, so injected states never recover.
+
+---
+
 ## Docker dev sandboxes — two different tools, don't conflate them
 
 **Files:** `docker-compose.dev.yml` · `scripts/dev-sandbox.sh` · `scripts/dev-entrypoint.sh` · `docker-compose.screenshots.yml` · `Dockerfile.screenshots` · `scripts/demo-seed.sh` · `scripts/seed-file-search-demo.sh`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,7 @@ Session status is **two orthogonal axes**, never one enum:
 | Axis | Field | Written by, exclusively |
 |------|-------|------------------------|
 | Lifecycle (is the agent busy?) | `session.lifecycle.state` | `daemon/src/services/lifecycle.ts`, 1s poll |
-| PR (what happened to the branch?) | `session.pr` | `daemon/src/services/prPoller.ts`, 10s poll |
+| PR (what happened to the branch?) | `session.pr` | `daemon/src/services/prPoller.ts`, 30s poll |
 
 Each poller writes **only** its own field. They previously shared one `LifecycleState` slot
 (`needs_review`) with three uncoordinated writers, which raced and silently destroyed the
@@ -179,8 +179,23 @@ A PR that changes behaviour without changing the matrix should be sent back.
 - **Colour and bucket deliberately disagree for `done`/`exited`** — the dot keeps the PR colour
   (blue/green) so you can see the branch landed, but the card stays in **Finished**, because
   `done` is an explicit manual user action. This is intentional; don't "fix" it into agreement.
-- **`idle` buckets to Waiting, not Finished** — so the Waiting column mixes 🔴 `waiting_for_human`
-  (agent needs you) with neutral `○` `idle` (nothing happening). Known and intentional.
+- **`idle` buckets to its own Idle column, not Finished** — an idle session is open work, not done.
+  Idle and `waiting_for_human` are separate dashboard columns (**Idle** vs **Needs you**), not one
+  mixed "Waiting" column — mixing them read as a bug (idle sat under "Waiting" with a neutral dot
+  and no red `!`). Both are shown by default; only Finished hides behind the toggle.
+- **The dashboard is per-session for LIFECYCLE, per-worktree for PR** (Phase 6, PR resolution
+  corrected by BLOCKING-2) — every non-archived agent session gets its own card, bucketed by its
+  own lifecycle status. The daemon (`prPoller.ts`) writes `session.pr` **only** to a worktree's
+  `isMain` session — nothing else ever writes it — so PR colour/bucket is resolved once per
+  worktree (`worktreePrStatus()`, off the `isMain` session, branch-guarded) and the UI fans that
+  single value out to every non-archived agent session card of that worktree; the daemon never
+  writes `pr` to more than one session (that would reintroduce write amplification — one write, N
+  reads is the shape). The sidebar's worktree rows roll up per worktree via
+  `worktreeRolledUpStatus()`/`worktreePrStatus()` (unchanged). The canvas tile border and agent
+  pane border are per-session for lifecycle (each reads its own `session.state`) but per-worktree
+  for PR, same as the dashboard (via `worktreePrStatus()`, branch-guarded against the tile's/pane's
+  own worktree) — none of these surfaces ever read a sibling session's own `session.pr` directly.
+  See `docs/STATUS-INDICATORS.md` § Per-session vs per-worktree.
 - **`working` beats PR; PR beats `waiting_for_human`.** The second one is easy to get backwards:
   an agent idles at its prompt right after opening a PR, so if red won you would almost never
   see blue — which was the original bug's symptom all over again.

--- a/daemon/src/__tests__/github.test.ts
+++ b/daemon/src/__tests__/github.test.ts
@@ -1,42 +1,234 @@
 /**
  * GitHub PR lookup (`daemon/src/services/github.ts`) — the VCS tool tab's PR
- * banner data source. Deliberately doesn't shell out to `gh`; talks to the
- * GitHub REST API directly, so `fetchPrForBranch` is tested via a stubbed
- * `global.fetch` rather than a real network call.
+ * banner data source, and the PR poller's transport. Deliberately doesn't
+ * shell out to `gh`; talks to the GitHub GraphQL API directly, so
+ * `fetchPrForBranch`/`fetchPrsForBranches` are tested via a stubbed
+ * `global.fetch` rather than a real network call. `listAccounts` (from
+ * `./githubAuth.js`) is mocked so these tests never touch the real
+ * filesystem (`~/.config/gh/hosts.yml`) or environment.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, mkdir, writeFile, rm, utimes } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   getRemoteUrl,
-  parseGithubRepo,
+  resolveGithubRemote,
   fetchPrForBranch,
+  fetchPrsForBranches,
   _clearPrCacheForTest,
 } from "../services/github.js";
 import { createGitFixture, removeGitFixture, type GitFixture } from "./gitFixture.js";
 
-describe("parseGithubRepo", () => {
-  it("Requirement 5 — accepts git@github.com:owner/repo.git", () => {
-    expect(parseGithubRepo("git@github.com:owner/repo.git")).toEqual({
+vi.mock("../services/githubAuth.js", () => ({
+  listAccounts: vi.fn(),
+}));
+
+import { listAccounts } from "../services/githubAuth.js";
+
+const mockedListAccounts = vi.mocked(listAccounts);
+
+describe("resolveGithubRemote", () => {
+  // Hermetic (N4): point HOME at an empty temp dir with no `.ssh/config` at
+  // all, so these tests never depend on — or are broken by — whatever real
+  // SSH config happens to exist on the machine running them.
+  let fakeHome: string;
+  const originalHome = process.env.HOME;
+
+  beforeEach(async () => {
+    fakeHome = await mkdtemp(join(tmpdir(), "vst-github-nohome-test-"));
+    process.env.HOME = fakeHome;
+    _clearPrCacheForTest();
+  });
+
+  afterEach(async () => {
+    process.env.HOME = originalHome;
+    _clearPrCacheForTest();
+    await rm(fakeHome, { recursive: true, force: true });
+  });
+
+  it("R1 — resolves an SSH host alias via the /^github[-.]/i heuristic (no ~/.ssh/config match)", async () => {
+    await expect(resolveGithubRemote("git@github-x:o/r.git")).resolves.toEqual({
+      host: "github-x",
+      owner: "o",
+      repo: "r",
+    });
+  });
+
+  it("rejects a non-GitHub remote (no heuristic or ssh-config match)", async () => {
+    await expect(resolveGithubRemote("git@gitlab.com:o/r.git")).resolves.toBeNull();
+  });
+
+  it("strips a trailing .git suffix", async () => {
+    await expect(resolveGithubRemote("git@github.com:owner/repo.git")).resolves.toEqual({
+      host: "github.com",
       owner: "owner",
       repo: "repo",
     });
   });
 
-  it("Requirement 5 — accepts https://github.com/owner/repo.git", () => {
-    expect(parseGithubRepo("https://github.com/owner/repo.git")).toEqual({
+  it("handles https:// remotes", async () => {
+    await expect(resolveGithubRemote("https://github.com/owner/repo.git")).resolves.toEqual({
+      host: "github.com",
       owner: "owner",
       repo: "repo",
     });
   });
 
-  it("Requirement 5 — accepts https://github.com/owner/repo (no .git suffix)", () => {
-    expect(parseGithubRepo("https://github.com/owner/repo")).toEqual({
+  it("handles ssh:// remotes", async () => {
+    await expect(resolveGithubRemote("ssh://git@github.com/owner/repo.git")).resolves.toEqual({
+      host: "github.com",
       owner: "owner",
       repo: "repo",
     });
   });
 
-  it("Requirement 5 — rejects a non-GitHub remote", () => {
-    expect(parseGithubRepo("git@gitlab.com:owner/repo.git")).toBeNull();
+  it("N3 — strips userinfo (user:token@) from an https:// remote's host", async () => {
+    await expect(resolveGithubRemote("https://user:token@github.com/owner/repo.git")).resolves.toEqual({
+      host: "github.com",
+      owner: "owner",
+      repo: "repo",
+    });
+  });
+
+  it("N3 — strips a :port suffix from an ssh:// remote's host", async () => {
+    await expect(resolveGithubRemote("ssh://git@github.com:22/owner/repo.git")).resolves.toEqual({
+      host: "github.com",
+      owner: "owner",
+      repo: "repo",
+    });
+  });
+});
+
+describe("~/.ssh/config parsing (hermetic, N4)", () => {
+  // Every test gets its own fake HOME with a purpose-built `.ssh/config` —
+  // never the real file on the machine running the suite.
+  let fakeHome: string;
+  let sshDir: string;
+  const originalHome = process.env.HOME;
+
+  beforeEach(async () => {
+    fakeHome = await mkdtemp(join(tmpdir(), "vst-github-sshconfig-test-"));
+    sshDir = join(fakeHome, ".ssh");
+    await mkdir(sshDir, { recursive: true });
+    process.env.HOME = fakeHome;
+    _clearPrCacheForTest();
+  });
+
+  afterEach(async () => {
+    process.env.HOME = originalHome;
+    _clearPrCacheForTest();
+    await rm(fakeHome, { recursive: true, force: true });
+  });
+
+  it("resolves an alias to a GitHub host via HostName, lowercase keywords", async () => {
+    await writeFile(
+      join(sshDir, "config"),
+      `host work-alias
+    hostname github.com
+    user git
+`,
+    );
+    await expect(resolveGithubRemote("git@work-alias:acme/widgets.git")).resolves.toEqual({
+      host: "work-alias",
+      owner: "acme",
+      repo: "widgets",
+    });
+  });
+
+  it("resolves via HostName with mixed-case keywords (Host/HostName)", async () => {
+    await writeFile(
+      join(sshDir, "config"),
+      `Host personal-alias
+    HostName github.com
+    User git
+`,
+    );
+    await expect(resolveGithubRemote("git@personal-alias:acme/widgets.git")).resolves.toEqual({
+      host: "personal-alias",
+      owner: "acme",
+      repo: "widgets",
+    });
+  });
+
+  it("a Host line with multiple space-separated patterns applies HostName to every one", async () => {
+    await writeFile(
+      join(sshDir, "config"),
+      `Host alias-one alias-two
+    HostName github.com
+`,
+    );
+    await expect(resolveGithubRemote("git@alias-one:acme/widgets.git")).resolves.toEqual({
+      host: "alias-one",
+      owner: "acme",
+      repo: "widgets",
+    });
+    await expect(resolveGithubRemote("git@alias-two:acme/widgets.git")).resolves.toEqual({
+      host: "alias-two",
+      owner: "acme",
+      repo: "widgets",
+    });
+  });
+
+  it("a HostName pointing somewhere other than github.com is rejected (no heuristic match)", async () => {
+    await writeFile(
+      join(sshDir, "config"),
+      `Host internal-alias
+    HostName git.internal.example.com
+`,
+    );
+    await expect(resolveGithubRemote("git@internal-alias:acme/widgets.git")).resolves.toBeNull();
+  });
+
+  it("resolves an alias via a single level of Include", async () => {
+    await writeFile(join(sshDir, "config"), `Include config.d/work\n`);
+    await mkdir(join(sshDir, "config.d"), { recursive: true });
+    await writeFile(
+      join(sshDir, "config.d", "work"),
+      `Host included-alias
+    HostName github.com
+`,
+    );
+    await expect(resolveGithubRemote("git@included-alias:acme/widgets.git")).resolves.toEqual({
+      host: "included-alias",
+      owner: "acme",
+      repo: "widgets",
+    });
+  });
+
+  it("N4 — an edit to an Include'd file invalidates the cache, not just the top-level file", async () => {
+    await writeFile(join(sshDir, "config"), `Include config.d/work\n`);
+    await mkdir(join(sshDir, "config.d"), { recursive: true });
+    const includedPath = join(sshDir, "config.d", "work");
+    await writeFile(
+      includedPath,
+      `Host included-alias
+    HostName git.internal.example.com
+`,
+    );
+
+    // First resolution: the alias resolves to a non-GitHub host via the
+    // Include'd file, so it's rejected.
+    await expect(resolveGithubRemote("git@included-alias:acme/widgets.git")).resolves.toBeNull();
+
+    // Edit ONLY the Include'd file (top-level `config`'s own mtime is
+    // untouched) so it now points at github.com, and bump its mtime forward
+    // to guarantee the filesystem records a change even on fast filesystems
+    // with coarse mtime resolution.
+    const future = new Date(Date.now() + 5000);
+    await writeFile(
+      includedPath,
+      `Host included-alias
+    HostName github.com
+`,
+    );
+    await utimes(includedPath, future, future);
+
+    await expect(resolveGithubRemote("git@included-alias:acme/widgets.git")).resolves.toEqual({
+      host: "included-alias",
+      owner: "acme",
+      repo: "widgets",
+    });
   });
 });
 
@@ -61,37 +253,46 @@ describe("getRemoteUrl", () => {
   });
 });
 
-/** Builds a fetch-mock response shaped like `GET /repos/:owner/:repo/pulls`. */
-function mockPrListResponse(prs: unknown[]): typeof fetch {
-  return vi.fn().mockResolvedValue({ ok: true, json: async () => prs }) as unknown as typeof fetch;
+/** Builds a GraphQL-shaped fetch-mock response for a single-repo query
+ *  aliased as `repo0`. */
+function mockGraphQLResponse(nodes: unknown[]): typeof fetch {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    headers: new Headers(),
+    json: async () => ({ data: { repo0: { pullRequests: { nodes } } } }),
+  }) as unknown as typeof fetch;
 }
 
-function fakePr(overrides: Partial<{
-  number: number;
-  html_url: string;
-  title: string;
-  state: string;
-  draft: boolean;
-  merged_at: string | null;
-  user: { login: string } | null;
-}> = {}) {
+function fakeNode(
+  overrides: Partial<{
+    number: number;
+    url: string;
+    title: string;
+    state: string;
+    isDraft: boolean;
+    merged: boolean;
+    author: { login: string } | null;
+  }> = {},
+) {
   return {
     number: 1,
-    html_url: "https://github.com/x/y/pull/1",
+    url: "https://github.com/x/y/pull/1",
     title: "A PR",
-    state: "open",
-    draft: false,
-    merged_at: null,
-    user: { login: "someone" },
+    state: "OPEN",
+    isDraft: false,
+    merged: false,
+    author: { login: "someone" },
     ...overrides,
   };
 }
 
-describe("fetchPrForBranch", () => {
+describe("fetchPrForBranch / fetchPrsForBranches", () => {
   const originalFetch = global.fetch;
 
   beforeEach(() => {
     _clearPrCacheForTest();
+    mockedListAccounts.mockReset();
+    mockedListAccounts.mockResolvedValue([{ login: "owner-match", token: "tok" }]);
   });
 
   afterEach(() => {
@@ -100,79 +301,116 @@ describe("fetchPrForBranch", () => {
     _clearPrCacheForTest();
   });
 
-  it("Requirement 7 — a non-OK API response resolves to null without throwing", async () => {
-    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 403 }) as unknown as typeof fetch;
-    await expect(fetchPrForBranch("owner-403", "repo-403", "some-branch")).resolves.toBeNull();
-  });
-
-  it("Requirement 7 — a network failure resolves to null without throwing", async () => {
-    global.fetch = vi.fn().mockRejectedValue(new Error("network down")) as unknown as typeof fetch;
-    await expect(fetchPrForBranch("owner-neterr", "repo-neterr", "some-branch")).resolves.toBeNull();
-  });
-
-  it("Requirement 7 — an empty PR list resolves to null", async () => {
-    global.fetch = mockPrListResponse([]);
-    await expect(fetchPrForBranch("owner-empty", "repo-empty", "some-branch")).resolves.toBeNull();
-  });
-
-  it("Requirement 8 — a matching PR is parsed into PrInfo, and the request is built correctly (URL, head filter, headers)", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => [
-        fakePr({
-          number: 42,
-          html_url: "https://github.com/owner-match/repo-match/pull/42",
-          title: "Add VCS commit graph",
-          user: { login: "octocat" },
-        }),
-      ],
-    });
-    global.fetch = fetchMock as unknown as typeof fetch;
-
-    const pr = await fetchPrForBranch("owner-match", "repo-match", "some-branch");
-    expect(pr).toEqual({
-      number: 42,
-      url: "https://github.com/owner-match/repo-match/pull/42",
-      title: "Add VCS commit graph",
-      state: "open",
-      merged: false,
-      draft: false,
-      author: "octocat",
-    });
-
-    // Guards the request-construction contract, not just the response
-    // parsing: wrong owner/repo in the URL path, or a missing/wrong
-    // `head=owner:branch` filter, would misattribute PRs from the wrong
-    // repo/branch to this worktree while every other assertion still passes.
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchMock.mock.calls[0]!;
-    expect(url).toContain("/repos/owner-match/repo-match/pulls");
-    expect(url).toContain("head=owner-match:some-branch");
-    expect(url).toContain("state=all");
-    expect((init as { headers: Record<string, string> }).headers.Accept).toBe(
-      "application/vnd.github+json",
+  it("Requirement 7 — a non-OK API response resolves to {kind:\"error\"} without throwing", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      headers: new Headers(),
+    }) as unknown as typeof fetch;
+    mockedListAccounts.mockResolvedValue([{ login: "owner-403", token: "tok" }]);
+    await expect(fetchPrForBranch("owner-403", "repo-403", "some-branch")).resolves.toMatchObject(
+      { kind: "error" },
     );
   });
 
+  it("Requirement 7 — a network failure resolves to {kind:\"error\",reason:\"network\"} without throwing", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("network down")) as unknown as typeof fetch;
+    mockedListAccounts.mockResolvedValue([{ login: "owner-neterr", token: "tok" }]);
+    await expect(
+      fetchPrForBranch("owner-neterr", "repo-neterr", "some-branch"),
+    ).resolves.toMatchObject({ kind: "error", reason: "network" });
+  });
+
+  it("Requirement 7 — an empty PR list resolves to {kind:\"no_pr\"}", async () => {
+    global.fetch = mockGraphQLResponse([]);
+    mockedListAccounts.mockResolvedValue([{ login: "owner-empty", token: "tok" }]);
+    await expect(fetchPrForBranch("owner-empty", "repo-empty", "some-branch")).resolves.toEqual({
+      kind: "no_pr",
+    });
+  });
+
+  it("no accounts configured resolves to {kind:\"no_credentials\"} without a network call", async () => {
+    mockedListAccounts.mockResolvedValue([]);
+    const fetchMock = vi.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    await expect(fetchPrForBranch("owner-nocred", "repo-nocred", "b")).resolves.toEqual({
+      kind: "no_credentials",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("Requirement 8 — a matching PR is parsed into PrInfo, and the request is built correctly (query, headers)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers(),
+      json: async () => ({
+        data: {
+          repo0: {
+            pullRequests: {
+              nodes: [
+                fakeNode({
+                  number: 42,
+                  url: "https://github.com/owner-match/repo-match/pull/42",
+                  title: "Add VCS commit graph",
+                  author: { login: "octocat" },
+                }),
+              ],
+            },
+          },
+        },
+      }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await fetchPrForBranch("owner-match", "repo-match", "some-branch");
+    expect(result).toEqual({
+      kind: "pr",
+      pr: {
+        number: 42,
+        url: "https://github.com/owner-match/repo-match/pull/42",
+        title: "Add VCS commit graph",
+        state: "open",
+        merged: false,
+        draft: false,
+        author: "octocat",
+      },
+    });
+
+    // Guards the request-construction contract, not just the response
+    // parsing: a missing/wrong owner/repo/branch in the aliased query would
+    // misattribute PRs from the wrong repo/branch to this worktree while
+    // every other assertion still passes.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("https://api.github.com/graphql");
+    const body = JSON.parse((init as { body: string }).body) as { query: string };
+    expect(body.query).toContain('owner: "owner-match"');
+    expect(body.query).toContain('name: "repo-match"');
+    expect(body.query).toContain('headRefName: "some-branch"');
+    expect((init as { headers: Record<string, string> }).headers.Authorization).toBe("Bearer tok");
+  });
+
   it("Requirement 8 — a merged PR sets merged: true and state: closed", async () => {
-    global.fetch = mockPrListResponse([
-      fakePr({
+    global.fetch = mockGraphQLResponse([
+      fakeNode({
         number: 7,
-        html_url: "https://github.com/owner-merged/repo-merged/pull/7",
+        url: "https://github.com/owner-merged/repo-merged/pull/7",
         title: "Merged feature",
-        state: "closed",
-        merged_at: "2026-01-01T00:00:00Z",
-        user: { login: "hubot" },
+        state: "MERGED",
+        merged: true,
+        author: { login: "hubot" },
       }),
     ]);
+    mockedListAccounts.mockResolvedValue([{ login: "owner-merged", token: "tok" }]);
 
-    const pr = await fetchPrForBranch("owner-merged", "repo-merged", "some-branch");
-    expect(pr).toMatchObject({ number: 7, merged: true, state: "closed" });
+    const result = await fetchPrForBranch("owner-merged", "repo-merged", "some-branch");
+    expect(result).toMatchObject({ kind: "pr", pr: { number: 7, merged: true, state: "closed" } });
   });
 
   it("caches a result for repeat calls with the same owner/repo/branch — fetch is called once", async () => {
-    const fetchMock = mockPrListResponse([fakePr({ number: 99 })]);
+    const fetchMock = mockGraphQLResponse([fakeNode({ number: 99 })]);
     global.fetch = fetchMock as unknown as typeof fetch;
+    mockedListAccounts.mockResolvedValue([{ login: "owner-cache", token: "tok" }]);
 
     const first = await fetchPrForBranch("owner-cache", "repo-cache", "branch-cache");
     const second = await fetchPrForBranch("owner-cache", "repo-cache", "branch-cache");
@@ -182,8 +420,9 @@ describe("fetchPrForBranch", () => {
   });
 
   it("a different branch (different cache key) triggers a fresh fetch", async () => {
-    const fetchMock = mockPrListResponse([fakePr({ number: 100 })]);
+    const fetchMock = mockGraphQLResponse([fakeNode({ number: 100 })]);
     global.fetch = fetchMock as unknown as typeof fetch;
+    mockedListAccounts.mockResolvedValue([{ login: "owner-cachekey", token: "tok" }]);
 
     await fetchPrForBranch("owner-cachekey", "repo-cachekey", "branch-a");
     await fetchPrForBranch("owner-cachekey", "repo-cachekey", "branch-b");
@@ -192,13 +431,176 @@ describe("fetchPrForBranch", () => {
   });
 
   it("_clearPrCacheForTest() forces a fresh fetch even for a previously-cached key", async () => {
-    const fetchMock = mockPrListResponse([fakePr({ number: 101 })]);
+    const fetchMock = mockGraphQLResponse([fakeNode({ number: 101 })]);
     global.fetch = fetchMock as unknown as typeof fetch;
+    mockedListAccounts.mockResolvedValue([{ login: "owner-clear", token: "tok" }]);
 
     await fetchPrForBranch("owner-clear", "repo-clear", "branch-clear");
     _clearPrCacheForTest();
+    mockedListAccounts.mockResolvedValue([{ login: "owner-clear", token: "tok" }]);
     await fetchPrForBranch("owner-clear", "repo-clear", "branch-clear");
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("an error result is never cached — the next call re-fetches", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 500, headers: new Headers() })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers(),
+        json: async () => ({ data: { repo0: { pullRequests: { nodes: [] } } } }),
+      });
+    global.fetch = fetchMock as unknown as typeof fetch;
+    mockedListAccounts.mockResolvedValue([{ login: "owner-noerrcache", token: "tok" }]);
+
+    const first = await fetchPrForBranch("owner-noerrcache", "repo-noerrcache", "b");
+    expect(first).toMatchObject({ kind: "error" });
+    const second = await fetchPrForBranch("owner-noerrcache", "repo-noerrcache", "b");
+    expect(second).toEqual({ kind: "no_pr" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("Requirement 4/T3 — one NOT_FOUND alias in a multi-repo query still returns sibling results", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers(),
+      json: async () => ({
+        data: {
+          repo0: null,
+          repo1: { pullRequests: { nodes: [fakeNode({ number: 5 })] } },
+        },
+        errors: [{ path: ["repo0"], type: "NOT_FOUND", message: "Could not resolve to a Repository" }],
+      }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+    mockedListAccounts.mockResolvedValue([{ login: "acct", token: "tok" }]);
+
+    const results = await fetchPrsForBranches([
+      { owner: "acct", repo: "missing", branch: "b" },
+      { owner: "acct", repo: "present", branch: "b" },
+    ]);
+
+    expect(results.get("acct/missing#b")).toEqual({ kind: "no_pr" });
+    expect(results.get("acct/present#b")).toMatchObject({ kind: "pr", pr: { number: 5 } });
+    // One aliased query per account, not one per repo (D1/K4).
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("Requirement T4 — a 403 with rate-limit headers maps to reason: rate_limited with retryAfterMs", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      headers: new Headers({ "x-ratelimit-remaining": "0", "retry-after": "30" }),
+    }) as unknown as typeof fetch;
+    mockedListAccounts.mockResolvedValue([{ login: "owner-ratelimit", token: "tok" }]);
+
+    await expect(
+      fetchPrForBranch("owner-ratelimit", "repo-ratelimit", "b"),
+    ).resolves.toEqual({
+      kind: "error",
+      reason: "rate_limited",
+      message: expect.any(String),
+      retryAfterMs: 30_000,
+    });
+  });
+
+  it("B1 — a 200 response with errors[] and NO data is a definitive {kind:\"error\"}, never no_pr", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers(),
+      json: async () => ({
+        errors: [{ type: "RATE_LIMITED", message: "API rate limit exceeded" }],
+        // No `data` key at all — this is the exact GraphQL shape GitHub uses
+        // for rate-limiting, INTERNAL errors, and SAML-enforced FORBIDDEN.
+      }),
+    });
+    mockedListAccounts.mockResolvedValue([{ login: "owner-nodata", token: "tok" }]);
+
+    const result = await fetchPrForBranch("owner-nodata", "repo-nodata", "b");
+    expect(result).toMatchObject({ kind: "error", reason: "rate_limited" });
+  });
+
+  it("B1 — a null alias with NO matching NOT_FOUND error surfaces as {kind:\"error\"}, never no_pr (siblings unaffected)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers(),
+      json: async () => ({
+        data: {
+          // repo0 is null but there's no corresponding NOT_FOUND error for
+          // it — e.g. a partial-failure response where a sibling repo was
+          // INTERNAL/RATE_LIMITED. Laundering this into `no_pr` would wipe
+          // real PR state (B1).
+          repo0: null,
+          repo1: { pullRequests: { nodes: [fakeNode({ number: 9 })] } },
+        },
+        errors: [{ path: ["repo0"], type: "INTERNAL", message: "Something went wrong" }],
+      }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+    mockedListAccounts.mockResolvedValue([{ login: "acct-partial", token: "tok" }]);
+
+    const results = await fetchPrsForBranches([
+      { owner: "acct-partial", repo: "broken", branch: "b" },
+      { owner: "acct-partial", repo: "ok", branch: "b" },
+    ]);
+
+    expect(results.get("acct-partial/broken#b")).toMatchObject({ kind: "error" });
+    expect(results.get("acct-partial/ok#b")).toMatchObject({ kind: "pr", pr: { number: 9 } });
+  });
+
+  it("N2 — a rate-limited 403 gates further requests for that account until retryAfterMs elapses", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      headers: new Headers({ "x-ratelimit-remaining": "0", "retry-after": "60" }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+    mockedListAccounts.mockResolvedValue([{ login: "owner-gated", token: "tok" }]);
+
+    const first = await fetchPrsForBranches([{ owner: "owner-gated", repo: "r", branch: "b" }]);
+    expect(first.get("owner-gated/r#b")).toMatchObject({ kind: "error", reason: "rate_limited" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Second call, same account, still within the retry window: must not
+    // hit the network again — the gate short-circuits it.
+    const second = await fetchPrsForBranches([{ owner: "owner-gated", repo: "r2", branch: "b" }]);
+    expect(second.get("owner-gated/r2#b")).toMatchObject({ kind: "error", reason: "rate_limited" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("N1 — two owners resolved to the same cached account are merged into ONE query, not one per owner", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers(),
+      json: async () => ({
+        data: {
+          repo0: { pullRequests: { nodes: [fakeNode({ number: 1 })] } },
+          repo1: { pullRequests: { nodes: [fakeNode({ number: 2 })] } },
+        },
+      }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+    mockedListAccounts.mockResolvedValue([{ login: "shared-acct", token: "tok" }]);
+
+    // First tick: both owners are new, each probes independently — 2 calls,
+    // but both resolve to the same account and get cached as such.
+    await fetchPrsForBranches([
+      { owner: "owner-a", repo: "repo-a", branch: "b" },
+      { owner: "owner-b", repo: "repo-b", branch: "b" },
+    ]);
+    fetchMock.mockClear();
+
+    // Second tick: both owners are now cached to `shared-acct` — must merge
+    // into a single request instead of one per owner (N1).
+    const results = await fetchPrsForBranches([
+      { owner: "owner-a", repo: "repo-a", branch: "b" },
+      { owner: "owner-b", repo: "repo-b", branch: "b" },
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(results.get("owner-a/repo-a#b")).toMatchObject({ kind: "pr", pr: { number: 1 } });
+    expect(results.get("owner-b/repo-b#b")).toMatchObject({ kind: "pr", pr: { number: 2 } });
   });
 });

--- a/daemon/src/__tests__/githubAuth.test.ts
+++ b/daemon/src/__tests__/githubAuth.test.ts
@@ -1,0 +1,209 @@
+/**
+ * `daemon/src/services/githubAuth.ts` — GitHub credential resolution, no
+ * `gh` binary dependency (D2/D3). Uses a real temp `~/.config/gh/hosts.yml`-
+ * shaped file (via `GH_CONFIG_DIR`) rather than mocking `node:fs`, so the
+ * parser itself is exercised end to end; `gh` is never actually invoked
+ * because the tests never leave the fallback chain's last step reachable
+ * with a real PATH lookup succeeding (PATH is cleared).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { listAccounts, parseHostsYml } from "../services/githubAuth.js";
+
+describe("parseHostsYml", () => {
+  it("extracts login + oauth_token for every user under every host's users: block", () => {
+    const text = `github.com:
+    users:
+        techwithnidhi:
+            oauth_token: gho_aaa
+        fastestdevalive:
+            oauth_token: gho_bbb
+    git_protocol: ssh
+    user: techwithnidhi
+    oauth_token: gho_aaa
+`;
+    expect(parseHostsYml(text)).toEqual([
+      { login: "techwithnidhi", token: "gho_aaa" },
+      { login: "fastestdevalive", token: "gho_bbb" },
+    ]);
+  });
+
+  it("returns a null token for a keyring-backed login with no plaintext oauth_token", () => {
+    const text = `github.com:
+    users:
+        keyring-user: {}
+    git_protocol: https
+`;
+    expect(parseHostsYml(text)).toEqual([{ login: "keyring-user", token: null }]);
+  });
+
+  it("returns [] for empty or unrelated content", () => {
+    expect(parseHostsYml("")).toEqual([]);
+    expect(parseHostsYml("some_other_key: value\n")).toEqual([]);
+  });
+
+  it("excludes logins nested under a GHES host block — their tokens aren't valid against api.github.com", () => {
+    const text = `my-ghes.example.com:
+    users:
+        ghes-user:
+            oauth_token: ghes_token
+github.com:
+    users:
+        real-user:
+            oauth_token: gho_real
+`;
+    expect(parseHostsYml(text)).toEqual([{ login: "real-user", token: "gho_real" }]);
+  });
+
+  it("handles a login line with a trailing comment (`login: # nickname`)", () => {
+    const text = `github.com:
+    users:
+        commented-login: # some nickname
+            oauth_token: gho_commented
+`;
+    expect(parseHostsYml(text)).toEqual([{ login: "commented-login", token: "gho_commented" }]);
+  });
+});
+
+describe("listAccounts", () => {
+  let configDir: string;
+  const originalEnv = { ...process.env };
+  const originalPath = process.env.PATH;
+
+  beforeEach(async () => {
+    configDir = await mkdtemp(join(tmpdir(), "vst-githubauth-test-"));
+    process.env.GH_CONFIG_DIR = configDir;
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.GH_TOKEN;
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith("GH_TOKEN_")) delete process.env[key];
+    }
+    // Keep `gh auth token` unreachable — listAccounts must never throw or
+    // hang trying to shell out when nothing else resolves a login's token.
+    process.env.PATH = "/nonexistent-bin-dir";
+  });
+
+  afterEach(async () => {
+    process.env = { ...originalEnv };
+    process.env.PATH = originalPath;
+    await rm(configDir, { recursive: true, force: true });
+  });
+
+  it("Requirement 1.T2 — [] when neither env nor hosts.yml exist (no throw)", async () => {
+    await expect(listAccounts()).resolves.toEqual([]);
+  });
+
+  it("Requirement 1.T2 — a generic GITHUB_TOKEN env var wins over hosts.yml's token for the same login", async () => {
+    await mkdir(configDir, { recursive: true });
+    await writeFile(
+      join(configDir, "hosts.yml"),
+      `github.com:
+    users:
+        solo-user:
+            oauth_token: gho_from_file
+`,
+    );
+    process.env.GITHUB_TOKEN = "gho_from_env";
+
+    const accounts = await listAccounts();
+    expect(accounts).toEqual([{ login: "solo-user", token: "gho_from_env" }]);
+  });
+
+  it("hosts.yml alone resolves accounts when no env token is set", async () => {
+    await mkdir(configDir, { recursive: true });
+    await writeFile(
+      join(configDir, "hosts.yml"),
+      `github.com:
+    users:
+        techwithnidhi:
+            oauth_token: gho_aaa
+        fastestdevalive:
+            oauth_token: gho_bbb
+`,
+    );
+
+    const accounts = await listAccounts();
+    expect(accounts.sort((a, b) => a.login.localeCompare(b.login))).toEqual([
+      { login: "fastestdevalive", token: "gho_bbb" },
+      { login: "techwithnidhi", token: "gho_aaa" },
+    ]);
+  });
+
+  it("GH_TOKEN_<LOGIN> overrides hosts.yml's token for that one login only", async () => {
+    await mkdir(configDir, { recursive: true });
+    await writeFile(
+      join(configDir, "hosts.yml"),
+      `github.com:
+    users:
+        techwithnidhi:
+            oauth_token: gho_aaa
+        fastestdevalive:
+            oauth_token: gho_bbb
+`,
+    );
+    process.env.GH_TOKEN_TECHWITHNIDHI = "gho_override";
+
+    const accounts = await listAccounts();
+    const byLogin = new Map(accounts.map((a) => [a.login, a.token]));
+    expect(byLogin.get("techwithnidhi")).toBe("gho_override");
+    expect(byLogin.get("fastestdevalive")).toBe("gho_bbb");
+  });
+
+  it("B3 — a generic GITHUB_TOKEN does NOT overwrite either login's existing hosts.yml token when there are TWO accounts", async () => {
+    // Regression: stamping a single generic token onto every known login
+    // silently breaks whichever account it isn't actually for — that
+    // account's private repos 404 under the wrong token, indistinguishable
+    // from "no PR exists" (the exact bug this whole feature exists to fix).
+    await mkdir(configDir, { recursive: true });
+    await writeFile(
+      join(configDir, "hosts.yml"),
+      `github.com:
+    users:
+        techwithnidhi:
+            oauth_token: gho_aaa
+        fastestdevalive:
+            oauth_token: gho_bbb
+`,
+    );
+    process.env.GITHUB_TOKEN = "gho_generic_should_not_apply";
+
+    const accounts = await listAccounts();
+    const byLogin = new Map(accounts.map((a) => [a.login, a.token]));
+    expect(byLogin.get("techwithnidhi")).toBe("gho_aaa");
+    expect(byLogin.get("fastestdevalive")).toBe("gho_bbb");
+  });
+
+  it("B3 — a generic GITHUB_TOKEN DOES fill in a two-account login that has no token of its own (keyring-backed)", async () => {
+    await mkdir(configDir, { recursive: true });
+    await writeFile(
+      join(configDir, "hosts.yml"),
+      `github.com:
+    users:
+        techwithnidhi:
+            oauth_token: gho_aaa
+        keyring-user: {}
+`,
+    );
+    process.env.GITHUB_TOKEN = "gho_generic_fallback";
+
+    const accounts = await listAccounts();
+    const byLogin = new Map(accounts.map((a) => [a.login, a.token]));
+    expect(byLogin.get("techwithnidhi")).toBe("gho_aaa");
+    expect(byLogin.get("keyring-user")).toBe("gho_generic_fallback");
+  });
+
+  it("a keyring-backed login with no plaintext token and no gh on PATH is omitted, not thrown", async () => {
+    await mkdir(configDir, { recursive: true });
+    await writeFile(
+      join(configDir, "hosts.yml"),
+      `github.com:
+    users:
+        keyring-user: {}
+`,
+    );
+
+    await expect(listAccounts()).resolves.toEqual([]);
+  });
+});

--- a/daemon/src/__tests__/githubAuth.test.ts
+++ b/daemon/src/__tests__/githubAuth.test.ts
@@ -7,7 +7,7 @@
  * with a real PATH lookup succeeding (PATH is cleared).
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { mkdtemp, mkdir, writeFile, rm, chmod } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { listAccounts, parseHostsYml } from "../services/githubAuth.js";
@@ -192,6 +192,52 @@ describe("listAccounts", () => {
     const byLogin = new Map(accounts.map((a) => [a.login, a.token]));
     expect(byLogin.get("techwithnidhi")).toBe("gho_aaa");
     expect(byLogin.get("keyring-user")).toBe("gho_generic_fallback");
+  });
+
+  it("nit — `gh auth token --user X` (step 4) wins over the generic-token >=2-account fallback for a keyring-backed login", async () => {
+    // Regression for the ordering bug: the >=2-account generic-fill used to
+    // run BEFORE `gh auth token --user X`, so a keyring-backed second login
+    // (no plaintext token in hosts.yml) got stamped with the generic token
+    // and step 4 then saw it as "already resolved" and never ran — exactly
+    // the wrong-token->404 failure the fallback chain exists to avoid. Now
+    // that fill is deferred to run only after step 4.
+    await mkdir(configDir, { recursive: true });
+    await writeFile(
+      join(configDir, "hosts.yml"),
+      `github.com:
+    users:
+        techwithnidhi:
+            oauth_token: gho_aaa
+        keyring-user: {}
+`,
+    );
+    process.env.GITHUB_TOKEN = "gho_generic_should_lose";
+
+    // A fake `gh` on PATH that answers `gh auth token --user keyring-user`
+    // with a real per-user token, and fails `--version`/anything else so the
+    // isGhOnPath()/other-user checks behave predictably.
+    const binDir = await mkdtemp(join(tmpdir(), "vst-fakegh-"));
+    const ghPath = join(binDir, "gh");
+    await writeFile(
+      ghPath,
+      `#!/bin/sh
+if [ "$1" = "--version" ]; then echo "gh version 0.0.0-fake"; exit 0; fi
+if [ "$1" = "auth" ] && [ "$2" = "token" ] && [ "$4" = "keyring-user" ]; then
+  echo "gho_from_gh_cli"
+  exit 0
+fi
+exit 1
+`,
+    );
+    await chmod(ghPath, 0o755);
+    process.env.PATH = binDir;
+
+    const accounts = await listAccounts();
+    const byLogin = new Map(accounts.map((a) => [a.login, a.token]));
+    expect(byLogin.get("techwithnidhi")).toBe("gho_aaa");
+    expect(byLogin.get("keyring-user")).toBe("gho_from_gh_cli");
+
+    await rm(binDir, { recursive: true, force: true });
   });
 
   it("a keyring-backed login with no plaintext token and no gh on PATH is omitted, not thrown", async () => {

--- a/daemon/src/__tests__/prPoller.test.ts
+++ b/daemon/src/__tests__/prPoller.test.ts
@@ -42,8 +42,8 @@ vi.mock("../broadcaster.js", () => ({
 }));
 
 describe("PR poller configuration", () => {
-  it("polls once every 10s (K8)", () => {
-    expect(PR_POLL_INTERVAL_MS).toBe(10_000);
+  it("polls once every 30s (K8)", () => {
+    expect(PR_POLL_INTERVAL_MS).toBe(30_000);
   });
 });
 
@@ -284,7 +284,12 @@ describe("PR poller behavior", () => {
   });
 
   it("2.T1 — a kind:\"error\" result holds session.pr.state AND leaves lifecycle unchanged (R4)", async () => {
-    await seedProject("waiting_for_human", { state: "open", number: 5, checkedAt: "2020-01-01T00:00:00.000Z" });
+    await seedProject("waiting_for_human", {
+      state: "open",
+      number: 5,
+      checkedAt: "2020-01-01T00:00:00.000Z",
+      prBranch: "feature-branch-0",
+    });
     github.fetchPrsForBranches.mockResolvedValue(
       new Map([
         [
@@ -313,7 +318,12 @@ describe("PR poller behavior", () => {
   });
 
   it("2.T1 — a kind:\"no_credentials\" result holds session.pr.state (R4)", async () => {
-    await seedProject("idle", { state: "open", number: 5, checkedAt: "2020-01-01T00:00:00.000Z" });
+    await seedProject("idle", {
+      state: "open",
+      number: 5,
+      checkedAt: "2020-01-01T00:00:00.000Z",
+      prBranch: "feature-branch-0",
+    });
     github.fetchPrsForBranches.mockResolvedValue(
       new Map([["acme/widgets#feature-branch-0", { kind: "no_credentials" as const }]]),
     );
@@ -329,6 +339,56 @@ describe("PR poller behavior", () => {
     );
     const session = await getSession();
     expect(session.pr?.state).toBe("open");
+  });
+
+  it("BLOCKING-1 — a kind:\"error\" result does NOT hold a PR from a different branch (D20)", async () => {
+    // Session's persisted PR was last checked against a branch the worktree
+    // has since left — `nextPrStatus` must not re-stamp it onto the CURRENT
+    // branch (`feature-branch-0`) just because a transient failure occurred.
+    await seedProject("idle", {
+      state: "open",
+      number: 10,
+      url: "https://github.com/acme/widgets/pull/10",
+      checkedAt: "2020-01-01T00:00:00.000Z",
+      prBranch: "old-branch",
+    });
+    github.fetchPrsForBranches.mockResolvedValue(
+      new Map([
+        [
+          "acme/widgets#feature-branch-0",
+          { kind: "error" as const, reason: "network" as const, message: "boom" },
+        ],
+      ]),
+    );
+
+    await pollAllPrs();
+
+    const session = await getSession();
+    expect(session.pr?.state).toBe("none");
+    expect(session.pr?.number).toBeUndefined();
+    expect(session.pr?.url).toBeUndefined();
+    expect(session.pr?.prBranch).toBe("feature-branch-0");
+  });
+
+  it("BLOCKING-1 — a kind:\"no_credentials\" result does NOT hold a PR from a different branch (D20)", async () => {
+    await seedProject("idle", {
+      state: "open",
+      number: 10,
+      url: "https://github.com/acme/widgets/pull/10",
+      checkedAt: "2020-01-01T00:00:00.000Z",
+      prBranch: "old-branch",
+    });
+    github.fetchPrsForBranches.mockResolvedValue(
+      new Map([["acme/widgets#feature-branch-0", { kind: "no_credentials" as const }]]),
+    );
+
+    await pollAllPrs();
+
+    const session = await getSession();
+    expect(session.pr?.state).toBe("none");
+    expect(session.pr?.number).toBeUndefined();
+    expect(session.pr?.url).toBeUndefined();
+    expect(session.pr?.prBranch).toBe("feature-branch-0");
   });
 
   it("2.T3 — one tick, 3 worktrees → exactly one batched fetchPrsForBranches call", async () => {

--- a/daemon/src/__tests__/prPoller.test.ts
+++ b/daemon/src/__tests__/prPoller.test.ts
@@ -4,12 +4,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import * as githubNs from "../services/github.js";
 import * as broadcasterNs from "../broadcaster.js";
-import {
-  PR_POLL_INTERVAL_MS,
-  pollAllPrs,
-  _resetPrPollerWarningForTest,
-} from "../services/prPoller.js";
-import type { ProjectRecord, LifecycleState } from "../types.js";
+import { PR_POLL_INTERVAL_MS, pollAllPrs, _resetPrPollerWarningForTest } from "../services/prPoller.js";
+import type { ProjectRecord, LifecycleState, PrStatus } from "../types.js";
 
 let tempDir: string;
 
@@ -32,8 +28,10 @@ vi.mock("../services/paths.js", async () => {
 
 vi.mock("../services/github.js", () => ({
   getRemoteUrl: vi.fn(),
-  parseGithubRepo: vi.fn(),
+  resolveGithubRemote: vi.fn(),
+  fetchPrsForBranches: vi.fn(),
   fetchPrForBranch: vi.fn(),
+  _clearPrCacheForTest: vi.fn(),
 }));
 
 vi.mock("../broadcaster.js", () => ({
@@ -44,70 +42,22 @@ vi.mock("../broadcaster.js", () => ({
 }));
 
 describe("PR poller configuration", () => {
-  it("polls once every 60s (Decision 3b)", () => {
-    expect(PR_POLL_INTERVAL_MS).toBe(60_000);
+  it("polls once every 10s (K8)", () => {
+    expect(PR_POLL_INTERVAL_MS).toBe(10_000);
   });
 });
 
 describe("PR poller behavior", () => {
   const github = vi.mocked(githubNs);
 
-  async function seedProject(initialState: LifecycleState = "working"): Promise<void> {
-    const { _clearStoreForTest, addProject } = await import("../state/project-store.js");
-    _clearStoreForTest();
-    const record: ProjectRecord = {
-      id: "proj-pr",
-      absolutePath: join(tempDir, "repo"),
-      prefix: "pfx",
-      isGit: true,
-      defaultBranch: "main",
-      createdAt: new Date().toISOString(),
-      directSessions: [],
-      worktrees: [
-        {
-          id: "wt-pr",
-          branch: "feature-branch",
-          baseBranch: "main",
-          baseSha: "a".repeat(40),
-          createdAt: new Date().toISOString(),
-          sessions: [
-            {
-              id: "sess-pr",
-              slot: "m",
-              isMain: true,
-              type: "agent",
-              modeId: "mode",
-              tmuxName: "pane-pr",
-              lifecycle: {
-                state: initialState,
-                lastTransitionAt: new Date().toISOString(),
-              },
-            },
-          ],
-        },
-      ],
-    };
-    await addProject(record);
-  }
-
-  async function getCurrentState(): Promise<LifecycleState> {
-    const { getProject } = await import("../state/project-store.js");
-    return getProject("proj-pr")!.worktrees[0]!.sessions[0]!.lifecycle.state;
-  }
-
-  async function getCurrentPrMergedAt(): Promise<string | undefined> {
-    const { getProject } = await import("../state/project-store.js");
-    return getProject("proj-pr")!.worktrees[0]!.prMergedAt;
-  }
-
-  /** Same as `seedProject`, plus a pre-existing `prMergedAt` on the worktree
-   *  — for the "clear on fresh PR" test below. */
-  async function seedProjectWithMergedAt(
-    initialState: LifecycleState,
-    prMergedAt: string,
+  async function seedProject(
+    lifecycleState: LifecycleState = "working",
+    pr?: PrStatus,
+    opts?: { worktreeCount?: number },
   ): Promise<void> {
     const { _clearStoreForTest, addProject } = await import("../state/project-store.js");
     _clearStoreForTest();
+    const worktreeCount = opts?.worktreeCount ?? 1;
     const record: ProjectRecord = {
       id: "proj-pr",
       absolutePath: join(tempDir, "repo"),
@@ -116,32 +66,37 @@ describe("PR poller behavior", () => {
       defaultBranch: "main",
       createdAt: new Date().toISOString(),
       directSessions: [],
-      worktrees: [
-        {
-          id: "wt-pr",
-          branch: "feature-branch",
-          baseBranch: "main",
-          baseSha: "a".repeat(40),
-          createdAt: new Date().toISOString(),
-          prMergedAt,
-          sessions: [
-            {
-              id: "sess-pr",
-              slot: "m",
-              isMain: true,
-              type: "agent",
-              modeId: "mode",
-              tmuxName: "pane-pr",
-              lifecycle: {
-                state: initialState,
-                lastTransitionAt: new Date().toISOString(),
-              },
+      worktrees: Array.from({ length: worktreeCount }, (_, i) => ({
+        id: `wt-pr-${i}`,
+        branch: `feature-branch-${i}`,
+        baseBranch: "main",
+        baseSha: "a".repeat(40),
+        createdAt: new Date().toISOString(),
+        sortOrder: i,
+        sessions: [
+          {
+            id: `sess-pr-${i}`,
+            isMain: true,
+            sortOrder: 0,
+            type: "agent" as const,
+            modeId: "mode",
+            tmuxName: `pane-pr-${i}`,
+            useTmux: true,
+            lifecycle: {
+              state: lifecycleState,
+              lastTransitionAt: new Date().toISOString(),
             },
-          ],
-        },
-      ],
+            ...(pr ? { pr } : {}),
+          },
+        ],
+      })),
     };
     await addProject(record);
+  }
+
+  async function getSession(index = 0): Promise<{ lifecycle: { state: LifecycleState }; pr?: PrStatus }> {
+    const { getProject } = await import("../state/project-store.js");
+    return getProject("proj-pr")!.worktrees[index]!.sessions[0]!;
   }
 
   beforeEach(async () => {
@@ -149,182 +104,304 @@ describe("PR poller behavior", () => {
     await mkdir(join(tempDir, "projects", "proj-pr"), { recursive: true });
     await mkdir(join(tempDir, "repo"), { recursive: true });
     github.getRemoteUrl.mockReset();
-    github.parseGithubRepo.mockReset();
-    github.fetchPrForBranch.mockReset();
+    github.resolveGithubRemote.mockReset();
+    github.fetchPrsForBranches.mockReset();
     vi.mocked(broadcasterNs.broadcastAll).mockClear();
     _resetPrPollerWarningForTest();
     // Default happy path: a resolvable GitHub remote.
     github.getRemoteUrl.mockResolvedValue("https://github.com/acme/widgets.git");
-    github.parseGithubRepo.mockReturnValue({ owner: "acme", repo: "widgets" });
+    github.resolveGithubRemote.mockResolvedValue({ host: "github.com", owner: "acme", repo: "widgets" });
   });
 
   afterEach(async () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
-  it("1b.T1 — an open non-draft PR transitions the worktree's main session to needs_review", async () => {
+  it("2.T2 — an open non-draft PR sets pr.state to open", async () => {
     await seedProject("idle");
-    github.fetchPrForBranch.mockResolvedValue({
-      number: 7,
-      url: "https://github.com/acme/widgets/pull/7",
-      title: "Add widget",
-      state: "open",
-      merged: false,
-      draft: false,
-      author: "octocat",
-    });
+    github.fetchPrsForBranches.mockResolvedValue(
+      new Map([
+        [
+          "acme/widgets#feature-branch-0",
+          {
+            kind: "pr" as const,
+            pr: {
+              number: 7,
+              url: "https://github.com/acme/widgets/pull/7",
+              title: "Add widget",
+              state: "open" as const,
+              merged: false,
+              draft: false,
+              author: "octocat",
+            },
+          },
+        ],
+      ]),
+    );
 
     await pollAllPrs();
 
-    expect(await getCurrentState()).toBe("needs_review");
+    const session = await getSession();
+    expect(session.pr?.state).toBe("open");
+    expect(session.pr?.number).toBe(7);
+    // Lifecycle is never touched by this poller (D5/D6).
+    expect(session.lifecycle.state).toBe("idle");
   });
 
-  it("does not flag a draft PR as needs_review", async () => {
+  it("2.T2 — a merged PR sets pr.state to merged", async () => {
     await seedProject("idle");
-    github.fetchPrForBranch.mockResolvedValue({
-      number: 8,
-      url: "https://github.com/acme/widgets/pull/8",
-      title: "WIP widget",
-      state: "open",
-      merged: false,
-      draft: true,
-      author: "octocat",
-    });
+    github.fetchPrsForBranches.mockResolvedValue(
+      new Map([
+        [
+          "acme/widgets#feature-branch-0",
+          {
+            kind: "pr" as const,
+            pr: {
+              number: 7,
+              url: "https://github.com/acme/widgets/pull/7",
+              title: "Add widget",
+              state: "closed" as const,
+              merged: true,
+              draft: false,
+              author: "octocat",
+            },
+          },
+        ],
+      ]),
+    );
 
     await pollAllPrs();
 
-    expect(await getCurrentState()).toBe("idle");
+    expect((await getSession()).pr?.state).toBe("merged");
   });
 
-  it("1b.T2 — a merged PR transitions the session OUT of needs_review", async () => {
-    await seedProject("needs_review");
-    github.fetchPrForBranch.mockResolvedValue({
-      number: 7,
-      url: "https://github.com/acme/widgets/pull/7",
-      title: "Add widget",
-      state: "closed",
-      merged: true,
-      draft: false,
-      author: "octocat",
-    });
-
-    await pollAllPrs();
-
-    expect(await getCurrentState()).not.toBe("needs_review");
-    expect(await getCurrentState()).toBe("idle");
-  });
-
-  it("dashboard-bucket-fixes — a merged PR also stamps the worktree's prMergedAt", async () => {
-    await seedProject("needs_review");
-    github.fetchPrForBranch.mockResolvedValue({
-      number: 7,
-      url: "https://github.com/acme/widgets/pull/7",
-      title: "Add widget",
-      state: "closed",
-      merged: true,
-      draft: false,
-      author: "octocat",
-    });
-
-    await pollAllPrs();
-
-    expect(await getCurrentPrMergedAt()).toBeDefined();
-  });
-
-  it("a closed-without-merge PR also transitions the session out of needs_review", async () => {
-    await seedProject("needs_review");
-    github.fetchPrForBranch.mockResolvedValue({
-      number: 9,
-      url: "https://github.com/acme/widgets/pull/9",
-      title: "Abandoned",
-      state: "closed",
-      merged: false,
-      draft: false,
-      author: "octocat",
-    });
-
-    await pollAllPrs();
-
-    expect(await getCurrentState()).toBe("idle");
-  });
-
-  it("dashboard-bucket-fixes — a closed-without-merge PR does NOT stamp prMergedAt", async () => {
-    await seedProject("needs_review");
-    github.fetchPrForBranch.mockResolvedValue({
-      number: 9,
-      url: "https://github.com/acme/widgets/pull/9",
-      title: "Abandoned",
-      state: "closed",
-      merged: false,
-      draft: false,
-      author: "octocat",
-    });
-
-    await pollAllPrs();
-
-    expect(await getCurrentPrMergedAt()).toBeUndefined();
-  });
-
-  it("dashboard-bucket-fixes — a fresh open+non-draft PR on the same branch clears a previously-set prMergedAt", async () => {
-    await seedProjectWithMergedAt("idle", "2024-01-01T00:00:00.000Z");
-    github.fetchPrForBranch.mockResolvedValue({
-      number: 12,
-      url: "https://github.com/acme/widgets/pull/12",
-      title: "Round two",
-      state: "open",
-      merged: false,
-      draft: false,
-      author: "octocat",
-    });
-
-    await pollAllPrs();
-
-    expect(await getCurrentState()).toBe("needs_review");
-    expect(await getCurrentPrMergedAt()).toBeUndefined();
-  });
-
-  it("no PR at all transitions the session out of needs_review", async () => {
-    await seedProject("needs_review");
-    github.fetchPrForBranch.mockResolvedValue(null);
-
-    await pollAllPrs();
-
-    expect(await getCurrentState()).toBe("idle");
-  });
-
-  it("leaves a done session alone even with an open PR", async () => {
-    await seedProject("done");
-    github.fetchPrForBranch.mockResolvedValue({
-      number: 7,
-      url: "https://github.com/acme/widgets/pull/7",
-      title: "Add widget",
-      state: "open",
-      merged: false,
-      draft: false,
-      author: "octocat",
-    });
-
-    await pollAllPrs();
-
-    expect(await getCurrentState()).toBe("done");
-  });
-
-  it("1b.T3 — a worktree with a non-GitHub remote is skipped without throwing", async () => {
+  it("2.T2 — a draft PR sets pr.state to draft", async () => {
     await seedProject("idle");
-    github.parseGithubRepo.mockReturnValue(null);
+    github.fetchPrsForBranches.mockResolvedValue(
+      new Map([
+        [
+          "acme/widgets#feature-branch-0",
+          {
+            kind: "pr" as const,
+            pr: {
+              number: 8,
+              url: "https://github.com/acme/widgets/pull/8",
+              title: "WIP widget",
+              state: "open" as const,
+              merged: false,
+              draft: true,
+              author: "octocat",
+            },
+          },
+        ],
+      ]),
+    );
 
-    await expect(pollAllPrs()).resolves.toBeUndefined();
-    expect(github.fetchPrForBranch).not.toHaveBeenCalled();
-    expect(await getCurrentState()).toBe("idle");
+    await pollAllPrs();
+
+    expect((await getSession()).pr?.state).toBe("draft");
   });
 
-  it("1b.T3 — a worktree with no resolvable remote at all is skipped without throwing", async () => {
+  it("2.T2 — a closed-without-merge PR sets pr.state to closed", async () => {
+    await seedProject("idle");
+    github.fetchPrsForBranches.mockResolvedValue(
+      new Map([
+        [
+          "acme/widgets#feature-branch-0",
+          {
+            kind: "pr" as const,
+            pr: {
+              number: 9,
+              url: "https://github.com/acme/widgets/pull/9",
+              title: "Abandoned",
+              state: "closed" as const,
+              merged: false,
+              draft: false,
+              author: "octocat",
+            },
+          },
+        ],
+      ]),
+    );
+
+    await pollAllPrs();
+
+    expect((await getSession()).pr?.state).toBe("closed");
+  });
+
+  it("pr-status-axis 5 — records the branch it queried (D20)", async () => {
+    await seedProject("idle");
+    github.fetchPrsForBranches.mockResolvedValue(
+      new Map([
+        [
+          "acme/widgets#feature-branch-0",
+          {
+            kind: "pr" as const,
+            pr: {
+              number: 7,
+              url: "https://github.com/acme/widgets/pull/7",
+              title: "Add widget",
+              state: "open" as const,
+              merged: false,
+              draft: false,
+              author: "octocat",
+            },
+          },
+        ],
+      ]),
+    );
+
+    await pollAllPrs();
+
+    expect((await getSession()).pr?.prBranch).toBe("feature-branch-0");
+  });
+
+  it("2.T2 — a no_pr result sets pr.state to none", async () => {
+    await seedProject("idle", { state: "open", number: 3, checkedAt: "2020-01-01T00:00:00.000Z" });
+    github.fetchPrsForBranches.mockResolvedValue(
+      new Map([["acme/widgets#feature-branch-0", { kind: "no_pr" as const }]]),
+    );
+
+    await pollAllPrs();
+
+    expect((await getSession()).pr?.state).toBe("none");
+  });
+
+  it("2.T2 — a not_github worktree is skipped: no batch call, no session write, no log", async () => {
+    await seedProject("idle");
+    github.resolveGithubRemote.mockResolvedValue(null);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await pollAllPrs();
+
+    expect(github.fetchPrsForBranches).not.toHaveBeenCalled();
+    expect((await getSession()).pr).toBeUndefined();
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it("2.T1 — a kind:\"error\" result holds session.pr.state AND leaves lifecycle unchanged (R4)", async () => {
+    await seedProject("waiting_for_human", { state: "open", number: 5, checkedAt: "2020-01-01T00:00:00.000Z" });
+    github.fetchPrsForBranches.mockResolvedValue(
+      new Map([
+        [
+          "acme/widgets#feature-branch-0",
+          { kind: "error" as const, reason: "network" as const, message: "boom" },
+        ],
+      ]),
+    );
+
+    await pollAllPrs();
+
+    // `error` is surfaced live over the WS broadcast (not a persisted column,
+    // see § Data model) — assert it there; the persisted/re-read state must
+    // still hold its previous value.
+    expect(broadcasterNs.broadcastAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "session:updated",
+        sessionId: "sess-pr-0",
+        pr: expect.objectContaining({ state: "open", number: 5, error: "boom" }),
+      }),
+    );
+    const session = await getSession();
+    expect(session.pr?.state).toBe("open");
+    expect(session.pr?.number).toBe(5);
+    expect(session.lifecycle.state).toBe("waiting_for_human");
+  });
+
+  it("2.T1 — a kind:\"no_credentials\" result holds session.pr.state (R4)", async () => {
+    await seedProject("idle", { state: "open", number: 5, checkedAt: "2020-01-01T00:00:00.000Z" });
+    github.fetchPrsForBranches.mockResolvedValue(
+      new Map([["acme/widgets#feature-branch-0", { kind: "no_credentials" as const }]]),
+    );
+
+    await pollAllPrs();
+
+    expect(broadcasterNs.broadcastAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "session:updated",
+        sessionId: "sess-pr-0",
+        pr: expect.objectContaining({ state: "open", error: expect.any(String) }),
+      }),
+    );
+    const session = await getSession();
+    expect(session.pr?.state).toBe("open");
+  });
+
+  it("2.T3 — one tick, 3 worktrees → exactly one batched fetchPrsForBranches call", async () => {
+    await seedProject("idle", undefined, { worktreeCount: 3 });
+    github.fetchPrsForBranches.mockResolvedValue(new Map());
+
+    await pollAllPrs();
+
+    expect(github.fetchPrsForBranches).toHaveBeenCalledTimes(1);
+    const entries = github.fetchPrsForBranches.mock.calls[0]![0];
+    expect(entries).toHaveLength(3);
+  });
+
+  it("2.T4 — getRemoteUrl returning null makes zero fetch calls and zero log lines (R9/C5)", async () => {
     await seedProject("idle");
     github.getRemoteUrl.mockResolvedValue(null);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
     await expect(pollAllPrs()).resolves.toBeUndefined();
-    expect(github.fetchPrForBranch).not.toHaveBeenCalled();
-    expect(await getCurrentState()).toBe("idle");
+
+    expect(github.fetchPrsForBranches).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it("B2 — a second tick with an unchanged PR result performs no write and no broadcast", async () => {
+    const existing: PrStatus = {
+      state: "open",
+      number: 7,
+      url: "https://github.com/acme/widgets/pull/7",
+      checkedAt: "2020-01-01T00:00:00.000Z",
+      prBranch: "feature-branch-0",
+    };
+    await seedProject("idle", existing);
+    github.fetchPrsForBranches.mockResolvedValue(
+      new Map([
+        [
+          "acme/widgets#feature-branch-0",
+          {
+            kind: "pr" as const,
+            pr: {
+              number: 7,
+              url: "https://github.com/acme/widgets/pull/7",
+              title: "Add widget",
+              state: "open" as const,
+              merged: false,
+              draft: false,
+              author: "octocat",
+            },
+          },
+        ],
+      ]),
+    );
+
+    await pollAllPrs();
+
+    expect(broadcasterNs.broadcastAll).not.toHaveBeenCalled();
+    // The write itself was skipped, so `checkedAt` was never bumped — it
+    // still holds the value from the seed, not this tick's `now`.
+    expect((await getSession()).pr).toEqual(existing);
+  });
+
+  it("B2 — getRemoteUrl/resolveGithubRemote are called once per project per tick, not once per worktree", async () => {
+    await seedProject("idle", undefined, { worktreeCount: 5 });
+    github.fetchPrsForBranches.mockResolvedValue(new Map());
+
+    await pollAllPrs();
+
+    expect(github.getRemoteUrl).toHaveBeenCalledTimes(1);
+    expect(github.resolveGithubRemote).toHaveBeenCalledTimes(1);
   });
 
   it("skips a worktree with no main agent session, without throwing", async () => {
@@ -345,6 +422,7 @@ describe("PR poller behavior", () => {
           baseBranch: "main",
           baseSha: "a".repeat(40),
           createdAt: new Date().toISOString(),
+          sortOrder: 0,
           sessions: [],
         },
       ],
@@ -352,6 +430,6 @@ describe("PR poller behavior", () => {
     await addProject(record);
 
     await expect(pollAllPrs()).resolves.toBeUndefined();
-    expect(github.fetchPrForBranch).not.toHaveBeenCalled();
+    expect(github.fetchPrsForBranches).not.toHaveBeenCalled();
   });
 });

--- a/daemon/src/__tests__/project-store.test.ts
+++ b/daemon/src/__tests__/project-store.test.ts
@@ -171,6 +171,185 @@ describe("project-store (SQL-backed)", () => {
     ).toBe(false);
   });
 
+  it("B2 — updateSessionPr writes one row (not a full project rewrite) and is reflected in the cached graph", async () => {
+    const { addProject, updateSessionPr, getProject } = await import("../state/project-store.js");
+    const project = makeProject("pr-fastpath-proj");
+    project.worktrees = [
+      {
+        id: "pr-fastpath-wt",
+        branch: "b",
+        baseBranch: "main",
+        baseSha: "a".repeat(40),
+        createdAt: new Date().toISOString(),
+        sortOrder: 0,
+        sessions: [
+          {
+            id: "pr-fastpath-sess",
+            type: "agent",
+            modeId: "m",
+            tmuxName: "pr-fastpath-pane",
+            useTmux: true,
+            isMain: true,
+            sortOrder: 0,
+            lifecycle: { state: "idle", lastTransitionAt: new Date().toISOString() },
+          },
+        ],
+      },
+    ];
+    await addProject(project);
+
+    const { getDb } = await import("../state/db.js");
+    const db = getDb();
+    const spy = vi.spyOn(db, "prepare");
+    try {
+      const ok = await updateSessionPr("pr-fastpath-proj", "pr-fastpath-sess", {
+        state: "open",
+        number: 11,
+        url: "https://github.com/acme/widgets/pull/11",
+        checkedAt: "2026-01-01T00:00:00.000Z",
+      });
+      expect(ok).toBe(true);
+      // The fast path must not go through `writeProjectFull` (which re-`db.prepare()`s
+      // its INSERT/DELETE statements every call) — only the one prepared UPDATE.
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(getProject("pr-fastpath-proj")!.worktrees[0]!.sessions[0]!.pr).toEqual({
+      state: "open",
+      number: 11,
+      url: "https://github.com/acme/widgets/pull/11",
+      checkedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    // Unknown session id is a no-op, not a throw.
+    expect(
+      await updateSessionPr("pr-fastpath-proj", "nope", { state: "none", checkedAt: new Date().toISOString() }),
+    ).toBe(false);
+  });
+
+  it("pr-status-axis 2.T5 — session.pr survives a write->read round-trip through project-store (guards the explicit INSERT column list)", async () => {
+    // The `sessions` table is written via an EXPLICIT column list in
+    // writeProjectFull — adding pr* columns to dbSchema.ts/sqliteRowMappers.ts
+    // alone is not enough; if the INSERT/VALUES lists aren't also extended,
+    // every write silently drops the new fields even though the mapper and
+    // schema both look correct in isolation.
+    const { addProject, mutateProject, getProject } = await import("../state/project-store.js");
+    const project = makeProject("pr-status-proj");
+    project.worktrees = [
+      {
+        id: "pr-wt",
+        branch: "b",
+        baseBranch: "main",
+        baseSha: "a".repeat(40),
+        createdAt: new Date().toISOString(),
+        sortOrder: 0,
+        sessions: [
+          {
+            id: "pr-sess",
+            type: "agent",
+            modeId: "m",
+            tmuxName: "pr-pane",
+            useTmux: true,
+            isMain: true,
+            sortOrder: 0,
+            lifecycle: { state: "idle", lastTransitionAt: new Date().toISOString() },
+          },
+        ],
+      },
+    ];
+    await addProject(project);
+
+    await mutateProject("pr-status-proj", (p) => ({
+      ...p,
+      worktrees: p.worktrees.map((w) => ({
+        ...w,
+        sessions: w.sessions.map((s) => ({
+          ...s,
+          pr: {
+            state: "open" as const,
+            number: 42,
+            url: "https://github.com/acme/widgets/pull/42",
+            checkedAt: "2026-01-01T00:00:00.000Z",
+          },
+        })),
+      })),
+    }));
+
+    const pr = getProject("pr-status-proj")!.worktrees[0]!.sessions[0]!.pr;
+    expect(pr).toEqual({
+      state: "open",
+      number: 42,
+      url: "https://github.com/acme/widgets/pull/42",
+      checkedAt: "2026-01-01T00:00:00.000Z",
+    });
+  });
+
+  it("pr-status-axis 5.T4 — prBranch survives a write->read round-trip through project-store (same INSERT-column trap as 2.T5)", async () => {
+    const { addProject, mutateProject, updateSessionPr, getProject } = await import("../state/project-store.js");
+    const project = makeProject("pr-branch-proj");
+    project.worktrees = [
+      {
+        id: "pr-branch-wt",
+        branch: "feature-x",
+        baseBranch: "main",
+        baseSha: "a".repeat(40),
+        createdAt: new Date().toISOString(),
+        sortOrder: 0,
+        sessions: [
+          {
+            id: "pr-branch-sess",
+            type: "agent",
+            modeId: "m",
+            tmuxName: "pr-branch-pane",
+            useTmux: true,
+            isMain: true,
+            sortOrder: 0,
+            lifecycle: { state: "idle", lastTransitionAt: new Date().toISOString() },
+          },
+        ],
+      },
+    ];
+    await addProject(project);
+
+    // Via writeProjectFull's explicit INSERT column list.
+    await mutateProject("pr-branch-proj", (p) => ({
+      ...p,
+      worktrees: p.worktrees.map((w) => ({
+        ...w,
+        sessions: w.sessions.map((s) => ({
+          ...s,
+          pr: {
+            state: "open" as const,
+            number: 9,
+            url: "https://github.com/acme/widgets/pull/9",
+            checkedAt: "2026-01-01T00:00:00.000Z",
+            prBranch: "feature-x",
+          },
+        })),
+      })),
+    }));
+    expect(getProject("pr-branch-proj")!.worktrees[0]!.sessions[0]!.pr?.prBranch).toBe("feature-x");
+
+    // Via the updateSessionPr fast path (B2).
+    const ok = await updateSessionPr("pr-branch-proj", "pr-branch-sess", {
+      state: "merged",
+      number: 9,
+      url: "https://github.com/acme/widgets/pull/9",
+      checkedAt: "2026-01-02T00:00:00.000Z",
+      prBranch: "feature-y",
+    });
+    expect(ok).toBe(true);
+    expect(getProject("pr-branch-proj")!.worktrees[0]!.sessions[0]!.pr).toEqual({
+      state: "merged",
+      number: 9,
+      url: "https://github.com/acme/widgets/pull/9",
+      checkedAt: "2026-01-02T00:00:00.000Z",
+      prBranch: "feature-y",
+    });
+  });
+
   it("2.T3 POST /worktrees -> GET /worktrees round-trips correctly through the SQL-backed store", async () => {
     const { buildServer } = await import("../server.js");
     const repoDir = join(tempDir, "repo");

--- a/daemon/src/__tests__/sessions.test.ts
+++ b/daemon/src/__tests__/sessions.test.ts
@@ -544,6 +544,39 @@ describe("Session routes", () => {
     expect(fetched.state).toBe("not_started");
   });
 
+  it("serializeSession carries `pr` through the REST GET — the initial-load carrier a reload depends on", async () => {
+    // `prStatusEquivalent` (prPoller.ts) means a steady-state PR never
+    // re-broadcasts over WS — the REST fetch on page load is the ONLY path
+    // that would ever surface it. If `serializeSession` ever dropped `pr`,
+    // a reload would show nothing indefinitely with no test catching it.
+    const created = await app.inject({
+      method: "POST",
+      url: "/sessions",
+      payload: { worktreeId, type: "agent", modeId: "bugfix" },
+    });
+    const { id: sessionId } = created.json<SessionRecord>();
+
+    // No PR yet — REST must send an explicit `pr: null`, not an omitted key
+    // (web-ui's `Session.pr` type is `PrStatus | null | undefined`, but the
+    // wire contract here is always an explicit `null`).
+    const beforeRes = await app.inject({ method: "GET", url: `/sessions/${sessionId}` });
+    expect(beforeRes.json<{ pr: unknown }>().pr).toBeNull();
+
+    const { updateSessionPr } = await import("../state/project-store.js");
+    const pr = {
+      state: "open" as const,
+      number: 42,
+      url: "https://github.com/acme/widgets/pull/42",
+      checkedAt: new Date().toISOString(),
+      prBranch: "main",
+    };
+    const changed = await updateSessionPr(projectId, sessionId, pr);
+    expect(changed).toBe(true);
+
+    const afterRes = await app.inject({ method: "GET", url: `/sessions/${sessionId}` });
+    expect(afterRes.json<{ pr: typeof pr }>().pr).toEqual(pr);
+  });
+
   it("skipAutoTurn — worktree-scoped channel:json + prompt names the session but does NOT auto-enqueue turn 1", async () => {
     const jsonAgentChat = await import("../services/jsonAgentChat.js");
     const startJsonCreateTurnMock = vi.mocked(jsonAgentChat.startJsonCreateTurn);

--- a/daemon/src/__tests__/sqliteRowMappers.test.ts
+++ b/daemon/src/__tests__/sqliteRowMappers.test.ts
@@ -8,8 +8,42 @@ import {
   worktreeToRow,
   rowToProject,
   projectToRow,
+  type SessionRow,
 } from "../state/sqliteRowMappers.js";
 import type { ProjectRecord, SessionRecord, WorktreeRecord } from "../types.js";
+
+/** Base fields shared by every `SessionRow` fixture below (Phase 4 back-compat tests). */
+const baseRow: SessionRow = {
+  id: "vs-1-a-abcd1234",
+  worktreeId: "vs-1",
+  projectId: "proj-1",
+  isMain: 1,
+  sortOrder: 1,
+  type: "agent",
+  modeId: null,
+  name: null,
+  nameSource: null,
+  tmuxName: "vst-vs-1-a-abcd1234",
+  useTmux: 1,
+  channel: null,
+  state: "working",
+  reason: null,
+  lastTransitionAt: "2024-01-01T00:00:00.000Z",
+  transcriptKind: null,
+  transcriptPath: null,
+  agentChatId: null,
+  modelOverride: null,
+  pinnedAt: null,
+  initialPrompt: null,
+  archivedAt: null,
+  handoffSummary: null,
+  spawnedFrom: null,
+  prState: null,
+  prNumber: null,
+  prUrl: null,
+  prCheckedAt: null,
+  prBranch: null,
+};
 
 describe("rowToBool / boolToRow", () => {
   it("1.T5 rowToBool(0) === false, rowToBool(1) === true", () => {
@@ -70,6 +104,81 @@ describe("session row <-> record round-trip", () => {
     expect(back).toEqual(minimal);
     expect(back.worktreeId).toBeUndefined();
     expect(back.transcriptRef).toBeUndefined();
+  });
+});
+
+describe("rowToSession — needs_review back-compat (R10, 4.T4)", () => {
+  it("maps a persisted needs_review state to idle lifecycle + an open PR", () => {
+    const row: SessionRow = { ...baseRow, state: "needs_review" };
+    const back = rowToSession(row);
+    expect(back.lifecycle.state).toBe("idle");
+    expect(back.pr).toEqual({ state: "open", checkedAt: "" });
+  });
+
+  it("does not clobber a real PR poller result already persisted for the row", () => {
+    const row: SessionRow = {
+      ...baseRow,
+      state: "needs_review",
+      prState: "merged",
+      prNumber: 42,
+      prUrl: "https://github.com/o/r/pull/42",
+      prCheckedAt: "2024-01-03T00:00:00.000Z",
+    };
+    const back = rowToSession(row);
+    expect(back.lifecycle.state).toBe("idle");
+    expect(back.pr).toEqual({
+      state: "merged",
+      number: 42,
+      url: "https://github.com/o/r/pull/42",
+      checkedAt: "2024-01-03T00:00:00.000Z",
+    });
+  });
+
+  it("leaves a non-legacy state untouched", () => {
+    const row: SessionRow = { ...baseRow, state: "working" };
+    const back = rowToSession(row);
+    expect(back.lifecycle.state).toBe("working");
+    expect(back.pr).toBeUndefined();
+  });
+});
+
+describe("pr-status-axis 5.T4 — prBranch row <-> record mapping", () => {
+  it("rowToSession includes prBranch when the column is set", () => {
+    const row: SessionRow = {
+      ...baseRow,
+      state: "working",
+      prState: "open",
+      prNumber: 7,
+      prUrl: "https://github.com/o/r/pull/7",
+      prCheckedAt: "2024-01-03T00:00:00.000Z",
+      prBranch: "feature-x",
+    };
+    const back = rowToSession(row);
+    expect(back.pr).toEqual({
+      state: "open",
+      number: 7,
+      url: "https://github.com/o/r/pull/7",
+      checkedAt: "2024-01-03T00:00:00.000Z",
+      prBranch: "feature-x",
+    });
+  });
+
+  it("sessionToRow writes prBranch from session.pr.prBranch, null when absent", () => {
+    const session: SessionRecord = {
+      id: "s1",
+      projectId: "proj-1",
+      isMain: true,
+      sortOrder: 0,
+      type: "agent",
+      tmuxName: "t1",
+      useTmux: true,
+      lifecycle: { state: "idle", lastTransitionAt: "2024-01-01T00:00:00.000Z" },
+      pr: { state: "open", checkedAt: "2024-01-01T00:00:00.000Z", prBranch: "feature-x" },
+    };
+    expect(sessionToRow(session, "proj-1", null).prBranch).toBe("feature-x");
+
+    const noPr: SessionRecord = { ...session, pr: undefined };
+    expect(sessionToRow(noPr, "proj-1", null).prBranch).toBeNull();
   });
 });
 

--- a/daemon/src/__tests__/worktrees.test.ts
+++ b/daemon/src/__tests__/worktrees.test.ts
@@ -862,18 +862,18 @@ describe("Worktree routes", () => {
       expect(res.statusCode).toBe(404);
     });
 
-    it("Requirement 10 — GET /worktrees/:id/pr returns { pr: null } when the project repo has no origin remote", async () => {
+    it("Requirement 10 — GET /worktrees/:id/pr returns {kind:\"not_github\"} when the project repo has no origin remote", async () => {
       const wt = await createWorktree("vcs", "no-remote");
       const res = await app.inject({ method: "GET", url: `/worktrees/${wt.id}/pr` });
       expect(res.statusCode).toBe(200);
-      expect(res.json()).toEqual({ pr: null });
+      expect(res.json()).toEqual({ kind: "not_github" });
     });
 
     it("GET /worktrees/:id/pr wires owner/repo/branch through to fetchPrForBranch correctly and returns its result verbatim", async () => {
-      // Real git remote (getRemoteUrl + parseGithubRepo run for real); only
-      // the actual network call (fetchPrForBranch) is stubbed — this proves
-      // the route's argument pass-through, not just the trivial no-remote
-      // short-circuit that the test above covers.
+      // Real git remote (getRemoteUrl + resolveGithubRemote run for real);
+      // only the actual network call (fetchPrForBranch) is stubbed — this
+      // proves the route's argument pass-through, not just the trivial
+      // no-remote short-circuit that the test above covers.
       execSync(`git -C "${repoDir}" remote add origin git@github.com:acme/widgets.git`, {
         stdio: "ignore",
       });
@@ -887,18 +887,22 @@ describe("Worktree routes", () => {
 
       const github = await import("../services/github.js");
       const spy = vi.spyOn(github, "fetchPrForBranch").mockResolvedValue({
-        number: 55,
-        url: "https://github.com/acme/widgets/pull/55",
-        title: "Wired-through PR",
-        state: "open",
-        merged: false,
-        draft: false,
-        author: "someone",
+        kind: "pr",
+        pr: {
+          number: 55,
+          url: "https://github.com/acme/widgets/pull/55",
+          title: "Wired-through PR",
+          state: "open",
+          merged: false,
+          draft: false,
+          author: "someone",
+        },
       });
 
       const res = await app.inject({ method: "GET", url: `/worktrees/${wt.id}/pr` });
       expect(res.statusCode).toBe(200);
       expect(res.json()).toEqual({
+        kind: "pr",
         pr: {
           number: 55,
           url: "https://github.com/acme/widgets/pull/55",
@@ -910,6 +914,28 @@ describe("Worktree routes", () => {
         },
       });
       expect(spy).toHaveBeenCalledWith("acme", "widgets", "wired-branch-name");
+      spy.mockRestore();
+    });
+
+    it("GET /worktrees/:id/pr returns 503 {kind:\"no_credentials\"} without treating it as no PR", async () => {
+      execSync(`git -C "${repoDir}" remote add origin git@github.com:acme/nocred.git`, {
+        stdio: "ignore",
+      });
+      const createRes = await app.inject({
+        method: "POST",
+        url: "/worktrees",
+        payload: { projectId, branch: "nocred-branch", modeId: "bug-fix" },
+      });
+      const wt = createRes.json<{ id: string }>();
+
+      const github = await import("../services/github.js");
+      const spy = vi
+        .spyOn(github, "fetchPrForBranch")
+        .mockResolvedValue({ kind: "no_credentials" });
+
+      const res = await app.inject({ method: "GET", url: `/worktrees/${wt.id}/pr` });
+      expect(res.statusCode).toBe(503);
+      expect(res.json()).toEqual({ kind: "no_credentials" });
       spy.mockRestore();
     });
 

--- a/daemon/src/main.ts
+++ b/daemon/src/main.ts
@@ -171,7 +171,8 @@ async function main() {
 
   // Detect tmux pane death + drive session:exited / state transitions
   startLifecyclePoller();
-  // Poll for PR review-readiness → needs_review (plan 03, Decision 3/3b)
+  // Poll for PR outcome (open/merged/closed) on the orthogonal `session.pr`
+  // axis — pr-status-axis plan, Phase 2. Never touches lifecycle state.
   startPrPoller();
 
   // Graceful shutdown

--- a/daemon/src/routes/sessions.ts
+++ b/daemon/src/routes/sessions.ts
@@ -392,6 +392,7 @@ export function serializeSession(worktreeId: string | null, projectId: string, s
     sortOrder: s.sortOrder,
     handoffSummary: s.handoffSummary ?? null,
     spawnedFrom: s.spawnedFrom ?? null,
+    pr: s.pr ?? null,
   };
 }
 

--- a/daemon/src/routes/worktrees.ts
+++ b/daemon/src/routes/worktrees.ts
@@ -17,7 +17,7 @@ import {
   listCommits,
   resolveBaseSha,
 } from "../services/git.js";
-import { getRemoteUrl, parseGithubRepo, fetchPrForBranch } from "../services/github.js";
+import { getRemoteUrl, resolveGithubRemote, fetchPrForBranch } from "../services/github.js";
 import { rollbackWorktreeCreate } from "../services/rollback.js";
 import { spawnSession } from "../services/spawn.js";
 import { worktreePath as getWorktreePath, cleanupSessionDataDir, sessionDataDir } from "../services/paths.js";
@@ -137,9 +137,6 @@ export function serializeWorktree(projectId: string, w: WorktreeRecord) {
     createdAt: w.createdAt,
     // Always emit pinnedAt so the client doesn't have to special-case undefined.
     pinnedAt: w.pinnedAt ?? null,
-    // Same rationale — set by prPoller.ts when this worktree's PR is seen
-    // merged, so the dashboard can keep crediting "PR created" through it.
-    prMergedAt: w.prMergedAt ?? null,
     sortOrder: w.sortOrder,
     // Id of the worktree's main agent session (isMain === true — replaces the
     // old slot==="m" check, Decision 1). Lets the create-dialog JSON path
@@ -1154,10 +1151,11 @@ export function registerWorktreeRoutes(app: FastifyInstance): void {
   });
 
   // GET /worktrees/:id/pr
-  // Best-effort GitHub PR lookup for the worktree's branch, for the VCS tool
-  // tab's PR banner. Always 200s with `{ pr: null }` when there's no GitHub
-  // remote, no PR, or the lookup fails — this is an annotation, not a
-  // required resource.
+  // GitHub PR lookup for the worktree's branch, for the VCS tool tab's PR
+  // banner. Returns a `PrLookupResult`-shaped body (see
+  // `daemon/src/services/github.ts`) so a transient failure is distinguishable
+  // from "definitely no PR" — a blind `{ pr: null }` for every non-success
+  // case is exactly the silent-failure bug this replaced.
   app.get("/worktrees/:id/pr", async (req, reply) => {
     const { id: wtId } = req.params as { id: string };
 
@@ -1166,10 +1164,18 @@ export function registerWorktreeRoutes(app: FastifyInstance): void {
     const worktree = project.worktrees.find((w) => w.id === wtId)!;
 
     const remoteUrl = await getRemoteUrl(project.absolutePath);
-    const gh = remoteUrl ? parseGithubRepo(remoteUrl) : null;
-    if (!gh) return reply.send({ pr: null });
+    const gh = remoteUrl ? await resolveGithubRemote(remoteUrl) : null;
+    if (!gh) return reply.send({ kind: "not_github" });
 
-    const pr = await fetchPrForBranch(gh.owner, gh.repo, worktree.branch);
-    return reply.send({ pr });
+    const result = await fetchPrForBranch(gh.owner, gh.repo, worktree.branch);
+    if (result.kind === "no_credentials") {
+      return reply.status(503).send({ kind: "no_credentials" });
+    }
+    if (result.kind === "error") {
+      return reply
+        .status(503)
+        .send({ kind: "error", reason: result.reason, message: result.message });
+    }
+    return reply.send(result);
   });
 }

--- a/daemon/src/services/dbSchema.ts
+++ b/daemon/src/services/dbSchema.ts
@@ -108,12 +108,20 @@ export function ensureSchema(db: Database): void {
   // leaving a dangling id is harmless (Research: the client-side workspace
   // tile scan simply won't find a match, S5).
   addColumnIfMissing(db, "sessions", "spawnedFrom", "TEXT");
-  // prMergedAt (dashboard-bucket-fixes) — ISO8601 timestamp remembering that
-  // this worktree's PR was seen merged, so the dashboard can keep crediting
-  // "PR created" instead of reading as idle/working again once the poller
-  // falls the session back out of needs_review. NULL until a merge is seen;
-  // cleared once a fresh open+non-draft PR appears on the same branch.
-  addColumnIfMissing(db, "worktrees", "prMergedAt", "TEXT");
+  // pr* (pr-status-axis) — VCS status for this session's branch, written
+  // exclusively by prPoller.ts. NULL until the first poll tick checks this
+  // session's worktree. prState mirrors PrStatus.state ("none"|"draft"|
+  // "open"|"merged"|"closed"); prNumber/prUrl are set iff a PR exists;
+  // prCheckedAt is the ISO8601 timestamp of the last check (successful or not).
+  addColumnIfMissing(db, "sessions", "prState", "TEXT");
+  addColumnIfMissing(db, "sessions", "prNumber", "INTEGER");
+  addColumnIfMissing(db, "sessions", "prUrl", "TEXT");
+  addColumnIfMissing(db, "sessions", "prCheckedAt", "TEXT");
+  // prBranch (pr-status-axis Phase 5, D20) — the branch prPoller.ts queried
+  // GitHub for when it wrote prState/prNumber/prUrl/prCheckedAt. The UI
+  // renders the PR colour only when this matches the worktree's current
+  // branch, so a branch switch never shows a stale PR colour.
+  addColumnIfMissing(db, "sessions", "prBranch", "TEXT");
 }
 
 /** Add `column` to `table` via `ALTER TABLE` if `PRAGMA table_info` shows it's absent. */

--- a/daemon/src/services/github.ts
+++ b/daemon/src/services/github.ts
@@ -1,16 +1,24 @@
 /**
- * GitHub PR lookup for the VCS tool tab.
+ * GitHub PR lookup for the VCS tool tab + the PR poller.
  *
  * Deliberately does NOT shell out to the `gh` CLI: it isn't provisioned by
- * dev.Dockerfile or any other environment this daemon runs in (see the
- * "no PR integration" research that preceded this file — `git.ts`/`tmux.ts`
- * are the only existing examples of wrapping an external CLI, and both wrap
- * tools that ARE guaranteed present). Talking to the GitHub REST API
- * directly needs nothing beyond network access, which the daemon already has
- * for `fetchOrigin()`.
+ * `dev.Dockerfile` or any other environment this daemon runs in. Talks to
+ * the GitHub GraphQL API directly via `fetch`; credentials are resolved by
+ * `./githubAuth.js` from env vars and gh's own config *file*
+ * (`~/.config/gh/hosts.yml`), never by invoking `gh` unless it's already on
+ * PATH and every other source came up empty (see `githubAuth.ts`).
+ *
+ * SSH remotes that use a host alias (`git@github-<login>:owner/repo`, a
+ * common multi-account setup) are resolved by parsing `~/.ssh/config` in
+ * TypeScript — never by shelling out to `ssh -G`, which isn't guaranteed
+ * present either.
  */
 import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
+import { readFile, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join, isAbsolute } from "node:path";
+import { listAccounts, type GithubAccount } from "./githubAuth.js";
 
 const execFile = promisify(execFileCb);
 
@@ -24,6 +32,18 @@ export interface PrInfo {
   author: string | null;
 }
 
+export type PrLookupResult =
+  | { kind: "pr"; pr: PrInfo }
+  | { kind: "no_pr" }
+  | { kind: "not_github" }
+  | { kind: "no_credentials" }
+  | {
+      kind: "error";
+      reason: "network" | "rate_limited" | "auth" | "api";
+      message: string;
+      retryAfterMs?: number;
+    };
+
 /** Returns the `origin` remote URL for a repo, or null if there is none. */
 export async function getRemoteUrl(repoPath: string): Promise<string | null> {
   try {
@@ -36,105 +56,525 @@ export async function getRemoteUrl(repoPath: string): Promise<string | null> {
   }
 }
 
-/**
- * Parses `owner/repo` out of a GitHub remote URL. Handles the common forms:
- * `git@github.com:owner/repo.git`, `https://github.com/owner/repo.git`,
- * `https://github.com/owner/repo`, `ssh://git@github.com/owner/repo.git`.
- * Returns null for non-GitHub remotes (GitHub Enterprise, GitLab, etc. are
- * out of scope for now).
- */
-export function parseGithubRepo(remoteUrl: string): { owner: string; repo: string } | null {
+interface RawRemote {
+  host: string;
+  owner: string;
+  repo: string;
+}
+
+/** Strips userinfo (`user:token@`) and a trailing `:port` off a captured
+ *  host, e.g. `https://user:token@github.com/o/r.git` and
+ *  `ssh://git@github.com:22/o/r.git` — both otherwise capture the wrong
+ *  string as `host` and silently fail the GitHub check (N3). */
+function stripUserinfoAndPort(host: string): string {
+  const withoutUserinfo = host.includes("@") ? host.slice(host.lastIndexOf("@") + 1) : host;
+  return withoutUserinfo.replace(/:\d+$/, "");
+}
+
+/** Captures `host`/`owner`/`repo` out of any remote URL shape, GitHub or not. */
+function parseHostOwnerRepo(remoteUrl: string): RawRemote | null {
+  const trimmed = remoteUrl.trim();
   const patterns = [
-    /^git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/,
-    /^(?:https?|ssh):\/\/(?:git@)?github\.com[/:]([^/]+)\/(.+?)(?:\.git)?$/,
+    /^git@([^:]+):([^/]+)\/(.+?)(?:\.git)?$/,
+    /^(?:https?|ssh):\/\/(?:git@)?([^/]+)\/([^/]+)\/(.+?)(?:\.git)?$/,
   ];
   for (const re of patterns) {
-    const m = remoteUrl.trim().match(re);
-    if (m) return { owner: m[1]!, repo: m[2]!.replace(/\.git$/, "") };
+    const m = trimmed.match(re);
+    if (m) return { host: stripUserinfoAndPort(m[1]!), owner: m[2]!, repo: m[3]!.replace(/\.git$/, "") };
   }
   return null;
 }
 
+// ── ~/.ssh/config parsing (D4/K2) — cached by the mtime of every file the
+// parse actually visited (top-level config + every `Include`d file), so an
+// edit to an `Include`d file invalidates the cache too, not just the
+// top-level file. ──
+
+interface SshConfigCache {
+  /** path -> mtimeMs, for the top-level config file AND every `Include`d
+   *  file the parse visited. */
+  fileMtimes: Map<string, number>;
+  hostMap: Map<string, string>;
+}
+
+let sshConfigCache: SshConfigCache | null = null;
+
+function resolveIncludePath(raw: string, sshDir: string): string {
+  const cleaned = raw.trim().replace(/^["']|["']$/g, "");
+  if (isAbsolute(cleaned)) return cleaned;
+  if (cleaned.startsWith("~/")) return join(homedir(), cleaned.slice(2));
+  return join(sshDir, cleaned);
+}
+
+/** Parses one `~/.ssh/config`-shaped file into `alias -> HostName`. Handles a
+ *  single level of `Include` (D4/risk #2); no glob expansion, no `Match`.
+ *  Records every successfully-read file's mtime into `fileMtimes` so the
+ *  caller can key the cache off the whole dependency set, not just the
+ *  top-level file. */
+async function parseSshConfigFile(
+  path: string,
+  depth: number,
+  sshDir: string,
+  hostMap: Map<string, string>,
+  fileMtimes: Map<string, number>,
+): Promise<void> {
+  if (depth > 1) return; // one Include level, per the locked design.
+  let text: string;
+  try {
+    const st = await stat(path);
+    text = await readFile(path, "utf8");
+    fileMtimes.set(path, st.mtimeMs);
+  } catch {
+    return;
+  }
+
+  let currentHosts: string[] = [];
+  for (const raw of text.split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const spaceIdx = line.search(/\s/);
+    const key = (spaceIdx === -1 ? line : line.slice(0, spaceIdx)).toLowerCase();
+    const value = spaceIdx === -1 ? "" : line.slice(spaceIdx + 1).trim();
+
+    if (key === "host") {
+      currentHosts = value.split(/\s+/).filter(Boolean);
+    } else if (key === "hostname") {
+      for (const alias of currentHosts) {
+        if (!alias.includes("*") && !alias.includes("?")) hostMap.set(alias, value);
+      }
+    } else if (key === "include") {
+      for (const incRaw of value.split(/\s+/).filter(Boolean)) {
+        // No glob expansion — literal-path Includes only.
+        await parseSshConfigFile(resolveIncludePath(incRaw, sshDir), depth + 1, sshDir, hostMap, fileMtimes);
+      }
+    }
+  }
+}
+
+async function statMtime(path: string): Promise<number | null> {
+  try {
+    return (await stat(path)).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+/** True iff every file the last parse visited (top-level + every `Include`)
+ *  still has the mtime it had when parsed. */
+async function isSshConfigCacheFresh(c: SshConfigCache): Promise<boolean> {
+  for (const [path, mtimeMs] of c.fileMtimes) {
+    if ((await statMtime(path)) !== mtimeMs) return false;
+  }
+  return true;
+}
+
+async function resolveSshAliasHost(alias: string): Promise<string | null> {
+  const sshDir = join(homedir(), ".ssh");
+  const configPath = join(sshDir, "config");
+
+  if ((await statMtime(configPath)) == null) {
+    sshConfigCache = null;
+    return null;
+  }
+
+  if (!sshConfigCache || !(await isSshConfigCacheFresh(sshConfigCache))) {
+    const hostMap = new Map<string, string>();
+    const fileMtimes = new Map<string, number>();
+    await parseSshConfigFile(configPath, 0, sshDir, hostMap, fileMtimes);
+    sshConfigCache = { fileMtimes, hostMap };
+  }
+  return sshConfigCache.hostMap.get(alias) ?? null;
+}
+
+/**
+ * Replaces `parseGithubRepo`. Relaxed regex captures any host, then resolves
+ * whether it's actually GitHub: a literal `github.com` host short-circuits;
+ * otherwise the alias is looked up in `~/.ssh/config` for a `HostName`
+ * ending in `github.com`, falling back to the `/^github[-.]/i` naming
+ * heuristic (D4). The returned `host` is always the *raw* host/alias from
+ * the remote URL, unchanged — only whether the remote resolves to GitHub is
+ * decided here.
+ */
+export async function resolveGithubRemote(
+  remoteUrl: string,
+): Promise<{ host: string; owner: string; repo: string } | null> {
+  const parsed = parseHostOwnerRepo(remoteUrl);
+  if (!parsed) return null;
+  if (parsed.host === "github.com") return parsed;
+
+  const resolvedHostName = await resolveSshAliasHost(parsed.host);
+  if (resolvedHostName && /(^|\.)github\.com$/i.test(resolvedHostName)) return parsed;
+
+  if (/^github[-.]/i.test(parsed.host)) return parsed;
+
+  return null;
+}
+
+function entryKey(e: { owner: string; repo: string; branch: string }): string {
+  return `${e.owner}/${e.repo}#${e.branch}`;
+}
+
+interface GraphQLPrNode {
+  number: number;
+  url: string;
+  title: string;
+  state: "OPEN" | "CLOSED" | "MERGED";
+  isDraft: boolean;
+  merged: boolean;
+  author: { login: string } | null;
+}
+
+function toPrInfo(node: GraphQLPrNode): PrInfo {
+  return {
+    number: node.number,
+    url: node.url,
+    title: node.title,
+    state: node.state === "OPEN" ? "open" : "closed",
+    merged: node.merged,
+    draft: node.isDraft,
+    author: node.author?.login ?? null,
+  };
+}
+
+function classifyHttpError(status: number, headers: Headers): PrLookupResult {
+  if (status === 401) {
+    return { kind: "error", reason: "auth", message: `GitHub API auth failed (${status})` };
+  }
+  if (status === 403) {
+    const remaining = headers.get("x-ratelimit-remaining");
+    const retryAfterHeader = headers.get("retry-after");
+    const resetHeader = headers.get("x-ratelimit-reset");
+    if (remaining === "0" || retryAfterHeader || resetHeader) {
+      let retryAfterMs: number | undefined;
+      if (retryAfterHeader) retryAfterMs = Number(retryAfterHeader) * 1000;
+      else if (resetHeader) retryAfterMs = Math.max(0, Number(resetHeader) * 1000 - Date.now());
+      return {
+        kind: "error",
+        reason: "rate_limited",
+        message: `GitHub API rate limited (${status})`,
+        ...(retryAfterMs != null && Number.isFinite(retryAfterMs) ? { retryAfterMs } : {}),
+      };
+    }
+    return { kind: "error", reason: "auth", message: `GitHub API forbidden (${status})` };
+  }
+  return { kind: "error", reason: "api", message: `GitHub API error (${status})` };
+}
+
+/** Sentinel: this alias came back `NOT_FOUND` for this account (wrong
+ *  account, or the repo genuinely doesn't exist) — never surfaced to
+ *  callers, only used internally to decide whether an account "owns" a
+ *  repo's owner (K3/D4b). */
+const NOT_FOUND = Symbol("not_found");
+
+/** N2: per-account rate-limit gate. Set from a 403's `retryAfterMs`;
+ *  consulted before every subsequent request for that account so the poller
+ *  doesn't keep burning requests into the same rate-limit window — it was
+ *  computed and never read before this fix. */
+const rateLimitedUntil = new Map<string, number>();
+
+/** Maps a top-level GraphQL `errors[]` array (no usable `data` at all — the
+ *  shape GitHub uses for rate-limiting, internal errors, and SAML-enforced
+ *  `FORBIDDEN`) to a definitive `{kind:"error"}`. Never `no_pr` — a 200 with
+ *  errors and no data is not "no PR exists" (B1: this was the exact bug that
+ *  wiped real PR state across every worktree of an owner). */
+function mapTopLevelGraphQLErrors(
+  errors: Array<{ type?: string; message?: string }> | undefined,
+): PrLookupResult {
+  const first = errors?.[0];
+  const reason = first?.type === "RATE_LIMITED" ? "rate_limited" : "api";
+  const message = first?.message
+    ? `GitHub GraphQL error: ${first.message}`
+    : "GitHub GraphQL API returned no data";
+  return { kind: "error", reason, message };
+}
+
+async function queryAccountGraphQL(
+  account: GithubAccount,
+  entries: Array<{ owner: string; repo: string; branch: string }>,
+): Promise<
+  | { ok: true; perEntry: Map<string, PrLookupResult | typeof NOT_FOUND> }
+  | { ok: false; error: PrLookupResult }
+> {
+  const gateUntil = rateLimitedUntil.get(account.login);
+  if (gateUntil != null && gateUntil > Date.now()) {
+    return {
+      ok: false,
+      error: {
+        kind: "error",
+        reason: "rate_limited",
+        message: `GitHub API rate limited for ${account.login} until ${new Date(gateUntil).toISOString()}`,
+        retryAfterMs: gateUntil - Date.now(),
+      },
+    };
+  }
+
+  const alias = (i: number) => `repo${i}`;
+  const fields = entries
+    .map(
+      (e, i) => `${alias(i)}: repository(owner: ${JSON.stringify(e.owner)}, name: ${JSON.stringify(e.repo)}) {
+    pullRequests(headRefName: ${JSON.stringify(e.branch)}, last: 1, orderBy: {field: CREATED_AT, direction: DESC}) {
+      nodes { number url title state isDraft merged author { login } }
+    }
+  }`,
+    )
+    .join("\n");
+  const query = `query { ${fields} }`;
+
+  let res: Response;
+  try {
+    res = await fetch("https://api.github.com/graphql", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${account.token}`,
+        "Content-Type": "application/json",
+        "User-Agent": "vibe-station",
+      },
+      body: JSON.stringify({ query }),
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      error: {
+        kind: "error",
+        reason: "network",
+        message: err instanceof Error ? err.message : String(err),
+      },
+    };
+  }
+
+  if (!res.ok) {
+    const classified = classifyHttpError(res.status, res.headers);
+    if (classified.kind === "error" && classified.reason === "rate_limited" && classified.retryAfterMs != null) {
+      rateLimitedUntil.set(account.login, Date.now() + classified.retryAfterMs);
+    }
+    return { ok: false, error: classified };
+  }
+
+  let body: {
+    data?: Record<string, { pullRequests: { nodes: GraphQLPrNode[] } } | null> | null;
+    errors?: Array<{ path?: Array<string | number>; type?: string; message?: string }>;
+  };
+  try {
+    body = (await res.json()) as typeof body;
+  } catch {
+    return { ok: false, error: { kind: "error", reason: "api", message: "Invalid JSON from GitHub GraphQL API" } };
+  }
+
+  // B1: GitHub signals rate-limiting, internal errors, and SAML-enforced
+  // FORBIDDEN as HTTP 200 with `errors[]` and NO `data` at all. Previously
+  // every alias fell through the `!repoData` branch below and was laundered
+  // into the internal `NOT_FOUND` sentinel, which the caller then converts
+  // to a definitive `no_pr` — wiping every worktree's real PR state for the
+  // whole rate-limit window. A response with no `data` can never mean "no
+  // PR exists"; it must surface as a transport-level error so the poller
+  // holds the prior state (D8/R4).
+  if (body.data == null) {
+    return { ok: false, error: mapTopLevelGraphQLErrors(body.errors) };
+  }
+
+  const notFoundAliases = new Set<string>();
+  const erroredAliases = new Map<string, string>();
+  for (const err of body.errors ?? []) {
+    const path0 = err.path?.[0];
+    if (typeof path0 !== "string") continue;
+    if (err.type === "NOT_FOUND") notFoundAliases.add(path0);
+    else erroredAliases.set(path0, err.type ?? "UNKNOWN");
+  }
+
+  const perEntry = new Map<string, PrLookupResult | typeof NOT_FOUND>();
+  entries.forEach((e, i) => {
+    const a = alias(i);
+    const k = entryKey(e);
+    const repoData = body.data?.[a];
+    if (notFoundAliases.has(a)) {
+      perEntry.set(k, NOT_FOUND);
+      return;
+    }
+    if (!repoData) {
+      // A null alias with NO matching NOT_FOUND error (partial-failure
+      // responses can null out some aliases while others are RATE_LIMITED /
+      // INTERNAL / FORBIDDEN, or an alias can simply be missing with no
+      // error entry at all) must never be laundered into `no_pr` — surface
+      // it as a definitive error so the poller holds the prior state (B1).
+      const errType = erroredAliases.get(a);
+      perEntry.set(k, {
+        kind: "error",
+        reason: errType === "RATE_LIMITED" ? "rate_limited" : "api",
+        message: errType
+          ? `GitHub GraphQL error for ${e.owner}/${e.repo}: ${errType}`
+          : `GitHub GraphQL returned no data for ${e.owner}/${e.repo}`,
+      });
+      return;
+    }
+    const node = repoData.pullRequests.nodes[0];
+    perEntry.set(k, node ? { kind: "pr", pr: toPrInfo(node) } : { kind: "no_pr" });
+  });
+
+  return { ok: true, perEntry };
+}
+
+/** Cached `owner -> login` — avoids re-probing which account can see a given
+ *  owner's repos on every tick (K3/D4b). */
+const ownerAccountCache = new Map<string, string>();
+
+/** Orders candidate accounts for probing an owner: the login that matches
+ *  the owner first (common single-account-per-org case), then the rest. */
+function orderAccountsForOwner(accounts: GithubAccount[], owner: string): GithubAccount[] {
+  const lower = owner.toLowerCase();
+  return [...accounts].sort((a, b) => {
+    const aMatch = a.login.toLowerCase() === lower ? 0 : 1;
+    const bMatch = b.login.toLowerCase() === lower ? 0 : 1;
+    return aMatch - bMatch;
+  });
+}
+
+/**
+ * Looks up the most recent PR for each `{owner, repo, branch}` entry, one
+ * aliased GraphQL query per GitHub *account* (D1/K4/N1) — steady-state cost
+ * is O(distinct credentialed accounts actually in use), not O(distinct
+ * owners). Owners whose serving account is already known (`ownerAccountCache`)
+ * are merged into a single query per account regardless of how many distinct
+ * owners that account serves; only an owner seen for the first time still
+ * probes candidate accounts one owner at a time (unavoidable — which account
+ * can see it isn't known yet).
+ */
+export async function fetchPrsForBranches(
+  entries: Array<{ owner: string; repo: string; branch: string }>,
+): Promise<Map<string, PrLookupResult>> {
+  const results = new Map<string, PrLookupResult>();
+  if (entries.length === 0) return results;
+
+  const accounts = await listAccounts();
+  if (accounts.length === 0) {
+    for (const e of entries) results.set(entryKey(e), { kind: "no_credentials" });
+    return results;
+  }
+  const accountByLogin = new Map(accounts.map((a) => [a.login, a] as const));
+
+  const byOwner = new Map<string, typeof entries>();
+  for (const e of entries) {
+    const list = byOwner.get(e.owner);
+    if (list) list.push(e);
+    else byOwner.set(e.owner, [e]);
+  }
+
+  // N1: split into owners whose serving account is already cached (merge by
+  // account, one query total per account) vs. owners seen for the first
+  // time (still probed one owner at a time).
+  const cachedByLogin = new Map<string, typeof entries>();
+  const uncachedOwners: string[] = [];
+  for (const [owner, ownerEntries] of byOwner) {
+    const cachedLogin = ownerAccountCache.get(owner);
+    if (cachedLogin && accountByLogin.has(cachedLogin)) {
+      const list = cachedByLogin.get(cachedLogin);
+      if (list) list.push(...ownerEntries);
+      else cachedByLogin.set(cachedLogin, [...ownerEntries]);
+    } else {
+      uncachedOwners.push(owner);
+    }
+  }
+
+  await Promise.all([
+    ...[...cachedByLogin.entries()].map(async ([login, accountEntries]) => {
+      const account = accountByLogin.get(login)!;
+      const queried = await queryAccountGraphQL(account, accountEntries);
+      if (!queried.ok) {
+        // Same rationale as the uncached path below: a transport-level
+        // failure is not "wrong account" — surface it immediately (D8).
+        for (const e of accountEntries) results.set(entryKey(e), queried.error);
+        return;
+      }
+      // Already-known-good account: commit unconditionally, exactly like the
+      // single-candidate cached path used to (a NOT_FOUND for one repo under
+      // a verified account is that repo's own state, not a wrong-account signal).
+      for (const [k, v] of queried.perEntry) {
+        results.set(k, v === NOT_FOUND ? { kind: "no_pr" } : v);
+      }
+    }),
+    ...uncachedOwners.map(async (owner) => {
+      const ownerEntries = byOwner.get(owner)!;
+      const candidates = orderAccountsForOwner(accounts, owner);
+
+      for (const account of candidates) {
+        const queried = await queryAccountGraphQL(account, ownerEntries);
+        if (!queried.ok) {
+          // A transport-level failure (network/rate-limit/auth/api) is not
+          // "wrong account" — trying another candidate wouldn't help and
+          // would burn extra quota, so surface it immediately (D8: hold on
+          // non-definitive results, never silently retry-as-guess).
+          for (const e of ownerEntries) results.set(entryKey(e), queried.error);
+          return;
+        }
+
+        const anyFound = [...queried.perEntry.values()].some((v) => v !== NOT_FOUND);
+        if (anyFound) {
+          ownerAccountCache.set(owner, account.login);
+          for (const [k, v] of queried.perEntry) {
+            results.set(k, v === NOT_FOUND ? { kind: "no_pr" } : v);
+          }
+          return;
+        }
+        // Every repo for this owner NOT_FOUND under this account — try the next.
+      }
+
+      // No candidate account could see any repo for this owner.
+      for (const e of ownerEntries) {
+        results.set(entryKey(e), {
+          kind: "error",
+          reason: "auth",
+          message: `No credentialed GitHub account can access ${owner}`,
+        });
+      }
+    }),
+  ]);
+
+  return results;
+}
+
 interface CacheEntry {
-  value: PrInfo | null;
+  value: PrLookupResult;
   expiresAt: number;
 }
 
-// Keyed by `${owner}/${repo}#${branch}`. Unauthenticated GitHub API calls are
-// capped at 60/hr per IP — a short TTL keeps the VCS tab responsive (each
-// manual refresh / worktree switch would otherwise burn a call) without
-// requiring the caller to build its own polling/caching layer.
-const CACHE_TTL_MS = 30_000;
+// Keyed by `${owner}/${repo}#${branch}`. K8: 5s TTL — short enough that the
+// 10s poll interval isn't defeated by a stale cached value, long enough that
+// a manual VCS-tab refresh right after a poll tick doesn't double the call.
+const CACHE_TTL_MS = 5_000;
 const cache = new Map<string, CacheEntry>();
 
 /**
- * Looks up the most relevant open-or-recently-updated PR for `branch` in
- * `owner/repo` via the GitHub REST API. Returns null if there's no PR, the
- * repo/branch can't be resolved, or the request fails (rate limit, no
- * network, private repo without a token, etc.) — this is a "nice to have"
- * annotation on the commit graph, never a hard failure.
+ * Single-entry wrapper over `fetchPrsForBranches`, for callers (the VCS tool
+ * tab route) that only ever want one branch's result. `error` results are
+ * never cached — a transient failure must not "stick" past its own tick.
  */
 export async function fetchPrForBranch(
   owner: string,
   repo: string,
   branch: string,
-): Promise<PrInfo | null> {
-  const key = `${owner}/${repo}#${branch}`;
+): Promise<PrLookupResult> {
+  const key = entryKey({ owner, repo, branch });
   const cached = cache.get(key);
   if (cached && cached.expiresAt > Date.now()) return cached.value;
 
-  const value = await fetchPrForBranchUncached(owner, repo, branch);
-  cache.set(key, { value, expiresAt: Date.now() + CACHE_TTL_MS });
+  const results = await fetchPrsForBranches([{ owner, repo, branch }]);
+  const value: PrLookupResult = results.get(key) ?? {
+    kind: "error",
+    reason: "api",
+    message: "No result returned for this branch",
+  };
+  if (value.kind !== "error") {
+    cache.set(key, { value, expiresAt: Date.now() + CACHE_TTL_MS });
+  }
   return value;
 }
 
-/** Test-only: clears the module-level PR cache. Matches the `_clearStoreForTest`/
- * `_resetModesCacheForTest` convention used elsewhere in this codebase for
- * module-level test state. */
+/** Test-only: clears the module-level PR + owner->account caches. Matches
+ *  the `_clearStoreForTest`/`_resetModesCacheForTest` convention used
+ *  elsewhere in this codebase for module-level test state. */
 export function _clearPrCacheForTest(): void {
   cache.clear();
-}
-
-async function fetchPrForBranchUncached(
-  owner: string,
-  repo: string,
-  branch: string,
-): Promise<PrInfo | null> {
-  const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
-  const headers: Record<string, string> = {
-    Accept: "application/vnd.github+json",
-    "User-Agent": "vibe-station",
-  };
-  if (token) headers.Authorization = `Bearer ${token}`;
-
-  try {
-    // `state=all` + head filter: most recent PR for the branch, whether
-    // open, merged, or closed-without-merge — the VCS tab wants to show
-    // "was there ever a PR" state, not just "is one currently open".
-    const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls?head=${encodeURIComponent(owner)}:${encodeURIComponent(branch)}&state=all&per_page=1&sort=created&direction=desc`;
-    const res = await fetch(url, { headers, signal: AbortSignal.timeout(5000) });
-    if (!res.ok) return null;
-    const list = (await res.json()) as Array<{
-      number: number;
-      html_url: string;
-      title: string;
-      state: string;
-      draft: boolean;
-      merged_at: string | null;
-      user: { login: string } | null;
-    }>;
-    const pr = list[0];
-    if (!pr) return null;
-    return {
-      number: pr.number,
-      url: pr.html_url,
-      title: pr.title,
-      state: pr.state === "closed" ? "closed" : "open",
-      merged: pr.merged_at != null,
-      draft: pr.draft,
-      author: pr.user?.login ?? null,
-    };
-  } catch {
-    return null;
-  }
+  ownerAccountCache.clear();
+  rateLimitedUntil.clear();
+  sshConfigCache = null;
 }

--- a/daemon/src/services/githubAuth.ts
+++ b/daemon/src/services/githubAuth.ts
@@ -1,0 +1,222 @@
+/**
+ * GitHub credential resolution (D2/D3 in
+ * `.vibekit/reports/2026-08-16-pr-detection-broken-root-cause-and-fix.md`).
+ *
+ * Deliberately does NOT require the `gh` binary — `gh` is not provisioned by
+ * `dev.Dockerfile` (or any environment this daemon runs in), so it can only
+ * ever be an opportunistic last resort, never a hard dependency. Reads gh's
+ * own *data file* (`~/.config/gh/hosts.yml`) instead, which holds a
+ * per-login plaintext `oauth_token` on every host inspected so far (a
+ * keyring-backed `hosts.yml` with no plaintext token is a known, unhandled
+ * gap — see the research report's "Not checked" section).
+ *
+ * Credential chain, per account login (D3):
+ *   1. `GH_TOKEN_<LOGIN>` env var (login upper-cased, `-`/`.` -> `_`)
+ *   2. `GITHUB_TOKEN` / `GH_TOKEN` env var (generic — single-account fallback)
+ *   3. `~/.config/gh/hosts.yml` -> `users.<login>.oauth_token`
+ *   4. `gh auth token --user <login>`, only if `gh` happens to be on PATH
+ *
+ * `listAccounts()` never throws; it resolves to `[]` when nothing is found.
+ */
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCb);
+
+export interface GithubAccount {
+  login: string;
+  token: string;
+}
+
+function hostsYmlPath(): string {
+  return join(process.env.GH_CONFIG_DIR || join(homedir(), ".config", "gh"), "hosts.yml");
+}
+
+/**
+ * Minimal, purpose-built parser for gh's `hosts.yml` shape — not a general
+ * YAML parser (no library dependency for one file format). Handles:
+ *
+ *   github.com:
+ *       users:
+ *           some-login:
+ *               oauth_token: gho_xxxx
+ *           other-login: {}
+ *       oauth_token: gho_xxxx   # top-level = currently-active user's token
+ *       user: some-login
+ *
+ * Returns every login found under the `github.com:` host's `users:` block
+ * only — logins nested under a GitHub Enterprise Server host block (a
+ * top-level key other than `github.com`) are deliberately excluded, since
+ * their tokens are only valid against that GHES instance's API, not
+ * `api.github.com`, and this daemon only ever talks to the latter.
+ *
+ * `oauth_token` when present (absent for keyring-backed logins).
+ */
+export function parseHostsYml(text: string): Array<{ login: string; token: string | null }> {
+  const lines = text.split("\n");
+  const found: Array<{ login: string; token: string | null }> = [];
+
+  let currentHost: string | null = null;
+  let inUsers = false;
+  let usersIndent = -1;
+  let currentLogin: string | null = null;
+  let currentLoginIndent = -1;
+  let currentToken: string | null = null;
+
+  const flushCurrent = () => {
+    if (currentLogin !== null && currentHost === "github.com") {
+      found.push({ login: currentLogin, token: currentToken });
+    }
+    currentLogin = null;
+    currentToken = null;
+  };
+
+  for (const raw of lines) {
+    if (!raw.trim() || raw.trim().startsWith("#")) continue;
+    const indent = raw.length - raw.trimStart().length;
+    const trimmed = raw.trim();
+
+    // Top-level host block header, e.g. `github.com:` or a GHES hostname.
+    if (indent === 0) {
+      const hostMatch = /^([^:]+):\s*$/.exec(trimmed);
+      if (hostMatch) {
+        flushCurrent();
+        inUsers = false;
+        currentHost = hostMatch[1]!.trim();
+        continue;
+      }
+    }
+
+    if (trimmed === "users:") {
+      flushCurrent();
+      inUsers = true;
+      usersIndent = indent;
+      continue;
+    }
+    if (!inUsers) continue;
+
+    if (indent <= usersIndent) {
+      flushCurrent();
+      inUsers = false;
+      continue;
+    }
+
+    if (currentLogin === null || indent <= currentLoginIndent) {
+      // Strip a trailing ` # comment` before matching — `login: # nickname`
+      // is valid hosts.yml and previously failed to match at all, silently
+      // dropping that login.
+      const withoutComment = trimmed.replace(/\s+#.*$/, "");
+      const m = /^([^:]+):\s*(\{\s*\})?\s*$/.exec(withoutComment);
+      if (m) {
+        flushCurrent();
+        currentLogin = m[1]!.trim();
+        currentLoginIndent = indent;
+      }
+      continue;
+    }
+
+    const tokenMatch = /^oauth_token:\s*(.+)$/.exec(trimmed);
+    if (tokenMatch) {
+      currentToken = tokenMatch[1]!.trim().replace(/^["']|["']$/g, "");
+    }
+  }
+  flushCurrent();
+  return found;
+}
+
+async function readHostsYmlAccounts(): Promise<Array<{ login: string; token: string | null }>> {
+  try {
+    const text = await readFile(hostsYmlPath(), "utf8");
+    return parseHostsYml(text);
+  } catch {
+    return [];
+  }
+}
+
+async function isGhOnPath(): Promise<boolean> {
+  try {
+    await execFile("gh", ["--version"]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function ghAuthTokenForUser(login: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFile("gh", ["auth", "token", "--user", login]);
+    const token = stdout.trim();
+    return token || null;
+  } catch {
+    return null;
+  }
+}
+
+function envTokenForLogin(login: string): string | undefined {
+  const key = `GH_TOKEN_${login.toUpperCase().replace(/[-.]/g, "_")}`;
+  return process.env[key];
+}
+
+/**
+ * Resolves every GitHub account this daemon can act as, one token per login,
+ * strongest source wins per the chain above. Cheap enough to call per poll
+ * tick (one file read, no network) that no in-memory cache is needed here —
+ * callers that want a stable view across a tick should call it once and
+ * reuse the result.
+ */
+export async function listAccounts(): Promise<GithubAccount[]> {
+  const tokens = new Map<string, string>();
+  const knownLogins = new Set<string>();
+
+  // 3. hosts.yml — establishes known logins even when a login has no
+  //    plaintext token (keyring-backed), so step 4 still knows to try it.
+  const hostsAccounts = await readHostsYmlAccounts();
+  for (const { login, token } of hostsAccounts) {
+    knownLogins.add(login);
+    if (token) tokens.set(login, token);
+  }
+
+  // 2. Generic GITHUB_TOKEN/GH_TOKEN — env wins over hosts.yml, but ONLY when
+  //    there's a single account in play. Covers the common solo-account case
+  //    with no hosts.yml at all (synthetic login). With >=2 known logins a
+  //    single generic token cannot possibly be valid for all of them —
+  //    stamping it onto every login silently breaks whichever account(s) it
+  //    isn't actually for (that account's repos 404 under the wrong token,
+  //    which looks identical to "no PR" — the exact bug this fallback chain
+  //    exists to avoid). In that case only fill logins still missing a token
+  //    of their own.
+  const generic = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  if (generic) {
+    if (knownLogins.size === 0) {
+      knownLogins.add("default");
+      tokens.set("default", generic);
+    } else if (knownLogins.size === 1) {
+      for (const login of knownLogins) tokens.set(login, generic);
+    } else {
+      for (const login of knownLogins) {
+        if (!tokens.has(login)) tokens.set(login, generic);
+      }
+    }
+  }
+
+  // 1. GH_TOKEN_<LOGIN> — highest priority, per-account override.
+  for (const login of knownLogins) {
+    const perAccount = envTokenForLogin(login);
+    if (perAccount) tokens.set(login, perAccount);
+  }
+
+  // 4. `gh auth token --user X` — only for logins still missing a token, and
+  //    only if `gh` happens to be on PATH. Never required.
+  const stillMissing = [...knownLogins].filter((login) => !tokens.has(login));
+  if (stillMissing.length > 0 && (await isGhOnPath())) {
+    for (const login of stillMissing) {
+      const token = await ghAuthTokenForUser(login);
+      if (token) tokens.set(login, token);
+    }
+  }
+
+  return [...tokens.entries()].map(([login, token]) => ({ login, token }));
+}

--- a/daemon/src/services/githubAuth.ts
+++ b/daemon/src/services/githubAuth.ts
@@ -179,15 +179,12 @@ export async function listAccounts(): Promise<GithubAccount[]> {
     if (token) tokens.set(login, token);
   }
 
-  // 2. Generic GITHUB_TOKEN/GH_TOKEN — env wins over hosts.yml, but ONLY when
-  //    there's a single account in play. Covers the common solo-account case
-  //    with no hosts.yml at all (synthetic login). With >=2 known logins a
-  //    single generic token cannot possibly be valid for all of them —
-  //    stamping it onto every login silently breaks whichever account(s) it
-  //    isn't actually for (that account's repos 404 under the wrong token,
-  //    which looks identical to "no PR" — the exact bug this fallback chain
-  //    exists to avoid). In that case only fill logins still missing a token
-  //    of their own.
+  // 2a. Generic GITHUB_TOKEN/GH_TOKEN — env wins over hosts.yml, but ONLY when
+  //    there's a single account in play (covers the common solo-account case
+  //    with no hosts.yml at all — synthetic "default" login). With >=2 known
+  //    logins a single generic token cannot possibly be valid for all of
+  //    them, so filling it in here is deferred to 2b below, AFTER step 4 has
+  //    had a chance to resolve each login's own real token — see 2b for why.
   const generic = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
   if (generic) {
     if (knownLogins.size === 0) {
@@ -195,10 +192,6 @@ export async function listAccounts(): Promise<GithubAccount[]> {
       tokens.set("default", generic);
     } else if (knownLogins.size === 1) {
       for (const login of knownLogins) tokens.set(login, generic);
-    } else {
-      for (const login of knownLogins) {
-        if (!tokens.has(login)) tokens.set(login, generic);
-      }
     }
   }
 
@@ -209,12 +202,28 @@ export async function listAccounts(): Promise<GithubAccount[]> {
   }
 
   // 4. `gh auth token --user X` — only for logins still missing a token, and
-  //    only if `gh` happens to be on PATH. Never required.
+  //    only if `gh` happens to be on PATH. Never required. Must run BEFORE
+  //    2b below: a keyring-backed second login has no plaintext token in
+  //    hosts.yml, so if 2b's generic-token fill ran first it would stamp the
+  //    (wrong-for-this-login) generic token onto it and this step would then
+  //    see it as already resolved and skip it — the exact wrong-token->404
+  //    failure this fallback chain exists to avoid.
   const stillMissing = [...knownLogins].filter((login) => !tokens.has(login));
   if (stillMissing.length > 0 && (await isGhOnPath())) {
     for (const login of stillMissing) {
       const token = await ghAuthTokenForUser(login);
       if (token) tokens.set(login, token);
+    }
+  }
+
+  // 2b. Generic GITHUB_TOKEN/GH_TOKEN, >=2-account fallback — only NOW, for
+  //    logins that even `gh auth token --user` couldn't resolve a real token
+  //    for. Still a guess (one token for every remaining login), but it's a
+  //    last resort after every login-specific source has been tried, not a
+  //    pre-emptive stamp that blocks a better source from running.
+  if (generic && knownLogins.size >= 2) {
+    for (const login of knownLogins) {
+      if (!tokens.has(login)) tokens.set(login, generic);
     }
   }
 

--- a/daemon/src/services/prPoller.ts
+++ b/daemon/src/services/prPoller.ts
@@ -26,11 +26,13 @@ import type { PrInfo, PrLookupResult } from "./github.js";
 import type { PrStatus, SessionRecord } from "../types.js";
 
 /**
- * 10s (K8) — matches `github.ts`'s own 5s cache TTL closely enough that the
- * cache never defeats the interval, while staying well under the authed
- * GitHub rate limit (5,000 req/hr) given the batching above.
+ * 30s — comfortably above `github.ts`'s 5s cache TTL, so the cache never
+ * defeats the interval, and ~240 req/hr (≈5% of the authed 5,000/hr limit)
+ * given `fetchPrsForBranches` batches to one aliased GraphQL query per
+ * ACCOUNT rather than one per worktree. Worst-case latency for a newly
+ * opened PR to surface is one interval.
  */
-export const PR_POLL_INTERVAL_MS = 10_000;
+export const PR_POLL_INTERVAL_MS = 30_000;
 
 let pollerHandle: ReturnType<typeof setInterval> | null = null;
 
@@ -75,10 +77,16 @@ function nextPrStatus(
             "— PR status will not update until credentials are available.",
         );
       }
+      // Only hold `current` forward when it was last checked against THIS
+      // branch — otherwise a worktree that switched branches since the last
+      // successful check would get a stale PR re-stamped onto its new branch
+      // (defeats the D20 branch guard). See BLOCKING-1 in the review this
+      // fixes.
+      const held = current?.prBranch === branch ? current : undefined;
       return {
-        state: current?.state ?? "none",
-        ...(current?.number != null ? { number: current.number } : {}),
-        ...(current?.url != null ? { url: current.url } : {}),
+        state: held?.state ?? "none",
+        ...(held?.number != null ? { number: held.number } : {}),
+        ...(held?.url != null ? { url: held.url } : {}),
         checkedAt: now,
         error: "No credentialed GitHub account available",
         prBranch: branch,
@@ -91,10 +99,12 @@ function nextPrStatus(
         lastErrorWarnAt.set(lookup.reason, nowMs);
         console.warn(`[prPoller] GitHub lookup failed (${lookup.reason}): ${lookup.message}`);
       }
+      // Same same-branch hold as `no_credentials` above.
+      const held = current?.prBranch === branch ? current : undefined;
       return {
-        state: current?.state ?? "none",
-        ...(current?.number != null ? { number: current.number } : {}),
-        ...(current?.url != null ? { url: current.url } : {}),
+        state: held?.state ?? "none",
+        ...(held?.number != null ? { number: held.number } : {}),
+        ...(held?.url != null ? { url: held.url } : {}),
         checkedAt: now,
         error: lookup.message,
         prBranch: branch,
@@ -192,7 +202,7 @@ export async function pollAllPrs(): Promise<void> {
       // B2: nothing but `checkedAt` changed — skip the write AND the
       // broadcast entirely rather than doing a full DB write + a
       // `session:updated` broadcast (which the web-ui rebuilds its whole
-      // `sessions` array in response to) every 10s for every worktree,
+      // `sessions` array in response to) every 30s for every worktree,
       // forever, even when the PR status genuinely hasn't changed.
       if (prStatusEquivalent(c.session.pr, nextPr)) return;
       try {

--- a/daemon/src/services/prPoller.ts
+++ b/daemon/src/services/prPoller.ts
@@ -1,181 +1,242 @@
 /**
- * PR-review poller (plan 03, "Interaction States", Decision 3/3b).
+ * PR-status poller (pr-status-axis plan, Phase 2).
  *
  * Mirrors `lifecycle.ts`'s `pollAll`/`startLifecyclePoller`/`stopLifecyclePoller`
  * shape: one `setInterval`, one sweep per tick over every worktree, not one
- * timer per worktree. Every tick, checks each worktree's branch for an open
- * non-draft PR via the existing `github.ts` service (`fetchPrForBranch`,
- * already cached/rate-limit-aware) and flips the worktree's MAIN agent
- * session's lifecycle to `"needs_review"` (R6/R7). When the PR is no longer
- * open (merged, closed, or gone) while that session is currently
- * `"needs_review"`, it reverts to `"working"`/`"idle"` (R6).
+ * timer per worktree.
  *
- * `needs_review` is deliberately NOT part of the 1Hz `lifecycle.ts` poller's
- * idle/working detection (its membership guard excludes it, same as
- * done/exited) — this poller is its sole owner, entry and exit, matching R5
- * ("absorbed into done/exited like every other non-terminal state, no
- * special-case guard needed" — nothing OTHER than done/exited/this poller
- * ever touches a `needs_review` session).
+ * Ownership invariant (D5/D6): this poller writes **only** `SessionRecord.pr`
+ * — the orthogonal VCS-outcome axis. It never touches `SessionLifecycle`
+ * (agent-activity axis); `lifecycle.ts` is the sole writer of that. This is
+ * what removes the three-writer clobber race that made PR detection
+ * effectively dead (see
+ * `.vibekit/reports/2026-08-16-pr-detection-broken-root-cause-and-fix.md`).
+ *
+ * Every tick batches ALL worktrees' branch lookups into a single
+ * `fetchPrsForBranches` call (R3) rather than one call per worktree —
+ * `fetchPrsForBranches` itself groups by GitHub account internally (one
+ * aliased GraphQL query per account, K4).
  */
 
-import { getAllProjects, mutateProject } from "../state/project-store.js";
-import { getRemoteUrl, parseGithubRepo, fetchPrForBranch } from "./github.js";
-import { persistLifecycleState } from "./lifecycle.js";
-import { jsonAgentRegistry } from "../state/jsonAgentRegistry.js";
-import { sessionChannel } from "./channel.js";
+import { getAllProjects, updateSessionPr } from "../state/project-store.js";
+import { getRemoteUrl, resolveGithubRemote, fetchPrsForBranches } from "./github.js";
+import { listAccounts } from "./githubAuth.js";
 import { broadcastAll } from "../broadcaster.js";
-import { serializeWorktree } from "../routes/worktrees.js";
-import type { SessionRecord, WorktreeRecord } from "../types.js";
+import type { PrInfo, PrLookupResult } from "./github.js";
+import type { PrStatus, SessionRecord } from "../types.js";
 
 /**
- * 60s (Decision 3b): >= github.ts's own 30s cache TTL (polling faster is
- * pure churn against a cached value), and — per-worktree — already at the
- * unauthenticated GitHub rate-limit ceiling (60 req/hr) with a single
- * worktree polled continuously, which is exactly why 1b.4's token warning
- * exists. Not configurable this round (matches `lifecycle.ts`'s own
- * `POLL_INTERVAL_MS` precedent).
+ * 10s (K8) — matches `github.ts`'s own 5s cache TTL closely enough that the
+ * cache never defeats the interval, while staying well under the authed
+ * GitHub rate limit (5,000 req/hr) given the batching above.
  */
-export const PR_POLL_INTERVAL_MS = 60_000;
+export const PR_POLL_INTERVAL_MS = 10_000;
 
 let pollerHandle: ReturnType<typeof setInterval> | null = null;
 
-/** 1b.4 — warn once per daemon lifetime, not once per tick. */
-let warnedNoToken = false;
+/** Warn once per daemon lifetime — not once per tick, not once per worktree. */
+let warnedNoCredentials = false;
 
-function hasGithubToken(): boolean {
-  return Boolean(process.env.GITHUB_TOKEN || process.env.GH_TOKEN);
+/** Warn at most once per 10 minutes, per error `reason`. */
+const ERROR_WARN_THROTTLE_MS = 10 * 60 * 1000;
+const lastErrorWarnAt = new Map<string, number>();
+
+function classifyPrState(pr: PrInfo): PrStatus["state"] {
+  if (pr.merged) return "merged";
+  if (pr.draft) return "draft";
+  if (pr.state === "closed") return "closed";
+  return "open";
 }
 
 /**
- * Best-effort "what should this session fall back to, now that its PR is no
- * longer open" (R6). The 1Hz lifecycle poller never touches a
- * `needs_review` session (see module doc), so by the time this fires the
- * session's activity is otherwise unobserved — a live JSON agent with a
- * turn in flight reports "working"; everything else falls back to "idle"
- * (matches plan CUJ 3's example transition).
+ * Maps one `PrLookupResult` to the `SessionRecord.pr` write it produces, per
+ * the plan's § System boundaries table. Returns `null` when nothing should be
+ * written (not reached in practice here — `not_github`/no-remote worktrees
+ * are filtered out before this is called — but kept total for safety).
  */
-function fallbackStateFor(session: SessionRecord): "working" | "idle" {
-  if (sessionChannel(session) === "json") {
-    const agent = jsonAgentRegistry.get(session.id);
-    if (agent && agent.getMeta().turnState !== "idle") return "working";
-  }
-  return "idle";
-}
-
-/**
- * Set/clear `WorktreeRecord.prMergedAt` (dashboard-bucket-fixes) and
- * broadcast the change — same mutate-then-broadcast shape as the `/pin`
- * route (`routes/worktrees.ts`), just triggered by the poller instead of a
- * user action. `null` drops the field entirely rather than persisting an
- * explicit null, matching `pinnedAt`'s own unset convention.
- */
-async function setWorktreePrMergedAt(
-  projectId: string,
-  worktreeId: string,
-  value: string | null,
-): Promise<void> {
-  let updated: WorktreeRecord | undefined;
-  await mutateProject(projectId, (p) => ({
-    ...p,
-    worktrees: p.worktrees.map((w) => {
-      if (w.id !== worktreeId) return w;
-      if (value == null) {
-        const { prMergedAt: _drop, ...rest } = w;
-        void _drop;
-        updated = rest;
-        return rest;
-      }
-      const next = { ...w, prMergedAt: value };
-      updated = next;
-      return next;
-    }),
-  }));
-  if (updated) {
-    broadcastAll({ type: "worktree:updated", worktree: serializeWorktree(projectId, updated) });
-  }
-}
-
-async function pollWorktree(
-  projectId: string,
-  projectAbsolutePath: string,
-  worktreeId: string,
+function nextPrStatus(
+  current: PrStatus | undefined,
+  lookup: PrLookupResult,
+  now: string,
   branch: string,
-  mainSession: SessionRecord | undefined,
-  currentPrMergedAt: string | undefined,
-): Promise<void> {
-  if (!mainSession) return; // No agent session to attribute needs_review to.
-  // Terminal state — same as lifecycle.ts's own terminal-state early return.
-  if (mainSession.lifecycle.state === "done" || mainSession.lifecycle.state === "exited") return;
-
-  const remoteUrl = await getRemoteUrl(projectAbsolutePath);
-  const gh = remoteUrl ? parseGithubRepo(remoteUrl) : null;
-  if (!gh) return; // 1b.5 — non-GitHub remote, skip silently (matches GET /worktrees/:id/pr).
-
-  const pr = await fetchPrForBranch(gh.owner, gh.repo, branch);
-  const isReviewable = pr !== null && pr.state === "open" && !pr.draft;
-
-  if (isReviewable) {
-    if (mainSession.lifecycle.state !== "needs_review") {
-      await persistLifecycleState(projectId, worktreeId, mainSession.id, "needs_review");
+): PrStatus | null {
+  switch (lookup.kind) {
+    case "pr": {
+      const { pr } = lookup;
+      return { state: classifyPrState(pr), number: pr.number, url: pr.url, checkedAt: now, prBranch: branch };
     }
-    // A fresh reviewable PR on this branch is a new review cycle — any
-    // earlier merge we remembered no longer applies.
-    if (currentPrMergedAt != null) {
-      await setWorktreePrMergedAt(projectId, worktreeId, null);
+    case "no_pr":
+      return { state: "none", checkedAt: now, prBranch: branch };
+    case "no_credentials": {
+      if (!warnedNoCredentials) {
+        warnedNoCredentials = true;
+        console.warn(
+          "[prPoller] No credentialed GitHub account found (env vars / ~/.config/gh/hosts.yml / gh CLI) " +
+            "— PR status will not update until credentials are available.",
+        );
+      }
+      return {
+        state: current?.state ?? "none",
+        ...(current?.number != null ? { number: current.number } : {}),
+        ...(current?.url != null ? { url: current.url } : {}),
+        checkedAt: now,
+        error: "No credentialed GitHub account available",
+        prBranch: branch,
+      };
     }
-    return;
+    case "error": {
+      const last = lastErrorWarnAt.get(lookup.reason) ?? 0;
+      const nowMs = Date.now();
+      if (nowMs - last >= ERROR_WARN_THROTTLE_MS) {
+        lastErrorWarnAt.set(lookup.reason, nowMs);
+        console.warn(`[prPoller] GitHub lookup failed (${lookup.reason}): ${lookup.message}`);
+      }
+      return {
+        state: current?.state ?? "none",
+        ...(current?.number != null ? { number: current.number } : {}),
+        ...(current?.url != null ? { url: current.url } : {}),
+        checkedAt: now,
+        error: lookup.message,
+        prBranch: branch,
+      };
+    }
+    case "not_github":
+      // Never reached — filtered out before the batch call — but stays a
+      // no-op (untouched, no log, ever) if it ever is.
+      return null;
   }
+}
 
-  // PR merged/closed/gone — only act if WE are the one holding this session
-  // in needs_review; anything else (done/exited, handled above) wins as-is.
-  if (mainSession.lifecycle.state === "needs_review") {
-    // Distinguish "merged" (worth remembering — dashboard-bucket-fixes) from
-    // "closed without merging" / "gone entirely": only a genuine merge sets
-    // prMergedAt. `pr` can be null here (PR deleted/branch gone).
-    if (pr?.merged && currentPrMergedAt == null) {
-      await setWorktreePrMergedAt(projectId, worktreeId, new Date().toISOString());
-    }
-    await persistLifecycleState(projectId, worktreeId, mainSession.id, fallbackStateFor(mainSession));
-  }
+/** True iff `next` differs from `current` in nothing but `checkedAt` — B2:
+ *  `checkedAt` changes every tick, so without this every tick is a "change"
+ *  and there is no no-op case; skip the write AND the broadcast entirely in
+ *  that case (an unwritten `checkedAt` just goes stale in the DB, which is
+ *  the accepted tradeoff — see B2 in the pr-status-axis review). */
+function prStatusEquivalent(current: PrStatus | undefined, next: PrStatus): boolean {
+  if (!current) return false;
+  return (
+    current.state === next.state &&
+    current.number === next.number &&
+    current.url === next.url &&
+    current.error === next.error &&
+    current.prBranch === next.prBranch
+  );
+}
+
+async function setSessionPr(projectId: string, sessionId: string, pr: PrStatus): Promise<void> {
+  const changed = await updateSessionPr(projectId, sessionId, pr);
+  if (!changed) return;
+  broadcastAll({ type: "session:updated", sessionId, pr });
+}
+
+interface PollContext {
+  projectId: string;
+  worktreeId: string;
+  session: SessionRecord;
+  owner: string;
+  repo: string;
+  branch: string;
+}
+
+function entryKey(owner: string, repo: string, branch: string): string {
+  return `${owner}/${repo}#${branch}`;
 }
 
 /** Exported for deterministic daemon tests (single poll tick). */
 export async function pollAllPrs(): Promise<void> {
   const projects = getAllProjects();
 
-  // 1b.4 — warn once, only when it's actually going to matter (more than one
-  // worktree means we're already past the point a single continuously-polled
-  // worktree already exhausts the unauthenticated rate limit — see Decision 3b).
-  const worktreeCount = projects.reduce((n, p) => n + p.worktrees.length, 0);
-  if (!warnedNoToken && !hasGithubToken() && worktreeCount > 1) {
-    warnedNoToken = true;
-    console.warn(
-      `[prPoller] No GITHUB_TOKEN/GH_TOKEN set — polling ${worktreeCount} worktrees for PR status ` +
-        `against the unauthenticated GitHub rate limit (60 req/hr). Set GITHUB_TOKEN to avoid rate-limiting.`,
-    );
+  const contexts: PollContext[] = [];
+  for (const project of projects) {
+    if (project.worktrees.length === 0) continue;
+
+    // B2: `getRemoteUrl`/`resolveGithubRemote` resolve a PER-PROJECT value
+    // (the project's own `origin`, shared by every worktree in it) — calling
+    // them once per worktree here used to mean 147 `git remote get-url`
+    // child processes + 147 `~/.ssh/config` stats per tick on a real
+    // install. Hoisted to once per project per tick.
+    const remoteUrl = await getRemoteUrl(project.absolutePath);
+    if (!remoteUrl) continue; // R9/C5 — no remote at all, zero network, zero logs.
+    const gh = await resolveGithubRemote(remoteUrl);
+    if (!gh) continue; // not_github — zero network, zero logs, ever.
+
+    for (const worktree of project.worktrees) {
+      const mainSession = worktree.sessions.find((s) => s.isMain);
+      if (!mainSession) continue;
+
+      contexts.push({
+        projectId: project.id,
+        worktreeId: worktree.id,
+        session: mainSession,
+        owner: gh.owner,
+        repo: gh.repo,
+        branch: worktree.branch,
+      });
+    }
   }
 
-  await Promise.all(
-    projects.flatMap((project) =>
-      project.worktrees.map((worktree) => {
-        const mainSession = worktree.sessions.find((s) => s.isMain);
-        return pollWorktree(
-          project.id,
-          project.absolutePath,
-          worktree.id,
-          worktree.branch,
-          mainSession,
-          worktree.prMergedAt,
-        ).catch((err) => {
-          console.error(`[prPoller] Poll error for worktree ${worktree.id}:`, err);
-        });
-      }),
-    ),
+  if (contexts.length === 0) return;
+
+  // R3 — exactly one batched call per tick, regardless of worktree count.
+  const results = await fetchPrsForBranches(
+    contexts.map((c) => ({ owner: c.owner, repo: c.repo, branch: c.branch })),
   );
+
+  const now = new Date().toISOString();
+  await Promise.all(
+    contexts.map(async (c) => {
+      const lookup = results.get(entryKey(c.owner, c.repo, c.branch));
+      if (!lookup) return;
+      const nextPr = nextPrStatus(c.session.pr, lookup, now, c.branch);
+      if (!nextPr) return;
+      // B2: nothing but `checkedAt` changed — skip the write AND the
+      // broadcast entirely rather than doing a full DB write + a
+      // `session:updated` broadcast (which the web-ui rebuilds its whole
+      // `sessions` array in response to) every 10s for every worktree,
+      // forever, even when the PR status genuinely hasn't changed.
+      if (prStatusEquivalent(c.session.pr, nextPr)) return;
+      try {
+        await setSessionPr(c.projectId, c.session.id, nextPr);
+      } catch (err) {
+        console.error(`[prPoller] Failed to persist PR status for worktree ${c.worktreeId}:`, err);
+      }
+    }),
+  );
+}
+
+/**
+ * D10 startup self-check — logged once, at daemon boot, so a misconfigured
+ * environment (no resolvable remote, no credentials) is visible immediately
+ * rather than discovered by "PR status never updates" weeks later.
+ */
+async function logStartupSelfCheck(): Promise<void> {
+  try {
+    const projects = getAllProjects();
+    const accounts = await listAccounts();
+    const credentialSummary =
+      accounts.length > 0
+        ? `credentialed (${accounts.length} account${accounts.length === 1 ? "" : "s"}: ${accounts.map((a) => a.login).join(", ")})`
+        : "no credentials found";
+
+    for (const project of projects) {
+      if (project.worktrees.length === 0) continue;
+      const remoteUrl = await getRemoteUrl(project.absolutePath);
+      const gh = remoteUrl ? await resolveGithubRemote(remoteUrl) : null;
+      const remoteSummary = gh
+        ? `resolvable (${gh.owner}/${gh.repo})`
+        : remoteUrl
+          ? "remote is not GitHub"
+          : "no git remote";
+      console.log(`[prPoller] startup check — project ${project.id}: ${remoteSummary}, ${credentialSummary}`);
+    }
+  } catch (err) {
+    console.error("[prPoller] startup self-check failed:", err);
+  }
 }
 
 export function startPrPoller(): void {
   if (pollerHandle) return;
+  void logStartupSelfCheck();
   // Overlap guard — same rationale as lifecycle.ts's poller: a slow tick
   // (many worktrees, slow GitHub API) must not stack on the next one.
   let inFlight = false;
@@ -198,7 +259,8 @@ export function stopPrPoller(): void {
   }
 }
 
-/** Test helper — resets the once-per-lifetime token warning. */
+/** Test helper — resets the once-per-lifetime credentials warning + error throttle. */
 export function _resetPrPollerWarningForTest(): void {
-  warnedNoToken = false;
+  warnedNoCredentials = false;
+  lastErrorWarnAt.clear();
 }

--- a/daemon/src/state/project-store.ts
+++ b/daemon/src/state/project-store.ts
@@ -46,7 +46,7 @@
  * INCLUDING `mutateProject`'s `Promise<ProjectRecord>` return (not `void`).
  */
 import type { Database as DB, Statement } from "better-sqlite3";
-import type { ProjectRecord, SessionRecord, WorktreeRecord } from "../types.js";
+import type { ProjectRecord, PrStatus, SessionRecord, WorktreeRecord } from "../types.js";
 import { withProjectLock } from "../services/mutex.js";
 import { getDb } from "./db.js";
 import { migrateManifestsToSqlite } from "../services/dbMigration.js";
@@ -77,6 +77,7 @@ interface Prepared {
   selectWorktreeSessions: Statement;
   selectDirectSessions: Statement;
   updateSessionLifecycle: Statement;
+  updateSessionPr: Statement;
 }
 
 /** Per-handle cache: prepared statements + the assembled project graph. */
@@ -126,6 +127,9 @@ function store(): StoreCache {
       ),
       updateSessionLifecycle: db.prepare(
         "UPDATE sessions SET state = ?, reason = ?, lastTransitionAt = ? WHERE id = ?",
+      ),
+      updateSessionPr: db.prepare(
+        "UPDATE sessions SET prState = ?, prNumber = ?, prUrl = ?, prCheckedAt = ?, prBranch = ? WHERE id = ?",
       ),
     },
   };
@@ -250,12 +254,12 @@ function writeProjectFull(record: ProjectRecord): void {
     db.prepare("DELETE FROM worktrees WHERE projectId = ?").run(p.id);
 
     const insertWorktree = db.prepare(
-      `INSERT INTO worktrees (id, projectId, name, branch, baseBranch, baseSha, createdAt, pinnedAt, prMergedAt, sortOrder, terminalSeq, agentSeq, branchIsPlaceholder)
-       VALUES (@id, @projectId, @name, @branch, @baseBranch, @baseSha, @createdAt, @pinnedAt, @prMergedAt, @sortOrder, @terminalSeq, @agentSeq, @branchIsPlaceholder)`,
+      `INSERT INTO worktrees (id, projectId, name, branch, baseBranch, baseSha, createdAt, pinnedAt, sortOrder, terminalSeq, agentSeq, branchIsPlaceholder)
+       VALUES (@id, @projectId, @name, @branch, @baseBranch, @baseSha, @createdAt, @pinnedAt, @sortOrder, @terminalSeq, @agentSeq, @branchIsPlaceholder)`,
     );
     const insertSession = db.prepare(
-      `INSERT INTO sessions (id, worktreeId, projectId, isMain, sortOrder, type, modeId, name, nameSource, tmuxName, useTmux, channel, state, reason, lastTransitionAt, transcriptKind, transcriptPath, agentChatId, modelOverride, pinnedAt, initialPrompt, archivedAt, handoffSummary, spawnedFrom)
-       VALUES (@id, @worktreeId, @projectId, @isMain, @sortOrder, @type, @modeId, @name, @nameSource, @tmuxName, @useTmux, @channel, @state, @reason, @lastTransitionAt, @transcriptKind, @transcriptPath, @agentChatId, @modelOverride, @pinnedAt, @initialPrompt, @archivedAt, @handoffSummary, @spawnedFrom)`,
+      `INSERT INTO sessions (id, worktreeId, projectId, isMain, sortOrder, type, modeId, name, nameSource, tmuxName, useTmux, channel, state, reason, lastTransitionAt, transcriptKind, transcriptPath, agentChatId, modelOverride, pinnedAt, initialPrompt, archivedAt, handoffSummary, spawnedFrom, prState, prNumber, prUrl, prCheckedAt, prBranch)
+       VALUES (@id, @worktreeId, @projectId, @isMain, @sortOrder, @type, @modeId, @name, @nameSource, @tmuxName, @useTmux, @channel, @state, @reason, @lastTransitionAt, @transcriptKind, @transcriptPath, @agentChatId, @modelOverride, @pinnedAt, @initialPrompt, @archivedAt, @handoffSummary, @spawnedFrom, @prState, @prNumber, @prUrl, @prCheckedAt, @prBranch)`,
     );
 
     for (const w of p.worktrees) {
@@ -345,6 +349,42 @@ export async function updateSessionLifecycle(
     // Re-assemble just this project from the DB rather than patching the
     // frozen graph by hand — one project's worth of queries, only on an actual
     // transition, and it cannot drift from what was just written.
+    refreshProject(projectId);
+    return true;
+  });
+}
+
+/**
+ * Fast path for a PR-status write (B2 in the pr-status-axis review).
+ *
+ * Mirrors `updateSessionLifecycle`: without this, `prPoller`'s per-tick
+ * writes went through `mutateProject` -> `writeProjectFull`, which DELETEs
+ * and re-INSERTs every worktree and session row of the WHOLE PROJECT just to
+ * set one session's `pr`. On a real install (147 worktrees / 269 sessions in
+ * one project) that's ~43k SQL statements + 147 fsyncs every 10s poll tick,
+ * forever — even when nothing changed. This does the single UPDATE the
+ * change actually needs and patches the cached record in place.
+ *
+ * `pr.error` (transient, WS-only) is intentionally NOT persisted here —
+ * there's no `prError` column, matching `sessionToRow`'s existing contract.
+ *
+ * Returns false if the session isn't in the DB (caller treats it as a no-op).
+ */
+export async function updateSessionPr(projectId: string, sessionId: string, pr: PrStatus): Promise<boolean> {
+  return withProjectLock(projectId, async () => {
+    const s = store();
+    const res = s.stmts.updateSessionPr.run(
+      pr.state,
+      pr.number ?? null,
+      pr.url ?? null,
+      pr.checkedAt,
+      pr.prBranch ?? null,
+      sessionId,
+    );
+    if (res.changes === 0) return false;
+    // Re-assemble just this project from the DB rather than patching the
+    // frozen graph by hand — one project's worth of queries, only on an
+    // actual write, and it cannot drift from what was just written.
     refreshProject(projectId);
     return true;
   });

--- a/daemon/src/state/sqliteRowMappers.ts
+++ b/daemon/src/state/sqliteRowMappers.ts
@@ -5,7 +5,7 @@
  * `true`/`false` — `rowToBool` is the single coercion point so this isn't
  * reimplemented ad hoc (and inevitably forgotten) at each call site.
  */
-import type { ProjectRecord, SessionRecord, WorktreeRecord, TranscriptRef } from "../types.js";
+import type { ProjectRecord, SessionRecord, WorktreeRecord, TranscriptRef, PrStatus } from "../types.js";
 import { resolveUseTmux } from "../services/resolveUseTmux.js";
 
 export function rowToBool(v: number): boolean {
@@ -40,6 +40,11 @@ export interface SessionRow {
   archivedAt: string | null;
   handoffSummary: string | null;
   spawnedFrom: string | null;
+  prState: string | null;
+  prNumber: number | null;
+  prUrl: string | null;
+  prCheckedAt: string | null;
+  prBranch: string | null;
 }
 
 export function rowToSession(row: SessionRow): SessionRecord {
@@ -47,6 +52,25 @@ export function rowToSession(row: SessionRow): SessionRecord {
     row.transcriptKind != null
       ? { kind: row.transcriptKind as TranscriptRef["kind"], ...(row.transcriptPath != null ? { path: row.transcriptPath } : {}) }
       : undefined;
+
+  const pr: PrStatus | undefined =
+    row.prState != null
+      ? {
+          state: row.prState as PrStatus["state"],
+          ...(row.prNumber != null ? { number: row.prNumber } : {}),
+          ...(row.prUrl != null ? { url: row.prUrl } : {}),
+          checkedAt: row.prCheckedAt ?? "",
+          ...(row.prBranch != null ? { prBranch: row.prBranch } : {}),
+        }
+      : undefined;
+
+  // Back-compat (R10): a row persisted before the PR-status split with
+  // `state === "needs_review"` maps to `idle` lifecycle + an open PR, since
+  // that was the only thing `needs_review` ever meant. One-way — never
+  // written back as `needs_review`.
+  const isLegacyNeedsReview = row.state === "needs_review";
+  const lifecycleState = (isLegacyNeedsReview ? "idle" : row.state) as SessionRecord["lifecycle"]["state"];
+  const legacyPr: PrStatus | undefined = isLegacyNeedsReview && !pr ? { state: "open", checkedAt: "" } : pr;
 
   return {
     id: row.id,
@@ -62,7 +86,7 @@ export function rowToSession(row: SessionRow): SessionRecord {
     useTmux: rowToBool(row.useTmux),
     ...(row.channel != null ? { channel: row.channel as SessionRecord["channel"] } : {}),
     lifecycle: {
-      state: row.state as SessionRecord["lifecycle"]["state"],
+      state: lifecycleState,
       ...(row.reason != null ? { reason: row.reason } : {}),
       lastTransitionAt: row.lastTransitionAt,
     },
@@ -74,6 +98,7 @@ export function rowToSession(row: SessionRow): SessionRecord {
     ...(row.archivedAt != null ? { archivedAt: row.archivedAt } : {}),
     ...(row.handoffSummary != null ? { handoffSummary: row.handoffSummary } : {}),
     ...(row.spawnedFrom != null ? { spawnedFrom: row.spawnedFrom } : {}),
+    ...(legacyPr ? { pr: legacyPr } : {}),
   };
 }
 
@@ -118,6 +143,11 @@ export function sessionToRow(session: SessionRecord, projectId: string, worktree
     archivedAt: session.archivedAt ?? null,
     handoffSummary: session.handoffSummary ?? null,
     spawnedFrom: session.spawnedFrom ?? null,
+    prState: session.pr?.state ?? null,
+    prNumber: session.pr?.number ?? null,
+    prUrl: session.pr?.url ?? null,
+    prCheckedAt: session.pr?.checkedAt ?? null,
+    prBranch: session.pr?.prBranch ?? null,
   };
 }
 
@@ -130,7 +160,6 @@ export interface WorktreeRow {
   baseSha: string | null;
   createdAt: string;
   pinnedAt: string | null;
-  prMergedAt: string | null;
   sortOrder: number;
   terminalSeq: number;
   agentSeq: number;
@@ -147,7 +176,6 @@ export function rowToWorktree(row: WorktreeRow, sessions: SessionRecord[]): Work
     baseSha: row.baseSha ?? "",
     createdAt: row.createdAt,
     ...(row.pinnedAt != null ? { pinnedAt: row.pinnedAt } : {}),
-    ...(row.prMergedAt != null ? { prMergedAt: row.prMergedAt } : {}),
     sortOrder: row.sortOrder,
     terminalSeq: row.terminalSeq,
     agentSeq: row.agentSeq,
@@ -165,7 +193,6 @@ export function worktreeToRow(w: WorktreeRecord, projectId: string): WorktreeRow
     baseSha: w.baseSha ?? null,
     createdAt: w.createdAt,
     pinnedAt: w.pinnedAt ?? null,
-    prMergedAt: w.prMergedAt ?? null,
     sortOrder: w.sortOrder ?? 0,
     terminalSeq: w.terminalSeq ?? 0,
     agentSeq: w.agentSeq ?? 0,

--- a/daemon/src/types.ts
+++ b/daemon/src/types.ts
@@ -10,7 +10,6 @@ export type LifecycleState =
   | "working"
   | "idle"
   | "waiting_for_human"
-  | "needs_review"
   | "done"
   | "exited";
 
@@ -18,6 +17,30 @@ export interface SessionLifecycle {
   state: LifecycleState;
   reason?: string;
   lastTransitionAt: string; // ISO8601
+}
+
+/**
+ * VCS outcome axis for a session's branch — orthogonal to `LifecycleState`
+ * (agent-activity axis). Written exclusively by `prPoller.ts` (see its module
+ * doc); nothing else ever mutates `SessionRecord.pr`.
+ */
+export interface PrStatus {
+  state: "none" | "draft" | "open" | "merged" | "closed";
+  /** Present iff a PR exists (i.e. `state !== "none"`). */
+  number?: number;
+  /** Present iff a PR exists (i.e. `state !== "none"`). */
+  url?: string;
+  /** ISO8601 — when this status was last (successfully or not) checked. */
+  checkedAt: string;
+  /** Set on `no_credentials`/`error` results; `state` is held, not guessed (R4). */
+  error?: string;
+  /**
+   * The branch `prPoller.ts` queried GitHub for when it produced this status
+   * (D20). The UI only renders the PR colour when this matches the
+   * worktree's CURRENT branch (`worktreePrStatus`) — otherwise a branch
+   * switch would show a stale PR colour until the next 10s poll tick.
+   */
+  prBranch?: string;
 }
 
 export type SessionType = "agent" | "terminal";
@@ -264,6 +287,12 @@ export interface SessionRecord {
    * simply finds no match, S5).
    */
   spawnedFrom?: string | null;
+  /**
+   * VCS status for this session's branch, written only by `prPoller.ts`.
+   * Absent ≡ never checked (e.g. session just created, or its worktree has
+   * no GitHub remote).
+   */
+  pr?: PrStatus;
 }
 
 export interface WorktreeRecord {
@@ -290,16 +319,6 @@ export interface WorktreeRecord {
    * (newest pinned first), so we don't need a separate sort field.
    */
   pinnedAt?: string; // ISO8601
-  /**
-   * When set, this worktree's PR was seen merged by `prPoller.ts` while its
-   * main session was `needs_review` — kept around (distinct from a PR that
-   * was merely closed without merging) so the dashboard can keep crediting
-   * "PR created" instead of silently reading as idle/working again. Cleared
-   * the moment `prPoller.ts` finds a fresh open, non-draft PR on the same
-   * branch (a new review cycle has started). Absent / undefined ≡ no
-   * remembered merge.
-   */
-  prMergedAt?: string; // ISO8601
   /** Fractional display-order rank among a project's worktrees (F9 — reordering itself is Part 03). */
   sortOrder: number;
   /**

--- a/daemon/src/ws/protocol.ts
+++ b/daemon/src/ws/protocol.ts
@@ -5,6 +5,20 @@ import { z } from "zod";
  * Based on docs/API-CONTRACT.md WebSocket section.
  */
 
+/** Mirrors `PrStatus` (`daemon/src/types.ts`) — the VCS-outcome axis, written
+ *  only by `prPoller.ts`. Shared by `session:updated` here and the plain-JSON
+ *  `serializeSession` output. */
+const PrStatusSchema = z.object({
+  state: z.enum(["none", "draft", "open", "merged", "closed"]),
+  number: z.number().optional(),
+  url: z.string().optional(),
+  checkedAt: z.string(),
+  error: z.string().optional(),
+  // D20 — the branch this status was queried for; the UI only renders the
+  // PR colour when it matches the worktree's current branch.
+  prBranch: z.string().optional(),
+});
+
 const SubscribeMessage = z.object({
   type: z.literal("subscribe"),
   sessionIds: z.array(z.string()),
@@ -206,6 +220,11 @@ const SessionCreatedSnapshot = z.object({
   tmuxName: z.string(),
   useTmux: z.boolean().optional().default(true),
   channel: z.enum(["tmux", "pty", "json"]).optional(),
+  // `needs_review` is retained here as an accepted INPUT value only — it is
+  // never emitted by this daemon build (removed from `LifecycleState` in
+  // daemon/src/types.ts). Keeping it in the enum lets legacy persisted
+  // records and older clients still parse; back-compat mapping happens once,
+  // on read, in `sqliteRowMappers.ts` (`rowToSession`).
   state: z.enum([
     "not_started",
     "working",
@@ -215,6 +234,7 @@ const SessionCreatedSnapshot = z.object({
     "done",
     "exited",
   ]),
+  // See `needs_review` comment above — accepted input, never emitted.
   lifecycleState: z.enum([
     "not_started",
     "working",
@@ -250,6 +270,8 @@ const SessionCreatedEvent = z.object({
 const SessionStateEvent = z.object({
   type: z.literal("session:state"),
   sessionId: z.string(),
+  // `needs_review` accepted as input only (never emitted) — see comment on
+  // `SessionCreatedSnapshot.state` above.
   state: z.enum([
     "not_started",
     "working",
@@ -309,6 +331,8 @@ const SessionUpdatedEvent = z.object({
   archivedAt: z.string().optional(),
   /** After a reorder (PATCH .../reorder) — the session's new fractional display-order rank. */
   sortOrder: z.number().optional(),
+  /** After a `prPoller.ts` tick updates this session's VCS status (pr-status-axis). */
+  pr: PrStatusSchema.nullable().optional(),
 });
 
 /**

--- a/docs/STATUS-INDICATORS.md
+++ b/docs/STATUS-INDICATORS.md
@@ -14,7 +14,7 @@ Background/rationale: `.vibekit/reports/2026-08-16-pr-detection-broken-root-caus
 | Axis | Field | Values | Written by |
 |------|-------|--------|-----------|
 | **Lifecycle** — is the agent busy? | `session.lifecycle.state` (`LifecycleState`) | `not_started, working, idle, waiting_for_human, done, exited` | `daemon/src/services/lifecycle.ts` poller, 1s |
-| **PR** — what happened to the branch? | `session.pr` (`PrStatus`) | `none, draft, open, merged, closed` | `daemon/src/services/prPoller.ts`, 10s |
+| **PR** — what happened to the branch? | `session.pr` (`PrStatus`) | `none, draft, open, merged, closed` | `daemon/src/services/prPoller.ts`, 30s |
 
 - **Invariant:** each poller writes **only** its own field. Neither ever touches the other's.
   This is what removed the three-writer clobber race — do not reintroduce cross-writes.
@@ -32,10 +32,10 @@ Bucket resolved by `bucketForRollup()` — `web-ui/src/components/layout/Dashboa
 | `not_started` | any | neutral, dashed | `◐` | **Working** |
 | `waiting_for_human` | `open` | 🔵 blue | `●` | **PR** |
 | `waiting_for_human` | `merged` | 🟢 green | `●` | **PR** |
-| `waiting_for_human` | `draft` / `closed` / `none` / unset | 🔴 red | `!` | **Waiting** |
+| `waiting_for_human` | `draft` / `closed` / `none` / unset | 🔴 red | `!` | **Needs you** |
 | `idle` | `open` | 🔵 blue | `●` | **PR** |
 | `idle` | `merged` | 🟢 green | `●` | **PR** |
-| `idle` | `draft` / `closed` / `none` / unset | neutral | `○` | **Waiting** |
+| `idle` | `draft` / `closed` / `none` / unset | neutral | `○` | **Idle** |
 | `done` | `open` | 🔵 blue | `✓` | **Finished** |
 | `done` | `merged` | 🟢 green | `✓` | **Finished** |
 | `done` | `draft` / `closed` / `none` / unset | neutral | `✓` | **Finished** |
@@ -43,35 +43,50 @@ Bucket resolved by `bucketForRollup()` — `web-ui/src/components/layout/Dashboa
 | `exited` | `merged` | 🟢 green | `×` | **Finished** |
 | `exited` | `draft` / `closed` / `none` / unset | neutral, dimmed | `×` | **Finished** |
 
-### Precedence — dot colour (D18, D21)
+**Home bucket union (Phase 6, 6.6):** `"working" | "needs-you" | "idle" | "pr" | "finished"`.
+The former single **Waiting** column is split into **Needs you** (`waiting_for_human`, red `!`) and
+**Idle** (`idle`, neutral `○`) — mixing them under one "Waiting" label read as a bug (an idle
+session sitting under "Waiting" with a neutral dot and no red `!`). Both are shown by default;
+only **Finished** hides behind the `dashboard:showFinished` toggle — idle is still open work, not
+done.
+
+### Precedence — dot colour (D18, D21, B2)
 ```
-1. working | not_started            → "working"            🟡
-2. pr = merged   (branch-matched)   → "pr-merged"          🟢
-3. pr = open     (branch-matched)   → "pr-open"            🔵
-4. waiting_for_human                → "waiting_for_human"  🔴
-5. idle                             → null                 neutral
-6. done | exited                    → PR colour if any, else neutral   (D21)
+1. done | exited                    → PR colour if any, else neutral   (D21)
+2. working                          → "working"            🟡
+3. not_started | spawning           → neutral, dashed       ◐          (B2)
+4. pr = merged   (branch-matched)   → "pr-merged"          🟢
+5. pr = open     (branch-matched)   → "pr-open"            🔵
+6. waiting_for_human                → "waiting_for_human"  🔴
+7. idle                             → "idle"                neutral
 ```
+- `not_started`/`spawning` wins over any PR on the branch (B2, decided): a session
+  that has not started has done nothing, so colouring it by a PR that already exists on
+  the branch would misleadingly read as "landed and finished" for a session that never ran.
 - `draft` and `closed` **never** drive colour or bucket — they are informational only.
 - `working` beats PR on purpose: if you ask for more work on a branch that already has a PR, the
   in-progress signal is the more current fact.
 - PR beats `waiting_for_human` on purpose: an agent idles at its prompt immediately after opening
   a PR, so red would otherwise mask blue permanently.
 
-### Precedence — dashboard bucket (D19)
+### Precedence — dashboard bucket (D19, split by 6.6)
 ```
 1. done | exited        → Finished     (checked FIRST, unconditionally)
 2. working | spawning   → Working
 3. pr = open | merged   → PR
-4. waiting_for_human | idle → Waiting
-5. otherwise            → Finished
+4. waiting_for_human    → Needs you
+5. idle                 → Idle
+6. otherwise            → Finished
 ```
 - **Colour and bucket deliberately disagree for `done`/`exited`** (D21): the dot keeps the PR
   colour so you can see the branch landed, but the card stays in Finished, because `done` is an
   explicit manual user action meaning "I am finished with this". Do not "fix" this to agree.
-- `idle` lives in **Waiting**, not Finished — an idle worktree is open work, not done.
-  Consequence: the Waiting column contains both 🔴 `waiting_for_human` (agent needs you) and
-  neutral `○` `idle` (nothing happening). This is known and intentional.
+- `idle` buckets to its own **Idle** column, not Finished — an idle session is open work, not
+  done. Before Phase 6 this was merged with `waiting_for_human` into one "Waiting" column, which
+  read as a bug (an idle session sitting under "Waiting" with a neutral dot and no red `!`).
+  They're now separate columns: 🔴 **Needs you** (`waiting_for_human`, agent explicitly blocked)
+  and neutral **Idle** (`idle`, nothing happening). Both are shown by default — only Finished
+  hides behind "Show finished".
 
 ## Tokens
 
@@ -96,21 +111,52 @@ Bucket resolved by `bucketForRollup()` — `web-ui/src/components/layout/Dashboa
 
 | Surface | File | Notes |
 |---|---|---|
-| Sidebar rows | `LeftSidebar.tsx` (4 `<StatusDot>` sites) | worktree rows roll up; session rows are per-session |
-| Dashboard cards | `DashboardPanel.tsx` | worktree cards **and** direct (worktree-less) agent cards |
-| Canvas tile border | `WorkspaceCanvas.tsx` | gated on the `showAgentStatusBorders` setting |
+| Sidebar rows | `LeftSidebar.tsx` (4 `<StatusDot>` sites) | worktree rows roll up per worktree; the sidebar's session rows are both direct-session sites, hardcoded to `pr={null}` — a direct session never has a worktree to show a PR for |
+| Dashboard cards | `DashboardPanel.tsx` | one card per non-archived agent session (Phase 6) — worktree-attached and direct alike, no rollup |
+| Canvas tile border | `WorkspaceCanvas.tsx` | gated on the `showAgentStatusBorders` setting; per-session (`sessionStatus(session.state)` + a per-tile branch-guarded `session.pr`), not rolled up |
 | Agent pane border | `AgentPaneSlot.tsx` | single session, so no rollup |
 | VCS panel PR pill | `workspace.css` `.vcs-pr--*` | must use the same `--pr-*` tokens |
 
 ## Per-session vs per-worktree
 
-- The **dot** is per session.
-- The **bucket** is per worktree, rolled up over its non-archived agent sessions:
-  - `hasLiveActivity` — ANY session `working`/`not_started` → Working, short-circuiting the rest
-    (so one sibling's `waiting_for_human` can't hide another's `working`).
-  - the bucket's PR comes from `worktreePrStatus()`, which reads the **`isMain`** session only,
-    matching the session `prPoller` writes to.
-- Archived sessions (`archivedAt != null`) are excluded from bucketing entirely.
+- The **dot** is always per session.
+- **The dashboard is per-session for LIFECYCLE, but per-worktree for PR** (Phase 6 amendment,
+  2026-08-17; PR resolution corrected 2026-08-17 — BLOCKING-2). Every non-archived agent session
+  (`type === "agent" && archivedAt == null`) gets its own card, bucketed by its own lifecycle
+  status (`bucketForRollup`) — worktree-attached and direct alike. This replaces an earlier
+  per-worktree rollup that picked one "winning" session's status for the whole worktree; that
+  rollup shipped a real bug (`966b676`): one session's `waiting_for_human` (rank 8) hid a
+  sibling's `working` (rank 6) for the entire worktree, patched at the time with a
+  `hasLiveActivity` short-circuit. Both the rollup and the patch are gone from
+  `DashboardPanel.tsx` — per-session cards make that class of bug structurally impossible, since
+  each session always gets its own card in its own column.
+  - **PR is a property of the BRANCH, not the session, and the daemon only ever writes it to
+    ONE session.** `prPoller.ts` writes `SessionRecord.pr` exclusively to a worktree's `isMain`
+    session — nothing else in the daemon ever writes it, so a sibling (non-main) session's own
+    `.pr` field is always empty. The UI resolves the PR **per worktree** — `worktreePrStatus()`
+    (`web-ui/src/lib/statusColor.ts`, not `worktreeStatus.ts`) reads the `isMain` session's `pr`
+    and branch-guards it against the worktree's CURRENT branch (D20) — then fans that single
+    resolved value out to every non-archived agent session card belonging to that worktree. This
+    is "one write, N reads": the daemon never fans out the write itself (that would reintroduce
+    write amplification), but every session card of a multi-agent worktree still shows the
+    branch's PR colour/bucket. This is intentional duplication, not a bug (user decision, Phase 6
+    amendment): a worktree is normally single-agent, so this only shows up in the rare multi-agent
+    case, and every session showing the branch's real outcome is more truthful than picking a
+    "winner" to hide behind.
+  - A direct (worktree-less) session has no worktree to resolve a PR against, so it can **never**
+    show a PR — its card is always lifecycle-only, regardless of what `session.pr` holds.
+  - Archived sessions (`archivedAt != null`) produce no card at all.
+- **The sidebar's worktree rows roll up per worktree** (unchanged by Phase 6) — see
+  `worktreeRolledUpStatus()` in `web-ui/src/lib/worktreeStatus.ts`, used by `LeftSidebar.tsx`'s
+  worktree-row `<StatusDot>` sites. There, the rolled-up worktree PR colour comes from
+  `worktreePrStatus()` (`web-ui/src/lib/statusColor.ts`), which reads the **`isMain`** session
+  only, matching the session `prPoller` writes to (K9). The sidebar's *session* rows, by contrast,
+  are both direct-session sites and are hardcoded to `pr={null}` — see the surface table above.
+  - `WorkspaceCanvas.tsx`'s tile border and `AgentPaneSlot.tsx`'s pane border are per-session for
+    LIFECYCLE (each reads its own `session.state`), but per-worktree for PR, same as the
+    dashboard: both resolve the tile's/pane's worktree PR via `worktreePrStatus()` — never a
+    sibling session's own `session.pr` directly — and branch-guard it against that worktree's
+    current branch before applying it to the tile/pane border.
 
 ## Testing without a daemon
 

--- a/docs/STATUS-INDICATORS.md
+++ b/docs/STATUS-INDICATORS.md
@@ -1,0 +1,121 @@
+# Status indicators — the two-axis matrix
+
+> **This file is the single source of truth for session status colour, glyph, and dashboard
+> bucketing.** Any change to `statusColor.ts`, `bucketForRollup`, `StatusDot`, the
+> `--status-*`/`--pr-*` tokens, or the `LifecycleState`/`PrStatus` unions **must** update the
+> matrix below in the same commit. See `AGENTS.md` § Status indicators.
+
+Background/rationale: `.vibekit/reports/2026-08-16-pr-detection-broken-root-cause-and-fix.md` (decisions D5, D17–D21).
+
+---
+
+## Two orthogonal axes
+
+| Axis | Field | Values | Written by |
+|------|-------|--------|-----------|
+| **Lifecycle** — is the agent busy? | `session.lifecycle.state` (`LifecycleState`) | `not_started, working, idle, waiting_for_human, done, exited` | `daemon/src/services/lifecycle.ts` poller, 1s |
+| **PR** — what happened to the branch? | `session.pr` (`PrStatus`) | `none, draft, open, merged, closed` | `daemon/src/services/prPoller.ts`, 10s |
+
+- **Invariant:** each poller writes **only** its own field. Neither ever touches the other's.
+  This is what removed the three-writer clobber race — do not reintroduce cross-writes.
+- `session.pr.prBranch` records the branch the PR was found on. A PR is only ever rendered when
+  `prBranch === worktree.branch` — a stale PR after a branch switch must never colour anything.
+
+## The matrix
+
+Dot colour resolved by `resolveStatusClass()` — `web-ui/src/lib/statusColor.ts`.
+Bucket resolved by `bucketForRollup()` — `web-ui/src/components/layout/DashboardPanel.tsx`.
+
+| Lifecycle | PR | Dot | Glyph | Home bucket |
+|---|---|---|---|---|
+| `working` | any (`open`/`merged`/`draft`/`closed`/`none`) | 🟡 yellow | `●` | **Working** |
+| `not_started` | any | neutral, dashed | `◐` | **Working** |
+| `waiting_for_human` | `open` | 🔵 blue | `●` | **PR** |
+| `waiting_for_human` | `merged` | 🟢 green | `●` | **PR** |
+| `waiting_for_human` | `draft` / `closed` / `none` / unset | 🔴 red | `!` | **Waiting** |
+| `idle` | `open` | 🔵 blue | `●` | **PR** |
+| `idle` | `merged` | 🟢 green | `●` | **PR** |
+| `idle` | `draft` / `closed` / `none` / unset | neutral | `○` | **Waiting** |
+| `done` | `open` | 🔵 blue | `✓` | **Finished** |
+| `done` | `merged` | 🟢 green | `✓` | **Finished** |
+| `done` | `draft` / `closed` / `none` / unset | neutral | `✓` | **Finished** |
+| `exited` | `open` | 🔵 blue | `×` | **Finished** |
+| `exited` | `merged` | 🟢 green | `×` | **Finished** |
+| `exited` | `draft` / `closed` / `none` / unset | neutral, dimmed | `×` | **Finished** |
+
+### Precedence — dot colour (D18, D21)
+```
+1. working | not_started            → "working"            🟡
+2. pr = merged   (branch-matched)   → "pr-merged"          🟢
+3. pr = open     (branch-matched)   → "pr-open"            🔵
+4. waiting_for_human                → "waiting_for_human"  🔴
+5. idle                             → null                 neutral
+6. done | exited                    → PR colour if any, else neutral   (D21)
+```
+- `draft` and `closed` **never** drive colour or bucket — they are informational only.
+- `working` beats PR on purpose: if you ask for more work on a branch that already has a PR, the
+  in-progress signal is the more current fact.
+- PR beats `waiting_for_human` on purpose: an agent idles at its prompt immediately after opening
+  a PR, so red would otherwise mask blue permanently.
+
+### Precedence — dashboard bucket (D19)
+```
+1. done | exited        → Finished     (checked FIRST, unconditionally)
+2. working | spawning   → Working
+3. pr = open | merged   → PR
+4. waiting_for_human | idle → Waiting
+5. otherwise            → Finished
+```
+- **Colour and bucket deliberately disagree for `done`/`exited`** (D21): the dot keeps the PR
+  colour so you can see the branch landed, but the card stays in Finished, because `done` is an
+  explicit manual user action meaning "I am finished with this". Do not "fix" this to agree.
+- `idle` lives in **Waiting**, not Finished — an idle worktree is open work, not done.
+  Consequence: the Waiting column contains both 🔴 `waiting_for_human` (agent needs you) and
+  neutral `○` `idle` (nothing happening). This is known and intentional.
+
+## Tokens
+
+`web-ui/src/styles/tokens.css` — defined in **both** `[data-theme="dark"]` and
+`[data-theme="light"]` blocks. Never a bare hex in a component or another stylesheet.
+
+| Token | dark | light |
+|---|---|---|
+| `--status-working` | `#eab308` | `#a16207` |
+| `--status-waiting` | `#ef4444` | `#dc2626` |
+| `--pr-open` | `#3b82f6` | `#1d4ed8` |
+| `--pr-merged` | `#22c55e` | `#15803d` |
+| `--pr-draft` | `#8a8a8a` | `#737373` |
+| `--pr-closed` | `#6b6b6b` | `#737373` |
+
+- Per-theme is mandatory: a single hex fails light-mode contrast (`#22c55e` on white ≈ 2.1:1 vs
+  the ≥3:1 bar for non-text UI).
+- Non-colour cues that must survive any recolour: `tile--spawning { border-style: dashed }`,
+  `tile--exited { opacity: .9 }`.
+
+## Where each surface reads from
+
+| Surface | File | Notes |
+|---|---|---|
+| Sidebar rows | `LeftSidebar.tsx` (4 `<StatusDot>` sites) | worktree rows roll up; session rows are per-session |
+| Dashboard cards | `DashboardPanel.tsx` | worktree cards **and** direct (worktree-less) agent cards |
+| Canvas tile border | `WorkspaceCanvas.tsx` | gated on the `showAgentStatusBorders` setting |
+| Agent pane border | `AgentPaneSlot.tsx` | single session, so no rollup |
+| VCS panel PR pill | `workspace.css` `.vcs-pr--*` | must use the same `--pr-*` tokens |
+
+## Per-session vs per-worktree
+
+- The **dot** is per session.
+- The **bucket** is per worktree, rolled up over its non-archived agent sessions:
+  - `hasLiveActivity` — ANY session `working`/`not_started` → Working, short-circuiting the rest
+    (so one sibling's `waiting_for_human` can't hide another's `working`).
+  - the bucket's PR comes from `worktreePrStatus()`, which reads the **`isMain`** session only,
+    matching the session `prPoller` writes to.
+- Archived sessions (`archivedAt != null`) are excluded from bucketing entirely.
+
+## Testing without a daemon
+
+Press **Ctrl+Shift+D** in the web UI for the dev state simulator
+(`web-ui/src/components/dev/DevStatePanel.tsx`). It drives both axes and patches the client
+stores directly, so no GitHub, no daemon writes, no restart. It sets `prBranch` to the session's
+real worktree branch automatically — otherwise the branch guard filters the PR out and nothing
+renders.

--- a/web-ui/src/api/client.ts
+++ b/web-ui/src/api/client.ts
@@ -7,6 +7,7 @@ import type {
   CliId,
   CommitLogEntry,
   PrInfo,
+  PrLookupResult,
   CreateDirectSessionBody,
   CreateModeBody,
   CreateProjectBody,
@@ -603,12 +604,16 @@ export function createClientApi() {
       return commits;
     },
 
-    /** Best-effort GitHub PR lookup for the worktree's branch; null if there is none. */
+    /** Best-effort GitHub PR lookup for the worktree's branch; null if there
+     *  is none, the remote isn't GitHub, or the lookup couldn't be checked
+     *  (transient failure, no credentials) — switches on `kind` rather than
+     *  blindly casting the response, so a shape change here fails loudly
+     *  instead of silently blanking the PR banner. */
     async getPr(worktreeId: string): Promise<PrInfo | null> {
       const root = baseUrl();
       const res = await apiFetch(`${root}/worktrees/${encodeURIComponent(worktreeId)}/pr`);
-      const { pr } = await parseJson<{ pr: PrInfo | null }>(res);
-      return pr;
+      const result = await parseJson<PrLookupResult>(res);
+      return result.kind === "pr" ? result.pr : null;
     },
 
     async listModes(): Promise<Mode[]> {

--- a/web-ui/src/api/types.ts
+++ b/web-ui/src/api/types.ts
@@ -115,8 +115,10 @@ export interface Session {
    *  workspaces/04-workspaces Phase 4). Write-once, set at creation. */
   spawnedFrom?: string | null;
   /** VCS outcome axis — orthogonal to `state`/`lifecycleState` (mirrors
-   *  daemon `SessionRecord.pr`). Absent ≡ never checked. */
-  pr?: PrStatus;
+   *  daemon `SessionRecord.pr`). Absent ≡ never checked (e.g. legacy/test
+   *  fixtures); REST (`sessions.ts`'s `serializeSession`) always sends an
+   *  explicit `null` when there's no PR yet, matching `spawnedFrom`. */
+  pr?: PrStatus | null;
 }
 
 /**

--- a/web-ui/src/api/types.ts
+++ b/web-ui/src/api/types.ts
@@ -36,15 +36,6 @@ export interface Worktree {
    * default sort order (newest first).
    */
   pinnedAt: string | null;
-  /**
-   * ISO8601 timestamp set by the daemon's PR poller when this worktree's PR
-   * was seen merged while its main session was `needs_review` — lets the
-   * dashboard keep crediting "PR created" instead of reading as idle/working
-   * again once the poller falls the session back out of `needs_review`.
-   * Cleared once a fresh open, non-draft PR appears on the same branch.
-   * Optional for legacy/test fixtures predating this field (same as `sortOrder` below).
-   */
-  prMergedAt?: string | null;
   /** Fractional display-order rank among a project's worktrees (F9). Optional for legacy/test fixtures predating this field. */
   sortOrder?: number;
   /**
@@ -65,18 +56,20 @@ export type FileScope = "worktree" | "project";
 export type SessionType = "agent" | "terminal";
 
 /**
- * `waiting_for_human` (idle-after-having-worked, R3) and `needs_review` (open
- * PR poller) are both wired up daemon-side as of
- * .vibekit/feature-plans/wip/agent-interaction-workspaces/03-interaction-states —
- * real `session:state` events carry these values, not just the dev-only
+ * `waiting_for_human` (idle-after-having-worked, R3) is wired up daemon-side
+ * as of .vibekit/feature-plans/wip/agent-interaction-workspaces/03-interaction-states —
+ * real `session:state` events carry this value, not just the dev-only
  * state-simulation panel (components/dev/DevStatePanel.tsx).
+ *
+ * PR outcome is a separate, orthogonal axis (`Session.pr`, see `PrStatus`
+ * below) — it is no longer folded into this lifecycle union. See
+ * .vibekit/feature-plans/wip/pr-status-axis for the split.
  */
 export type SessionState =
   | "not_started"
   | "working"
   | "idle"
   | "waiting_for_human"
-  | "needs_review"
   | "done"
   | "exited";
 
@@ -121,6 +114,33 @@ export interface Session {
   /** SessionId this session was spawned from, or null (agent-interaction-
    *  workspaces/04-workspaces Phase 4). Write-once, set at creation. */
   spawnedFrom?: string | null;
+  /** VCS outcome axis — orthogonal to `state`/`lifecycleState` (mirrors
+   *  daemon `SessionRecord.pr`). Absent ≡ never checked. */
+  pr?: PrStatus;
+}
+
+/**
+ * VCS outcome axis for a session's branch (mirror of daemon `PrStatus`,
+ * `daemon/src/types.ts`) — orthogonal to `SessionState` (agent-activity
+ * axis). Written exclusively by the daemon's PR poller.
+ */
+export interface PrStatus {
+  state: "none" | "draft" | "open" | "merged" | "closed";
+  /** Present iff a PR exists (i.e. `state !== "none"`). */
+  number?: number;
+  /** Present iff a PR exists (i.e. `state !== "none"`). */
+  url?: string;
+  /** ISO8601 — when this status was last (successfully or not) checked. */
+  checkedAt: string;
+  /** Set on `no_credentials`/`error` results; `state` is held, not guessed (R4). */
+  error?: string;
+  /**
+   * The branch the daemon's `prPoller` queried GitHub for when it produced
+   * this status (D20). `worktreePrStatus` only returns this status when it
+   * matches the worktree's CURRENT branch — otherwise a branch switch would
+   * show a stale PR colour until the next poll tick.
+   */
+  prBranch?: string;
 }
 
 /** Token / cost usage numbers (mirror of daemon `UsageInfo`). */
@@ -335,6 +355,8 @@ export type WSEvent =
       archivedAt?: string | null;
       /** After a reorder (PATCH .../reorder) — the session's new fractional display-order rank. */
       sortOrder?: number;
+      /** After a `prPoller.ts` tick updates this session's VCS status (pr-status-axis). */
+      pr?: PrStatus | null;
     }
   | {
       type: "session:error";
@@ -491,6 +513,21 @@ export interface PrInfo {
   draft: boolean;
   author: string | null;
 }
+
+/** Mirrors daemon `PrLookupResult` (`daemon/src/services/github.ts`) — the
+ *  body shape of `GET /worktrees/:id/pr`. A tagged union so "couldn't check"
+ *  is never confused with "definitely no PR" (the bug this replaced). */
+export type PrLookupResult =
+  | { kind: "pr"; pr: PrInfo }
+  | { kind: "no_pr" }
+  | { kind: "not_github" }
+  | { kind: "no_credentials" }
+  | {
+      kind: "error";
+      reason: "network" | "rate_limited" | "auth" | "api";
+      message: string;
+      retryAfterMs?: number;
+    };
 
 export interface ProjectBranchesResponse {
   branches: string[];

--- a/web-ui/src/components/dev/DevStatePanel.tsx
+++ b/web-ui/src/components/dev/DevStatePanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { useServerStore } from "@/hooks/useServerStore";
 import { useWorkspaceStore } from "@/hooks/useStore";
-import type { SessionState } from "@/api/types";
+import type { PrStatus, SessionState } from "@/api/types";
 
 /**
  * Dev-only floating popup for faking `session:state` transitions on real
@@ -19,10 +19,18 @@ const STATES: SessionState[] = [
   "working",
   "idle",
   "waiting_for_human",
-  "needs_review",
   "done",
   "exited",
 ];
+
+/**
+ * PR-axis values, orthogonal to `SessionState` — the two combine via
+ * `resolveStatusClass` (see `lib/statusColor.ts`), so both dropdowns matter:
+ * e.g. `waiting_for_human` + `open` renders BLUE, not red.
+ * `"(unset)"` clears the field entirely (no PR ever checked).
+ */
+const PR_STATES = ["(unset)", "none", "draft", "open", "merged", "closed"] as const;
+type PrChoice = (typeof PR_STATES)[number];
 
 export function DevStatePanel(): ReactNode {
   const devEnabled =
@@ -32,8 +40,10 @@ export function DevStatePanel(): ReactNode {
   const [pos, setPos] = useState({ x: 24, y: 24 });
   const [sessionId, setSessionId] = useState<string>("");
   const [state, setState] = useState<SessionState>("working");
+  const [prState, setPrState] = useState<PrChoice>("(unset)");
 
   const sessions = useServerStore((s) => s.sessions);
+  const worktrees = useServerStore((s) => s.worktrees);
 
   const drag = useRef<{ startX: number; startY: number; origX: number; origY: number } | null>(
     null,
@@ -73,7 +83,28 @@ export function DevStatePanel(): ReactNode {
 
   function handleApply() {
     if (!sessionId) return;
-    useServerStore.getState().applySessionUpdated(sessionId, { state, lifecycleState: state });
+    const patch: { state: SessionState; lifecycleState: SessionState; pr?: PrStatus } = {
+      state,
+      lifecycleState: state,
+    };
+    if (prState !== "(unset)") {
+      // `prBranch` MUST match the session's worktree's current branch or
+      // `worktreePrStatus` filters the PR out by design (D20) — so mirror the
+      // real branch here, otherwise the colour silently won't render.
+      const session = sessions.find((s) => s.id === sessionId);
+      const branch = worktrees.find((w) => w.id === session?.worktreeId)?.branch;
+      patch.pr =
+        prState === "none"
+          ? { state: "none", checkedAt: new Date().toISOString(), prBranch: branch }
+          : {
+              state: prState,
+              number: 999,
+              url: "https://github.com/example/repo/pull/999",
+              checkedAt: new Date().toISOString(),
+              prBranch: branch,
+            };
+    }
+    useServerStore.getState().applySessionUpdated(sessionId, patch);
     useWorkspaceStore.getState().patchSessionState(sessionId, state);
   }
 
@@ -117,6 +148,8 @@ export function DevStatePanel(): ReactNode {
         }}
       >
         <span>DEV: State Simulator</span>
+        {/* Two orthogonal axes — lifecycle + PR. Precedence (D18):
+            working → pr=merged → pr=open → waiting_for_human → idle. */}
         <button
           onClick={() => setOpen(false)}
           style={{
@@ -170,6 +203,27 @@ export function DevStatePanel(): ReactNode {
             }}
           >
             {STATES.map((st) => (
+              <option key={st} value={st}>
+                {st}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+          PR state (orthogonal axis)
+          <select
+            value={prState}
+            onChange={(e) => setPrState(e.target.value as PrChoice)}
+            style={{
+              background: "#111",
+              color: "#e0e0e0",
+              border: "1px solid #444",
+              borderRadius: 4,
+              padding: "4px 6px",
+            }}
+          >
+            {PR_STATES.map((st) => (
               <option key={st} value={st}>
                 {st}
               </option>

--- a/web-ui/src/components/layout/AgentPaneSlot.test.tsx
+++ b/web-ui/src/components/layout/AgentPaneSlot.test.tsx
@@ -182,6 +182,46 @@ describe("AgentPaneSlot remount invariant (4.T5 / Decision 14)", () => {
     expect(root?.className).not.toContain("agent-pane-slot--exited");
   });
 
+  // --- PR colour is resolved by the CALLER (Workspace.tsx), branch-guarded here ---
+  // BLOCKING-2 / cross-worktree pane test gap: Workspace.tsx's `renderWorktreePane`
+  // resolves `branch`/`pr` from the pane SESSION's own `worktreeId`
+  // (`worktrees.find((w) => w.id === paneSession.worktreeId)`), not the
+  // route's `activeWorktreeId` — because a pane can belong to a worktree
+  // other than whatever is currently active (a saved workspace doc's
+  // cross-worktree tile set). A regression back to `activeWorktreeId` would
+  // be invisible unless something asserts the pane colours correctly off of
+  // `branch`/`pr` props alone, independent of any notion of "active" —
+  // AgentPaneSlot itself has no such notion, so this is exactly that check.
+  it("colours the pane agent-pane-slot--pr-open when `pr`/`branch` are supplied, regardless of any 'active worktree' concept", () => {
+    const s: Session = { ...session("tty1", "tmux"), state: "idle" };
+    const { container } = render(
+      <AgentPaneSlot
+        api={api}
+        sessionId="tty1"
+        session={s}
+        branch="feature-x"
+        pr={{ state: "open", number: 9, checkedAt: "", prBranch: "feature-x" }}
+      />,
+    );
+    const root = container.querySelector(".agent-pane-slot");
+    expect(root?.className).toContain("agent-pane-slot--pr-open");
+  });
+
+  it("suppresses the PR colour when `pr.prBranch` does not match the supplied `branch` (D20 branch guard)", () => {
+    const s: Session = { ...session("tty1", "tmux"), state: "idle" };
+    const { container } = render(
+      <AgentPaneSlot
+        api={api}
+        sessionId="tty1"
+        session={s}
+        branch="new-branch"
+        pr={{ state: "open", number: 9, checkedAt: "", prBranch: "old-branch" }}
+      />,
+    );
+    const root = container.querySelector(".agent-pane-slot");
+    expect(root?.className).not.toContain("agent-pane-slot--pr-open");
+  });
+
   it("hides the status border entirely when the showAgentStatusBorders toggle is off", async () => {
     const { useWorkspaceStore } = await import("@/hooks/useStore");
     const prev = useWorkspaceStore.getState().showAgentStatusBorders;

--- a/web-ui/src/components/layout/AgentPaneSlot.tsx
+++ b/web-ui/src/components/layout/AgentPaneSlot.tsx
@@ -1,5 +1,5 @@
 import type { ApiInstance } from "@/api";
-import type { Session } from "@/api/types";
+import type { PrStatus, Session } from "@/api/types";
 import { TerminalPane } from "./TerminalPane";
 import { TerminalChannelToggle } from "./TerminalChannelToggle";
 import { TerminalAttachmentUpload } from "./TerminalAttachmentUpload";
@@ -13,6 +13,23 @@ interface AgentPaneSlotProps {
   /** Active agent session for this slot (worktree main/additional or direct). */
   sessionId: string | null;
   session?: Session;
+  /**
+   * The session's worktree's CURRENT branch (D20), or `null`/`undefined` for
+   * a direct (worktree-less) session. Required to branch-guard `pr` the same
+   * way `WorkspaceCanvas.tsx`/`LeftSidebar.tsx` do — without it, a stale PR
+   * from a branch the worktree has since switched off of would still colour
+   * the pane border.
+   */
+  branch?: string | null;
+  /**
+   * The worktree's PR (BLOCKING-2 fix), already resolved by the caller via
+   * `worktreePrStatus()` — the daemon writes `session.pr` only to a
+   * worktree's `isMain` session, so a sibling agent's pane must NOT read
+   * `session.pr` directly (it's always empty there). `worktreePrStatus()`
+   * already branch-guards internally (D20), so this is `null` whenever the
+   * PR was last checked against a branch the worktree has since left.
+   */
+  pr?: PrStatus | null;
 }
 
 /**
@@ -26,7 +43,7 @@ interface AgentPaneSlotProps {
  * never unmounts the terminal, so it cannot recreate the ghost-stream remount
  * bug fixed in 9dc10ef.
  */
-export function AgentPaneSlot({ api, sessionId, session }: AgentPaneSlotProps) {
+export function AgentPaneSlot({ api, sessionId, session, branch = null, pr = null }: AgentPaneSlotProps) {
   const isJson = session?.channel === "json";
   // The channel toggle is handed to `TerminalPane` so a single owner decides its
   // placement: a top-right overlay while the terminal is live, but rendered
@@ -56,9 +73,17 @@ export function AgentPaneSlot({ api, sessionId, session }: AgentPaneSlotProps) {
   // sessions (no tile header to host a StatusDot dot in either case), so a
   // border is the only "colored rectangle" surface available here.
   const showAgentStatusBorders = useWorkspaceStore((s) => s.showAgentStatusBorders);
+  // D20 — branch-guard the PR the same way WorkspaceCanvas/LeftSidebar do: a
+  // PR only colours the border while it was last checked against this
+  // session's worktree's CURRENT branch. `branch` is null for a direct
+  // (worktree-less) session, which correctly suppresses the PR unconditionally.
+  // `pr` is already resolved per-worktree by the caller (BLOCKING-2 fix) —
+  // NOT read off `session.pr` directly, since the daemon only ever writes
+  // `pr` to a worktree's `isMain` session and this pane may host a sibling.
+  const sessionPr = pr && branch && pr.prBranch === branch ? pr : null;
   const status =
     session && showAgentStatusBorders
-      ? resolveStatusClass(sessionStatus(session.state), session.pr ?? null)
+      ? resolveStatusClass(sessionStatus(session.state), sessionPr)
       : null;
   return (
     <div className={`agent-pane-slot${status ? ` agent-pane-slot--${status}` : ""}`}>

--- a/web-ui/src/components/layout/AgentPaneSlot.tsx
+++ b/web-ui/src/components/layout/AgentPaneSlot.tsx
@@ -5,6 +5,7 @@ import { TerminalChannelToggle } from "./TerminalChannelToggle";
 import { TerminalAttachmentUpload } from "./TerminalAttachmentUpload";
 import { ChatPane } from "./ChatPane";
 import { sessionStatus } from "@/lib/worktreeStatus";
+import { resolveStatusClass } from "@/lib/statusColor";
 import { useWorkspaceStore } from "@/hooks/useStore";
 
 interface AgentPaneSlotProps {
@@ -55,7 +56,10 @@ export function AgentPaneSlot({ api, sessionId, session }: AgentPaneSlotProps) {
   // sessions (no tile header to host a StatusDot dot in either case), so a
   // border is the only "colored rectangle" surface available here.
   const showAgentStatusBorders = useWorkspaceStore((s) => s.showAgentStatusBorders);
-  const status = session && showAgentStatusBorders ? sessionStatus(session.state) : null;
+  const status =
+    session && showAgentStatusBorders
+      ? resolveStatusClass(sessionStatus(session.state), session.pr ?? null)
+      : null;
   return (
     <div className={`agent-pane-slot${status ? ` agent-pane-slot--${status}` : ""}`}>
       <div

--- a/web-ui/src/components/layout/DashboardPanel.test.tsx
+++ b/web-ui/src/components/layout/DashboardPanel.test.tsx
@@ -9,7 +9,7 @@ import { DashboardPanel, bucketForRollup } from "./DashboardPanel";
 import { useServerStore } from "@/hooks/useServerStore";
 import { useServerSync } from "@/hooks/useServerSync";
 
-describe("bucketForRollup (4.T1, inverted by 5.T3/D19)", () => {
+describe("bucketForRollup (4.T1, inverted by 5.T3/D19, split by 6.T1/6.6)", () => {
   it("5.T3 — done + pr=merged lands in finished, NOT the pr bucket (D19 — done is terminal)", () => {
     expect(bucketForRollup("done", { state: "merged", checkedAt: "" })).toBe("finished");
   });
@@ -26,11 +26,15 @@ describe("bucketForRollup (4.T1, inverted by 5.T3/D19)", () => {
     expect(bucketForRollup("idle", { state: "open", checkedAt: "" })).toBe("pr");
   });
 
-  it("idle + pr=draft/closed/none does not land in the pr bucket", () => {
-    expect(bucketForRollup("idle", { state: "draft", checkedAt: "" })).toBe("waiting");
-    expect(bucketForRollup("idle", { state: "closed", checkedAt: "" })).toBe("waiting");
-    expect(bucketForRollup("idle", { state: "none", checkedAt: "" })).toBe("waiting");
-    expect(bucketForRollup("idle", null)).toBe("waiting");
+  it("6.T1 — waiting_for_human maps to needs-you", () => {
+    expect(bucketForRollup("waiting_for_human", null)).toBe("needs-you");
+  });
+
+  it("6.T1 — idle + pr=draft/closed/none/null maps to idle, not needs-you", () => {
+    expect(bucketForRollup("idle", { state: "draft", checkedAt: "" })).toBe("idle");
+    expect(bucketForRollup("idle", { state: "closed", checkedAt: "" })).toBe("idle");
+    expect(bucketForRollup("idle", { state: "none", checkedAt: "" })).toBe("idle");
+    expect(bucketForRollup("idle", null)).toBe("idle");
   });
 
   it("done + no pr lands in finished", () => {
@@ -67,7 +71,7 @@ describe("DashboardPanel", () => {
     });
   });
 
-  it("renders working and waiting-for-user sections, with finished hidden until toggled", async () => {
+  it("renders working and idle sections (6.6 split), with finished hidden until toggled", async () => {
     const api = createMockApi();
     render(
       <MemoryRouter>
@@ -80,8 +84,11 @@ describe("DashboardPanel", () => {
       expect(screen.getAllByText(/Proj A/i).length).toBeGreaterThan(0);
     });
     expect(screen.getByText("working")).toBeInTheDocument();
-    // wt-3's idle session buckets under "waiting for user", not "finished".
-    expect(screen.getByText("waiting for user")).toBeInTheDocument();
+    // wt-1's sess-agent2 and wt-3's sess-wt3-main are idle sessions — bucket
+    // to "idle" (6.6 split), not "finished" and not "needs you" (no session
+    // is waiting_for_human in the default fixture).
+    expect(screen.getByText("idle")).toBeInTheDocument();
+    expect(screen.queryByText("needs you")).toBeNull();
     // wt-2's "done" session is finished — hidden by default.
     expect(screen.queryByText("finished")).toBeNull();
 
@@ -89,7 +96,7 @@ describe("DashboardPanel", () => {
     expect(screen.getByText("finished")).toBeInTheDocument();
   });
 
-  it("dashboard-direct-agents — shows a direct (worktree-less) agent session, bucketed and linking to /session/:id", async () => {
+  it("6.T3 — dashboard-direct-agents — shows a direct (worktree-less) agent session, bucketed by its own state and linking to /session/:id", async () => {
     const api = createMockApi();
     render(
       <MemoryRouter>
@@ -131,7 +138,7 @@ describe("DashboardPanel", () => {
     });
   });
 
-  it("updates worktree row bucket when session:state fires", async () => {
+  it("updates a session's card bucket when session:state fires", async () => {
     const api = createMockApi();
     render(
       <MemoryRouter>
@@ -145,6 +152,7 @@ describe("DashboardPanel", () => {
     });
     const workingSection = screen.getByText("working").closest("section");
     expect(workingSection).not.toBeNull();
+    // Only sess-main is working at this point — one card in this section.
     expect(within(workingSection!).getByRole("link", { name: /Proj A/i })).toHaveAttribute(
       "href",
       "/worktree/wt-1",
@@ -156,17 +164,19 @@ describe("DashboardPanel", () => {
       // Bucket hides entirely when empty — old section refs would point at stale detached DOM.
       expect(screen.queryByText("working")).toBeNull();
     });
-    const idleSection = screen.getByText("waiting for user").closest("section");
+    const idleSection = screen.getByText("idle").closest("section");
     expect(idleSection).not.toBeNull();
     await waitFor(() => {
-      expect(within(idleSection!).getByRole("link", { name: /Proj A/i })).toHaveAttribute(
-        "href",
-        "/worktree/wt-1",
-      );
+      // sess-main now joins sess-agent2 (idle since fixture setup) — two
+      // separate cards, both linking to /worktree/wt-1 (one per session,
+      // 6.1 — no rollup to a single worktree card anymore).
+      const links = within(idleSection!).getAllByRole("link", { name: /Proj A/i });
+      expect(links.length).toBe(2);
+      for (const link of links) expect(link).toHaveAttribute("href", "/worktree/wt-1");
     });
   });
 
-  it("dashboard-bucket-fixes — a sibling session actively working keeps the worktree bucketed as working, even if another session is waiting_for_human", async () => {
+  it("6.T5 — a working session and a waiting_for_human sibling now render as two separate cards in two different columns (966b676 regression, structurally impossible now)", async () => {
     const api = createMockApi();
     render(
       <MemoryRouter>
@@ -179,10 +189,11 @@ describe("DashboardPanel", () => {
       expect(screen.getAllByText(/Proj A/i).length).toBeGreaterThan(0);
     });
 
-    // wt-1: sess-main stays "working"; sess-agent2 flips to waiting_for_human
-    // (rank 8, would normally outrank "working" rank 6 in the single-winner
-    // rollup) — the worktree must still read as "working" because SOME
-    // session is actively working right now.
+    // wt-1: sess-main stays "working"; sess-agent2 flips to waiting_for_human.
+    // Under the old rollup, one worktree card had to pick a single winner —
+    // that's the 966b676 bug (waiting_for_human, rank 8, hid working, rank
+    // 6). Per-session cards (6.1) make that structurally impossible: each
+    // session gets its own card in its own column.
     api.__test.emit({ type: "session:state", sessionId: "sess-agent2", state: "waiting_for_human" });
 
     await waitFor(() => {
@@ -192,10 +203,62 @@ describe("DashboardPanel", () => {
         "href",
         "/worktree/wt-1",
       );
+      const needsYouSection = screen.getByText("needs you").closest("section");
+      expect(needsYouSection).not.toBeNull();
+      expect(within(needsYouSection!).getByRole("link", { name: /Proj A/i })).toHaveAttribute(
+        "href",
+        "/worktree/wt-1",
+      );
     });
   });
 
-  it("dashboard-bucket-fixes — excludes an archived session from bucketing", async () => {
+  it("6.T2 — PR set on the `isMain` session ALONE still colours the sibling (non-main) session's card too — the real daemon write shape (BLOCKING-2 fix)", async () => {
+    // The daemon's prPoller writes `session.pr` ONLY to a worktree's `isMain`
+    // session (prPoller.ts:164) — nothing else ever writes it. So this test
+    // must NOT hand-emit a `pr` payload for the sibling (`sess-agent2`); that
+    // was masking the real gap (the daemon can never produce a `pr` write for
+    // a non-main session). Seeding the PR on `sess-main` only and asserting
+    // the sibling's card ALSO shows it is the guarantee that actually matters
+    // — PR is resolved per WORKTREE (`worktreePrStatus()` off the `isMain`
+    // session), then fanned out in the UI to every non-archived agent session
+    // card of that worktree, per docs/STATUS-INDICATORS.md § Per-session vs
+    // per-worktree.
+    const api = createMockApi();
+    render(
+      <MemoryRouter>
+        <Harness api={api}>
+          <DashboardPanel api={api} />
+        </Harness>
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getAllByText(/Proj A/i).length).toBeGreaterThan(0);
+    });
+
+    // Both wt-1 sessions go idle; only the isMain session (`sess-main`) gets
+    // the matching-branch open PR — exactly what the real daemon does.
+    api.__test.emit({ type: "session:state", sessionId: "sess-main", state: "idle" });
+    api.__test.emit({
+      type: "session:updated",
+      sessionId: "sess-main",
+      pr: { state: "open", checkedAt: new Date().toISOString(), prBranch: "wt-1" },
+    });
+
+    await waitFor(() => {
+      const prSection = screen.getByText("pr created").closest("section");
+      expect(prSection).not.toBeNull();
+      const links = within(prSection!).getAllByRole("link", { name: /Proj A/i });
+      expect(links).toHaveLength(2);
+      for (const link of links) expect(link).toHaveAttribute("href", "/worktree/wt-1");
+      // Both cards' dots resolve to pr-open — no isMain preference on which
+      // CARD shows the branch's PR, even though only the isMain session's
+      // own `.pr` field was ever written.
+      const dots = within(prSection!).getAllByLabelText(/status: pr-open/i);
+      expect(dots).toHaveLength(2);
+    });
+  });
+
+  it("6.T4 — dashboard-bucket-fixes — excludes an archived session from bucketing", async () => {
     const api = createMockApi();
     render(
       <MemoryRouter>
@@ -208,9 +271,8 @@ describe("DashboardPanel", () => {
       expect(document.querySelector('a[href="/worktree/wt-3"]')).not.toBeNull();
     });
 
-    // wt-3's only agent session (idle) gets archived — with no non-archived
-    // agent sessions left, the worktree must drop out of every bucket
-    // entirely rather than keep poisoning "waiting for user".
+    // wt-3's only agent session (idle) gets archived — an archived session
+    // produces no card at all (6.T4).
     api.__test.emit({
       type: "session:updated",
       sessionId: "sess-wt3-main",
@@ -288,7 +350,7 @@ describe("DashboardPanel", () => {
     });
   });
 
-  it("4.T6 — a direct session with pr.state==='open' lands in the PR bucket", async () => {
+  it("6.3 — a direct session's PR is never rendered/bucketed (no worktree to branch-guard against), superseding 4.T6", async () => {
     const api = createMockApi();
     render(
       <MemoryRouter>
@@ -324,11 +386,16 @@ describe("DashboardPanel", () => {
     api.__test.emit({ type: "session:updated", sessionId: "sess-direct-pr", pr: { state: "open", checkedAt: new Date().toISOString() } });
 
     await waitFor(() => {
-      const prSection = screen.getByText("pr created").closest("section");
-      expect(prSection).not.toBeNull();
-      const link = within(prSection!).getByRole("link", { name: /Direct PR Agent/i });
+      // Direct sessions have no worktree, so `session.pr` can never be
+      // branch-guarded and is never shown — the card stays lifecycle-only,
+      // bucketed under "idle" (its own state), not "pr created".
+      const link = screen.getByRole("link", { name: /Direct PR Agent/i });
       expect(link).toHaveAttribute("href", "/session/sess-direct-pr");
     });
+    expect(screen.queryByText("pr created")).toBeNull();
+    const idleSection = screen.getByText("idle").closest("section");
+    expect(idleSection).not.toBeNull();
+    expect(within(idleSection!).getByRole("link", { name: /Direct PR Agent/i })).toBeInTheDocument();
   });
 
   it("4.T6 — an archivedAt-set session in waiting_for_human does not place its worktree in the Waiting bucket", async () => {
@@ -396,5 +463,69 @@ describe("DashboardPanel", () => {
     expect(screen.queryByText("Proj A")).toBeNull();
     // A visible project's worktree (proj-b / wt-3) is unaffected.
     expect(document.querySelector('a[href="/worktree/wt-3"]')).not.toBeNull();
+  });
+
+  it("excludes a direct (worktree-less) session's card when its project is hidden", async () => {
+    const api = createMockApi();
+    render(
+      <MemoryRouter>
+        <Harness api={api}>
+          <DashboardPanel api={api} />
+        </Harness>
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getAllByText(/Proj A/i).length).toBeGreaterThan(0);
+    });
+
+    api.__test.emit({
+      type: "session:created",
+      sessionId: "sess-direct-hide",
+      worktreeId: null,
+      projectId: "proj-a",
+      sessionType: "agent",
+      snapshot: {
+        id: "sess-direct-hide",
+        worktreeId: null,
+        projectId: "proj-a",
+        modeId: "mode-1",
+        type: "agent",
+        name: "Direct Hide Agent",
+        isMain: false,
+        state: "working",
+        lifecycleState: "working",
+        tmuxName: "sess-direct-hide",
+        createdAt: new Date().toISOString(),
+      },
+    });
+
+    await waitFor(() => {
+      const workingSection = screen.getByText("working").closest("section");
+      expect(workingSection).not.toBeNull();
+      expect(
+        within(workingSection!).getByRole("link", { name: /Direct Hide Agent/i }),
+      ).toBeInTheDocument();
+    });
+
+    // Hiding the direct session's project (proj-a, the `s.projectId` branch
+    // of the filter at DashboardPanel.tsx's hidden-project check) must drop
+    // its card too, the same as a worktree-attached session's card.
+    api.__test.emit({
+      type: "project:updated",
+      project: {
+        id: "proj-a",
+        name: "Proj A",
+        path: "/home/dev/proj-a",
+        prefix: "pa",
+        isGit: true,
+        defaultBranch: "main",
+        createdAt: new Date().toISOString(),
+        hidden: true,
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("link", { name: /Direct Hide Agent/i })).toBeNull();
+    });
   });
 });

--- a/web-ui/src/components/layout/DashboardPanel.test.tsx
+++ b/web-ui/src/components/layout/DashboardPanel.test.tsx
@@ -5,9 +5,38 @@ import { describe, it, expect, beforeEach } from "vitest";
 import type { ReactNode } from "react";
 import type { ApiInstance } from "@/api";
 import { createMockApi } from "@/api/mock";
-import { DashboardPanel } from "./DashboardPanel";
+import { DashboardPanel, bucketForRollup } from "./DashboardPanel";
 import { useServerStore } from "@/hooks/useServerStore";
 import { useServerSync } from "@/hooks/useServerSync";
+
+describe("bucketForRollup (4.T1, inverted by 5.T3/D19)", () => {
+  it("5.T3 — done + pr=merged lands in finished, NOT the pr bucket (D19 — done is terminal)", () => {
+    expect(bucketForRollup("done", { state: "merged", checkedAt: "" })).toBe("finished");
+  });
+
+  it("exited + pr=open also lands in finished (D19 applies to exited too)", () => {
+    expect(bucketForRollup("exited", { state: "open", checkedAt: "" })).toBe("finished");
+  });
+
+  it("working + pr=open stays in working — live activity wins", () => {
+    expect(bucketForRollup("working", { state: "open", checkedAt: "" })).toBe("working");
+  });
+
+  it("idle + pr=open lands in the pr bucket", () => {
+    expect(bucketForRollup("idle", { state: "open", checkedAt: "" })).toBe("pr");
+  });
+
+  it("idle + pr=draft/closed/none does not land in the pr bucket", () => {
+    expect(bucketForRollup("idle", { state: "draft", checkedAt: "" })).toBe("waiting");
+    expect(bucketForRollup("idle", { state: "closed", checkedAt: "" })).toBe("waiting");
+    expect(bucketForRollup("idle", { state: "none", checkedAt: "" })).toBe("waiting");
+    expect(bucketForRollup("idle", null)).toBe("waiting");
+  });
+
+  it("done + no pr lands in finished", () => {
+    expect(bucketForRollup("done", null)).toBe("finished");
+  });
+});
 
 /** Mirrors production wiring (useServerSync lives in Workspace) so WS events
  *  emitted via api.__test.emit flow into the central store. */
@@ -182,6 +211,143 @@ describe("DashboardPanel", () => {
     // wt-3's only agent session (idle) gets archived — with no non-archived
     // agent sessions left, the worktree must drop out of every bucket
     // entirely rather than keep poisoning "waiting for user".
+    api.__test.emit({
+      type: "session:updated",
+      sessionId: "sess-wt3-main",
+      archivedAt: new Date().toISOString(),
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector('a[href="/worktree/wt-3"]')).toBeNull();
+    });
+  });
+
+  it("4.T2/5.T3 — an idle worktree whose PR merges moves into the PR column across a session:updated event", async () => {
+    const api = createMockApi();
+    render(
+      <MemoryRouter>
+        <Harness api={api}>
+          <DashboardPanel api={api} />
+        </Harness>
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getAllByText(/Proj A/i).length).toBeGreaterThan(0);
+    });
+    // wt-3's only session (sess-wt3-main) starts idle — bucketed under
+    // "waiting for user" until its PR is reported merged.
+    expect(screen.queryByText("pr created")).toBeNull();
+
+    api.__test.emit({
+      type: "session:updated",
+      sessionId: "sess-wt3-main",
+      pr: { state: "merged", checkedAt: new Date().toISOString(), prBranch: "wt-main" },
+    });
+
+    await waitFor(() => {
+      const prSection = screen.getByText("pr created").closest("section");
+      expect(prSection).not.toBeNull();
+      expect(within(prSection!).getByRole("link", { name: /Proj B/i })).toHaveAttribute(
+        "href",
+        "/worktree/wt-3",
+      );
+    });
+  });
+
+  it("5.T3 (D19) — a DONE worktree's PR merging does NOT pull it out of finished/into the PR column", async () => {
+    const api = createMockApi();
+    render(
+      <MemoryRouter>
+        <Harness api={api}>
+          <DashboardPanel api={api} />
+        </Harness>
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getAllByText(/Proj A/i).length).toBeGreaterThan(0);
+    });
+    // wt-2's only session (sess-wt2-main) is "done" — hidden behind "Show
+    // finished" and MUST stay there even once its PR merges (D19 — done is
+    // terminal, checked before the PR check in bucketForRollup).
+    expect(screen.queryByText("pr created")).toBeNull();
+
+    api.__test.emit({
+      type: "session:updated",
+      sessionId: "sess-wt2-main",
+      pr: { state: "merged", checkedAt: new Date().toISOString(), prBranch: "wt-2" },
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("pr created")).toBeNull();
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByLabelText(/show finished/i));
+    await waitFor(() => {
+      expect(document.querySelector('a[href="/worktree/wt-2"]')).not.toBeNull();
+    });
+  });
+
+  it("4.T6 — a direct session with pr.state==='open' lands in the PR bucket", async () => {
+    const api = createMockApi();
+    render(
+      <MemoryRouter>
+        <Harness api={api}>
+          <DashboardPanel api={api} />
+        </Harness>
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getAllByText(/Proj A/i).length).toBeGreaterThan(0);
+    });
+
+    api.__test.emit({
+      type: "session:created",
+      sessionId: "sess-direct-pr",
+      worktreeId: null,
+      projectId: "proj-a",
+      sessionType: "agent",
+      snapshot: {
+        id: "sess-direct-pr",
+        worktreeId: null,
+        projectId: "proj-a",
+        modeId: "mode-1",
+        type: "agent",
+        name: "Direct PR Agent",
+        isMain: false,
+        state: "idle",
+        lifecycleState: "idle",
+        tmuxName: "sess-direct-pr",
+        createdAt: new Date().toISOString(),
+      },
+    });
+    api.__test.emit({ type: "session:updated", sessionId: "sess-direct-pr", pr: { state: "open", checkedAt: new Date().toISOString() } });
+
+    await waitFor(() => {
+      const prSection = screen.getByText("pr created").closest("section");
+      expect(prSection).not.toBeNull();
+      const link = within(prSection!).getByRole("link", { name: /Direct PR Agent/i });
+      expect(link).toHaveAttribute("href", "/session/sess-direct-pr");
+    });
+  });
+
+  it("4.T6 — an archivedAt-set session in waiting_for_human does not place its worktree in the Waiting bucket", async () => {
+    const api = createMockApi();
+    render(
+      <MemoryRouter>
+        <Harness api={api}>
+          <DashboardPanel api={api} />
+        </Harness>
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(document.querySelector('a[href="/worktree/wt-3"]')).not.toBeNull();
+    });
+
+    // wt-3's only agent session flips to waiting_for_human but is archived in
+    // the same update — archived sessions are excluded from bucketing, so
+    // the worktree must drop out entirely rather than land in "waiting for user".
+    api.__test.emit({ type: "session:state", sessionId: "sess-wt3-main", state: "waiting_for_human" });
     api.__test.emit({
       type: "session:updated",
       sessionId: "sess-wt3-main",

--- a/web-ui/src/components/layout/DashboardPanel.tsx
+++ b/web-ui/src/components/layout/DashboardPanel.tsx
@@ -10,7 +10,7 @@ import { StatusDot } from "@/components/layout/StatusDot";
 import { useSubscription } from "@/hooks/useSubscription";
 import { useWorkspaceStore } from "@/hooks/useStore";
 import { useServerStore } from "@/hooks/useServerStore";
-import { type WorktreeRolledUpStatus, sessionStatus, worktreeRolledUpStatus } from "@/lib/worktreeStatus";
+import { type WorktreeRolledUpStatus, sessionStatus } from "@/lib/worktreeStatus";
 import { worktreePrStatus } from "@/lib/statusColor";
 import { sessionLabel } from "@/lib/sessionLabel";
 
@@ -18,18 +18,14 @@ interface DashboardPanelProps {
   api: ApiInstance;
 }
 
-/** A dashboard card is either a worktree or a direct (worktree-less) agent
- *  session — both bucket into the same Working/Waiting/PR/Finished sections. */
-type DashboardItem = { kind: "worktree"; worktree: Worktree } | { kind: "direct"; session: Session };
-
 /**
  * Dashboard buckets, coarser than the full `WorktreeRolledUpStatus` set.
- * `pr` is checked out-of-band from the lifecycle rollup (`r`) — it's the
- * orthogonal PR axis (`statusColor.ts`), not a `WorktreeRolledUpStatus`
- * value.
+ * `pr` is checked out-of-band from the session's own lifecycle status (`r`)
+ * — it's the orthogonal PR axis (`statusColor.ts`), not a
+ * `WorktreeRolledUpStatus` value.
  *
  * Order (D19): `done`/`exited` are checked FIRST and unconditionally bucket
- * to "finished" — a merged PR must never pull a done/exited worktree back
+ * to "finished" — a merged PR must never pull a done/exited session back
  * into the PR column (this reverses the earlier "done + merged → PR
  * bucket" behavior). Only then does live lifecycle activity
  * (`working`/`spawning`) win over PR outcome, since active work is the more
@@ -39,16 +35,24 @@ type DashboardItem = { kind: "worktree"; worktree: Worktree } | { kind: "direct"
  *    recognizable state at all. Hidden by default behind "Show finished".
  *  - "working": actively running, or not started yet (`spawning`).
  *  - "pr": this session's branch has an open or merged PR (`session.pr`).
- *  - "waiting": stopped and needs a human — either explicitly flagged
- *    (`waiting_for_human`) or just idle after finishing a turn (`idle`).
- *    Idle deliberately lives here, NOT in "finished" — an idle worktree is
- *    still open work waiting on the user, not done.
+ *  - "needs-you": `waiting_for_human` — the agent is explicitly blocked on a
+ *    human. Was previously folded into "waiting" together with `idle`,
+ *    which put a neutral, nothing-to-see idle session in a column labeled
+ *    "Waiting" with no red indicator — read as a bug (Phase 6, 6.6). Split
+ *    out so this column is always the red-`!` "needs you" case.
+ *  - "idle": stopped after finishing a turn, nothing flagged. Deliberately
+ *    NOT "finished" — an idle session is still open work, just not urgent.
+ *    Shown by default (not hidden behind "Show finished").
  */
-export function bucketForRollup(r: WorktreeRolledUpStatus, pr: PrStatus | null): "working" | "waiting" | "pr" | "finished" {
+export function bucketForRollup(
+  r: WorktreeRolledUpStatus,
+  pr: PrStatus | null,
+): "working" | "needs-you" | "idle" | "pr" | "finished" {
   if (r === "done" || r === "exited") return "finished";
   if (r === "working" || r === "spawning") return "working";
   if (pr?.state === "open" || pr?.state === "merged") return "pr";
-  if (r === "waiting_for_human" || r === "idle") return "waiting";
+  if (r === "waiting_for_human") return "needs-you";
+  if (r === "idle") return "idle";
   return "finished";
 }
 
@@ -140,68 +144,81 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
    *  back to the REST session's `state` field. */
   const sessionStates = useWorkspaceStore((s) => s.sessionStates);
 
-  const { working, waiting, pr, finished } = useMemo(() => {
-    const wtsWorking: DashboardItem[] = [];
-    const wtsWaiting: DashboardItem[] = [];
-    const wtsPr: DashboardItem[] = [];
-    const wtsFinished: DashboardItem[] = [];
+  const worktreeById = useMemo(
+    () => new Map(worktrees.map((w) => [w.id, w])),
+    [worktrees],
+  );
+
+  /**
+   * PR is a property of the BRANCH, not any one session (BLOCKING-2 fix).
+   * The daemon writes `session.pr` only to a worktree's `isMain` session
+   * (`prPoller.ts`); resolve it once per worktree here via the same
+   * `worktreePrStatus()` the sidebar rollup uses, then apply it to every
+   * non-archived agent session card of that worktree below — this is what
+   * makes sibling (non-main) agent sessions on the same branch also show the
+   * PR colour/bucket, per docs/STATUS-INDICATORS.md § Per-session vs
+   * per-worktree, without the daemon fanning out writes to N sessions.
+   */
+  const worktreePrById = useMemo(() => {
+    const map = new Map<string, PrStatus | null>();
     for (const wt of worktrees) {
-      if (hiddenProjectIds.has(wt.projectId)) continue;
-      // Archived (handed-off/reset) sessions are excluded from bucketing —
-      // one stuck in `waiting_for_human` shouldn't poison this worktree's
-      // bucket the way a live session's state should.
-      const agentSessions = sessions.filter(
-        (s) => s.worktreeId === wt.id && s.type === "agent" && s.archivedAt == null,
-      );
-      if (agentSessions.length === 0) continue;
-      // "Working" means "is there live activity here right now" — ANY
-      // session actively working takes priority over the rollup's single
-      // highest-ranked status, which would otherwise let one session's
-      // `waiting_for_human` (rank 8) hide a SIBLING session's `working`
-      // (rank 6) for the whole worktree.
-      const hasLiveActivity = agentSessions.some((s) => {
-        const st = sessionStates[s.id] ?? s.state;
-        return st === "working" || st === "not_started";
-      });
-      const wtItem: DashboardItem = { kind: "worktree", worktree: wt };
-      if (hasLiveActivity) {
-        wtsWorking.push(wtItem);
-        continue;
-      }
-      const rolled = worktreeRolledUpStatus(agentSessions, sessionStates);
-      const pr = worktreePrStatus(agentSessions, wt.branch);
-      const b = bucketForRollup(rolled, pr);
-      if (b === "waiting") wtsWaiting.push(wtItem);
-      else if (b === "pr") wtsPr.push(wtItem);
-      else if (b === "finished") wtsFinished.push(wtItem);
-      else wtsWorking.push(wtItem); // defensive — hasLiveActivity already covers "working"
+      const sessionsForWt = sessions.filter((s) => s.worktreeId === wt.id);
+      map.set(wt.id, worktreePrStatus(sessionsForWt, wt.branch));
     }
-    // Direct (worktree-less) agent sessions bucket the same way, one card per
-    // session — there's no rollup to do since there's only ever one session
-    // per card here.
+    return map;
+  }, [worktrees, sessions]);
+
+  const { working, needsYou, idle, pr, finished } = useMemo(() => {
+    const sWorking: Session[] = [];
+    const sNeedsYou: Session[] = [];
+    const sIdle: Session[] = [];
+    const sPr: Session[] = [];
+    const sFinished: Session[] = [];
+    // One card per non-archived agent session — worktree-attached and direct
+    // alike (Phase 6). Archived (handed-off/reset) sessions are excluded:
+    // one stuck in `waiting_for_human` shouldn't produce a stray card.
     for (const s of sessions) {
-      if (s.type !== "agent" || s.worktreeId != null || s.archivedAt != null) continue;
-      if (!s.projectId || hiddenProjectIds.has(s.projectId)) continue;
-      const item: DashboardItem = { kind: "direct", session: s };
-      // No sibling sessions to prioritize over (one session = one card here),
-      // so — unlike the worktree loop above — a plain rollup is sufficient.
-      const b = bucketForRollup(sessionStatus(sessionStates[s.id] ?? s.state), s.pr ?? null);
-      if (b === "working") wtsWorking.push(item);
-      else if (b === "waiting") wtsWaiting.push(item);
-      else if (b === "pr") wtsPr.push(item);
-      else wtsFinished.push(item);
+      if (s.type !== "agent" || s.archivedAt != null) continue;
+      const wt = s.worktreeId != null ? worktreeById.get(s.worktreeId) : undefined;
+      if (wt) {
+        if (hiddenProjectIds.has(wt.projectId)) continue;
+      } else {
+        // Direct (worktree-less) session.
+        if (!s.projectId || hiddenProjectIds.has(s.projectId)) continue;
+      }
+      const status = sessionStatus(sessionStates[s.id] ?? s.state);
+      // PR is resolved per WORKTREE (branch-guarded, D20), not per session —
+      // `worktreePrById` reads it from the worktree's `isMain` session and
+      // is applied to every non-archived agent session card of that
+      // worktree. A direct session has no worktree, so it can never show a
+      // PR (6.3). No `isMain` preference on which CARDS show it — every
+      // non-archived session on a branch shows that branch's PR;
+      // duplication across sibling sessions on the same branch is expected,
+      // not guarded against (user decision, Phase 6 amendment — see
+      // docs/STATUS-INDICATORS.md).
+      const sessionPr = wt ? worktreePrById.get(wt.id) ?? null : null;
+      const b = bucketForRollup(status, sessionPr);
+      if (b === "working") sWorking.push(s);
+      else if (b === "needs-you") sNeedsYou.push(s);
+      else if (b === "idle") sIdle.push(s);
+      else if (b === "pr") sPr.push(s);
+      else sFinished.push(s);
     }
-    return { working: wtsWorking, waiting: wtsWaiting, pr: wtsPr, finished: wtsFinished };
-  }, [worktrees, sessions, sessionStates, hiddenProjectIds]);
+    return { working: sWorking, needsYou: sNeedsYou, idle: sIdle, pr: sPr, finished: sFinished };
+  }, [sessions, sessionStates, hiddenProjectIds, worktreeById, worktreePrById]);
 
   const daemonOk = connState === "online";
 
   const renderDashboardItem = useCallback(
-    (item: DashboardItem) => {
-      if (item.kind === "direct") {
-        const s = item.session;
-        const status = sessionStatus(sessionStates[s.id] ?? s.state);
-        const proj = projectById[s.projectId];
+    (s: Session) => {
+      const status = sessionStatus(sessionStates[s.id] ?? s.state);
+      const wt = s.worktreeId != null ? worktreeById.get(s.worktreeId) : undefined;
+      const sessionPr = wt ? worktreePrById.get(wt.id) ?? null : null;
+      const proj = projectById[s.projectId];
+      const showDismiss = wt != null && (status === "done" || status === "exited");
+      if (!wt) {
+        // Direct (worktree-less) session — no worktree context to show, no
+        // dismiss affordance (nothing to dismiss).
         return (
           <div key={s.id} className="dashboard-card-shell">
             <Link
@@ -209,7 +226,7 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
               className="dashboard-card dashboard-card--session dashboard-card--worktree"
             >
               <span className="dashboard-card__dot dashboard-card__dot--status">
-                <StatusDot status={status} pr={s.pr ?? null} />
+                <StatusDot status={status} pr={sessionPr} />
               </span>
               <span className="dashboard-card__session-main">
                 <span className="dashboard-card__primary">{sessionLabel(s)}</span>
@@ -220,16 +237,10 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
           </div>
         );
       }
-      const wt = item.worktree;
-      const agentSessions = sessions.filter((s) => s.worktreeId === wt.id && s.type === "agent");
-      const rolled = worktreeRolledUpStatus(agentSessions, sessionStates);
-      const pr = worktreePrStatus(agentSessions, wt.branch);
-      const sessionsForWt = sessions.filter((s) => s.worktreeId === wt.id);
-      const proj = projectById[wt.projectId];
-      const showDismiss = rolled === "done" || rolled === "exited";
+      const sessionsForWt = sessions.filter((s2) => s2.worktreeId === wt.id);
       return (
         <div
-          key={wt.id}
+          key={s.id}
           className={`dashboard-card-shell${showDismiss ? " dashboard-card-shell--dismissable" : ""}`}
         >
           <Link
@@ -238,11 +249,13 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
             onClick={() => setActiveWorktree(wt.projectId, wt.id, sessionsForWt)}
           >
             <span className="dashboard-card__dot dashboard-card__dot--status">
-              <StatusDot status={rolled} pr={pr} />
+              <StatusDot status={status} pr={sessionPr} />
             </span>
             <span className="dashboard-card__session-main">
-              <span className="dashboard-card__primary">{wt.branch}</span>
-              <span className="dashboard-card__branch">{wt.id}</span>
+              <span className="dashboard-card__primary">{sessionLabel(s)}</span>
+              <span className="dashboard-card__branch">
+                {wt.branch} · {wt.id}
+              </span>
             </span>
             <span className="dashboard-card__secondary">{proj?.name ?? ""}</span>
           </Link>
@@ -250,7 +263,7 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
             <button
               type="button"
               className="icon-btn dashboard-card__dismiss"
-              aria-label={`Dismiss ${wt.branch} from tracking`}
+              aria-label={`Dismiss ${sessionLabel(s)} (${wt.branch}) from tracking`}
               title="Dismiss from tracking (keep files)"
               onClick={(e) => {
                 e.preventDefault();
@@ -264,7 +277,7 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
         </div>
       );
     },
-    [projectById, sessionStates, sessions, setActiveWorktree],
+    [projectById, sessionStates, sessions, setActiveWorktree, worktreeById, worktreePrById],
   );
 
   const toggleViewLabel =
@@ -321,33 +334,44 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
             {working.length > 0 ? (
               <section className="dashboard-section">
                 <div className="dashboard-section__label">working</div>
-                <div className="dashboard-card-list">{working.map((item) => renderDashboardItem(item))}</div>
+                <div className="dashboard-card-list">{working.map((s) => renderDashboardItem(s))}</div>
               </section>
             ) : null}
 
-            {waiting.length > 0 ? (
+            {needsYou.length > 0 ? (
               <section className="dashboard-section">
-                <div className="dashboard-section__label">waiting for user</div>
-                <div className="dashboard-card-list">{waiting.map((item) => renderDashboardItem(item))}</div>
+                <div className="dashboard-section__label">needs you</div>
+                <div className="dashboard-card-list">{needsYou.map((s) => renderDashboardItem(s))}</div>
+              </section>
+            ) : null}
+
+            {idle.length > 0 ? (
+              <section className="dashboard-section">
+                <div className="dashboard-section__label">idle</div>
+                <div className="dashboard-card-list">{idle.map((s) => renderDashboardItem(s))}</div>
               </section>
             ) : null}
 
             {pr.length > 0 ? (
               <section className="dashboard-section">
                 <div className="dashboard-section__label">pr created</div>
-                <div className="dashboard-card-list">{pr.map((item) => renderDashboardItem(item))}</div>
+                <div className="dashboard-card-list">{pr.map((s) => renderDashboardItem(s))}</div>
               </section>
             ) : null}
 
             {showFinished && finished.length > 0 ? (
               <section className="dashboard-section">
                 <div className="dashboard-section__label">finished</div>
-                <div className="dashboard-card-list">{finished.map((item) => renderDashboardItem(item))}</div>
+                <div className="dashboard-card-list">{finished.map((s) => renderDashboardItem(s))}</div>
               </section>
             ) : null}
 
-            {working.length === 0 && waiting.length === 0 && pr.length === 0 && (!showFinished || finished.length === 0) ? (
-              <p className="dashboard-empty">No agent worktrees yet. Add a project with the CLI.</p>
+            {working.length === 0 &&
+            needsYou.length === 0 &&
+            idle.length === 0 &&
+            pr.length === 0 &&
+            (!showFinished || finished.length === 0) ? (
+              <p className="dashboard-empty">No agent sessions yet. Add a project with the CLI.</p>
             ) : null}
           </>
         ) : (
@@ -356,26 +380,32 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
               <div className="dashboard-kanban__col-header">
                 Working <span className="dashboard-kanban__col-count">({working.length})</span>
               </div>
-              <div className="dashboard-card-list">{working.map((item) => renderDashboardItem(item))}</div>
+              <div className="dashboard-card-list">{working.map((s) => renderDashboardItem(s))}</div>
             </div>
             <div className="dashboard-kanban__col">
               <div className="dashboard-kanban__col-header">
-                Waiting for User <span className="dashboard-kanban__col-count">({waiting.length})</span>
+                Needs You <span className="dashboard-kanban__col-count">({needsYou.length})</span>
               </div>
-              <div className="dashboard-card-list">{waiting.map((item) => renderDashboardItem(item))}</div>
+              <div className="dashboard-card-list">{needsYou.map((s) => renderDashboardItem(s))}</div>
+            </div>
+            <div className="dashboard-kanban__col">
+              <div className="dashboard-kanban__col-header">
+                Idle <span className="dashboard-kanban__col-count">({idle.length})</span>
+              </div>
+              <div className="dashboard-card-list">{idle.map((s) => renderDashboardItem(s))}</div>
             </div>
             <div className="dashboard-kanban__col">
               <div className="dashboard-kanban__col-header">
                 PR Created <span className="dashboard-kanban__col-count">({pr.length})</span>
               </div>
-              <div className="dashboard-card-list">{pr.map((item) => renderDashboardItem(item))}</div>
+              <div className="dashboard-card-list">{pr.map((s) => renderDashboardItem(s))}</div>
             </div>
             {showFinished ? (
               <div className="dashboard-kanban__col">
                 <div className="dashboard-kanban__col-header">
                   Finished <span className="dashboard-kanban__col-count">({finished.length})</span>
                 </div>
-                <div className="dashboard-card-list">{finished.map((item) => renderDashboardItem(item))}</div>
+                <div className="dashboard-card-list">{finished.map((s) => renderDashboardItem(s))}</div>
               </div>
             ) : null}
           </div>

--- a/web-ui/src/components/layout/DashboardPanel.tsx
+++ b/web-ui/src/components/layout/DashboardPanel.tsx
@@ -4,13 +4,14 @@ import { Link } from "react-router-dom";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 import type { ApiInstance } from "@/api";
 import type { ConnectionState } from "@/api/client";
-import type { HealthResponse, Session, Worktree } from "@/api/types";
+import type { HealthResponse, PrStatus, Session, Worktree } from "@/api/types";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
 import { StatusDot } from "@/components/layout/StatusDot";
 import { useSubscription } from "@/hooks/useSubscription";
 import { useWorkspaceStore } from "@/hooks/useStore";
 import { useServerStore } from "@/hooks/useServerStore";
 import { type WorktreeRolledUpStatus, sessionStatus, worktreeRolledUpStatus } from "@/lib/worktreeStatus";
+import { worktreePrStatus } from "@/lib/statusColor";
 import { sessionLabel } from "@/lib/sessionLabel";
 
 interface DashboardPanelProps {
@@ -22,20 +23,32 @@ interface DashboardPanelProps {
 type DashboardItem = { kind: "worktree"; worktree: Worktree } | { kind: "direct"; session: Session };
 
 /**
- * Dashboard buckets, coarser than the full `WorktreeRolledUpStatus` set:
+ * Dashboard buckets, coarser than the full `WorktreeRolledUpStatus` set.
+ * `pr` is checked out-of-band from the lifecycle rollup (`r`) — it's the
+ * orthogonal PR axis (`statusColor.ts`), not a `WorktreeRolledUpStatus`
+ * value.
+ *
+ * Order (D19): `done`/`exited` are checked FIRST and unconditionally bucket
+ * to "finished" — a merged PR must never pull a done/exited worktree back
+ * into the PR column (this reverses the earlier "done + merged → PR
+ * bucket" behavior). Only then does live lifecycle activity
+ * (`working`/`spawning`) win over PR outcome, since active work is the more
+ * urgent signal; PR outcome in turn wins over a merely idle/waiting-for-human
+ * lifecycle, since a merged/open PR is a more meaningful summary than "idle".
+ *  - "finished": `done` or `exited` (D19, checked first) — or no
+ *    recognizable state at all. Hidden by default behind "Show finished".
  *  - "working": actively running, or not started yet (`spawning`).
+ *  - "pr": this session's branch has an open or merged PR (`session.pr`).
  *  - "waiting": stopped and needs a human — either explicitly flagged
  *    (`waiting_for_human`) or just idle after finishing a turn (`idle`).
  *    Idle deliberately lives here, NOT in "finished" — an idle worktree is
  *    still open work waiting on the user, not done.
- *  - "pr": the review poller found an open PR for this session (`needs_review`).
- *  - "finished": actually done or exited (or no recognizable state at all) —
- *    hidden by default behind the "Show finished" checkbox.
  */
-function bucketForRollup(r: WorktreeRolledUpStatus): "working" | "waiting" | "pr" | "finished" {
+export function bucketForRollup(r: WorktreeRolledUpStatus, pr: PrStatus | null): "working" | "waiting" | "pr" | "finished" {
+  if (r === "done" || r === "exited") return "finished";
   if (r === "working" || r === "spawning") return "working";
+  if (pr?.state === "open" || pr?.state === "merged") return "pr";
   if (r === "waiting_for_human" || r === "idle") return "waiting";
-  if (r === "needs_review") return "pr";
   return "finished";
 }
 
@@ -155,15 +168,9 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
         wtsWorking.push(wtItem);
         continue;
       }
-      // A remembered PR merge (see prPoller.ts) keeps reading as "PR
-      // created" instead of silently falling back to idle/waiting — as long
-      // as nothing here is actively working (checked above).
-      if (wt.prMergedAt) {
-        wtsPr.push(wtItem);
-        continue;
-      }
       const rolled = worktreeRolledUpStatus(agentSessions, sessionStates);
-      const b = bucketForRollup(rolled);
+      const pr = worktreePrStatus(agentSessions, wt.branch);
+      const b = bucketForRollup(rolled, pr);
       if (b === "waiting") wtsWaiting.push(wtItem);
       else if (b === "pr") wtsPr.push(wtItem);
       else if (b === "finished") wtsFinished.push(wtItem);
@@ -178,7 +185,7 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
       const item: DashboardItem = { kind: "direct", session: s };
       // No sibling sessions to prioritize over (one session = one card here),
       // so — unlike the worktree loop above — a plain rollup is sufficient.
-      const b = bucketForRollup(sessionStatus(sessionStates[s.id] ?? s.state));
+      const b = bucketForRollup(sessionStatus(sessionStates[s.id] ?? s.state), s.pr ?? null);
       if (b === "working") wtsWorking.push(item);
       else if (b === "waiting") wtsWaiting.push(item);
       else if (b === "pr") wtsPr.push(item);
@@ -202,7 +209,7 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
               className="dashboard-card dashboard-card--session dashboard-card--worktree"
             >
               <span className="dashboard-card__dot dashboard-card__dot--status">
-                <StatusDot status={status} />
+                <StatusDot status={status} pr={s.pr ?? null} />
               </span>
               <span className="dashboard-card__session-main">
                 <span className="dashboard-card__primary">{sessionLabel(s)}</span>
@@ -216,6 +223,7 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
       const wt = item.worktree;
       const agentSessions = sessions.filter((s) => s.worktreeId === wt.id && s.type === "agent");
       const rolled = worktreeRolledUpStatus(agentSessions, sessionStates);
+      const pr = worktreePrStatus(agentSessions, wt.branch);
       const sessionsForWt = sessions.filter((s) => s.worktreeId === wt.id);
       const proj = projectById[wt.projectId];
       const showDismiss = rolled === "done" || rolled === "exited";
@@ -230,7 +238,7 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
             onClick={() => setActiveWorktree(wt.projectId, wt.id, sessionsForWt)}
           >
             <span className="dashboard-card__dot dashboard-card__dot--status">
-              <StatusDot status={rolled} />
+              <StatusDot status={rolled} pr={pr} />
             </span>
             <span className="dashboard-card__session-main">
               <span className="dashboard-card__primary">{wt.branch}</span>

--- a/web-ui/src/components/layout/LeftSidebar.tsx
+++ b/web-ui/src/components/layout/LeftSidebar.tsx
@@ -25,6 +25,7 @@ import { useLayout } from "@/hooks/useLayout";
 import { useDragClickGuard } from "@/hooks/useDragClickGuard";
 import { useSubscription } from "@/hooks/useSubscription";
 import { StatusDot } from "@/components/layout/StatusDot";
+import { worktreePrStatus } from "@/lib/statusColor";
 import { worktreeRolledUpStatus, type WorktreeRolledUpStatus } from "@/lib/worktreeStatus";
 import { sessionLabel } from "@/lib/sessionLabel";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
@@ -140,7 +141,7 @@ function disambiguatedAbbrev(
 /** Map SessionState to WorktreeRolledUpStatus for StatusDot. */
 function sessionStateToStatus(state: SessionState): WorktreeRolledUpStatus {
   if (state === "not_started") return "spawning";
-  return state; // working, idle, waiting_for_human, needs_review, done, exited all map directly
+  return state; // working, idle, waiting_for_human, done, exited all map directly
 }
 
 function worktreeIsInactive(sessions: Session[], live: Record<string, SessionState | undefined>): boolean {
@@ -935,8 +936,11 @@ export function LeftSidebar({
                               }}
                               tabIndex={-1}
                             />
-                            <span className="wt-leading-slot pinned-row__leading" aria-hidden>
-                              <StatusDot status={sessionStateToStatus(sessionStates[sess.id] ?? sess.state)} />
+                            <span className="wt-leading-slot pinned-row__leading">
+                              <StatusDot
+                                status={sessionStateToStatus(sessionStates[sess.id] ?? sess.state)}
+                                pr={sess.pr ?? null}
+                              />
                             </span>
                             <div className="pinned-row__text">
                               {inlineRename?.kind === "session" &&
@@ -1061,9 +1065,10 @@ export function LeftSidebar({
                               }}
                               tabIndex={-1}
                             />
-                            <span className="wt-leading-slot pinned-row__leading" aria-hidden>
+                            <span className="wt-leading-slot pinned-row__leading">
                               <StatusDot
                                 status={worktreeRolledUpStatus(sessionMap[w.id] ?? [], sessionStates)}
+                                pr={worktreePrStatus(sessionMap[w.id] ?? [], w.branch)}
                               />
                             </span>
                             <div className="pinned-row__text">
@@ -1464,8 +1469,11 @@ export function LeftSidebar({
                                         }}
                                         tabIndex={-1}
                                       />
-                                      <span className="direct-session__icon" aria-hidden>
-                                        <StatusDot status={sessionStateToStatus(sessionStates[sess.id] ?? sess.state)} />
+                                      <span className="direct-session__icon">
+                                        <StatusDot
+                                          status={sessionStateToStatus(sessionStates[sess.id] ?? sess.state)}
+                                          pr={sess.pr ?? null}
+                                        />
                                       </span>
                                       {!collapsed &&
                                       inlineRename?.kind === "session" &&
@@ -1613,9 +1621,10 @@ export function LeftSidebar({
                                     />
                                     <div className="wt-row__expand">
                                       {!collapsed ? (
-                                        <span className="wt-leading-slot" aria-hidden>
+                                        <span className="wt-leading-slot">
                                           <StatusDot
                                             status={worktreeRolledUpStatus(sessionMap[w.id] ?? [], sessionStates)}
+                                            pr={worktreePrStatus(sessionMap[w.id] ?? [], w.branch)}
                                           />
                                         </span>
                                       ) : null}

--- a/web-ui/src/components/layout/LeftSidebar.tsx
+++ b/web-ui/src/components/layout/LeftSidebar.tsx
@@ -939,7 +939,9 @@ export function LeftSidebar({
                             <span className="wt-leading-slot pinned-row__leading">
                               <StatusDot
                                 status={sessionStateToStatus(sessionStates[sess.id] ?? sess.state)}
-                                pr={sess.pr ?? null}
+                                // Direct session — no worktree to branch-guard a PR against, so
+                                // it can never show one (docs/STATUS-INDICATORS.md).
+                                pr={null}
                               />
                             </span>
                             <div className="pinned-row__text">
@@ -1472,7 +1474,10 @@ export function LeftSidebar({
                                       <span className="direct-session__icon">
                                         <StatusDot
                                           status={sessionStateToStatus(sessionStates[sess.id] ?? sess.state)}
-                                          pr={sess.pr ?? null}
+                                          // Direct session — no worktree to branch-guard a PR
+                                          // against, so it can never show one
+                                          // (docs/STATUS-INDICATORS.md).
+                                          pr={null}
                                         />
                                       </span>
                                       {!collapsed &&

--- a/web-ui/src/components/layout/StatusDot.test.tsx
+++ b/web-ui/src/components/layout/StatusDot.test.tsx
@@ -56,4 +56,26 @@ describe("StatusDot (5.T5 — one indicator, D17/D18)", () => {
     const { container } = render(<StatusDot status="idle" />);
     expect(container.querySelector(".status-dot")).toHaveClass("status-dot--idle");
   });
+
+  it("B1 — done + an open/merged PR keeps the ✓ glyph, not the recoloured ● (terminal glyph survives recolour)", () => {
+    const openDot = render(<StatusDot status="done" pr={pr("open")} />).container.querySelector(".status-dot");
+    expect(openDot).toHaveClass("status-dot--pr-open");
+    expect(openDot).toHaveTextContent("✓");
+
+    const mergedDot = render(<StatusDot status="done" pr={pr("merged")} />).container.querySelector(".status-dot");
+    expect(mergedDot).toHaveClass("status-dot--pr-merged");
+    expect(mergedDot).toHaveTextContent("✓");
+  });
+
+  it("B1 — exited + an open/merged PR keeps the × glyph, not the recoloured ●", () => {
+    const openDot = render(<StatusDot status="exited" pr={pr("open")} />).container.querySelector(".status-dot");
+    expect(openDot).toHaveClass("status-dot--pr-open");
+    expect(openDot).toHaveTextContent("×");
+
+    const mergedDot = render(<StatusDot status="exited" pr={pr("merged")} />).container.querySelector(
+      ".status-dot",
+    );
+    expect(mergedDot).toHaveClass("status-dot--pr-merged");
+    expect(mergedDot).toHaveTextContent("×");
+  });
 });

--- a/web-ui/src/components/layout/StatusDot.test.tsx
+++ b/web-ui/src/components/layout/StatusDot.test.tsx
@@ -1,0 +1,59 @@
+import { render } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { StatusDot } from "./StatusDot";
+import type { PrStatus } from "@/api/types";
+
+function pr(state: PrStatus["state"], prBranch = "feature-x"): PrStatus {
+  return { state, checkedAt: "2026-08-16T00:00:00.000Z", prBranch };
+}
+
+describe("StatusDot (5.T5 — one indicator, D17/D18)", () => {
+  it("waiting_for_human + pr=open renders the round ● dot with the pr-open class, not the waiting !", () => {
+    const { container, getByLabelText } = render(<StatusDot status="waiting_for_human" pr={pr("open")} />);
+    const dot = container.querySelector(".status-dot");
+    expect(dot).toHaveClass("status-dot--pr-open");
+    expect(dot).toHaveTextContent("●");
+    // title/aria-label name the resolved state so it isn't colour-only.
+    expect(getByLabelText("status: pr-open")).toBeInTheDocument();
+    expect(dot).toHaveAttribute("title", "pr-open");
+  });
+
+  it("waiting_for_human with no PR keeps the shape-distinct red ! and its own class", () => {
+    const { container, getByLabelText } = render(<StatusDot status="waiting_for_human" pr={null} />);
+    const dot = container.querySelector(".status-dot");
+    expect(dot).toHaveClass("status-dot--waiting_for_human");
+    expect(dot).toHaveTextContent("!");
+    expect(getByLabelText("status: waiting_for_human")).toBeInTheDocument();
+  });
+
+  it("working renders ● with the working class", () => {
+    const { container } = render(<StatusDot status="working" pr={null} />);
+    const dot = container.querySelector(".status-dot");
+    expect(dot).toHaveClass("status-dot--working");
+    expect(dot).toHaveTextContent("●");
+  });
+
+  it("pr=merged renders ● with the pr-merged class even when lifecycle is idle", () => {
+    const { container } = render(<StatusDot status="idle" pr={pr("merged")} />);
+    const dot = container.querySelector(".status-dot");
+    expect(dot).toHaveClass("status-dot--pr-merged");
+    expect(dot).toHaveTextContent("●");
+  });
+
+  it("done/idle/exited stay neutral glyphs when there is no PR", () => {
+    expect(render(<StatusDot status="done" pr={null} />).container.querySelector(".status-dot")).toHaveTextContent(
+      "✓",
+    );
+    expect(render(<StatusDot status="idle" pr={null} />).container.querySelector(".status-dot")).toHaveTextContent(
+      "○",
+    );
+    expect(
+      render(<StatusDot status="exited" pr={null} />).container.querySelector(".status-dot"),
+    ).toHaveTextContent("×");
+  });
+
+  it("pr defaults to null when omitted, matching callers that never track a PR", () => {
+    const { container } = render(<StatusDot status="idle" />);
+    expect(container.querySelector(".status-dot")).toHaveClass("status-dot--idle");
+  });
+});

--- a/web-ui/src/components/layout/StatusDot.tsx
+++ b/web-ui/src/components/layout/StatusDot.tsx
@@ -1,8 +1,11 @@
+import type { PrStatus } from "@/api/types";
 import type { WorktreeRolledUpStatus } from "@/lib/worktreeStatus";
+import { resolveStatusClass } from "@/lib/statusColor";
 
+/** Raw-lifecycle glyph fallback — used whenever the PR axis doesn't produce
+ *  a distinct resolved state (see `StatusDot` below). */
 const GLYPH: Record<WorktreeRolledUpStatus, string> = {
   waiting_for_human: "!",
-  needs_review: "◆",
   working: "●",
   spawning: "◐",
   idle: "○",
@@ -11,13 +14,35 @@ const GLYPH: Record<WorktreeRolledUpStatus, string> = {
   none: "·",
 };
 
-export function StatusDot({ status }: { status: WorktreeRolledUpStatus }) {
-  const glyph = GLYPH[status];
+interface StatusDotProps {
+  status: WorktreeRolledUpStatus;
+  /** PR axis for this worktree/session — `resolveStatusClass` folds it into
+   *  the lifecycle status. Defaults to `null` (no PR) for callers that don't
+   *  track a PR at all (e.g. terminal sessions). */
+  pr?: PrStatus | null;
+}
+
+/**
+ * One indicator, not two (D17/D18/5.8-5.9, superseding the separate
+ * `PrBadge`) — the same `●` dot is recolored by `resolveStatusClass` for
+ * `working` (yellow), `pr-open` (blue), `pr-merged` (green). Because D18
+ * lets an open/merged PR outrank `waiting_for_human`, the resolved state can
+ * differ from the raw `status` prop — e.g. `waiting_for_human` + an open PR
+ * resolves to `pr-open` and renders the round dot, not the waiting `!`
+ * (the PR is the fresher signal; see `resolveStatusClass`'s doc comment).
+ * `title`/`aria-label` always name the resolved state so this isn't
+ * colour-only (5.9's accepted trade-off note).
+ */
+export function StatusDot({ status, pr = null }: StatusDotProps) {
+  const resolved = resolveStatusClass(status, pr);
+  const isColoredDot = resolved === "working" || resolved === "pr-open" || resolved === "pr-merged";
+  const glyph = isColoredDot ? "●" : resolved === "waiting_for_human" ? "!" : GLYPH[status];
+  const label = resolved ?? status;
   return (
     <span
-      className={`status-dot status-dot--${status}`}
-      aria-label={`status: ${status}`}
-      title={status}
+      className={`status-dot status-dot--${label}`}
+      aria-label={`status: ${label}`}
+      title={label}
     >
       {glyph}
     </span>

--- a/web-ui/src/components/layout/StatusDot.tsx
+++ b/web-ui/src/components/layout/StatusDot.tsx
@@ -36,7 +36,18 @@ interface StatusDotProps {
 export function StatusDot({ status, pr = null }: StatusDotProps) {
   const resolved = resolveStatusClass(status, pr);
   const isColoredDot = resolved === "working" || resolved === "pr-open" || resolved === "pr-merged";
-  const glyph = isColoredDot ? "●" : resolved === "waiting_for_human" ? "!" : GLYPH[status];
+  // Terminal lifecycle (done/exited) always keeps its own glyph, regardless
+  // of what colour the PR axis resolves to — D21 only ever meant to recolour
+  // the dot, never to destroy the ✓/× "this is finished" cue (see
+  // docs/STATUS-INDICATORS.md's non-colour-cues note).
+  const isTerminal = status === "done" || status === "exited";
+  const glyph = isTerminal
+    ? GLYPH[status]
+    : isColoredDot
+      ? "●"
+      : resolved === "waiting_for_human"
+        ? "!"
+        : GLYPH[status];
   const label = resolved ?? status;
   return (
     <span

--- a/web-ui/src/components/layout/WorkspaceCanvas.test.tsx
+++ b/web-ui/src/components/layout/WorkspaceCanvas.test.tsx
@@ -279,6 +279,91 @@ describe("WorkspaceCanvas - saveAsWorkspace detachment", () => {
   });
 });
 
+describe("WorkspaceCanvas - tile status/PR class emission (D21 dedup)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useWorkspaceStore.persist.clearStorage?.();
+    useWorkspaceStore.setState({ layoutByWorktree: {}, workspaceDocs: {} });
+  });
+
+  const worktree = { id: W1, projectId: "proj-a", branch: "feature-x", name: "feature-x" } as never;
+
+  function renderOneAgentTile(session: Record<string, unknown>) {
+    const canvas: CanvasGeometry = {
+      mode: "free",
+      tiles: [{ id: "tile-a", kind: "agent", sessionId: "sess-a" }],
+      tree: null,
+      freeRects: { "tile-a": { x: 0, y: 0, w: 100, h: 100 } },
+    };
+    useWorkspaceStore.setState({
+      layoutByWorktree: { [W1]: { scratchCanvas: canvas } as never },
+      workspaceDocs: {},
+    });
+    return render(
+      <MemoryRouter>
+        <PaneOutletProvider>
+          <WorkspaceCanvas
+            worktreeId={W1}
+            agentSessions={[session as never]}
+            terminalSessions={[]}
+            hasTools={false}
+            toolPanelVisible
+            terminalDockVisible
+            allSessions={[session as never]}
+            worktrees={[worktree]}
+            projects={[]}
+            canvasToolbarVisible
+          />
+        </PaneOutletProvider>
+      </MemoryRouter>,
+    );
+  }
+
+  it("exited + merged PR emits exactly --pr-merged and --exited (D21: colour disagrees with the dimming cue on purpose)", () => {
+    const session = {
+      id: "sess-a",
+      worktreeId: W1,
+      projectId: "proj-a",
+      modeId: "mode-1",
+      type: "agent",
+      isMain: true,
+      state: "exited",
+      lifecycleState: "exited",
+      tmuxName: "sess-a",
+      createdAt: "",
+      pr: { state: "merged", checkedAt: "", prBranch: "feature-x" },
+    };
+    const { container } = renderOneAgentTile(session);
+    const tile = container.querySelector(".workspace-canvas__tile") as HTMLElement;
+    expect(tile.className).toContain("workspace-canvas__tile--pr-merged");
+    expect(tile.className).toContain("workspace-canvas__tile--exited");
+    // Exactly one of each — no accidental duplicate class token.
+    expect(tile.className.match(/workspace-canvas__tile--pr-merged/g)).toHaveLength(1);
+    expect(tile.className.match(/workspace-canvas__tile--exited/g)).toHaveLength(1);
+  });
+
+  it("exited with no PR emits --exited only once (no duplicate from the lifecycleClass dedup)", () => {
+    const session = {
+      id: "sess-a",
+      worktreeId: W1,
+      projectId: "proj-a",
+      modeId: "mode-1",
+      type: "agent",
+      isMain: true,
+      state: "exited",
+      lifecycleState: "exited",
+      tmuxName: "sess-a",
+      createdAt: "",
+    };
+    const { container } = renderOneAgentTile(session);
+    const tile = container.querySelector(".workspace-canvas__tile") as HTMLElement;
+    expect(tile.className).toContain("workspace-canvas__tile--exited");
+    expect(tile.className).not.toContain("pr-merged");
+    expect(tile.className).not.toContain("pr-open");
+    expect(tile.className.match(/workspace-canvas__tile--exited/g)).toHaveLength(1);
+  });
+});
+
 describe("WorkspaceCanvas - fullscreen reconciliation", () => {
   beforeEach(() => {
     localStorage.clear();

--- a/web-ui/src/components/layout/WorkspaceCanvas.tsx
+++ b/web-ui/src/components/layout/WorkspaceCanvas.tsx
@@ -27,6 +27,7 @@ import {
 import { PaneOutlet, usePaneOutletElement, WORKSPACE_CANVAS_TOOLBAR_KEY } from "@/components/layout/paneOutlets";
 import { StatusDot } from "@/components/layout/StatusDot";
 import { sessionStatus, worktreeRolledUpStatus } from "@/lib/worktreeStatus";
+import { resolveStatusClass } from "@/lib/statusColor";
 import { sessionLabel } from "@/lib/sessionLabel";
 import { randomId } from "@/lib/uuid";
 import { api } from "@/api";
@@ -814,6 +815,12 @@ export function WorkspaceCanvas({
       tile.kind !== "tools" && session && showAgentStatusBorders
         ? sessionStatus(session.state)
         : null;
+    // D20 — the PR color only applies while the session's PR was last
+    // checked against the tile's CURRENT branch; a branch switch shouldn't
+    // show a stale PR color before the next 10s poll tick.
+    const tilePr =
+      session?.pr && tileWorktree && session.pr.prBranch === tileWorktree.branch ? session.pr : null;
+    const statusClass = status ? resolveStatusClass(status, tilePr) : null;
     const paneKey = paneKeyForTile(tile, worktreeId);
     const outletVisible =
       tile.kind === "tools" ? toolPanelVisible : tile.kind === "terminal" ? terminalDockVisible : true;
@@ -844,7 +851,7 @@ export function WorkspaceCanvas({
         }}
         className={`workspace-canvas__tile${
           draggingTileId === tile.id ? " workspace-canvas__tile--dragging" : ""
-        }${status ? ` workspace-canvas__tile--${status}` : ""}${
+        }${statusClass ? ` workspace-canvas__tile--${statusClass}` : ""}${
           isFullscreen ? " workspace-canvas__tile--fullscreen" : ""
         }`}
         style={tileStyle}
@@ -864,7 +871,7 @@ export function WorkspaceCanvas({
               : (e) => startTileDrag(e, tile.id)
           }
         >
-          {status ? <StatusDot status={status} /> : null}
+          {status ? <StatusDot status={status} pr={tilePr} /> : null}
           <span className="workspace-canvas__tile-label" title={label}>{label}</span>
           {tile.kind === "agent" && session ? (
             <button

--- a/web-ui/src/components/layout/WorkspaceCanvas.tsx
+++ b/web-ui/src/components/layout/WorkspaceCanvas.tsx
@@ -27,7 +27,7 @@ import {
 import { PaneOutlet, usePaneOutletElement, WORKSPACE_CANVAS_TOOLBAR_KEY } from "@/components/layout/paneOutlets";
 import { StatusDot } from "@/components/layout/StatusDot";
 import { sessionStatus, worktreeRolledUpStatus } from "@/lib/worktreeStatus";
-import { resolveStatusClass } from "@/lib/statusColor";
+import { resolveStatusClass, worktreePrStatus } from "@/lib/statusColor";
 import { sessionLabel } from "@/lib/sessionLabel";
 import { randomId } from "@/lib/uuid";
 import { api } from "@/api";
@@ -378,6 +378,20 @@ export function WorkspaceCanvas({
   for (const s of terminalSessions) sessionById.set(s.id, s);
   const worktreeById = new Map(worktrees.map((w) => [w.id, w]));
   const projectById = new Map(projects.map((p) => [p.id, p]));
+  // PR is a property of the branch, not the session (BLOCKING-2 fix): the
+  // daemon writes `session.pr` only to a worktree's `isMain` session
+  // (`prPoller.ts`), so resolve it once per worktree via the shared
+  // `worktreePrStatus()` helper (same one the sidebar rollup uses) and apply
+  // it to whichever session's tile is showing, not just the `isMain` one.
+  const worktreePrById = new Map(
+    worktrees.map((w) => [
+      w.id,
+      worktreePrStatus(
+        allSessions.filter((s) => s.worktreeId === w.id),
+        w.branch,
+      ),
+    ]),
+  );
 
   const placedSessionIds = new Set(
     cv.tiles.filter((t) => t.sessionId).map((t) => t.sessionId as string),
@@ -796,7 +810,18 @@ export function WorkspaceCanvas({
     //     the cross-context picker never offers one, kept for correctness):
     //     "Project > Agent"
     //   tools tile: "Project > Tools" (no worktree segment, per design)
-    const tileWorktree = tile.worktreeId ? worktreeById.get(tile.worktreeId) : worktreeById.get(worktreeId);
+    // Prefer the SESSION's own worktree (stricter — matches Workspace.tsx's
+    // `renderWorktreePane`, which resolves branch from `paneSession.worktreeId`
+    // rather than the route's active worktree) so a cross-worktree tile in a
+    // detached workspace doc never gets attributed to whichever worktree
+    // happens to be active. `tile.worktreeId` covers session-less tiles
+    // (tools); the active `worktreeId` is only the last-resort fallback for a
+    // tile with neither.
+    const tileWorktree = session?.worktreeId
+      ? worktreeById.get(session.worktreeId)
+      : tile.worktreeId
+        ? worktreeById.get(tile.worktreeId)
+        : worktreeById.get(worktreeId);
     const tileProject = session
       ? projectById.get(session.projectId)
       : tileWorktree
@@ -815,12 +840,19 @@ export function WorkspaceCanvas({
       tile.kind !== "tools" && session && showAgentStatusBorders
         ? sessionStatus(session.state)
         : null;
-    // D20 — the PR color only applies while the session's PR was last
-    // checked against the tile's CURRENT branch; a branch switch shouldn't
-    // show a stale PR color before the next 10s poll tick.
-    const tilePr =
-      session?.pr && tileWorktree && session.pr.prBranch === tileWorktree.branch ? session.pr : null;
+    // BLOCKING-2 — PR is resolved per WORKTREE via `worktreePrById` (built
+    // from `worktreePrStatus()` above), not read off this tile's own
+    // `session.pr` — the daemon only ever writes `pr` to a worktree's
+    // `isMain` session, so a sibling session's tile must still pick up the
+    // branch's PR. `worktreePrStatus()` already branch-guards internally
+    // (D20): a branch switch shows nothing before the next 10s poll tick.
+    const tilePr = tileWorktree ? (worktreePrById.get(tileWorktree.id) ?? null) : null;
     const statusClass = status ? resolveStatusClass(status, tilePr) : null;
+    // `exited`'s dimming is a non-colour cue (B1/docs/STATUS-INDICATORS.md)
+    // that must survive being recoloured by a landed PR — `resolveStatusClass`
+    // returns "pr-open"/"pr-merged" in that case, not "exited", so the
+    // lifecycle class has to be added on top rather than read off `statusClass`.
+    const lifecycleClass = status === "exited" ? "exited" : null;
     const paneKey = paneKeyForTile(tile, worktreeId);
     const outletVisible =
       tile.kind === "tools" ? toolPanelVisible : tile.kind === "terminal" ? terminalDockVisible : true;
@@ -852,8 +884,8 @@ export function WorkspaceCanvas({
         className={`workspace-canvas__tile${
           draggingTileId === tile.id ? " workspace-canvas__tile--dragging" : ""
         }${statusClass ? ` workspace-canvas__tile--${statusClass}` : ""}${
-          isFullscreen ? " workspace-canvas__tile--fullscreen" : ""
-        }`}
+          lifecycleClass && lifecycleClass !== statusClass ? ` workspace-canvas__tile--${lifecycleClass}` : ""
+        }${isFullscreen ? " workspace-canvas__tile--fullscreen" : ""}`}
         style={tileStyle}
       >
         <div

--- a/web-ui/src/hooks/useServerSync.ts
+++ b/web-ui/src/hooks/useServerSync.ts
@@ -170,6 +170,7 @@ export function useServerSync(api: ApiInstance): void {
         if (ev.name !== undefined) patch.name = ev.name ?? null;
         if (ev.archivedAt !== undefined) patch.archivedAt = ev.archivedAt ?? null;
         if (ev.sortOrder !== undefined) patch.sortOrder = ev.sortOrder;
+        if (ev.pr !== undefined) patch.pr = ev.pr ?? undefined;
         applySessionUpdated(ev.sessionId, patch);
       }
     });

--- a/web-ui/src/hooks/useStore.ts
+++ b/web-ui/src/hooks/useStore.ts
@@ -170,7 +170,7 @@ export interface WorkspaceState {
   hideInactiveWorktrees: boolean;
   /** Show the colored border around agent panes/workspace tiles keyed to
    *  interaction state (waiting_for_human red) plus the orthogonal PR axis
-   *  (open yellow, merged green — see resolveStatusClass in statusColor.ts).
+   *  (open blue, merged green — see resolveStatusClass in statusColor.ts).
    *  Client-side view preference (persisted); does not affect the sidebar's
    *  StatusDot, which always shows. Defaults on. */
   showAgentStatusBorders: boolean;

--- a/web-ui/src/hooks/useStore.ts
+++ b/web-ui/src/hooks/useStore.ts
@@ -169,7 +169,8 @@ export interface WorkspaceState {
   /** Hide worktrees whose agent sessions are all explicitly marked done (not exited) */
   hideInactiveWorktrees: boolean;
   /** Show the colored border around agent panes/workspace tiles keyed to
-   *  interaction state (waiting_for_human red, needs_review violet, etc).
+   *  interaction state (waiting_for_human red) plus the orthogonal PR axis
+   *  (open yellow, merged green — see resolveStatusClass in statusColor.ts).
    *  Client-side view preference (persisted); does not affect the sidebar's
    *  StatusDot, which always shows. Defaults on. */
   showAgentStatusBorders: boolean;

--- a/web-ui/src/lib/statusColor.test.ts
+++ b/web-ui/src/lib/statusColor.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { resolveStatusClass, worktreePrStatus } from "./statusColor";
+import type { PrStatus, Session } from "@/api/types";
+
+function pr(state: PrStatus["state"], prBranch = "feature-x"): PrStatus {
+  return { state, checkedAt: "2026-08-16T00:00:00.000Z", prBranch };
+}
+
+function session(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "s1",
+    worktreeId: "wt-1",
+    projectId: "p1",
+    modeId: null,
+    type: "agent",
+    isMain: false,
+    state: "idle",
+    lifecycleState: "idle",
+    tmuxName: "t1",
+    createdAt: "2026-08-16T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("resolveStatusClass (D17/D18)", () => {
+  it("5.T1 — working beats pr=open (active work is the freshest signal)", () => {
+    expect(resolveStatusClass("working", pr("open"))).toBe("working");
+  });
+
+  it("5.T1 — waiting_for_human + pr=open resolves to pr-open (D18 inverts the old R7 rule)", () => {
+    expect(resolveStatusClass("waiting_for_human", pr("open"))).toBe("pr-open");
+  });
+
+  it("5.T1 — idle + pr=open resolves to pr-open", () => {
+    expect(resolveStatusClass("idle", pr("open"))).toBe("pr-open");
+  });
+
+  it("D21 — done INHERITS the PR colour (bucket stays finished, colour does not)", () => {
+    expect(resolveStatusClass("done", pr("merged"))).toBe("pr-merged");
+    expect(resolveStatusClass("done", pr("open"))).toBe("pr-open");
+  });
+
+  it("D21 — done with no landed PR is neutral (draft/closed/none never colour)", () => {
+    expect(resolveStatusClass("done", null)).toBeNull();
+    expect(resolveStatusClass("done", pr("draft"))).toBeNull();
+    expect(resolveStatusClass("done", pr("closed"))).toBeNull();
+    expect(resolveStatusClass("done", pr("none"))).toBeNull();
+  });
+
+  it("5.T1 — waiting_for_human with no PR still resolves to waiting_for_human", () => {
+    expect(resolveStatusClass("waiting_for_human", null)).toBe("waiting_for_human");
+  });
+
+  it("pr=merged wins over idle/waiting_for_human but never over working", () => {
+    expect(resolveStatusClass("idle", pr("merged"))).toBe("pr-merged");
+    expect(resolveStatusClass("waiting_for_human", pr("merged"))).toBe("pr-merged");
+    expect(resolveStatusClass("working", pr("merged"))).toBe("working");
+  });
+
+  it("D21 — exited inherits the PR colour too; keeps its literal class only when there's no PR (dimming cue)", () => {
+    expect(resolveStatusClass("exited", pr("merged"))).toBe("pr-merged");
+    expect(resolveStatusClass("exited", pr("open"))).toBe("pr-open");
+    expect(resolveStatusClass("exited", pr("draft"))).toBe("exited");
+    expect(resolveStatusClass("exited", null)).toBe("exited");
+  });
+
+  it("pr=draft and pr=closed never drive the border", () => {
+    expect(resolveStatusClass("idle", pr("draft"))).toBe("idle");
+    expect(resolveStatusClass("idle", pr("closed"))).toBe("idle");
+  });
+
+  it("falls back to lifecycle status when pr is none/null", () => {
+    expect(resolveStatusClass("working", pr("none"))).toBe("working");
+    expect(resolveStatusClass("idle", null)).toBe("idle");
+  });
+
+  it("returns null when lifecycle is none and there is no PR", () => {
+    expect(resolveStatusClass("none", null)).toBeNull();
+    expect(resolveStatusClass("none", pr("draft"))).toBeNull();
+  });
+});
+
+describe("worktreePrStatus (D20 — branch-keyed)", () => {
+  it("5.T2 — returns null when prBranch does not match the current branch", () => {
+    const sessions = [session({ id: "s1", isMain: true, pr: pr("open", "old-branch") })];
+    expect(worktreePrStatus(sessions, "new-branch")).toBeNull();
+  });
+
+  it("5.T2 — returns the status when prBranch matches the current branch", () => {
+    const sessions = [session({ id: "s1", isMain: true, pr: pr("open", "feature-x") })];
+    expect(worktreePrStatus(sessions, "feature-x")).toEqual(pr("open", "feature-x"));
+  });
+
+  it("returns the isMain session's pr, not a non-main sibling's", () => {
+    const sessions = [
+      session({ id: "s1", isMain: false, pr: pr("draft", "feature-x") }),
+      session({ id: "s2", isMain: true, pr: pr("open", "feature-x") }),
+    ];
+    expect(worktreePrStatus(sessions, "feature-x")).toEqual(pr("open", "feature-x"));
+  });
+
+  it("returns null when there is no main session", () => {
+    const sessions = [session({ id: "s1", isMain: false, pr: pr("open", "feature-x") })];
+    expect(worktreePrStatus(sessions, "feature-x")).toBeNull();
+  });
+
+  it("returns null when the main session has no pr", () => {
+    const sessions = [session({ id: "s1", isMain: true })];
+    expect(worktreePrStatus(sessions, "feature-x")).toBeNull();
+  });
+});

--- a/web-ui/src/lib/statusColor.test.ts
+++ b/web-ui/src/lib/statusColor.test.ts
@@ -78,6 +78,12 @@ describe("resolveStatusClass (D17/D18)", () => {
     expect(resolveStatusClass("none", null)).toBeNull();
     expect(resolveStatusClass("none", pr("draft"))).toBeNull();
   });
+
+  it("B2 — spawning wins over any PR, staying neutral + dashed (a not-yet-started session isn't 'landed')", () => {
+    expect(resolveStatusClass("spawning", pr("merged"))).toBe("spawning");
+    expect(resolveStatusClass("spawning", pr("open"))).toBe("spawning");
+    expect(resolveStatusClass("spawning", null)).toBe("spawning");
+  });
 });
 
 describe("worktreePrStatus (D20 — branch-keyed)", () => {

--- a/web-ui/src/lib/statusColor.ts
+++ b/web-ui/src/lib/statusColor.ts
@@ -49,12 +49,14 @@ export function worktreePrStatus(sessions: Session[], currentBranch: string): Pr
  * deliberately disagree here — see `docs/STATUS-INDICATORS.md`. With no PR,
  * `done` resolves to `null` and `exited` to its own literal class, which
  * exists only for the pre-existing non-color dimming cue
- * (`workspace-canvas__tile--exited{opacity:.9}`). `spawning` (the rolled-up form
- * of `not_started`) is likewise left as its own literal, non-colored class
- * so its dashed-border cue survives — see the pr-status-axis Phase 5 report
- * for why this doesn't fold `not_started` into the `working` color the way
- * D17's table literally reads; flagged there as an open question rather
- * than guessed silently.
+ * (`workspace-canvas__tile--exited{opacity:.9}`).
+ *
+ * `spawning` (the rolled-up form of `not_started`) wins over the PR branches
+ * (checked before them, same as `working`) and stays its own literal,
+ * non-colored class so the dashed-border cue survives — decided: a session
+ * that hasn't started has done nothing, so colouring it by a PR that already
+ * exists on the branch would misleadingly read as "landed and finished" for
+ * a session that never ran.
  */
 export function resolveStatusClass(
   lifecycle: WorktreeRolledUpStatus,
@@ -68,10 +70,10 @@ export function resolveStatusClass(
     return lifecycle === "exited" ? "exited" : null;
   }
   if (lifecycle === "working") return "working";
+  if (lifecycle === "spawning") return "spawning";
   if (pr?.state === "merged") return "pr-merged";
   if (pr?.state === "open") return "pr-open";
   if (lifecycle === "waiting_for_human") return "waiting_for_human";
   if (lifecycle === "idle") return "idle";
-  if (lifecycle === "spawning") return "spawning";
   return null;
 }

--- a/web-ui/src/lib/statusColor.ts
+++ b/web-ui/src/lib/statusColor.ts
@@ -1,0 +1,77 @@
+import type { PrStatus, Session } from "@/api/types";
+import type { WorktreeRolledUpStatus } from "@/lib/worktreeStatus";
+
+/**
+ * PR axis rendering — pure, no React. Reads a worktree's `pr` from its
+ * `isMain` session (matches how `daemon/src/services/prPoller.ts` picks the
+ * session it writes `session.pr` to, K9) and combines it with the lifecycle
+ * axis into a single CSS class suffix for the tile/pane border.
+ */
+
+/**
+ * The `isMain` session's `pr`, filtered to the worktree's CURRENT branch
+ * (D20) — `null` when there is no main session, no PR, or the PR was last
+ * checked against a branch the worktree has since moved off of (a branch
+ * switch must never show a stale PR colour before the next poll tick).
+ */
+export function worktreePrStatus(sessions: Session[], currentBranch: string): PrStatus | null {
+  const main = sessions.find((s) => s.isMain);
+  const pr = main?.pr;
+  if (!pr) return null;
+  if (pr.prBranch !== currentBranch) return null;
+  return pr;
+}
+
+/**
+ * Resolve the CSS class SUFFIX for a tile/pane border AND the `StatusDot`
+ * glyph/color (matches the existing `workspace-canvas__tile--${x}` /
+ * `agent-pane-slot--${x}` convention) — never a hex color or a `var(...)`
+ * string.
+ *
+ * Precedence (D17/D18), strictly in this order:
+ *   1. `working` (lifecycle) — active work is the freshest signal, beats
+ *      even a merged PR (agent asked to keep working on the branch)
+ *   2. `pr.state === "merged"` → `"pr-merged"`
+ *   3. `pr.state === "open"` → `"pr-open"`
+ *   4. `waiting_for_human` (lifecycle) — this INVERTS the old R7 rule: a PR
+ *      now beats waiting_for_human, since the agent idles at its prompt
+ *      right after opening a PR, so red would otherwise mask blue
+ *      permanently
+ *   5. `idle` (lifecycle)
+ *   6. `null`
+ *
+ * `pr.state === "draft"` and `"closed"` never drive the border.
+ *
+ * `done`/`exited` are terminal for BUCKETING (D19 — `bucketForRollup` sends
+ * them to "finished" unconditionally) but **do inherit the PR color** (D21):
+ * a landed branch should still read as blue/green so you can see the work
+ * shipped, even though the card sits in Finished. Colour and bucket
+ * deliberately disagree here — see `docs/STATUS-INDICATORS.md`. With no PR,
+ * `done` resolves to `null` and `exited` to its own literal class, which
+ * exists only for the pre-existing non-color dimming cue
+ * (`workspace-canvas__tile--exited{opacity:.9}`). `spawning` (the rolled-up form
+ * of `not_started`) is likewise left as its own literal, non-colored class
+ * so its dashed-border cue survives — see the pr-status-axis Phase 5 report
+ * for why this doesn't fold `not_started` into the `working` color the way
+ * D17's table literally reads; flagged there as an open question rather
+ * than guessed silently.
+ */
+export function resolveStatusClass(
+  lifecycle: WorktreeRolledUpStatus,
+  pr: PrStatus | null,
+): string | null {
+  // D21 — terminal states inherit the PR colour when the branch landed;
+  // otherwise neutral. Bucketing still forces them to "finished".
+  if (lifecycle === "done" || lifecycle === "exited") {
+    if (pr?.state === "merged") return "pr-merged";
+    if (pr?.state === "open") return "pr-open";
+    return lifecycle === "exited" ? "exited" : null;
+  }
+  if (lifecycle === "working") return "working";
+  if (pr?.state === "merged") return "pr-merged";
+  if (pr?.state === "open") return "pr-open";
+  if (lifecycle === "waiting_for_human") return "waiting_for_human";
+  if (lifecycle === "idle") return "idle";
+  if (lifecycle === "spawning") return "spawning";
+  return null;
+}

--- a/web-ui/src/lib/worktreeStatus.test.ts
+++ b/web-ui/src/lib/worktreeStatus.test.ts
@@ -51,20 +51,27 @@ describe("worktreeRolledUpStatus", () => {
     expect(worktreeRolledUpStatus(sessions, { a: "idle" })).toBe("idle");
   });
 
-  // --- 2.T1: waiting_for_human / needs_review rollup precedence (R8) ---
+  // --- 2.T1: waiting_for_human rollup precedence (R8) ---
 
   it("rolls up to waiting_for_human over working", () => {
     const sessions = [sess("a", "waiting_for_human"), sess("b", "working")];
     expect(worktreeRolledUpStatus(sessions, {})).toBe("waiting_for_human");
   });
 
-  it("rolls up to needs_review over working", () => {
-    const sessions = [sess("a", "needs_review"), sess("b", "working")];
-    expect(worktreeRolledUpStatus(sessions, {})).toBe("needs_review");
+  // --- 4.T5: `needs_review` removed from LifecycleState/SessionState (Phase 4) ---
+  // A legacy `needs_review` value can still arrive (e.g. a `session:state` WS
+  // event predating the daemon's back-compat read in sqliteRowMappers.ts, or
+  // any other stale/unexpected string) — `worktreeRolledUpStatus`'s default
+  // branch must treat it as unranked (`none`), not crash or silently sort it
+  // above other real states.
+
+  it("falls back to none for an unrecognized legacy state (e.g. needs_review)", () => {
+    const sessions = [sess("a", "needs_review" as unknown as SessionState)];
+    expect(worktreeRolledUpStatus(sessions, {})).toBe("none");
   });
 
-  it("prefers waiting_for_human over needs_review when both present", () => {
-    const sessions = [sess("a", "needs_review"), sess("b", "waiting_for_human")];
+  it("waiting_for_human still outranks an unrecognized legacy state", () => {
+    const sessions = [sess("a", "needs_review" as unknown as SessionState), sess("b", "waiting_for_human")];
     expect(worktreeRolledUpStatus(sessions, {})).toBe("waiting_for_human");
   });
 });

--- a/web-ui/src/lib/worktreeStatus.ts
+++ b/web-ui/src/lib/worktreeStatus.ts
@@ -2,7 +2,6 @@ import type { Session, SessionState } from "@/api/types";
 
 export type WorktreeRolledUpStatus =
   | "waiting_for_human"
-  | "needs_review"
   | "working"
   | "spawning"
   | "idle"
@@ -10,13 +9,12 @@ export type WorktreeRolledUpStatus =
   | "exited"
   | "none";
 
-// PRD R8 precedence: waiting_for_human outranks needs_review outranks
-// working — one session actively blocking on a human dominates the whole
-// worktree's displayed status; a ready-for-review PR is informational and
-// ranks just above ordinary activity, not above an active block.
+// PRD R8 precedence: waiting_for_human outranks working — one session
+// actively blocking on a human dominates the whole worktree's displayed
+// status. PR outcome is a separate axis layered on top by
+// `statusColor.ts#resolveStatusClass`, not part of this lifecycle rank.
 const rank: Record<WorktreeRolledUpStatus, number> = {
   waiting_for_human: 8,
-  needs_review: 7,
   working: 6,
   spawning: 5,
   idle: 4,
@@ -41,8 +39,6 @@ export function sessionStatus(state: SessionState): WorktreeRolledUpStatus {
       return "idle";
     case "waiting_for_human":
       return "waiting_for_human";
-    case "needs_review":
-      return "needs_review";
     case "done":
       return "done";
     case "exited":
@@ -76,7 +72,6 @@ export function worktreeRolledUpStatus(
     else if (st === "working") step = "working";
     else if (st === "idle") step = "idle";
     else if (st === "waiting_for_human") step = "waiting_for_human";
-    else if (st === "needs_review") step = "needs_review";
     else if (st === "done") step = "done";
     else if (st === "exited") step = "exited";
     else step = "none";

--- a/web-ui/src/routes/Workspace.tsx
+++ b/web-ui/src/routes/Workspace.tsx
@@ -22,6 +22,7 @@ import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { useWorkspaceUrlSync } from "@/hooks/useWorkspaceUrlSync";
 import { useWorkspaceKeyboardShortcuts } from "@/hooks/useWorkspaceKeyboardShortcuts";
 import { sessionLabel } from "@/lib/sessionLabel";
+import { worktreePrStatus } from "@/lib/statusColor";
 import { QuickOpen } from "@/components/dialogs/QuickOpen";
 import { NewSessionDialog } from "@/components/dialogs/NewSessionDialog";
 import { NewTabDialog } from "@/components/dialogs/NewTabDialog";
@@ -319,7 +320,34 @@ export function Workspace() {
     (key: PaneKey): ReactNode => {
       if (key.startsWith("agent:")) {
         const id = key.slice("agent:".length);
-        return <AgentPaneSlot api={api} sessionId={id} session={sessions.find((s) => s.id === id)} />;
+        const paneSession = sessions.find((s) => s.id === id);
+        // D20 — resolve the branch from the SESSION's own worktree, not the
+        // route's `activeWorktreeId`: `renderWorktreePane` is also reused for
+        // a detached workspace doc's cross-worktree pane set (see
+        // `detachedWorkspacePaneKeys` below), so a pane's session can belong
+        // to a different worktree than whatever is "active".
+        const paneBranch = paneSession?.worktreeId
+          ? worktrees.find((w) => w.id === paneSession.worktreeId)?.branch ?? null
+          : null;
+        // BLOCKING-2 — resolve the PR from the pane SESSION's own worktree
+        // (its `isMain` session), not `paneSession.pr` directly: the daemon
+        // only ever writes `pr` to a worktree's `isMain` session, so a
+        // sibling agent's pane would otherwise never show the branch's PR.
+        const panePr = paneSession?.worktreeId
+          ? worktreePrStatus(
+              sessions.filter((s) => s.worktreeId === paneSession.worktreeId),
+              paneBranch ?? "",
+            )
+          : null;
+        return (
+          <AgentPaneSlot
+            api={api}
+            sessionId={id}
+            session={paneSession}
+            branch={paneBranch}
+            pr={panePr}
+          />
+        );
       }
       if (key.startsWith("terminal:")) {
         const id = key.slice("terminal:".length);
@@ -444,6 +472,9 @@ export function Workspace() {
       <div className="tabs-strip tabs-strip--tools-only" role="toolbar" aria-label="Terminal controls">
         <PaneTools fsTarget="agent" />
       </div>
+      {/* A direct session has no worktree, so no branch to guard a PR
+          against — `branch` defaults to null, which unconditionally
+          suppresses `session.pr` (a direct session can never show a PR). */}
       <AgentPaneSlot api={api} sessionId={directSession.id} session={directSession} />
     </div>
   ) : null;

--- a/web-ui/src/styles/chat.css
+++ b/web-ui/src/styles/chat.css
@@ -13,13 +13,13 @@
 
 /* Colored rectangle around the pane (D17, 2026-08-17 — supersedes the
    narrower comment this replaces, which limited COLOR to waiting_for_human
-   only; re-broadened by user request to also cover `working`). Four states
-   now carry a border color: `working` (yellow — active), `pr-open` (blue),
-   `pr-merged` (green), `waiting_for_human` (red — needs you now). `idle`,
-   `done`, `exited`, `spawning`, none stay on the base rule's `transparent`
-   border (D19 — `done`/`exited` are terminal and are never re-colored by a
-   PR). PR outcome is a separate, orthogonal axis layered on top via
-   `resolveStatusClass` — see the `--pr-*` rules below. Mirrors
+   only; re-broadened by user request to also cover `working`). States that
+   carry a border color: `working` (yellow — active), `pr-open` (blue),
+   `pr-merged` (green), `waiting_for_human` (red — needs you now). `done`/
+   `exited` DO get recoloured by a landed PR too (D21) — only a `done`/
+   `exited` session with NO PR (or `spawning`/`idle`/none) stays on the base
+   rule's `transparent` border. PR outcome is a separate, orthogonal axis
+   layered on top via `resolveStatusClass` — see the `--pr-*` rules below. Mirrors
    WorkspaceCanvas's `.workspace-canvas__tile--*` rules exactly
    (workspace-canvas.css); note StatusDot's `.status-dot--*` rules
    (workspace.css) still carry the full status range and no longer match

--- a/web-ui/src/styles/chat.css
+++ b/web-ui/src/styles/chat.css
@@ -11,23 +11,37 @@
   transition: border-color 0.2s ease;
 }
 
-/* Colored rectangle around the pane, for the only TWO session states that
-   warrant one: `waiting_for_human` (red — needs you now) and `needs_review`
-   (green — a PR is ready, actionable but not urgent). Every other status
-   (`working`, `idle`, `done`, `exited`, `spawning`, none) is deliberately
-   left with the base rule's `transparent` border — a border on every state
-   made the colored ones meaningless. Mirrors WorkspaceCanvas's
-   `.workspace-canvas__tile--*` rules exactly (workspace-canvas.css); note
-   StatusDot's `.status-dot--*` rules (workspace.css) still carry the full
-   status range and no longer match this surface. Shared by the classic
-   single-agent-pane view and direct sessions — see AgentPaneSlot.tsx for why
-   this is the only "colored rectangle" surface available in either case. */
-.agent-pane-slot--waiting_for_human {
-  border-color: #ef4444;
+/* Colored rectangle around the pane (D17, 2026-08-17 — supersedes the
+   narrower comment this replaces, which limited COLOR to waiting_for_human
+   only; re-broadened by user request to also cover `working`). Four states
+   now carry a border color: `working` (yellow — active), `pr-open` (blue),
+   `pr-merged` (green), `waiting_for_human` (red — needs you now). `idle`,
+   `done`, `exited`, `spawning`, none stay on the base rule's `transparent`
+   border (D19 — `done`/`exited` are terminal and are never re-colored by a
+   PR). PR outcome is a separate, orthogonal axis layered on top via
+   `resolveStatusClass` — see the `--pr-*` rules below. Mirrors
+   WorkspaceCanvas's `.workspace-canvas__tile--*` rules exactly
+   (workspace-canvas.css); note StatusDot's `.status-dot--*` rules
+   (workspace.css) still carry the full status range and no longer match
+   this surface. Shared by the classic single-agent-pane view and direct
+   sessions — see AgentPaneSlot.tsx for why this is the only "colored
+   rectangle" surface available in either case. */
+.agent-pane-slot--working {
+  border-color: var(--status-working);
 }
 
-.agent-pane-slot--needs_review {
-  border-color: var(--success);
+.agent-pane-slot--waiting_for_human {
+  border-color: var(--status-waiting);
+}
+
+/* PR axis (orthogonal to lifecycle) — open renders blue (D17), merged
+   renders green, on the same colored-rectangle surface (R6). */
+.agent-pane-slot--pr-open {
+  border-color: var(--pr-open);
+}
+
+.agent-pane-slot--pr-merged {
+  border-color: var(--pr-merged);
 }
 .agent-pane-slot__terminal {
   min-height: 0;

--- a/web-ui/src/styles/tokens.css
+++ b/web-ui/src/styles/tokens.css
@@ -102,6 +102,16 @@
   --warning: #ca8a04;
   --warning-muted: #713f12;
 
+  /* D17 (2026-08-17, superseding D14) — four-colour scheme: `working` gets
+     the yellow that `pr-open` used to have; `pr-open` moves to blue (now
+     free since `working` no longer uses the blue-purple accent). */
+  --status-working: #eab308;
+  --status-waiting: #ef4444;
+  --pr-open: #3b82f6;
+  --pr-merged: #22c55e;
+  --pr-draft: #8a8a8a;
+  --pr-closed: #6b6b6b;
+
   color-scheme: dark;
 }
 
@@ -134,6 +144,13 @@
   --success-muted: #bbf7d0;
   --warning: #ca8a04;
   --warning-muted: #fef08a;
+
+  --status-working: #a16207;
+  --status-waiting: #dc2626;
+  --pr-open: #1d4ed8;
+  --pr-merged: #15803d;
+  --pr-draft: #737373;
+  --pr-closed: #737373;
 
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);

--- a/web-ui/src/styles/workspace-canvas.css
+++ b/web-ui/src/styles/workspace-canvas.css
@@ -398,17 +398,18 @@
 
 /* Colored rectangle around the whole tile (D17, 2026-08-17 — supersedes the
    narrower comment this replaces, which limited COLOR to waiting_for_human
-   only; re-broadened by user request to also cover `working`). Four states
-   now carry a border color: `working` (yellow — active), `pr-open` (blue),
-   `pr-merged` (green), `waiting_for_human` (red — needs you now). `idle`,
-   `done`, `exited`, `spawning`, none stay on the plain `--border-default`
-   border from the base rule above (D19 — `done`/`exited` are terminal and
-   are never re-colored by a PR). PR outcome is a separate, orthogonal axis
-   layered on top via `resolveStatusClass` — see the `--pr-*` rules below.
-   StatusDot's `.status-dot--*` rules (workspace.css) still carry the full
-   status range; this surface intentionally no longer mirrors them.
-   Panel/tools tiles carry no `status` at all (WorkspaceCanvas only computes
-   one for agent/terminal tiles), so they land on the same neutral default. */
+   only; re-broadened by user request to also cover `working`). States that
+   carry a border color: `working` (yellow — active), `pr-open` (blue),
+   `pr-merged` (green), `waiting_for_human` (red — needs you now). `done`/
+   `exited` DO get recoloured by a landed PR too (D21) — only a `done`/
+   `exited` session with NO PR (or `spawning`/`idle`/none) stays on the plain
+   `--border-default` border from the base rule above. PR outcome is a
+   separate, orthogonal axis layered on top via `resolveStatusClass` — see
+   the `--pr-*` rules below. StatusDot's `.status-dot--*` rules
+   (workspace.css) still carry the full status range; this surface
+   intentionally no longer mirrors them. Panel/tools tiles carry no `status`
+   at all (WorkspaceCanvas only computes one for agent/terminal tiles), so
+   they land on the same neutral default. */
 .workspace-canvas__tile--working {
   border-color: var(--status-working);
 }

--- a/web-ui/src/styles/workspace-canvas.css
+++ b/web-ui/src/styles/workspace-canvas.css
@@ -396,29 +396,42 @@
   border-width: 0;
 }
 
-/* Colored rectangle around the whole tile, for the only TWO session states
-   that warrant one: `waiting_for_human` (red — needs you now) and
-   `needs_review` (green — a PR is ready, actionable but not urgent). Every
-   other status (`working`, `idle`, `done`, `exited`, `spawning`, none) is
-   deliberately left with the plain `--border-default` border from the base
-   rule above — a border on every state made the colored ones meaningless.
+/* Colored rectangle around the whole tile (D17, 2026-08-17 — supersedes the
+   narrower comment this replaces, which limited COLOR to waiting_for_human
+   only; re-broadened by user request to also cover `working`). Four states
+   now carry a border color: `working` (yellow — active), `pr-open` (blue),
+   `pr-merged` (green), `waiting_for_human` (red — needs you now). `idle`,
+   `done`, `exited`, `spawning`, none stay on the plain `--border-default`
+   border from the base rule above (D19 — `done`/`exited` are terminal and
+   are never re-colored by a PR). PR outcome is a separate, orthogonal axis
+   layered on top via `resolveStatusClass` — see the `--pr-*` rules below.
    StatusDot's `.status-dot--*` rules (workspace.css) still carry the full
    status range; this surface intentionally no longer mirrors them.
    Panel/tools tiles carry no `status` at all (WorkspaceCanvas only computes
    one for agent/terminal tiles), so they land on the same neutral default. */
-.workspace-canvas__tile--waiting_for_human {
-  border-color: #ef4444;
+.workspace-canvas__tile--working {
+  border-color: var(--status-working);
 }
 
-.workspace-canvas__tile--needs_review {
-  border-color: var(--success);
+.workspace-canvas__tile--waiting_for_human {
+  border-color: var(--status-waiting);
+}
+
+/* PR axis (orthogonal to lifecycle) — open renders blue (D17), merged
+   renders green, on the same colored-rectangle surface (R6). */
+.workspace-canvas__tile--pr-open {
+  border-color: var(--pr-open);
+}
+
+.workspace-canvas__tile--pr-merged {
+  border-color: var(--pr-merged);
 }
 
 /* Non-color cues, kept independent of the border-color scope-down above:
    an exited session's tile still dims (it's gone, not just "no border"),
    and a spawning one still gets a dashed edge (not started yet) — the user
-   asked to limit COLOR to waiting_for_human/needs_review, not to drop every
-   other visual distinction these two states had. */
+   asked to limit COLOR to waiting_for_human, not to drop every other
+   visual distinction these states had. */
 .workspace-canvas__tile--exited {
   opacity: 0.9;
 }

--- a/web-ui/src/styles/workspace.css
+++ b/web-ui/src/styles/workspace.css
@@ -2118,15 +2118,27 @@
   animation: spawning-pulse 1s ease-in-out infinite alternate;
 }
 
-/* waiting_for_human is the one non-negotiable color mapping (PRD R7/W7) —
-   always red, regardless of theme. needs_review is a distinct, less-urgent
-   violet so the two "needs attention" states never visually collide. */
-.status-dot--waiting_for_human {
-  color: #ef4444;
+/* D17/D18/5.8-5.9 (2026-08-17) — one indicator, not two: `StatusDot` folds
+   the lifecycle axis and the PR axis into a single resolved class via
+   `resolveStatusClass` (statusColor.ts), so these three colors cover both
+   axes at once (`working`, and the PR outcomes `pr-open`/`pr-merged` — the
+   latter can outrank `waiting_for_human`'s red, see resolveStatusClass's
+   doc comment for why). `waiting_for_human` stays the one shape-distinct
+   glyph (`!`) as well as a color, so it's still legible without color. */
+.status-dot--working {
+  color: var(--status-working);
 }
 
-.status-dot--needs_review {
-  color: #b98cff;
+.status-dot--pr-open {
+  color: var(--pr-open);
+}
+
+.status-dot--pr-merged {
+  color: var(--pr-merged);
+}
+
+.status-dot--waiting_for_human {
+  color: var(--status-waiting);
 }
 
 .preview-body {
@@ -3854,15 +3866,15 @@ a.dashboard-card.dashboard-card--session {
 }
 
 .vcs-pr--open .vcs-pr__icon {
-  color: #4ade80;
+  color: var(--pr-open);
 }
 
 .vcs-pr--merged .vcs-pr__icon {
-  color: #a78bfa;
+  color: var(--pr-merged);
 }
 
 .vcs-pr--closed .vcs-pr__icon {
-  color: #f87171;
+  color: var(--pr-closed);
 }
 
 .vcs-pr--draft .vcs-pr__icon {
@@ -3894,18 +3906,18 @@ a.dashboard-card.dashboard-card--session {
 }
 
 .vcs-pr__badge--open {
-  color: #4ade80;
-  background: rgba(74, 222, 128, 0.12);
+  color: var(--pr-open);
+  background: color-mix(in srgb, var(--pr-open) 12%, transparent);
 }
 
 .vcs-pr__badge--merged {
-  color: #a78bfa;
-  background: rgba(167, 139, 250, 0.12);
+  color: var(--pr-merged);
+  background: color-mix(in srgb, var(--pr-merged) 12%, transparent);
 }
 
 .vcs-pr__badge--closed {
-  color: #f87171;
-  background: rgba(248, 113, 113, 0.12);
+  color: var(--pr-closed);
+  background: color-mix(in srgb, var(--pr-closed) 12%, transparent);
 }
 
 .vcs-pr__badge--draft {


### PR DESCRIPTION
## The bug

**PR detection had never worked once.** 0 of 269 sessions had ever reached `needs_review` since the feature shipped in `4ada68d`. Found while investigating why the `ch-62` worktree created a PR but never showed a "PR created" state.

Three silent, stacked failures in `daemon/src/services/github.ts`:

1. **`parseGithubRepo` required a literal `github.com` host** — but 103 of 147 worktrees use SSH host aliases (`git@github-<user>:owner/repo`). Those returned `null` and were skipped with **no log line at all**.
2. **No credentials**, and private repos 404 unauthenticated — read as "no PR exists".
3. **Per-worktree querying** — 147 requests/tick = 8,820/hr, over even the authenticated 5,000/hr cap.

All three returned the same `null` as "no PR", which is why it stayed invisible for weeks.

## Root design flaw

`needs_review` conflated two orthogonal facts — *is the agent busy* and *does a PR exist* — in one enum slot with **three uncoordinated writers**. Whichever wrote last won.

The fix splits them: lifecycle stays on `session.lifecycle.state` (1s poller), PR moves to `session.pr` (10s poller). **Each poller writes only its own field.** This also supersedes `prMergedAt` from 966b676 — merge-retention is free when derived live.

## Transport

No `gh` binary dependency (it isn't in `dev.Dockerfile`) — we read gh's `hosts.yml` *config file* instead:

- `resolveGithubRemote` — relaxed host capture + `~/.ssh/config` parsed in TS (never `ssh -G`, also absent from the image)
- `githubAuth` — env → `hosts.yml` → opportunistic `gh auth token`, per-account so **two GitHub accounts work simultaneously**
- `fetchPrsForBranches` — one aliased GraphQL query per account (cost 1); **~2 requests/tick regardless of scale**
- `PrLookupResult` replaces `PrInfo | null` — "couldn't check" no longer looks like "no PR"; a transient error **holds** state instead of wiping it

## UI

Two axes, one coloured dot. Per-theme tokens (a single hex failed light-mode contrast):

| State | Colour |
|---|---|
| `working` | 🟡 yellow |
| `waiting_for_human` | 🔴 red |
| PR open | 🔵 blue |
| PR merged | 🟢 green |

`done`/`exited` inherit the PR colour but always bucket to Finished. PR colour is keyed to the **branch**, so a switch re-derives instead of showing a stale colour.

The dashboard becomes **one card per agent session** — the per-worktree rollup and its `hasLiveActivity` patch are gone, making the 966b676 bug class (a sibling's `waiting_for_human` hiding another's `working`) structurally impossible. Waiting splits into **Needs you** (red) and **Idle** (neutral), since mixing them read as a bug.

`docs/STATUS-INDICATORS.md` is the normative matrix; `AGENTS.md` now requires any status change to update it in the same commit.

## Verification

- `pnpm typecheck` clean · `pnpm lint` 0 errors · **741 daemon + 450 web-ui tests pass**
- **Live smoke-tested** against the `ch-62` worktree that prompted this: the aliased remote resolves, both accounts load from `hosts.yml`, and real merged PR #84 is found
- **No DB migration needed** — all 5 new columns are nullable and added via `addColumnIfMissing` at boot; existing rows get `NULL`s. `prMergedAt` is left as a harmless orphan column (SQLite has no cheap `DROP COLUMN`); legacy `needs_review` rows map to `idle` + `pr.state:"open"` on read, one-way

Three review rounds; 7 blocking issues found and fixed, including two where a *colour* correctly inherited but destroyed a **non-colour cue**, and one where the hold-on-failure path re-stamped a stale PR onto a new branch.

## Not verified

- **The full loop has never run live.** The smoke test proves the transport; the chain poller → SQLite → WS → dot colour has only been exercised against mocks and an injected sandbox. Needs a daemon restart — the running binary predates even 966b676.
- `Workspace.tsx`'s cross-worktree pane branch resolution is guarded by code inspection only; there's no `Workspace.test.tsx` harness to extend.
- Pre-existing unrelated flake: an unhandled rejection in `sessions.test.ts` makes the daemon suite exit 1 on an all-pass run.

## Follow-ups

- `client.ts` returns `null` for `kind:"error"` while the route now returns **503**, so `parseJson` throws into a `.catch` — the tagged union dies at the client boundary
- The `sessions.test.ts` flake deserves its own fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
