### PR TITLE
Picker tickmark toggle + verified reset kill

### DIFF
--- a/.vibekit/feature-plans/wip/present-tickmark-replacement/02-reset-relink/plan-02-present-tickmark-replacement-reset-relink.md
+++ b/.vibekit/feature-plans/wip/present-tickmark-replacement/02-reset-relink/plan-02-present-tickmark-replacement-reset-relink.md
@@ -1,0 +1,714 @@
+<!--
+RULES — read before writing or implementing:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. REQUIREMENTS: One crisp line each — no verbose descriptions
+3. CHECKLIST: Mark items [x] as you complete them — this is your persistent todo list
+4. READING TIME: Optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+# Plan: 02-present-tickmark-replacement-reset-relink
+
+> Bug bundle spawned from user verification of `01`'s reset-termination fix (`910e4bb`):
+> that fix made the tmux kill itself reliable, but never addressed the client. After a
+> reset, the OLD session's tab/tile never goes away and the NEW session never takes its
+> place — the classic tab strip shows a permanent duplicate "Archived" tab, and a canvas
+> tile keeps rendering the dead session forever while the replacement gets no tile at all.
+
+**Branch:** `present-tickmark-replacement` (same branch/PR as `01`)
+**Status:** WIP
+**Spawned from:** `../plan-present-tickmark-replacement.md` (Phase 2) — verification finding,
+origin `bug-bundle` (M5).
+**No PRD** — bug fix, root cause is a confirmed, fully-traced client-side gap.
+
+**Reference files:**
+- Backend schema/broadcast: `daemon/src/types.ts`, `daemon/src/routes/sessions.ts`,
+  `daemon/src/services/dbSchema.ts`, `daemon/src/state/sqliteRowMappers.ts`,
+  `daemon/src/state/project-store.ts`, `daemon/src/ws/protocol.ts`
+- Client store: `web-ui/src/hooks/useStore.ts`, `web-ui/src/hooks/useServerSync.ts`
+- Client UI: `web-ui/src/components/layout/TabsStrip.tsx`,
+  `web-ui/src/api/types.ts`
+
+---
+
+## Problem
+
+- `POST /sessions/:id/reset` (`daemon/src/routes/sessions.ts:1274-1460`) archives the old
+  `SessionRecord` and creates a new one with a new id, inheriting `isMain`/`sortOrder`.
+- Nothing on the client ever consumes this to relink existing UI state to the new id.
+- **Canvas:** a `TileSpec.sessionId` pointing at the archived session keeps resolving via
+  `sessionById.get(tile.sessionId)` (`WorkspaceCanvas.tsx:819`, unfiltered) — the tile
+  renders a frozen, read-only `ChatPane` (`archived = session?.archivedAt != null`,
+  `ChatPane.tsx:174`) forever. The new session gets **no tile anywhere**.
+- **Classic tab strip:** `TabsStrip.tsx`'s `orderedSessions` (253-260) has no `archivedAt`
+  filter — the archived tab renders indefinitely with an "Archived" badge (545, 675-679),
+  indistinguishable in kind from an intentionally-kept `/done` history tab, sitting next
+  to the new session's own (correctly created and focused) tab as a permanent duplicate.
+- Both `resetSession` call sites (`TabsStrip.tsx:810-815`, `WorkspaceCanvas.tsx:1451-1460`)
+  discard the response `{archivedSessionId, newSessionId}` entirely.
+
+## Out of Scope
+
+- `LeftSidebar.tsx`'s pinned/direct-session rows (919, 976-977, 1453, 1514-1515) — same
+  badge-only treatment as `/done`-archived sessions; a reset-specific filter there is a
+  smaller, separable follow-up (direct sessions can't be worktree-canvas-tiled, so the
+  "no tile at all" half of this bug doesn't apply to them).
+- Any change to the `/vst reset --handoff` termination logic itself — `01`'s fix already
+  covers that; this is purely "what the client does after a correct reset."
+- A "show archived sessions" toggle/setting — out of scope; this plan only hides the
+  specific subset that was superseded by a live replacement, not archived history broadly.
+- `01`'s picker tickmark fix — already shipped in `910e4bb`, untouched here.
+- **Retroactive backfill for already-archived rows.** The new `supersededBy` column is
+  added via `addColumnIfMissing` (Phase 1) with no backfill — every session archived by a
+  reset BEFORE this fix ships stays `supersededBy: null` forever (there is no reliable way
+  to reconstruct "which new session replaced this" after the fact; the two records are
+  otherwise unlinked). Any duplicate tab/frozen tile that already exists from a past reset
+  is NOT retroactively cleaned up by this fix — only resets that happen after it ships.
+
+## Concept
+
+- Add a `supersededBy?: string` field to `SessionRecord`, set on the archived row at
+  reset time (mirrors the existing `spawnedFrom` field's plumbing exactly — same DB
+  column pattern, same broadcast pattern, same client type pattern).
+- Client store gets a pure `relinkSessionInCanvas` helper + a `relinkSessionTiles` action
+  that walks every canvas (scratch canvases + saved workspace docs) and repoints any tile
+  whose `sessionId` matches the archived id to the new id — same tile, same position.
+- `useServerSync.ts`'s central `session:updated` handler calls `relinkSessionTiles` when
+  the event carries `supersededBy` — this fires for every connected client, not just the
+  one that triggered the reset.
+- `TabsStrip.tsx` filters `supersededBy != null` sessions out of its visible tab list and,
+  if the active tab was the superseded one, switches focus to its replacement.
+- On every full bundle refetch (initial mount AND every WS reconnect —
+  `useServerSync.ts`'s `refresh()`), walk the fetched sessions for any still-unrelinked
+  `supersededBy` chain and relink it — covers a reset that happened via the CLI with no
+  browser open, or while this client was offline/disconnected.
+
+## Requirements
+
+| # | Requirement |
+|---|-------------|
+| 1 | A session archived by reset persists which session replaced it (`supersededBy`) |
+| 2 | Every tile (scratch canvas + every saved workspace doc) referencing the archived session is repointed to the new session, same tile id/position |
+| 3 | The relink happens for every connected client via the WS broadcast, not just the initiator |
+| 4 | The relink also self-heals on reconnect/reload for a reset that happened while this client was offline |
+| 5 | The classic tab strip never shows a reset-superseded tab as a normal live tab |
+| 6 | If the superseded tab was active, focus moves to its replacement |
+| 7 | Non-reset archival (`/done`, plain archive) is unaffected — those keep today's badge-and-show behavior |
+| 8 | Mock API mode (`VITE_USE_MOCK=true`) exercises the same `supersededBy` contract as the real daemon |
+
+---
+
+## Research
+
+### Backend — mirror the existing `spawnedFrom` field exactly
+
+- **`daemon/src/types.ts:289`** — `spawnedFrom?: string | null;` on `SessionRecord`. Add
+  `supersededBy?: string | null;` immediately after, same doc-comment style.
+- **`daemon/src/services/dbSchema.ts:110`** — `addColumnIfMissing(db, "sessions",
+  "spawnedFrom", "TEXT");`. Add an identical line for `"supersededBy"`.
+- **`daemon/src/state/sqliteRowMappers.ts`** — `SessionRow` interface has `spawnedFrom:
+  string | null;` (line 42); `rowToSession` reads it at line 100
+  (`...(row.spawnedFrom != null ? { spawnedFrom: row.spawnedFrom } : {}),`);
+  `sessionToRow` writes it at line 145 (`spawnedFrom: session.spawnedFrom ?? null,`). Add
+  `supersededBy` to all three, same pattern, same relative position.
+- **`daemon/src/state/project-store.ts:261-262`** — the `INSERT INTO sessions (...)`
+  column list and `VALUES (...)` placeholder list both include `spawnedFrom` /
+  `@spawnedFrom`. Add `supersededBy` / `@supersededBy` to both lists (order must match
+  between the two).
+- **`daemon/src/routes/sessions.ts:394`** — `serializeSession`'s `spawnedFrom: s.spawnedFrom
+  ?? null,`. Add `supersededBy: s.supersededBy ?? null,` alongside it — this is what makes
+  the field visible over REST (`GET /sessions/:id`, `GET /sessions`) for a page reload,
+  not just the live WS event.
+- **`daemon/src/routes/sessions.ts:1414-1415`** — the reset route's `archiveSession`
+  lambda, currently:
+  ```ts
+  const archiveSession = (s: SessionRecord): SessionRecord =>
+    s.id === session.id ? { ...s, archivedAt, handoffSummary: handoffText, isMain: false } : s;
+  ```
+  Add `supersededBy: newId` (the already-computed replacement id, `sessions.ts:1352`) to
+  the patched object — see Decision 1.
+- **`daemon/src/routes/sessions.ts:1430`** — `broadcastAll({ type: "session:updated",
+  sessionId: session.id, archivedAt });`. Add `supersededBy: newId` to this call.
+- **`daemon/src/ws/protocol.ts:317-336`** — `SessionUpdatedEvent` zod schema. Add
+  `supersededBy: z.string().nullable().optional(),` after `archivedAt` (line 331), same
+  style as the existing `spawnedFrom` field on `SessionCreatedEvent` (line 267).
+- **Deliberately NOT setting `spawnedFrom` on the new replacement session** (the literal
+  at `sessions.ts:1368-1394` already omits it, confirmed) — the Phase 4c auto-insert
+  listener (`useServerSync.ts:116-136`) would otherwise fire on every reset and INSERT an
+  extra tile via `insertTileIntoWorkspaceDoc`, rather than this plan's relink-in-place.
+
+### Client types — mirror `spawnedFrom` again
+
+- **`web-ui/src/api/types.ts:116`** (`Session` interface) — `spawnedFrom?: string | null;`.
+  Add `supersededBy?: string | null;` alongside it, doc comment: "Set once a reset
+  archives this session — the replacement session's id. Distinct from `archivedAt`
+  (`/done` also sets that; only a reset sets this)."
+- **`web-ui/src/api/types.ts:346-358`** (`WSEvent`'s `"session:updated"` variant) — add
+  `supersededBy?: string | null;` alongside the existing `archivedAt?: string | null;`
+  (357).
+
+### Client store — the relink primitive
+
+- **`web-ui/src/hooks/useStore.ts:335-345`** — `removeTileFromCanvas`, the closest
+  existing "pure geometry transform" to model the new helper on: same signature shape
+  (`(canvas: CanvasGeometry, ...) => CanvasGeometry`), same never-mutate contract.
+- **No existing "walk every canvas" helper** — `findWorkspacesTilingSession`
+  (`useStore.ts:354-359`) only scans `workspaceDocs`, not `layoutByWorktree[*
+  ].scratchCanvas`. This plan's action is the first to need both.
+- **`useStore.ts:697-705`** — `insertTileIntoWorkspaceDoc`, the closest existing action
+  for "find affected canvases, patch them via `set()`" — model the new action's `set()`
+  shape on this and on `updateScratchCanvas` (730-740).
+- Persistence: `layoutByWorktree` and `workspaceDocs` are both in `partialize`
+  (`useStore.ts:991-1015`) — no migration needed, this only rewrites existing tiles'
+  `sessionId` field, no new persisted shape.
+
+### `useServerSync.ts` — the hook point
+
+- **`useServerSync.ts:159-176`** — the central `session:updated` handler, already applies
+  `archivedAt`/`name`/`sortOrder`/`pinnedAt`/`channel`/`pr` patches from the event. Add a
+  branch reading `ev.supersededBy` and calling the new store action — see Decision 2.
+- This is the ONLY hook needed for the canvas half of the fix — `WorkspaceCanvas.tsx`
+  itself needs zero changes: it already reads tiles from the store and sessions from the
+  centrally-synced `useServerStore`, so once a tile's `sessionId` is repointed, the
+  existing (unfiltered, live) `sessionById.get(tile.sessionId)` lookup just resolves to
+  the new session on the next render.
+
+### `TabsStrip.tsx` — tab filtering + active-tab redirect
+
+- **`TabsStrip.tsx:253-260`** — `orderedSessions`, currently `sessions.slice().sort(...)`
+  with no filter. `sessions` (set via `setSessions`) is a **separate, worktree-scoped
+  list** fetched via `api.listSessions`, not the central store `useServerStore` —
+  confirmed by the comment at 408-412 explaining why this file has its own duplicate
+  `session:updated` listener — so it needs its own `supersededBy` handling independent of
+  `useServerSync`.
+- **`TabsStrip.tsx:413-430`** — this file's own `session:updated` listener, currently
+  patches `name`/`archivedAt`/`sortOrder`/`pinnedAt`/`channel` into `sessions` via
+  `setSessions`. Add `supersededBy` to the patch, per Decision 4.
+- **`TabsStrip.tsx:385-406`** — `session:deleted`'s handler is the exact pattern to mirror
+  for "if the affected tab was active, switch to a sibling": reads
+  `isAgent ? st.activeSessionId : st.activeTerminalSessionId`, compares to the affected
+  session id, calls `setActiveSession(target)`. Reuse this shape, target = `ev.
+  supersededBy` (always known and correct here, unlike the deleted case's "nearest
+  sibling" guess).
+- `web-ui/src/components/layout/LeftSidebar.tsx` — NOT touched (see Out of Scope).
+
+### Reconciliation on load/reconnect — closing the "offline reset" gap
+
+- The broadcast-driven relink (Decision 2) only reaches a client that is connected AT THE
+  MOMENT the reset happens. A reset triggered by the CLI with no browser open, or while
+  this client was disconnected, is invisible to it until the next full refetch.
+- **`useServerSync.ts:54-82`** — `refresh()` already runs on every mount AND every
+  `ws:open` (initial connect AND every reconnect, per its own doc comment at 21-34) and
+  already fetches the full `sessions` array (`api.listSessions()`, line 62) before calling
+  `syncSessionsFromApi(sessions)` (line 69). This is the natural place to also resolve any
+  still-unrelinked `supersededBy` chain, since it already has the freshest possible
+  `sessions` snapshot in hand and already runs on exactly the events ("I might have missed
+  something") this gap needs. See Decision 5.
+- A double reset while offline produces a chain (`A.supersededBy = B`, `B.supersededBy =
+  C`) — the reconciliation walk must resolve to the FINAL live id (`C`), not stop at the
+  first hop, or the tile ends up pointing at `B`, itself archived-and-superseded.
+
+### Mock API — `web-ui/src/api/mock.ts`
+
+- **`web-ui/src/api/mock.ts:593-632`** — `resetSession`'s mock implementation. It emits
+  `session:updated` with `archivedAt` only at line 606, and only computes `newId` at line
+  608 — AFTER the emit, so `supersededBy: newId` cannot simply be added to the existing
+  `emit(...)` call at line 606 without first moving `newId`'s computation earlier.
+  `web-ui/src/api/index.ts:6` selects this implementation whenever `VITE_USE_MOCK=true`,
+  and it backs roughly a dozen component tests — silently leaving it unthreaded means the
+  relink is only ever exercised against the real daemon, never in mock-mode
+  tests/demos/Storybook-style flows. See Decision 6.
+
+## Root Cause
+
+- The reset route was built "archive old, create new," never "archive old AND tell every
+  client which live session replaced it" — every consumer of `archivedAt` (badges, the
+  picker, tile rendering) can see "this is dead" but has no way to see "here's its
+  replacement," so nothing could ever have implemented a relink even if someone had
+  thought to.
+
+---
+
+## Design Details
+
+### System Boundaries
+
+| Boundary | Fields + types | Errors | Source of truth |
+|----------|----------------|--------|------------------|
+| SQLite ↔ daemon (`project-store.ts`) | `sessions.supersededBy TEXT` (nullable), read/written like `spawnedFrom` | none new — a missing column value reads back `null`, same as any other optional TEXT column | SQLite row |
+| Daemon ↔ REST client | `Session.supersededBy?: string \| null` on `GET /sessions`, `GET /sessions/:id` (`serializeSession`) | none new — reset's existing error paths (400/404, `sessions.ts:1283-1299`) are unchanged | daemon |
+| Daemon ↔ WS client | `session:updated` event gains `supersededBy?: string \| null` (`SessionUpdatedEvent` zod schema) | zod parse failure on a malformed event is already handled generically by the existing WS message parser — no new error path | daemon (event is fire-and-forget, at-most-once per reset) |
+| Client store ↔ UI | `useWorkspaceStore.relinkSessionTiles(fromSessionId, toSessionId): void` — synchronous, always succeeds (a no-op when nothing matches) | none — pure client-side geometry rewrite, cannot fail | `useWorkspaceStore` (`layoutByWorktree`, `workspaceDocs`) |
+
+### Data Model
+
+| Entity | Field | Type | Constraints | Notes |
+|--------|-------|------|-------------|-------|
+| `sessions` (SQLite) | `supersededBy` | `TEXT` | nullable, no FK enforcement (mirrors `spawnedFrom`, `types.ts:289`'s doc comment: "a deleted source session leaving a dangling id is harmless") | Set only by the reset route, on the OLD (archived) row, to the NEW row's id |
+
+- **Relationships:** `sessions.supersededBy` is a soft self-reference within the same
+  `sessions` table (old row → new row), same shape as the existing `spawnedFrom` column.
+- **Indexes:** none needed — always looked up by the row's own primary key (`id`), never
+  queried BY `supersededBy`.
+- **Migration:** additive only, via `addColumnIfMissing(db, "sessions", "supersededBy",
+  "TEXT")` (idempotent `ALTER TABLE`, runs on every daemon start, same as every other
+  column this table has gained over time). **No backfill** — see Out of Scope for exactly
+  what this means for already-archived rows.
+
+### Critical User Journeys (CUJs)
+
+#### CUJ 1 — Reset a session that's tiled on the canvas
+
+```
+User has an agent session open as a canvas tile
+  → Runs `/vst reset --handoff` (or the UI's Reset action)
+  → Daemon archives the old session (supersededBy: newId), creates the new one
+  → Daemon broadcasts session:updated {sessionId: oldId, archivedAt, supersededBy: newId}
+  → useServerSync's session:updated handler calls relinkSessionTiles(oldId, newId)
+  → The SAME tile (same id, same position/geometry) now has sessionId: newId
+  → WorkspaceCanvas re-renders that tile showing the NEW session, no manual action needed
+```
+
+- **Edge case:** the archived session was tiled in 3 different saved workspace docs at
+  once (a cross-context session can appear in multiple saved workspaces) — all 3 get
+  relinked in the same `set()` call, not just the currently-viewed one.
+- **Edge case:** the archived session had no tile anywhere (never was on a canvas) — the
+  relink walk finds nothing, `set()` still runs but returns the same object references
+  for every untouched canvas (Decision 3's identity-preserving requirement), no
+  unnecessary re-renders.
+
+#### CUJ 2 — Reset a session that's an open classic tab
+
+```
+User has an agent session open as a classic tab, it is the active tab
+  → Runs reset
+  → TabsStrip's own session:updated listener receives {sessionId: oldId, archivedAt,
+    supersededBy: newId} and patches supersededBy into sessions (via setSessions)
+  → orderedSessions' filter drops the now-supersededBy-set old session from the list
+  → Active-tab check: activeSessionId === oldId → setActiveSession(newId)
+  → User sees exactly one tab where there used to be one — the new session, focused
+```
+
+- **Error path:** the new session's own `session:created` event can race the old one's
+  `session:updated` in transit — order independent: whichever arrives first, the tab list
+  ends up correct once both have landed (the new tab is added by `session:created`
+  regardless of ordering; the old tab is dropped by the filter regardless of ordering).
+
+### Key Decisions
+
+#### Decision 1: `supersededBy` mirrors `spawnedFrom`'s plumbing exactly — *no snippet needed*
+
+- **Decision:** new field, same DB-column-add / row-mapper / INSERT-list / serialize /
+  broadcast / zod / client-type shape as the existing `spawnedFrom` field, at every layer.
+- **Rationale:** this exact "session A carries a soft reference to session B" shape
+  already exists and is proven (spawn-tracking); reusing its plumbing means no new
+  concepts, no new migration strategy, and reviewers already know the pattern.
+- **Where:** every file/line listed in Research → Backend above.
+
+#### Decision 2: relink triggers off the broadcast, not the response — *with a snippet*
+
+- **Decision:** `useServerSync.ts`'s central `session:updated` handler triggers the
+  relink, not the two `resetSession(...)` call sites' `.then()`.
+- **Rationale:** the WS broadcast reaches every connected client/tab, so a reset done
+  from one browser tab (or the CLI) correctly relinks tiles in every OTHER open browser
+  tab too — a response-based fix would only ever fix the initiator's own view.
+- **Where:** `web-ui/src/hooks/useServerSync.ts:159-176`.
+
+```ts
+const offSessUpdated = api.on("session:updated", (ev) => {
+  if (ev.type === "session:updated") {
+    const patch: Partial<Session> = {};
+    if (ev.channel !== undefined) {
+      patch.channel = ev.channel;
+      patch.useTmux = ev.channel === "tmux";
+    }
+    if (ev.pinnedAt !== undefined) patch.pinnedAt = ev.pinnedAt ?? null;
+    if (ev.name !== undefined) patch.name = ev.name ?? null;
+    if (ev.archivedAt !== undefined) patch.archivedAt = ev.archivedAt ?? null;
+    if (ev.sortOrder !== undefined) patch.sortOrder = ev.sortOrder;
+    if (ev.pr !== undefined) patch.pr = ev.pr ?? undefined;
+    if (ev.supersededBy !== undefined) patch.supersededBy = ev.supersededBy ?? null;
+    applySessionUpdated(ev.sessionId, patch);
+    // A reset's replacement takes the archived session's place in every canvas
+    // it was tiled in — same tile id/position, just repointed. Fires for every
+    // connected client (the broadcast, not the initiator's own response), so a
+    // reset triggered from the CLI/another tab relinks here too.
+    if (ev.supersededBy) {
+      useWorkspaceStore.getState().relinkSessionTiles(ev.sessionId, ev.supersededBy);
+    }
+  }
+});
+```
+
+#### Decision 3: relink is a pure, identity-preserving tile map — *with a snippet*
+
+- **Decision:** `relinkSessionInCanvas` returns the SAME `canvas` object (not a shallow
+  copy) when no tile matched, and `relinkSessionTiles`'s `set()` only replaces the
+  specific `layoutByWorktree`/`workspaceDocs` entries whose canvas actually changed.
+- **Rationale:** dozens of saved workspace docs can exist; re-rendering every one of them
+  on every reset (because a naive implementation always produces a new object) would be
+  wasteful and is easy to avoid for free.
+- **Where:** `web-ui/src/hooks/useStore.ts`, next to `removeTileFromCanvas` (~line 345)
+  for the pure helper, next to `insertTileIntoWorkspaceDoc`/`updateScratchCanvas`
+  (~line 705) for the store action.
+
+```ts
+/**
+ * Repoint every tile referencing `fromSessionId` to `toSessionId` — same tile
+ * id, same position/geometry, just a different session behind it (a reset's
+ * replacement taking the archived session's exact place). Returns the SAME
+ * `canvas` reference when nothing matched, so callers can skip a `set()` for
+ * canvases this reset didn't touch.
+ */
+export function relinkSessionInCanvas(
+  canvas: CanvasGeometry,
+  fromSessionId: string,
+  toSessionId: string,
+): CanvasGeometry {
+  if (!canvas.tiles.some((t) => t.sessionId === fromSessionId)) return canvas;
+  return {
+    ...canvas,
+    tiles: canvas.tiles.map((t) => (t.sessionId === fromSessionId ? { ...t, sessionId: toSessionId } : t)),
+  };
+}
+```
+
+```ts
+// Store action, alongside insertTileIntoWorkspaceDoc/updateScratchCanvas:
+relinkSessionTiles: (fromSessionId, toSessionId) =>
+  set((s) => {
+    let layoutChanged = false;
+    const nextLayoutByWorktree = { ...s.layoutByWorktree };
+    for (const [worktreeId, layout] of Object.entries(s.layoutByWorktree)) {
+      if (!layout.scratchCanvas) continue;
+      const relinked = relinkSessionInCanvas(layout.scratchCanvas, fromSessionId, toSessionId);
+      if (relinked !== layout.scratchCanvas) {
+        nextLayoutByWorktree[worktreeId] = { ...layout, scratchCanvas: relinked };
+        layoutChanged = true;
+      }
+    }
+    let docsChanged = false;
+    const nextWorkspaceDocs = { ...s.workspaceDocs };
+    for (const [docId, doc] of Object.entries(s.workspaceDocs)) {
+      const relinked = relinkSessionInCanvas(doc, fromSessionId, toSessionId);
+      if (relinked !== doc) {
+        nextWorkspaceDocs[docId] = { ...doc, ...relinked };
+        docsChanged = true;
+      }
+    }
+    if (!layoutChanged && !docsChanged) return s;
+    return {
+      ...(layoutChanged ? { layoutByWorktree: nextLayoutByWorktree } : {}),
+      ...(docsChanged ? { workspaceDocs: nextWorkspaceDocs } : {}),
+    };
+  }),
+```
+
+- Add `relinkSessionTiles: (fromSessionId: string, toSessionId: string) => void;` to the
+  store interface, next to `insertTileIntoWorkspaceDoc`'s declaration (`useStore.ts:261-266`).
+
+#### Decision 4: TabsStrip filters + redirects locally, mirroring `session:deleted` — *with a snippet*
+
+- **Decision:** `orderedSessions` drops `supersededBy != null` sessions; the existing
+  `session:updated` listener additionally checks whether the just-superseded session was
+  the active tab and redirects if so.
+- **Rationale:** `TabsStrip.tsx` maintains its own worktree-scoped session list
+  independent of the central store (documented at `TabsStrip.tsx:408-412`) — the central
+  `useServerSync` fix does not reach it, this needs its own, symmetric handling.
+- **Where:** `TabsStrip.tsx:253-260` (filter), `TabsStrip.tsx:413-430` (listener).
+
+```tsx
+const orderedSessions = useMemo(() => {
+  return sessions
+    .filter((s) => s.supersededBy == null)
+    .sort((a, b) => {
+      const ao = a.sortOrder ?? 0;
+      const bo = b.sortOrder ?? 0;
+      if (ao !== bo) return ao - bo;
+      return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+    });
+}, [sessions]);
+```
+
+```tsx
+const offUpdated = api.on("session:updated", (ev) => {
+  if (ev.type !== "session:updated") return;
+  setSessions((prev) =>
+    prev.map((s) => {
+      if (s.id !== ev.sessionId) return s;
+      const patch: Partial<Session> = {};
+      if (ev.name !== undefined) patch.name = ev.name ?? null;
+      if (ev.archivedAt !== undefined) patch.archivedAt = ev.archivedAt ?? null;
+      if (ev.sortOrder !== undefined) patch.sortOrder = ev.sortOrder;
+      if (ev.pinnedAt !== undefined) patch.pinnedAt = ev.pinnedAt ?? null;
+      if (ev.supersededBy !== undefined) patch.supersededBy = ev.supersededBy ?? null;
+      if (ev.channel !== undefined) {
+        patch.channel = ev.channel;
+        patch.useTmux = ev.channel === "tmux";
+      }
+      return { ...s, ...patch };
+    }),
+  );
+  // The superseded session's tab is about to disappear from orderedSessions —
+  // if it was the active one, follow it to its replacement instead of leaving
+  // the strip with no selected tab (mirrors the session:deleted handler above).
+  if (ev.supersededBy) {
+    const st = useWorkspaceStore.getState();
+    const cur = isAgent ? st.activeSessionId : st.activeTerminalSessionId;
+    if (cur === ev.sessionId) setActiveSession(ev.supersededBy);
+  }
+});
+```
+
+#### Decision 5: reconcile `supersededBy` chains on every full refetch — *with a snippet*
+
+- **Decision:** a new pure helper `resolveSupersededChains(sessions)` (in `useStore.ts`,
+  alongside `relinkSessionInCanvas`) computes every `{oldId, finalId}` pair that still
+  needs relinking, walking multi-hop chains to their final live id.
+  `useServerSync.ts`'s existing `refresh()` (runs on mount + every WS reconnect) calls it
+  right after `syncSessionsFromApi(sessions)` and relinks each pair.
+- **Rationale:** the broadcast-driven relink (Decision 2) only reaches a client connected
+  at the moment of the reset — a reset via the CLI with no browser open, or during this
+  client's disconnect window, is otherwise never healed. `refresh()` already runs at
+  exactly the right moments ("I might have missed events") and already has the freshest
+  `sessions` array in hand. Extracting the chain-walk as a pure function (rather than
+  inlining it in the effect) keeps it unit-testable without mocking the whole fetch flow.
+- **Where:** `web-ui/src/hooks/useStore.ts` (next to `relinkSessionInCanvas`) for the pure
+  helper; `web-ui/src/hooks/useServerSync.ts:54-82` (inside `refresh()`) for the call site.
+
+```ts
+// useStore.ts — pure, no store access, easy to unit-test in isolation.
+/**
+ * Every {oldId, finalId} pair still needing a relink, from a flat sessions
+ * list. Walks multi-hop chains (a double reset while offline produces
+ * A.supersededBy=B, B.supersededBy=C) to the FINAL live id — relinking to an
+ * intermediate hop that is itself archived would just move the bug.
+ */
+export function resolveSupersededChains(
+  sessions: Array<{ id: string; supersededBy?: string | null }>,
+): Array<{ oldId: string; finalId: string }> {
+  const supersededBy = new Map(
+    sessions.filter((s) => s.supersededBy != null).map((s) => [s.id, s.supersededBy as string]),
+  );
+  const result: Array<{ oldId: string; finalId: string }> = [];
+  for (const oldId of supersededBy.keys()) {
+    const seen = new Set<string>();
+    let finalId = oldId;
+    while (supersededBy.has(finalId) && !seen.has(finalId)) {
+      seen.add(finalId);
+      finalId = supersededBy.get(finalId)!;
+    }
+    if (finalId !== oldId) result.push({ oldId, finalId });
+  }
+  return result;
+}
+```
+
+```ts
+// useServerSync.ts, inside refresh(), right after syncSessionsFromApi(sessions):
+replaceAll({ projects, worktrees, sessions });
+syncSessionsFromApi(sessions);
+// Resolve any supersededBy chain this client missed the broadcast for (offline
+// during a reset, or the reset came from the CLI with no browser connected).
+for (const { oldId, finalId } of resolveSupersededChains(sessions)) {
+  useWorkspaceStore.getState().relinkSessionTiles(oldId, finalId);
+}
+```
+
+#### Decision 6: mock API mirrors the real daemon's `supersededBy` contract — *with a snippet*
+
+- **Decision:** `mock.ts`'s `resetSession` computes `newId` BEFORE emitting
+  `session:updated`, and includes `supersededBy: newId` in that emit — matching the real
+  daemon's `sessions.ts:1414-1430` ordering (archive-with-`supersededBy` happens, then the
+  broadcast carries it).
+- **Rationale:** `VITE_USE_MOCK=true` backs component tests and demo flows; leaving this
+  unthreaded means the whole relink feature is silently untestable outside a real daemon.
+- **Where:** `web-ui/src/api/mock.ts:593-632`.
+
+```ts
+// Full function, current source (mock.ts:593-632) reproduced with the 4 changed
+// lines marked — everything else is byte-identical to today.
+async resetSession(
+  id: string,
+  body?: { handoff?: boolean; prompt?: string },
+): Promise<{ ok: true; archivedSessionId: string; newSessionId: string }> {
+  const s = sessions.find((x) => x.id === id);
+  if (!s) throw new ApiError("not found", 404);
+  if (s.type !== "agent") throw new ApiError("reset only applies to agent sessions", 400);
+  if (s.archivedAt) throw new ApiError("session already archived", 400);
+
+  const archivedAt = nowIso();
+  const handoffSummary = body?.handoff ? "Mock handoff summary." : null;
+  const newId = `sess-${Date.now()}`; // CHANGED: moved up from below the emit — supersededBy needs this before the emit
+  s.archivedAt = archivedAt;
+  s.handoffSummary = handoffSummary;
+  s.supersededBy = newId; // CHANGED: new line
+  emit({ type: "session:updated", sessionId: id, archivedAt, supersededBy: newId }); // CHANGED: added supersededBy
+
+  const newSession: Session = {
+    ...structuredClone(s), // NOTE: this spreads `s`, which now HAS supersededBy: newId set above —
+    id: newId,             // the override below is load-bearing, not redundant, or the replacement
+    state: "working",      // session ends up superseding ITSELF and gets filtered out by TabsStrip's
+    lifecycleState: "working", // new supersededBy != null check (Decision 4) — the exact bug this
+    tmuxName: `tmux-${Date.now()}`, // fix is supposed to remove, just moved onto the new session.
+    createdAt: nowIso(),
+    archivedAt: null,
+    handoffSummary: null,
+    pinnedAt: null,
+    supersededBy: null, // CHANGED: new line — MUST override the spread, see NOTE above
+  };
+  sessions.push(newSession);
+  emit({
+    type: "session:created",
+    sessionId: newId,
+    worktreeId: newSession.worktreeId,
+    projectId: newSession.projectId,
+    sessionType: newSession.type,
+    mode: typeof newSession.modeId === "string" ? newSession.modeId : undefined,
+    snapshot: newSession,
+  });
+
+  return { ok: true, archivedSessionId: id, newSessionId: newId };
+},
+```
+
+---
+
+## Implementation Phases
+
+---
+
+### Phase 1 — Backend: persist + broadcast `supersededBy`
+
+- [x] **1.1** `daemon/src/types.ts:289` — add `supersededBy?: string | null;` to
+      `SessionRecord`, after `spawnedFrom`.
+- [x] **1.2** `daemon/src/services/dbSchema.ts:110` — add `addColumnIfMissing(db,
+      "sessions", "supersededBy", "TEXT");` after the `spawnedFrom` line.
+- [x] **1.3** `daemon/src/state/sqliteRowMappers.ts` — add `supersededBy: string | null;`
+      to `SessionRow` (~line 42), read it in `rowToSession` (~line 100), write it in
+      `sessionToRow` (~line 145) — all three mirroring `spawnedFrom`'s exact pattern.
+- [x] **1.4** `daemon/src/state/project-store.ts:261-262` — add `supersededBy` /
+      `@supersededBy` to the `INSERT`'s column list and `VALUES` placeholder list.
+- [x] **1.5** `daemon/src/routes/sessions.ts:394` — add `supersededBy: s.supersededBy ??
+      null,` to `serializeSession`.
+- [x] **1.6** `daemon/src/routes/sessions.ts:1414-1415` — add `supersededBy: newId` to the
+      reset route's `archiveSession` patch.
+- [x] **1.7** `daemon/src/ws/protocol.ts:317-336` — add `supersededBy: z.string()
+      .nullable().optional(),` to `SessionUpdatedEvent` (**before** 1.8 — `broadcastAll`
+      is typed against this zod schema, `daemon/src/broadcaster.ts:32`; adding the field
+      to the broadcast call before the schema accepts it is a compile error).
+- [x] **1.8** `daemon/src/routes/sessions.ts:1430` — add `supersededBy: newId` to the
+      `session:updated` broadcast call.
+
+**Verify phase 1:**
+- [x] **1.T1** Unit — `daemon/src/__tests__/sessions.reset.test.ts`: new test "reset sets
+      supersededBy on the archived row to the new session's id" — `POST .../reset`, then
+      `GET /sessions/:archivedSessionId` (using the response's `archivedSessionId`), assert
+      the JSON body's `.supersededBy === newSessionId` (mirror the existing 4.T5 test's
+      request/assert structure at lines 195-213, but assert via the GET route response —
+      not via `getProject` — so the test also exercises `serializeSession`'s new field,
+      item 1.5).
+- [x] **1.T2** Regression — `cd cli && npx vitest run
+      src/daemon/__tests__/sessionRuntime.test.ts src/daemon/__tests__/sessions.reset.test.ts
+      src/daemon/__tests__/sessions.reset.json.test.ts` — all passing, no regressions from
+      the new column/field.
+
+---
+
+### Phase 2 — Client store: relink primitive + central hook
+
+- [x] **2.1** `web-ui/src/api/types.ts:116` — add `supersededBy?: string | null;` to
+      `Session`.
+- [x] **2.2** `web-ui/src/api/types.ts:346-358` — add `supersededBy?: string | null;` to
+      the `WSEvent` `"session:updated"` variant.
+- [x] **2.3** `web-ui/src/hooks/useStore.ts` (~line 345, next to `removeTileFromCanvas`) —
+      add `relinkSessionInCanvas` per Decision 3's first snippet.
+- [x] **2.4** `web-ui/src/hooks/useStore.ts` — add `relinkSessionTiles` to the store
+      interface (~line 261-266, next to `insertTileIntoWorkspaceDoc`'s declaration) and
+      implement it (~line 705, next to `insertTileIntoWorkspaceDoc`'s implementation) per
+      Decision 3's second snippet.
+- [x] **2.5** `web-ui/src/hooks/useServerSync.ts:159-176` — wire the `relinkSessionTiles`
+      call into the `session:updated` handler per Decision 2's snippet.
+- [x] **2.6** `web-ui/src/hooks/useStore.ts` (next to `relinkSessionInCanvas`) — add the
+      pure `resolveSupersededChains` helper per Decision 5's first snippet.
+- [x] **2.7** `web-ui/src/hooks/useServerSync.ts:5` — add `resolveSupersededChains` to the
+      existing `import { useWorkspaceStore, findWorkspacesTilingSession } from
+      "./useStore"` line; `useServerSync.ts:54-82` — call it inside `refresh()` per
+      Decision 5's second snippet.
+- [x] **2.8** `web-ui/src/api/mock.ts:593-632` — reorder `newId`'s computation and thread
+      `supersededBy` per Decision 6's snippet.
+
+**Verify phase 2:**
+- [x] **2.T1** `npx tsc --noEmit` in `web-ui/` — clean.
+- [x] **2.T2** Unit — `web-ui/src/hooks/useStore.test.ts` (existing file — add cases to
+      the existing `describe("removeTileFromCanvas")` (line 371) and
+      `describe("findWorkspacesTilingSession")` (line 344) blocks, or a new adjacent
+      `describe("relinkSessionInCanvas")`/`describe("relinkSessionTiles")` block matching
+      the file's existing style): "a scratch-canvas tile referencing the old session gets
+      `sessionId` repointed to the new session, same tile id"; "a tile in a saved
+      workspace doc gets repointed"; "a tile in TWO saved docs at once both get repointed
+      in the same call"; "a canvas with no matching tile is returned by reference-equal
+      object (no unnecessary state update)".
+- [x] **2.T3** Unit — same file, new `describe("resolveSupersededChains")` block:
+      "sessions `[{id:A, supersededBy:B}, {id:B, supersededBy:C}]` resolve to a single
+      `{oldId:A, finalId:C}` pair, never `{oldId:A, finalId:B}`"; "a session with no
+      `supersededBy` produces no pair"; "a self-referencing/cyclic chain terminates
+      instead of looping forever (the `seen` guard)".
+
+---
+
+### Phase 3 — Classic tab strip: filter + active-tab redirect
+
+- [x] **3.1** `TabsStrip.tsx:253-260` — filter `supersededBy != null` out of
+      `orderedSessions` per Decision 4's first snippet.
+- [x] **3.2** `TabsStrip.tsx:413-430` — patch `supersededBy` into `sessions` (via
+      `setSessions`) and add the active-tab redirect per Decision 4's second snippet.
+
+**Verify phase 3:**
+- [x] **3.T1** `npx tsc --noEmit` in `web-ui/` — clean (re-run after Phase 3, catches any
+      cross-phase type drift).
+- [x] **3.T2** `npm run build` in `web-ui/` — clean.
+- [x] **3.T3** Unit — `web-ui/src/components/layout/TabsStrip.test.tsx` (existing file —
+      match its existing render/mock-api setup, including driving WS events via
+      `api.__test.emit(...)` wrapped in `act()`, `mock.ts:284-286` — the file's existing
+      tests already use this pattern for `session:updated`/`session:created`, mirror it
+      rather than inventing a new event-dispatch mechanism): "a session with
+      `supersededBy` set is absent from the rendered tab list"; "when the active tab's
+      session receives a `session:updated` event with `supersededBy`, the active tab
+      switches to that id".
+- [ ] **3.T4** Manual/browser — dev sandbox (`scripts/dev-sandbox.sh up`): reset an agent
+      session that is (a) the active classic tab — confirm the old tab disappears and the
+      new one is focused in the same position, no duplicate; (b) tiled on a canvas —
+      confirm the SAME tile now shows the new session's live pane, no manual re-add
+      needed; (c) tiled in a saved workspace doc from a second browser tab — confirm the
+      first tab's canvas relinks too, without a manual refresh.
+
+---
+
+## Files & Phase Impact
+
+| File | Status | Phase | Description / Contract Change |
+|------|--------|-------|-------------------------------|
+| `daemon/src/types.ts` | **Modified** | 1.1 | `SessionRecord.supersededBy?: string \| null` |
+| `daemon/src/services/dbSchema.ts` | **Modified** | 1.2 | New idempotent column |
+| `daemon/src/state/sqliteRowMappers.ts` | **Modified** | 1.3 | Row↔record mapping for the new field |
+| `daemon/src/state/project-store.ts` | **Modified** | 1.4 | INSERT column list |
+| `daemon/src/routes/sessions.ts` | **Modified** | 1.5, 1.6, 1.8 | `serializeSession`, reset's archive patch, `session:updated` broadcast all carry `supersededBy` |
+| `daemon/src/ws/protocol.ts` | **Modified** | 1.7 | `SessionUpdatedEvent` zod schema — done before 1.8 (broadcast call) needs it |
+| `daemon/src/__tests__/sessions.reset.test.ts` | **Modified** | 1.T1 | New `supersededBy` assertion |
+| `web-ui/src/api/types.ts` | **Modified** | 2.1-2.2 | `Session.supersededBy`, `WSEvent["session:updated"].supersededBy` |
+| `web-ui/src/hooks/useStore.ts` | **Modified** | 2.3-2.4, 2.6 | `relinkSessionInCanvas` (pure) + `relinkSessionTiles` (action) + `resolveSupersededChains` (pure) |
+| `web-ui/src/hooks/useServerSync.ts` | **Modified** | 2.5, 2.7 | `session:updated` handler triggers relink; `refresh()` reconciles chains on load/reconnect |
+| `web-ui/src/api/mock.ts` | **Modified** | 2.8 | `resetSession` mock threads `supersededBy` |
+| `web-ui/src/hooks/useStore.test.ts` | **Modified** | 2.T2, 2.T3 | Relink + chain-resolution unit tests |
+| `web-ui/src/components/layout/TabsStrip.tsx` | **Modified** | 3.1-3.2 | Filters superseded tabs, redirects active focus |
+| `web-ui/src/components/layout/TabsStrip.test.tsx` | **Modified** | 3.T3 | Filter + active-tab redirect unit tests |
+
+---
+
+## Risks / Open Questions
+
+| # | Question | Notes |
+|---|----------|-------|
+| 1 | **Does `WorkspaceCanvas.tsx` need ANY direct changes?** | Traced through: no. It reads tiles from the store and resolves `sessionById.get(tile.sessionId)` from the centrally-synced session list — once `relinkSessionTiles` repoints the tile and `applySessionUpdated`/`applySessionCreated` have the new session in the central store (already true today, `session:created`'s existing handling), the existing render path picks it up with no new code in that file. If manual verification (3.T4) finds otherwise, that's a signal this risk was wrong, not a reason to skip verifying it. |
+| 2 | **`LeftSidebar.tsx` left inconsistent with `TabsStrip.tsx`?** | Yes, deliberately (Out of Scope) — a reset-superseded direct session still shows there with just an "archived" badge, same as today. Small, separate, low-priority follow-up if it turns out to bother users in practice; not bundled here to keep this fix reviewable. |
+| 3 | **Momentary empty slot in a detached workspace view?** | `sessions.ts:1430`'s `session:updated` broadcast fires before `session:created` (1431+) — in a detached-workspace view keyed off a `sessions.some(...)` guard, a relinked tile can very briefly (single React tick, same WS message batch) fail to resolve before `session:created` lands and it resolves normally. Self-healing, not a stale state — not worth the complexity of reordering the two broadcasts or adding a loading placeholder for a sub-render-frame gap. |

--- a/.vibekit/feature-plans/wip/present-tickmark-replacement/plan-present-tickmark-replacement.md
+++ b/.vibekit/feature-plans/wip/present-tickmark-replacement/plan-present-tickmark-replacement.md
@@ -1,0 +1,406 @@
+<!--
+RULES — read before writing or implementing:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. REQUIREMENTS: One crisp line each — no verbose descriptions
+3. CHECKLIST: Mark items [x] as you complete them — this is your persistent todo list
+4. READING TIME: Optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+# Plan: present-tickmark-replacement
+
+> Two independent small fixes: (1) Add-tile picker shows a tickmark on already-placed
+> tiles instead of hiding them, click toggles add/remove; (2) `/vst reset --handoff`
+> gets a verified-kill hardening so a swallowed tmux failure can never leave the old
+> agent alive after the new one is spawned.
+
+**Branch:** `present-tickmark-replacement`
+**Status:** WIP
+**No PRD** — both fixes are self-contained, single-file-cluster, low-ambiguity.
+
+**Reference files:**
+- Picker: `web-ui/src/components/layout/WorkspaceCanvas.tsx`, `web-ui/src/styles/workspace-canvas.css`
+- Reset termination: `daemon/src/services/sessionRuntime.ts`, `daemon/src/services/tmux.ts`
+
+---
+
+## Problem
+
+- **Picker:** `WorkspaceCanvas.tsx`'s "Add tile" picker filters out any
+  session/tools pane already present as a tile on the canvas.
+- **Picker:** a user can't see what's already open in the picker, and can't remove
+  a tile from the picker itself.
+- **Reset:** `POST /sessions/:id/reset` kills the old runtime
+  (`releaseSessionRuntime`, `daemon/src/services/sessionRuntime.ts:56-61`) via
+  `killSession(session.tmuxName)` before archiving + spawning the replacement.
+- **Reset:** `killSession` (`tmux.ts:27-33`) swallows every error, including a
+  kill that failed for a reason other than "session already gone" — nothing
+  verifies the pane is actually dead before the route archives the old row.
+
+## Out of Scope
+
+- Any change to the already-verified archive/spawn/slot-inheritance logic in
+  `daemon/src/routes/sessions.ts`'s `POST /sessions/:id/reset` handler.
+- Any change to the `/vst` in-chat command wording in `daemon/src/agent-plugins/*.ts`.
+- Cross-project "done worktree" filtering in the picker — already shipped
+  (`.vibekit/feature-plans/wip/add-tile-picker-filters/`), unrelated to this fix.
+- Detached/orphaned child processes outside the tracked tmux pane's process group —
+  no reproducible case found; `spawn.ts`'s `onSpawn` already requires every plugin
+  to launch its own process group (Decision 13).
+- `directPtyRegistry`/`jsonAgentRegistry` kill-verification — see Risk #2: reasoned
+  to be a materially different (lower-risk) failure mode than the tmux path, not
+  bundled into this fix.
+
+## Concept
+
+- **Picker:** every item the picker can offer is always shown; a `Check` icon
+  replaces the trailing kind-tag when the item is already on the canvas. Clicking a
+  ticked item removes that tile from the canvas (same as its own close button);
+  clicking an unticked item adds it, exactly like today.
+- **Reset:** after `killSession`, verify the pane is actually gone
+  (`hasSession`); if not, retry once and log loudly on continued failure — the
+  archive+spawn still proceeds either way (never blocks a reset on a kill), but the
+  failure is no longer silent.
+
+## Requirements
+
+| # | Requirement |
+|---|-------------|
+| 1 | Add-tile picker never excludes an already-placed session/tools pane from its list |
+| 2 | Each picker item shows a checkmark when its tile is already on the canvas |
+| 3 | Clicking a checked item removes that tile from the canvas; clicking an unchecked item adds it |
+| 4 | Toggle applies to own-worktree agents/terminals/tools AND cross-project sessions/tools (saved workspaces) |
+| 5 | `releaseSessionRuntime`'s tmux kill is verified (not fire-and-forget) before the caller archives the old session row |
+| 6 | A kill that still leaves the pane alive after one retry is logged, never silently dropped |
+
+---
+
+## Research
+
+### Picker filtering
+
+- **File:** `web-ui/src/components/layout/WorkspaceCanvas.tsx:396-503`
+- `placedSessionIds` (396-398) / `placedToolWorktrees` (399-401): already-computed
+  sets of "on canvas right now" — reused as-is for the tickmark, no longer used to
+  *exclude*.
+- `availableAgents` (409-411) / `availableTerminals` (412-414): filter
+  `!placedSessionIds.has(s.id) && matchesSearch(...)` — drop the placed clause.
+- `canAddTools` (402): `hasTools && !placedToolWorktrees.has(worktreeId)` — becomes
+  two separate values: `showTools = hasTools` (render gate, used at line 500's
+  `pickerEmpty` calc and line 1177's render condition) and `toolsPlaced =
+  placedToolWorktrees.has(worktreeId)` (tickmark state, used at the render site).
+- `otherContextGroups` (457-493): worktree-nested `sessions` filter (474) drops
+  `!placedSessionIds.has(s.id)`; `directSessions` filter (489) drops the same
+  clause; `canAddTools: !placedToolWorktrees.has(w.id) && wtNameMatches` (477)
+  becomes `showTools: wtNameMatches` + `toolsPlaced: placedToolWorktrees.has(w.id)`
+  as two fields on the mapped entry.
+- **Every reference to the renamed field must be updated, not just its
+  definition** — `canAddTools`/`entry.canAddTools` is read again at line 480
+  (`entry.sessions.length > 0 || entry.canAddTools`) and destructured again at line
+  1214 (`{ worktree, sessions, canAddTools: wtTools }`); both must become
+  `showTools`. `pickerEmpty` at line 502 reads top-level `canAddTools` too — rename
+  to `showTools` there as well. Grep `canAddTools` after the edit — it must return
+  zero hits.
+- `pickerEmpty`'s semantics genuinely shift, not just its variable name: today
+  `showTools`'s predecessor (`canAddTools`) was `false` whenever Tools was already
+  placed, so `pickerEmpty` (detached view only) could read as "nothing left to
+  add" even when Tools was on the canvas. With `showTools = hasTools`
+  (placement-independent), `pickerEmpty` now means "this worktree truly has
+  nothing offerable" — update the empty-state copy at the `pickerEmpty` render site
+  (~1132) from `"Everything's already on the canvas"` to `"Nothing to add"`, since
+  the message must also cover the case where an active search matched nothing (a
+  pre-existing ambiguity, not introduced here, but now the dominant case since
+  placement no longer empties the list).
+- Group-emptiness filters at 480 (post-rename: `entry.sessions.length > 0 ||
+  entry.showTools`) and 493 (`group.worktrees.length > 0 ||
+  group.directSessions.length > 0`) need no *behavioral* change beyond the rename
+  — `sessions`/`showTools` stay non-empty for an all-placed entry, so the entry
+  keeps rendering (now fully ticked) instead of vanishing.
+- Click handlers (6 sites): `addTile("agent", s.id)` (1154), `addTile("terminal",
+  s.id)` (1168), `addTile("tools")` (1181), `addTile(s.type as TileKind, s.id,
+  worktree.id)` (1227), `addTile("tools", undefined, worktree.id)` (1244),
+  `addTile(s.type as TileKind, s.id)` (1266) — all six become
+  `togglePickerItem(...)` calls with the same arguments.
+- `removeTile(tileId: string)` (560-567): already exists, already does exactly
+  "remove this tile from the canvas geometry, no session/data deletion" — reuse
+  as-is, no new removal logic needed.
+- Per-row "is this placed?" check — each of the 6 render sites already has the data
+  needed without any new lookup: own agents/terminals/cross-session/cross-direct
+  rows use `placedSessionIds.has(s.id)` directly; own-Tools row uses `toolsPlaced`;
+  cross-Tools row uses the mapped entry's `toolsPlaced` field. No new helper
+  function needed for this check (only `togglePickerItem`, for the click, per
+  Decision 1).
+- `Check` icon: already imported (`WorkspaceCanvas.tsx:5`), already used once
+  (1079, unrelated "confirm save workspace" button) — reuse the same import.
+
+### Reset termination
+
+- **File:** `daemon/src/routes/sessions.ts:1274-1460` — `POST /sessions/:id/reset`.
+  Order verified against current source: validate → resolve handoff text →
+  `releaseSessionRuntime` (1341) → `forceCloseSessionStreams` (1342) →
+  build+archive+append new row in one `mutateProject` (1406-1427) →
+  `spawnNewSessionForChannel` (1450) → reply (1459). `isMain`/`sortOrder` inherited
+  onto the new row (1372-1373); old row's `isMain` explicitly cleared (1415, "Bug 3
+  fix" comment). No change in this plan.
+- **File:** `daemon/src/services/sessionRuntime.ts:35-64` — `releaseSessionRuntime`.
+  Tmux branch (55-60):
+  ```ts
+  try {
+    await killSession(session.tmuxName);
+  } catch {
+    // Pane already gone — nothing to reclaim.
+  }
+  ```
+  This try/catch is dead code today — `killSession` (`tmux.ts:27-33`) already
+  swallows every error internally, so nothing ever throws here.
+- **File:** `daemon/src/services/tmux.ts:27-33` — `killSession` catches ALL errors,
+  including ones that are not "session doesn't exist." No caller anywhere checks
+  whether the kill actually worked.
+- **File:** `daemon/src/services/tmux.ts:17-24` — `hasSession(name)` already exists:
+  `tmux has-session -t <name>`, resolves `true`/`false`, never throws — exactly the
+  verification primitive needed.
+- **File:** `daemon/src/__tests__/sessionRuntime.test.ts` — existing coverage mocks
+  `killSession` only; needs a `hasSession` mock added, plus new cases per Phase 2's
+  verify block.
+- **CLI/plugin layer already correct** (verified, no changes): self-target guard
+  (`cli/src/commands/session/reset.ts:33-41`) rejects `--handoff` against one's own
+  session before any daemon call; all three plugins' `/vst` command docs
+  (`daemon/src/agent-plugins/claude.ts:302-357`, `opencode.ts:415-433`,
+  `cursor.ts:414-432`) correctly route `reset --handoff` through the self-write +
+  `--handoff-file` path, never the blocking `--handoff` path.
+- **json-channel / direct-pty path — deliberately not touched, see Risk #2.**
+  `releaseSessionRuntime:51-61` only reaches the tmux branch when
+  `session.useTmux`. For `useTmux: false`, termination is either
+  `directPtyRegistry.get(id)?.kill?.()` (line 54, node-pty's own `.pty.kill()` —
+  `directPty.ts:233-240`, a direct OS syscall, not a separate CLI/socket
+  round-trip like `tmux kill-session`) or, for a json-channel session mid-turn,
+  `agent.release()` (line 47) against whatever `jsonAgentRegistry.get(session.id)`
+  returned at line 41 — a registry miss there is the documented no-live-turn case
+  (json sessions "spawn per turn and hold no long-lived pty" per the function's own
+  doc comment, lines 8-33), not a missed-termination case.
+
+## Root Cause
+
+- **Picker:** the picker's item lists were built as "addable" lists (filter out
+  what can't be added).
+- **Picker:** never built as "everything, annotated with state" lists — a modeling
+  choice, not a bug, but the wrong one for "let me see and manage what's open."
+- **Reset:** `killSession`'s blanket error-swallow (added so a "session already
+  gone" kill never surfaces as a route-level 500) has no companion verification
+  step.
+- **Reset:** that same swallow also silently absorbs the one failure mode that
+  actually matters — a kill that failed for a real reason.
+
+---
+
+## Design Details
+
+### Critical User Journeys (CUJs)
+
+#### CUJ 1 — Toggle a picker item off, then back on
+
+```
+User opens the Add-tile picker on a canvas with an agent tile already placed
+  → That agent's picker row renders with a checkmark instead of being absent
+  → User clicks the checked row
+  → System calls removeTile(tile.id) — the tile disappears from the canvas
+  → Picker closes (setPickerOpen(false))
+  → User reopens the picker
+  → The same row now renders unchecked
+  → User clicks it
+  → System calls addTile(...) — the tile reappears on the canvas, picker closes
+```
+
+- **Edge case:** a Tools row is worktree-scoped, not session-scoped — toggling it
+  off must remove the tile whose `kind === "tools"` for that worktree id, not any
+  session-backed tile.
+
+#### CUJ 2 — tmux kill fails silently today, is now surfaced
+
+```
+Agent runs `/vst reset --handoff` in-chat
+  → Daemon calls releaseSessionRuntime → killSession(tmuxName)
+  → tmux kill-session fails for a non-"already gone" reason (swallowed internally)
+  → hasSession(tmuxName) still resolves true
+  → Daemon retries killSession(tmuxName) once
+  → hasSession(tmuxName) still resolves true
+  → console.warn logs the session id + tmux name
+  → Route proceeds to archive the old row and spawn the replacement regardless
+    (never blocks the reset on a stuck kill)
+```
+
+### Key Decisions
+
+#### Decision 1: Toggle, don't add a second "remove" control — *with a snippet*
+
+- **Decision:** one click handler per picker item, branching on whether a matching
+  tile already exists on the canvas, rather than a separate remove button/icon.
+- **Rationale:** matches the ask exactly ("clicking over them again would remove
+  the tickmark") and reuses the existing `removeTile`/`addTile` primitives
+  untouched — no new canvas-geometry mutation code.
+- **Where:** `web-ui/src/components/layout/WorkspaceCanvas.tsx` — new
+  `togglePickerItem` function, placed next to `addTile`/`removeTile` (~line 567).
+
+```tsx
+// Single toggle for every picker item — session-backed (agent/terminal) or
+// worktree-scoped (tools). Mirrors the tile-close button's semantics: this only
+// touches canvas geometry, never the underlying session/data.
+// `t.sessionId != null` guards a "tools" call site (sessionId undefined) from
+// ever matching a tools tile, whose own `sessionId` field is also undefined.
+function togglePickerItem(kind: TileKind, sessionId?: string, tileWorktreeId?: string) {
+  const existing =
+    kind === "tools"
+      ? cv.tiles.find((t) => t.kind === "tools" && (t.worktreeId ?? worktreeId) === (tileWorktreeId ?? worktreeId))
+      : cv.tiles.find((t) => t.sessionId != null && t.sessionId === sessionId);
+  if (existing) {
+    removeTile(existing.id);
+    setPickerOpen(false);
+  } else {
+    addTile(kind, sessionId, tileWorktreeId);
+  }
+}
+```
+
+#### Decision 2: Verify-then-retry-then-log, never block the reset — *with a snippet*
+
+- **Decision:** `releaseSessionRuntime`'s tmux branch calls `killSession`, then
+  `hasSession` to verify; on a still-alive pane, retries the kill once and logs a
+  `console.warn` if it's still alive after the retry. Return type and caller
+  control flow are unchanged — never throws, never delays a reset past one extra
+  `has-session` + one retried `kill-session` round-trip.
+- **Rationale:** the reset route must never get stuck because a pane won't die; the
+  fix is making the survivor *visible* (server log), not retrying forever or
+  failing the request.
+- **Where:** `daemon/src/services/sessionRuntime.ts:55-61`.
+
+```ts
+} else {
+  await killSession(session.tmuxName);
+  if (await hasSession(session.tmuxName)) {
+    // First kill-session didn't take — try exactly once more before giving up
+    // loudly. Never throws, never blocks the caller past this one retry.
+    await killSession(session.tmuxName);
+    if (await hasSession(session.tmuxName)) {
+      console.warn(
+        `[sessionRuntime] tmux session '${session.tmuxName}' (session ${session.id}) ` +
+          `survived two kill-session attempts — it may still be running.`,
+      );
+    }
+  }
+}
+```
+
+- `killSession` keeps its internal try/catch (`tmux.ts:27-33`) — it still never
+  throws, so no new try/catch is needed at this call site.
+
+---
+
+## Implementation Phases
+
+---
+
+### Phase 1 — Picker tickmark toggle
+
+- [x] **1.1** `WorkspaceCanvas.tsx:409-414` — drop `!placedSessionIds.has(s.id)` from
+      `availableAgents`/`availableTerminals` filters (keep `matchesSearch`).
+- [x] **1.2** `WorkspaceCanvas.tsx:402` — split `canAddTools` into `const showTools =
+      hasTools` and `const toolsPlaced = placedToolWorktrees.has(worktreeId)`;
+      update the `pickerEmpty` calc (~502) to read `!showTools` instead of
+      `!canAddTools`; update the empty-state copy (~1132) from `"Everything's
+      already on the canvas"` to `"Nothing to add"`.
+- [x] **1.3** `WorkspaceCanvas.tsx:470-480` — drop `!placedSessionIds.has(s.id)` from
+      the worktree-nested `sessions` filter (474); rename the mapped entry's
+      `canAddTools` field to `showTools: wtNameMatches` and add `toolsPlaced:
+      placedToolWorktrees.has(w.id)` alongside it (477); update the emptiness
+      filter at line 480 to read `entry.sessions.length > 0 || entry.showTools`.
+- [x] **1.4** `WorkspaceCanvas.tsx:484-491` — drop `!placedSessionIds.has(s.id)` from
+      the `directSessions` filter.
+- [x] **1.5** Add `togglePickerItem` per Decision 1, next to `addTile`/`removeTile`
+      (~line 567).
+- [x] **1.6** `WorkspaceCanvas.tsx:1149-1276` — replace all 6 `addTile(...)` calls in
+      the picker JSX (own agents 1154, own terminals 1168, own tools 1181, cross
+      sessions 1227, cross tools 1244, cross direct sessions 1266) with
+      `togglePickerItem(...)` using the same arguments; at line 1177 the render
+      condition becomes `showTools && matchesSearch("Tools")`; at line 1214 the
+      destructure becomes `{ worktree, sessions, showTools: wtShowTools, toolsPlaced:
+      wtToolsPlaced }`; the Tools row's render condition at ~1240 becomes
+      `wtShowTools`.
+- [x] **1.7** For each of the 6 picker-item `<button>`s: compute `const placed =
+      placedSessionIds.has(s.id)` (own agents/terminals, cross session, cross
+      direct session rows) or use `toolsPlaced` / `wtToolsPlaced` directly (own
+      Tools / cross Tools rows); add `aria-pressed={placed}`; swap the trailing
+      `.workspace-canvas__picker-kind` label for `<Check size={13}
+      className="workspace-canvas__picker-check" aria-hidden />` when `placed`;
+      set `title`/`aria-label` to `"Remove from canvas"` vs `"Add to canvas"`
+      (mirroring the tile close button's own wording at line 935-936).
+- [x] **1.8** `web-ui/src/styles/workspace-canvas.css` — add
+      `.workspace-canvas__picker-check { color: var(--accent); flex-shrink: 0; }`
+      near the existing `.workspace-canvas__picker-kind` rule (~line 211).
+
+**Verify phase 1:**
+- [x] **1.T1** `grep -n "canAddTools" web-ui/src/components/layout/WorkspaceCanvas.tsx`
+      returns zero matches (confirms every reference was renamed, not just the
+      definition).
+- [x] **1.T2** `npx tsc --noEmit` in `web-ui/` — clean.
+- [x] **1.T3** `npm run build` in `web-ui/` — clean.
+- [ ] **1.T4** Manual/browser — dev sandbox (`scripts/dev-sandbox.sh up`): open a
+      saved workspace's Add Tile picker with at least one tile already on the
+      canvas; confirm that tile's picker row shows a checkmark instead of being
+      absent, clicking it removes the tile from the canvas (and the row goes back
+      to unchecked on reopen), and clicking an unchecked row still adds a tile
+      exactly as before. Cover: own-worktree agent, own-worktree Tools, and one
+      cross-project session (saved workspace). Cover the empty state (search query
+      matching nothing) shows the updated copy.
+
+---
+
+### Phase 2 — Reset termination verification
+
+- [x] **2.1** `daemon/src/services/sessionRuntime.ts` — import `hasSession` from
+      `./tmux.js` alongside the existing `killSession` import (line 5).
+- [x] **2.2** `daemon/src/services/sessionRuntime.ts:55-61` — replace the tmux
+      branch per Decision 2's snippet (verify → retry once → warn-log on continued
+      survival; drop the now-pointless outer try/catch).
+- [x] **2.3** `daemon/src/__tests__/sessionRuntime.test.ts:5-7` — extend the
+      `../services/tmux.js` mock to also export `hasSession: vi.fn()`, defaulting
+      to `mockResolvedValue(false)` (kill succeeds) unless a test overrides it.
+
+**Verify phase 2:**
+- [x] **2.T1** Unit — `sessionRuntime.test.ts`: kill succeeds, `hasSession`
+      resolves `false` immediately → `killSession` called once, no retry, no
+      `console.warn`.
+- [x] **2.T2** Unit — `sessionRuntime.test.ts`: `hasSession` resolves `true` once
+      then `false` → `killSession` called twice, `hasSession` called twice, no
+      `console.warn`.
+- [x] **2.T3** Unit — `sessionRuntime.test.ts`: `hasSession` resolves `true` both
+      times → `killSession` called twice, `console.warn` called once, message
+      includes the session id and tmux name.
+- [x] **2.T4** Regression — run, via `cd cli && npx vitest run
+      src/daemon/__tests__/sessionRuntime.test.ts
+      src/daemon/__tests__/sessions.reset.test.ts
+      src/daemon/__tests__/sessions.reset.json.test.ts` (daemon has no
+      `package.json` of its own — its tests run through `cli/`'s vitest config via
+      the `cli/src/daemon -> ../../daemon/src` symlink) — all passing, no
+      regressions. `sessions.reset.json.test.ts` is included specifically because
+      it covers the json-channel reset path this plan's Phase 2 does NOT modify
+      (Risk #2) — a regression there would mean this change had an unintended
+      cross-channel effect.
+
+---
+
+## Files & Phase Impact
+
+| File | Status | Phase | Description / Contract Change |
+|------|--------|-------|-------------------------------|
+| `web-ui/src/components/layout/WorkspaceCanvas.tsx` | **Modified** | 1.1-1.7 | Picker items always render; `togglePickerItem` replaces direct `addTile` calls in the picker JSX; `canAddTools` renamed to `showTools`/`toolsPlaced` throughout |
+| `web-ui/src/styles/workspace-canvas.css` | **Modified** | 1.8 | `.workspace-canvas__picker-check` rule |
+| `daemon/src/services/sessionRuntime.ts` | **Modified** | 2.1-2.2 | `releaseSessionRuntime`'s tmux branch verifies the kill via `hasSession`, retries once, logs on continued failure |
+| `daemon/src/__tests__/sessionRuntime.test.ts` | **Modified** | 2.3, 2.T1-2.T3 | `hasSession` mock + 3 new cases |
+
+---
+
+## Risks / Open Questions
+
+| # | Question | Notes |
+|---|----------|-------|
+| 1 | **Is there a live bug beyond the swallowed-kill-error gap?** | Code read of `sessions.ts`'s reset route, `sessionRuntime.ts`, `tmux.ts`, the CLI self-target guard, and all 3 plugins' `/vst` command docs found the archive/spawn/slot-inheritance/self-target-guard logic already correct and covered by existing passing tests. The one non-speculative gap found is the unverified tmux kill, addressed above. If the reported symptom recurs after this lands, the new `console.warn` (Decision 2) captures the exact session id + tmux name at the moment of failure — that's the next debugging input, not more speculation now. |
+| 2 | **Should json-channel/direct-pty termination get the same verify-retry-log treatment?** | Not bundled into this plan. `directPtyRegistry`'s `.kill()` (`directPty.ts:233-240`) calls `node-pty`'s own `.pty.kill()` directly — an OS syscall, not a separate CLI process shelling out over a socket the way `tmux kill-session` is — a meaningfully different (lower) failure surface. For json-channel sessions, `jsonAgentRegistry.get(session.id)` at the moment `/vst reset --handoff` runs is populated by construction (the reset command is itself running inside that very turn), so the release path is exercised, not skipped; a registry miss only occurs when no turn is in flight, i.e. nothing to terminate. If a future report specifically names a json-channel/direct-pty session, re-open this as its own follow-up rather than guessing at a fix now. |

--- a/daemon/src/__tests__/sessionRuntime.test.ts
+++ b/daemon/src/__tests__/sessionRuntime.test.ts
@@ -4,6 +4,7 @@ import type { SessionRecord } from "../types.js";
 // Mock tmux so no real tmux server is needed.
 vi.mock("../services/tmux.js", () => ({
   killSession: vi.fn().mockResolvedValue(undefined),
+  hasSession: vi.fn().mockResolvedValue(false),
 }));
 
 vi.mock("../services/lifecycle.js", () => ({
@@ -15,7 +16,7 @@ vi.mock("../state/attachmentRegistry.js", () => ({
 }));
 
 import { releaseSessionRuntime } from "../services/sessionRuntime.js";
-import { killSession } from "../services/tmux.js";
+import { killSession, hasSession } from "../services/tmux.js";
 import { clearIdleTracking } from "../services/lifecycle.js";
 import { clearSessionAttachments } from "../state/attachmentRegistry.js";
 import { jsonAgentRegistry } from "../state/jsonAgentRegistry.js";
@@ -103,7 +104,11 @@ describe("releaseSessionRuntime", () => {
   });
 
   it("1.T2c — a missing pane / unregistered pty is not an error", async () => {
-    vi.mocked(killSession).mockRejectedValueOnce(new Error("can't find session"));
+    // `killSession` never throws in production (it swallows internally,
+    // `tmux.ts:27-33`); `hasSession` resolving `false` here is what a
+    // "pane already gone" kill looks like from `releaseSessionRuntime`'s
+    // perspective.
+    vi.mocked(hasSession).mockResolvedValue(false);
     await expect(releaseSessionRuntime(makeSession({ id: "s-gone" }))).resolves.toBeUndefined();
   });
 
@@ -118,5 +123,44 @@ describe("releaseSessionRuntime", () => {
   it("1.T3b — always clears the lifecycle poller's idle-hash entry", async () => {
     await releaseSessionRuntime(makeSession({ id: "s-idle" }));
     expect(clearIdleTracking).toHaveBeenCalledWith("s-idle");
+  });
+
+  it("2.T1 — kill succeeds, hasSession resolves false immediately: killSession called once, no retry, no warn", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.mocked(hasSession).mockResolvedValue(false);
+
+    await releaseSessionRuntime(makeSession({ id: "s-kill-ok", tmuxName: "vr-kill-ok" }));
+
+    expect(killSession).toHaveBeenCalledTimes(1);
+    expect(hasSession).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("2.T2 — hasSession resolves true once then false: killSession called twice, hasSession called twice, no warn", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.mocked(hasSession).mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+    await releaseSessionRuntime(makeSession({ id: "s-kill-retry", tmuxName: "vr-kill-retry" }));
+
+    expect(killSession).toHaveBeenCalledTimes(2);
+    expect(hasSession).toHaveBeenCalledTimes(2);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("2.T3 — hasSession resolves true both times: killSession called twice, warn called once with session id + tmux name", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.mocked(hasSession).mockResolvedValue(true);
+
+    await releaseSessionRuntime(makeSession({ id: "s-kill-stuck", tmuxName: "vr-kill-stuck" }));
+
+    expect(killSession).toHaveBeenCalledTimes(2);
+    expect(hasSession).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [message] = warn.mock.calls[0];
+    expect(message).toContain("s-kill-stuck");
+    expect(message).toContain("vr-kill-stuck");
+    warn.mockRestore();
   });
 });

--- a/daemon/src/__tests__/sessions.reset.test.ts
+++ b/daemon/src/__tests__/sessions.reset.test.ts
@@ -41,16 +41,26 @@ vi.mock("../services/spawn.js", async (importOriginal) => {
 // {type: "terminal"}` in 4.T1 calls the route's own direct `newSession` call
 // (routes/sessions.ts bypasses the mocked spawn.js for terminal sessions),
 // leaking a real orphaned tmux session on every test run.
-vi.mock("../services/tmux.js", () => ({
-  newSession: vi.fn().mockResolvedValue(undefined),
-  hasSession: vi.fn().mockResolvedValue(true),
-  killSession: vi.fn().mockResolvedValue(undefined),
-  capturePane: vi.fn().mockResolvedValue(""),
-  pasteBuffer: vi.fn().mockResolvedValue(undefined),
-  sendKeys: vi.fn().mockResolvedValue(undefined),
-  listSessionNames: vi.fn().mockResolvedValue(new Set()),
-  listSessions: vi.fn().mockResolvedValue([]),
-}));
+vi.mock("../services/tmux.js", () => {
+  // `hasSession` defaults to `true` (a freshly spawned pane exists) so spawn's
+  // own post-launch verification keeps passing, but tracks names `killSession`
+  // has actually killed so `releaseSessionRuntime`'s post-kill verification
+  // (sessionRuntime.ts) sees the correct `false` for THAT name instead of
+  // spuriously warning "survived two kill-session attempts" on every reset.
+  const killed = new Set<string>();
+  return {
+    newSession: vi.fn().mockResolvedValue(undefined),
+    hasSession: vi.fn(async (name: string) => !killed.has(name)),
+    killSession: vi.fn(async (name: string) => {
+      killed.add(name);
+    }),
+    capturePane: vi.fn().mockResolvedValue(""),
+    pasteBuffer: vi.fn().mockResolvedValue(undefined),
+    sendKeys: vi.fn().mockResolvedValue(undefined),
+    listSessionNames: vi.fn().mockResolvedValue(new Set()),
+    listSessions: vi.fn().mockResolvedValue([]),
+  };
+});
 
 vi.mock("../services/handoff.js", () => ({
   runHandoffTurn: vi.fn(async () => false),

--- a/daemon/src/__tests__/sessions.reset.test.ts
+++ b/daemon/src/__tests__/sessions.reset.test.ts
@@ -212,6 +212,17 @@ describe("POST /sessions/:id/reset", () => {
     expect(newRow.initialPrompt).toBe("Handoff: finished the refactor, tests pending.");
   });
 
+  it("reset sets supersededBy on the archived row to the new session's id", async () => {
+    const res = await app.inject({ method: "POST", url: `/sessions/${mainSessionId}/reset`, payload: {} });
+    expect(res.statusCode).toBe(200);
+    const { archivedSessionId, newSessionId } = res.json<{ archivedSessionId: string; newSessionId: string }>();
+
+    const getRes = await app.inject({ method: "GET", url: `/sessions/${archivedSessionId}` });
+    expect(getRes.statusCode).toBe(200);
+    const archived = getRes.json<{ supersededBy: string | null }>();
+    expect(archived.supersededBy).toBe(newSessionId);
+  });
+
   it("4.T6 a handoff timeout/failure still completes the reset with handoffSummary: null", async () => {
     const handoffModule = await import("../services/handoff.js");
     vi.mocked(handoffModule.runHandoffTurn).mockResolvedValueOnce(false); // simulated timeout

--- a/daemon/src/routes/sessions.ts
+++ b/daemon/src/routes/sessions.ts
@@ -392,6 +392,7 @@ export function serializeSession(worktreeId: string | null, projectId: string, s
     sortOrder: s.sortOrder,
     handoffSummary: s.handoffSummary ?? null,
     spawnedFrom: s.spawnedFrom ?? null,
+    supersededBy: s.supersededBy ?? null,
     pr: s.pr ?? null,
   };
 }
@@ -1412,7 +1413,9 @@ export function registerSessionRoutes(app: FastifyInstance): void {
       // guard) resolve to the dead archived row instead of the live new one —
       // a permanent unclosable dead "main" tab.
       const archiveSession = (s: SessionRecord): SessionRecord =>
-        s.id === session.id ? { ...s, archivedAt, handoffSummary: handoffText, isMain: false } : s;
+        s.id === session.id
+          ? { ...s, archivedAt, handoffSummary: handoffText, isMain: false, supersededBy: newId }
+          : s;
       if (ctx.kind === "worktree") {
         return {
           ...p,
@@ -1427,7 +1430,7 @@ export function registerSessionRoutes(app: FastifyInstance): void {
     });
 
     const wtIdForSerialize = ctx.kind === "worktree" ? ctx.worktree.id : null;
-    broadcastAll({ type: "session:updated", sessionId: session.id, archivedAt });
+    broadcastAll({ type: "session:updated", sessionId: session.id, archivedAt, supersededBy: newId });
     broadcastAll({
       type: "session:created",
       sessionId: newId,

--- a/daemon/src/services/dbSchema.ts
+++ b/daemon/src/services/dbSchema.ts
@@ -108,6 +108,11 @@ export function ensureSchema(db: Database): void {
   // leaving a dangling id is harmless (Research: the client-side workspace
   // tile scan simply won't find a match, S5).
   addColumnIfMissing(db, "sessions", "spawnedFrom", "TEXT");
+  // supersededBy (present-tickmark-replacement/02-reset-relink) — the
+  // replacement session's id, set on the archived row by the reset route.
+  // NULL for sessions never reset (the common case) or archived by other
+  // means (/done, plain archive). No FK enforcement, mirrors spawnedFrom.
+  addColumnIfMissing(db, "sessions", "supersededBy", "TEXT");
   // pr* (pr-status-axis) — VCS status for this session's branch, written
   // exclusively by prPoller.ts. NULL until the first poll tick checks this
   // session's worktree. prState mirrors PrStatus.state ("none"|"draft"|

--- a/daemon/src/services/sessionRuntime.ts
+++ b/daemon/src/services/sessionRuntime.ts
@@ -2,7 +2,7 @@ import type { SessionRecord } from "../types.js";
 import { jsonAgentRegistry } from "../state/jsonAgentRegistry.js";
 import { directPtyRegistry } from "../state/directPtyRegistry.js";
 import { clearSessionAttachments } from "../state/attachmentRegistry.js";
-import { killSession } from "./tmux.js";
+import { killSession, hasSession } from "./tmux.js";
 import { clearIdleTracking } from "./lifecycle.js";
 
 /**
@@ -53,10 +53,17 @@ export async function releaseSessionRuntime(
     // there, since json sessions spawn per turn and hold no long-lived pty).
     directPtyRegistry.get(session.id)?.kill?.();
   } else {
-    try {
+    await killSession(session.tmuxName);
+    if (await hasSession(session.tmuxName)) {
+      // First kill-session didn't take — try exactly once more before giving up
+      // loudly. Never throws, never blocks the caller past this one retry.
       await killSession(session.tmuxName);
-    } catch {
-      // Pane already gone — nothing to reclaim.
+      if (await hasSession(session.tmuxName)) {
+        console.warn(
+          `[sessionRuntime] tmux session '${session.tmuxName}' (session ${session.id}) ` +
+            `survived two kill-session attempts — it may still be running.`,
+        );
+      }
     }
   }
 

--- a/daemon/src/state/project-store.ts
+++ b/daemon/src/state/project-store.ts
@@ -258,8 +258,8 @@ function writeProjectFull(record: ProjectRecord): void {
        VALUES (@id, @projectId, @name, @branch, @baseBranch, @baseSha, @createdAt, @pinnedAt, @sortOrder, @terminalSeq, @agentSeq, @branchIsPlaceholder)`,
     );
     const insertSession = db.prepare(
-      `INSERT INTO sessions (id, worktreeId, projectId, isMain, sortOrder, type, modeId, name, nameSource, tmuxName, useTmux, channel, state, reason, lastTransitionAt, transcriptKind, transcriptPath, agentChatId, modelOverride, pinnedAt, initialPrompt, archivedAt, handoffSummary, spawnedFrom, prState, prNumber, prUrl, prCheckedAt, prBranch)
-       VALUES (@id, @worktreeId, @projectId, @isMain, @sortOrder, @type, @modeId, @name, @nameSource, @tmuxName, @useTmux, @channel, @state, @reason, @lastTransitionAt, @transcriptKind, @transcriptPath, @agentChatId, @modelOverride, @pinnedAt, @initialPrompt, @archivedAt, @handoffSummary, @spawnedFrom, @prState, @prNumber, @prUrl, @prCheckedAt, @prBranch)`,
+      `INSERT INTO sessions (id, worktreeId, projectId, isMain, sortOrder, type, modeId, name, nameSource, tmuxName, useTmux, channel, state, reason, lastTransitionAt, transcriptKind, transcriptPath, agentChatId, modelOverride, pinnedAt, initialPrompt, archivedAt, handoffSummary, spawnedFrom, supersededBy, prState, prNumber, prUrl, prCheckedAt, prBranch)
+       VALUES (@id, @worktreeId, @projectId, @isMain, @sortOrder, @type, @modeId, @name, @nameSource, @tmuxName, @useTmux, @channel, @state, @reason, @lastTransitionAt, @transcriptKind, @transcriptPath, @agentChatId, @modelOverride, @pinnedAt, @initialPrompt, @archivedAt, @handoffSummary, @spawnedFrom, @supersededBy, @prState, @prNumber, @prUrl, @prCheckedAt, @prBranch)`,
     );
 
     for (const w of p.worktrees) {

--- a/daemon/src/state/sqliteRowMappers.ts
+++ b/daemon/src/state/sqliteRowMappers.ts
@@ -40,6 +40,7 @@ export interface SessionRow {
   archivedAt: string | null;
   handoffSummary: string | null;
   spawnedFrom: string | null;
+  supersededBy: string | null;
   prState: string | null;
   prNumber: number | null;
   prUrl: string | null;
@@ -98,6 +99,7 @@ export function rowToSession(row: SessionRow): SessionRecord {
     ...(row.archivedAt != null ? { archivedAt: row.archivedAt } : {}),
     ...(row.handoffSummary != null ? { handoffSummary: row.handoffSummary } : {}),
     ...(row.spawnedFrom != null ? { spawnedFrom: row.spawnedFrom } : {}),
+    ...(row.supersededBy != null ? { supersededBy: row.supersededBy } : {}),
     ...(legacyPr ? { pr: legacyPr } : {}),
   };
 }
@@ -143,6 +145,7 @@ export function sessionToRow(session: SessionRecord, projectId: string, worktree
     archivedAt: session.archivedAt ?? null,
     handoffSummary: session.handoffSummary ?? null,
     spawnedFrom: session.spawnedFrom ?? null,
+    supersededBy: session.supersededBy ?? null,
     prState: session.pr?.state ?? null,
     prNumber: session.pr?.number ?? null,
     prUrl: session.pr?.url ?? null,

--- a/daemon/src/types.ts
+++ b/daemon/src/types.ts
@@ -288,6 +288,13 @@ export interface SessionRecord {
    */
   spawnedFrom?: string | null;
   /**
+   * Set once a reset (`/vst reset --handoff`) archives this session — the
+   * replacement session's id. Distinct from `archivedAt` (`/done` also sets
+   * that; only a reset sets this). No FK enforcement — same rationale as
+   * `spawnedFrom` above.
+   */
+  supersededBy?: string | null;
+  /**
    * VCS status for this session's branch, written only by `prPoller.ts`.
    * Absent ≡ never checked (e.g. session just created, or its worktree has
    * no GitHub remote).

--- a/daemon/src/ws/protocol.ts
+++ b/daemon/src/ws/protocol.ts
@@ -333,6 +333,9 @@ const SessionUpdatedEvent = z.object({
   sortOrder: z.number().optional(),
   /** After a `prPoller.ts` tick updates this session's VCS status (pr-status-axis). */
   pr: PrStatusSchema.nullable().optional(),
+  /** Set on the archived session by a reset (POST .../reset) — the
+   *  replacement session's id (present-tickmark-replacement/02-reset-relink). */
+  supersededBy: z.string().nullable().optional(),
 });
 
 /**

--- a/web-ui/src/api/mock.ts
+++ b/web-ui/src/api/mock.ts
@@ -601,21 +601,23 @@ export function createMockApi() {
 
       const archivedAt = nowIso();
       const handoffSummary = body?.handoff ? "Mock handoff summary." : null;
+      const newId = `sess-${Date.now()}`; // moved up from below the emit — supersededBy needs this before the emit
       s.archivedAt = archivedAt;
       s.handoffSummary = handoffSummary;
-      emit({ type: "session:updated", sessionId: id, archivedAt });
+      s.supersededBy = newId;
+      emit({ type: "session:updated", sessionId: id, archivedAt, supersededBy: newId });
 
-      const newId = `sess-${Date.now()}`;
       const newSession: Session = {
-        ...structuredClone(s),
-        id: newId,
-        state: "working",
-        lifecycleState: "working",
-        tmuxName: `tmux-${Date.now()}`,
+        ...structuredClone(s), // NOTE: this spreads `s`, which now HAS supersededBy: newId set above —
+        id: newId,             // the override below is load-bearing, not redundant, or the replacement
+        state: "working",      // session ends up superseding ITSELF and gets filtered out by TabsStrip's
+        lifecycleState: "working", // new supersededBy != null check, the exact bug this fix is supposed
+        tmuxName: `tmux-${Date.now()}`, // to remove, just moved onto the new session.
         createdAt: nowIso(),
         archivedAt: null,
         handoffSummary: null,
         pinnedAt: null,
+        supersededBy: null, // MUST override the spread, see NOTE above
       };
       sessions.push(newSession);
       emit({

--- a/web-ui/src/api/types.ts
+++ b/web-ui/src/api/types.ts
@@ -114,6 +114,10 @@ export interface Session {
   /** SessionId this session was spawned from, or null (agent-interaction-
    *  workspaces/04-workspaces Phase 4). Write-once, set at creation. */
   spawnedFrom?: string | null;
+  /** Set once a reset archives this session — the replacement session's id.
+   *  Distinct from `archivedAt` (`/done` also sets that; only a reset sets
+   *  this). */
+  supersededBy?: string | null;
   /** VCS outcome axis — orthogonal to `state`/`lifecycleState` (mirrors
    *  daemon `SessionRecord.pr`). Absent ≡ never checked (e.g. legacy/test
    *  fixtures); REST (`sessions.ts`'s `serializeSession`) always sends an
@@ -359,6 +363,8 @@ export type WSEvent =
       sortOrder?: number;
       /** After a `prPoller.ts` tick updates this session's VCS status (pr-status-axis). */
       pr?: PrStatus | null;
+      /** Set on the archived session by a reset — the replacement session's id. */
+      supersededBy?: string | null;
     }
   | {
       type: "session:error";

--- a/web-ui/src/components/layout/TabsStrip.test.tsx
+++ b/web-ui/src/components/layout/TabsStrip.test.tsx
@@ -685,7 +685,11 @@ describe("TabsStrip", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
-  it("3.T3 — after a real reset, the old tab shows archived styling and the new tab appears live, no manual refresh needed", async () => {
+  it("3.T3 — after a real reset, the old tab disappears entirely and the new tab appears live, no manual refresh needed", async () => {
+    // present-tickmark-replacement/02-reset-relink: a reset-superseded
+    // session is filtered out of the tab strip entirely (Decision 4), not
+    // shown alongside its replacement as a permanent "archived" duplicate —
+    // that duplicate-tab behavior was the bug this plan fixes.
     const localApi = createMockApi();
     render(
       <MemoryRouter>
@@ -697,22 +701,74 @@ describe("TabsStrip", () => {
     expect(tabsBefore).toHaveLength(2); // main + agent-2
 
     // Directly exercise the daemon call (mocked here) — the mock emits
-    // session:updated (archivedAt) + session:created (new session) over WS,
-    // mirroring what a real daemon does for POST /sessions/:id/reset.
+    // session:updated (archivedAt, supersededBy) + session:created (new
+    // session) over WS, mirroring what a real daemon does for
+    // POST /sessions/:id/reset.
     await act(async () => {
       await localApi.resetSession("sess-agent2", { handoff: false });
     });
 
-    // Both the old tab's archived styling AND the freshly spawned replacement
-    // session arrive live from the same WS round-trip — no manual refresh.
+    // The old tab is gone (filtered by supersededBy) and the freshly spawned
+    // replacement session takes its place — still exactly 2 tabs, no
+    // duplicate, no manual refresh needed.
     await waitFor(() => {
-      expect(screen.getAllByRole("tab")).toHaveLength(3);
+      const tabs = screen.getAllByRole("tab");
+      expect(tabs).toHaveLength(2);
+      expect(tabs.some((t) => t.getAttribute("data-archived") === "true")).toBe(false);
     });
-    const archivedTab = screen
-      .getAllByRole("tab")
-      .find((t) => t.getAttribute("data-archived") === "true");
-    expect(archivedTab).toBeTruthy();
-    expect(within(archivedTab!).getByText(/archived/i)).toBeInTheDocument();
+  });
+
+  it("a session with supersededBy set is absent from the rendered tab list", async () => {
+    const localApi = createMockApi();
+    render(
+      <MemoryRouter>
+        <TabsStrip api={localApi} worktreeId="wt-1" kind="agent" />
+      </MemoryRouter>,
+    );
+    await screen.findByRole("tab", { name: /agent-2/i });
+    expect(screen.getAllByRole("tab")).toHaveLength(2);
+
+    await act(async () => {
+      localApi.__test.emit({
+        type: "session:updated",
+        sessionId: "sess-agent2",
+        archivedAt: new Date().toISOString(),
+        supersededBy: "sess-agent2-new",
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("tab", { name: /agent-2/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("when the active tab's session receives a session:updated event with supersededBy, the active tab switches to that id", async () => {
+    const localApi = createMockApi();
+    render(
+      <MemoryRouter>
+        <TabsStrip api={localApi} worktreeId="wt-1" kind="agent" />
+      </MemoryRouter>,
+    );
+    const agent2Tab = await screen.findByRole("tab", { name: /agent-2/i });
+    await act(async () => {
+      fireEvent.click(agent2Tab);
+    });
+    await waitFor(() => {
+      expect(useWorkspaceStore.getState().activeSessionId).toBe("sess-agent2");
+    });
+
+    await act(async () => {
+      localApi.__test.emit({
+        type: "session:updated",
+        sessionId: "sess-agent2",
+        archivedAt: new Date().toISOString(),
+        supersededBy: "sess-agent2-new",
+      });
+    });
+
+    await waitFor(() => {
+      expect(useWorkspaceStore.getState().activeSessionId).toBe("sess-agent2-new");
+    });
   });
 
   it("reflects a rename in real time from session:updated's name field, without a refetch", async () => {

--- a/web-ui/src/components/layout/TabsStrip.tsx
+++ b/web-ui/src/components/layout/TabsStrip.tsx
@@ -251,12 +251,14 @@ export function TabsStrip({ api, worktreeId, kind, scope = "worktree" }: TabsStr
   // below, so this never causes a remount of anything (and TabsStrip doesn't
   // render TerminalPane/ChatPane itself anyway — see SortableTab's doc comment).
   const orderedSessions = useMemo(() => {
-    return sessions.slice().sort((a, b) => {
-      const ao = a.sortOrder ?? 0;
-      const bo = b.sortOrder ?? 0;
-      if (ao !== bo) return ao - bo;
-      return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
-    });
+    return sessions
+      .filter((s) => s.supersededBy == null)
+      .sort((a, b) => {
+        const ao = a.sortOrder ?? 0;
+        const bo = b.sortOrder ?? 0;
+        if (ao !== bo) return ao - bo;
+        return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+      });
   }, [sessions]);
 
   /** Optimistically patch a session's `sortOrder` in whichever local store
@@ -420,6 +422,7 @@ export function TabsStrip({ api, worktreeId, kind, scope = "worktree" }: TabsStr
           if (ev.archivedAt !== undefined) patch.archivedAt = ev.archivedAt ?? null;
           if (ev.sortOrder !== undefined) patch.sortOrder = ev.sortOrder;
           if (ev.pinnedAt !== undefined) patch.pinnedAt = ev.pinnedAt ?? null;
+          if (ev.supersededBy !== undefined) patch.supersededBy = ev.supersededBy ?? null;
           if (ev.channel !== undefined) {
             patch.channel = ev.channel;
             patch.useTmux = ev.channel === "tmux";
@@ -427,6 +430,15 @@ export function TabsStrip({ api, worktreeId, kind, scope = "worktree" }: TabsStr
           return { ...s, ...patch };
         }),
       );
+      // The superseded session's tab is about to disappear from
+      // orderedSessions — if it was the active one, follow it to its
+      // replacement instead of leaving the strip with no selected tab
+      // (mirrors the session:deleted handler above).
+      if (ev.supersededBy) {
+        const st = useWorkspaceStore.getState();
+        const cur = isAgent ? st.activeSessionId : st.activeTerminalSessionId;
+        if (cur === ev.sessionId) setActiveSession(ev.supersededBy);
+      }
     });
 
     return () => {

--- a/web-ui/src/components/layout/WorkspaceCanvas.tsx
+++ b/web-ui/src/components/layout/WorkspaceCanvas.tsx
@@ -399,19 +399,16 @@ export function WorkspaceCanvas({
   const placedToolWorktrees = new Set(
     cv.tiles.filter((t) => t.kind === "tools").map((t) => t.worktreeId ?? worktreeId),
   );
-  const canAddTools = hasTools && !placedToolWorktrees.has(worktreeId);
+  const showTools = hasTools;
+  const toolsPlaced = placedToolWorktrees.has(worktreeId);
 
   const pickerQuery = pickerSearch.trim().toLowerCase();
   function matchesSearch(label: string): boolean {
     return !pickerQuery || label.toLowerCase().includes(pickerQuery);
   }
 
-  const availableAgents = agentSessions.filter(
-    (s) => !placedSessionIds.has(s.id) && matchesSearch(sessionLabel(s)),
-  );
-  const availableTerminals = terminalSessions.filter(
-    (s) => !placedSessionIds.has(s.id) && matchesSearch(sessionLabel(s)),
-  );
+  const availableAgents = agentSessions.filter((s) => matchesSearch(sessionLabel(s)));
+  const availableTerminals = terminalSessions.filter((s) => matchesSearch(sessionLabel(s)));
 
   /**
    * A worktree counts as "done" the same way the dashboard's "Finished"
@@ -471,13 +468,13 @@ export function WorkspaceCanvas({
                   (s) =>
                     s.worktreeId === w.id &&
                     (s.type === "agent" || s.type === "terminal") &&
-                    !placedSessionIds.has(s.id) &&
                     (wtNameMatches || matchesSearch(sessionLabel(s))),
                 ),
-                canAddTools: !placedToolWorktrees.has(w.id) && wtNameMatches,
+                showTools: wtNameMatches,
+                toolsPlaced: placedToolWorktrees.has(w.id),
               };
             })
-            .filter((entry) => entry.sessions.length > 0 || entry.canAddTools),
+            .filter((entry) => entry.sessions.length > 0 || entry.showTools),
           // Direct (worktree-less) sessions of the SAME project — no
           // worktree to nest under, so they get their own subheading instead
           // of a `{worktree, sessions}` entry above.
@@ -486,7 +483,6 @@ export function WorkspaceCanvas({
               s.projectId === project.id &&
               s.worktreeId == null &&
               (s.type === "agent" || s.type === "terminal") &&
-              !placedSessionIds.has(s.id) &&
               matchesSearch(sessionLabel(s)),
           ),
         }))
@@ -499,7 +495,7 @@ export function WorkspaceCanvas({
     isDetachedView &&
     availableAgents.length === 0 &&
     availableTerminals.length === 0 &&
-    !canAddTools &&
+    !showTools &&
     otherContextGroups.length === 0;
 
   function handleModeChange(next: "tiled" | "free") {
@@ -564,6 +560,24 @@ export function WorkspaceCanvas({
     // reconciliation effect above, not inline here, so it also covers
     // removals this component didn't itself trigger.
     patchCanvas(removeTileFromCanvas(cv, tileId));
+  }
+
+  // Single toggle for every picker item — session-backed (agent/terminal) or
+  // worktree-scoped (tools). Mirrors the tile-close button's semantics: this only
+  // touches canvas geometry, never the underlying session/data.
+  // `t.sessionId != null` guards a "tools" call site (sessionId undefined) from
+  // ever matching a tools tile, whose own `sessionId` field is also undefined.
+  function togglePickerItem(kind: TileKind, sessionId?: string, tileWorktreeId?: string) {
+    const existing =
+      kind === "tools"
+        ? cv.tiles.find((t) => t.kind === "tools" && (t.worktreeId ?? worktreeId) === (tileWorktreeId ?? worktreeId))
+        : cv.tiles.find((t) => t.sessionId != null && t.sessionId === sessionId);
+    if (existing) {
+      removeTile(existing.id);
+      setPickerOpen(false);
+    } else {
+      addTile(kind, sessionId, tileWorktreeId);
+    }
   }
 
   /**
@@ -1129,7 +1143,7 @@ export function WorkspaceCanvas({
                   />
                 </div>
                 {pickerEmpty ? (
-                  <div className="workspace-canvas__picker-empty">Everything's already on the canvas</div>
+                  <div className="workspace-canvas__picker-empty">Nothing to add</div>
                 ) : null}
                 {!isDetachedView && matchesSearch("New agent") ? (
                   <button
@@ -1146,45 +1160,69 @@ export function WorkspaceCanvas({
                     </span>
                   </button>
                 ) : null}
-                {availableAgents.map((s) => (
+                {availableAgents.map((s) => {
+                  const placed = placedSessionIds.has(s.id);
+                  return (
                   <button
                     key={s.id}
                     type="button"
                     className="workspace-canvas__picker-item"
-                    onClick={() => addTile("agent", s.id)}
+                    aria-pressed={placed}
+                    title={placed ? "Remove from canvas" : "Add to canvas"}
+                    onClick={() => togglePickerItem("agent", s.id)}
                   >
                     <span className="workspace-canvas__picker-item-main">
                       <Bot size={13} className="workspace-canvas__picker-icon" />
                       {sessionLabel(s)}
                     </span>
-                    <span className="workspace-canvas__picker-kind">agent</span>
+                    {placed ? (
+                      <Check size={13} className="workspace-canvas__picker-check" aria-hidden />
+                    ) : (
+                      <span className="workspace-canvas__picker-kind">agent</span>
+                    )}
                   </button>
-                ))}
-                {availableTerminals.map((s) => (
+                  );
+                })}
+                {availableTerminals.map((s) => {
+                  const placed = placedSessionIds.has(s.id);
+                  return (
                   <button
                     key={s.id}
                     type="button"
                     className="workspace-canvas__picker-item"
-                    onClick={() => addTile("terminal", s.id)}
+                    aria-pressed={placed}
+                    title={placed ? "Remove from canvas" : "Add to canvas"}
+                    onClick={() => togglePickerItem("terminal", s.id)}
                   >
                     <span className="workspace-canvas__picker-item-main">
                       <SquareTerminal size={13} className="workspace-canvas__picker-icon" />
                       {sessionLabel(s)}
                     </span>
-                    <span className="workspace-canvas__picker-kind">terminal</span>
+                    {placed ? (
+                      <Check size={13} className="workspace-canvas__picker-check" aria-hidden />
+                    ) : (
+                      <span className="workspace-canvas__picker-kind">terminal</span>
+                    )}
                   </button>
-                ))}
-                {canAddTools && matchesSearch("Tools") ? (
+                  );
+                })}
+                {showTools && matchesSearch("Tools") ? (
                   <button
                     type="button"
                     className="workspace-canvas__picker-item"
-                    onClick={() => addTile("tools")}
+                    aria-pressed={toolsPlaced}
+                    title={toolsPlaced ? "Remove from canvas" : "Add to canvas"}
+                    onClick={() => togglePickerItem("tools")}
                   >
                     <span className="workspace-canvas__picker-item-main">
                       <PanelRight size={13} className="workspace-canvas__picker-icon" />
                       Tools
                     </span>
-                    <span className="workspace-canvas__picker-kind">tools</span>
+                    {toolsPlaced ? (
+                      <Check size={13} className="workspace-canvas__picker-check" aria-hidden />
+                    ) : (
+                      <span className="workspace-canvas__picker-kind">tools</span>
+                    )}
                   </button>
                 ) : null}
                 {/* Cross-context panes — saved workspaces only (see otherContextGroups). */}
@@ -1211,7 +1249,7 @@ export function WorkspaceCanvas({
                     </button>
                     {expanded ? (
                       <>
-                        {group.worktrees.map(({ worktree, sessions, canAddTools: wtTools }) => (
+                        {group.worktrees.map(({ worktree, sessions, showTools: wtShowTools, toolsPlaced: wtToolsPlaced }) => (
                           <div key={worktree.id}>
                             <div className="workspace-canvas__picker-subheading">
                               <GitBranch size={12} className="workspace-canvas__picker-icon" />
@@ -1219,12 +1257,16 @@ export function WorkspaceCanvas({
                             </div>
                             <div className="workspace-canvas__picker-subitems">
                               <span className="workspace-canvas__picker-indent-line" aria-hidden />
-                              {sessions.map((s) => (
+                              {sessions.map((s) => {
+                                const placed = placedSessionIds.has(s.id);
+                                return (
                                 <button
                                   key={s.id}
                                   type="button"
                                   className="workspace-canvas__picker-item"
-                                  onClick={() => addTile(s.type as TileKind, s.id, worktree.id)}
+                                  aria-pressed={placed}
+                                  title={placed ? "Remove from canvas" : "Add to canvas"}
+                                  onClick={() => togglePickerItem(s.type as TileKind, s.id, worktree.id)}
                                 >
                                   <span className="workspace-canvas__picker-item-main">
                                     {s.type === "agent" ? (
@@ -1234,20 +1276,31 @@ export function WorkspaceCanvas({
                                     )}
                                     {sessionLabel(s)}
                                   </span>
-                                  <span className="workspace-canvas__picker-kind">{s.type}</span>
+                                  {placed ? (
+                                    <Check size={13} className="workspace-canvas__picker-check" aria-hidden />
+                                  ) : (
+                                    <span className="workspace-canvas__picker-kind">{s.type}</span>
+                                  )}
                                 </button>
-                              ))}
-                              {wtTools ? (
+                                );
+                              })}
+                              {wtShowTools ? (
                                 <button
                                   type="button"
                                   className="workspace-canvas__picker-item"
-                                  onClick={() => addTile("tools", undefined, worktree.id)}
+                                  aria-pressed={wtToolsPlaced}
+                                  title={wtToolsPlaced ? "Remove from canvas" : "Add to canvas"}
+                                  onClick={() => togglePickerItem("tools", undefined, worktree.id)}
                                 >
                                   <span className="workspace-canvas__picker-item-main">
                                     <PanelRight size={13} className="workspace-canvas__picker-icon" />
                                     Tools
                                   </span>
-                                  <span className="workspace-canvas__picker-kind">tools</span>
+                                  {wtToolsPlaced ? (
+                                    <Check size={13} className="workspace-canvas__picker-check" aria-hidden />
+                                  ) : (
+                                    <span className="workspace-canvas__picker-kind">tools</span>
+                                  )}
                                 </button>
                               ) : null}
                             </div>
@@ -1258,12 +1311,16 @@ export function WorkspaceCanvas({
                             <div className="workspace-canvas__picker-subheading">Direct</div>
                             <div className="workspace-canvas__picker-subitems">
                               <span className="workspace-canvas__picker-indent-line" aria-hidden />
-                              {group.directSessions.map((s) => (
+                              {group.directSessions.map((s) => {
+                                const placed = placedSessionIds.has(s.id);
+                                return (
                                 <button
                                   key={s.id}
                                   type="button"
                                   className="workspace-canvas__picker-item"
-                                  onClick={() => addTile(s.type as TileKind, s.id)}
+                                  aria-pressed={placed}
+                                  title={placed ? "Remove from canvas" : "Add to canvas"}
+                                  onClick={() => togglePickerItem(s.type as TileKind, s.id)}
                                 >
                                   <span className="workspace-canvas__picker-item-main">
                                     {s.type === "agent" ? (
@@ -1273,9 +1330,14 @@ export function WorkspaceCanvas({
                                     )}
                                     {sessionLabel(s)}
                                   </span>
-                                  <span className="workspace-canvas__picker-kind">{s.type}</span>
+                                  {placed ? (
+                                    <Check size={13} className="workspace-canvas__picker-check" aria-hidden />
+                                  ) : (
+                                    <span className="workspace-canvas__picker-kind">{s.type}</span>
+                                  )}
                                 </button>
-                              ))}
+                                );
+                              })}
                             </div>
                           </div>
                         ) : null}

--- a/web-ui/src/hooks/useServerSync.ts
+++ b/web-ui/src/hooks/useServerSync.ts
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import type { ApiInstance } from "@/api";
 import type { Session } from "@/api/types";
 import { useServerStore } from "./useServerStore";
-import { useWorkspaceStore, findWorkspacesTilingSession } from "./useStore";
+import { useWorkspaceStore, findWorkspacesTilingSession, resolveSupersededChains } from "./useStore";
 
 /**
  * Module-level in-flight guard. Collapses three refresh triggers that all
@@ -67,6 +67,12 @@ export function useServerSync(api: ApiInstance): void {
           // while we were offline never overrides our cached "working"/
           // "idle" entry, and the rollup keeps showing the worktree active.
           syncSessionsFromApi(sessions);
+          // Resolve any supersededBy chain this client missed the broadcast
+          // for (offline during a reset, or the reset came from the CLI with
+          // no browser connected).
+          for (const { oldId, finalId } of resolveSupersededChains(sessions)) {
+            useWorkspaceStore.getState().relinkSessionTiles(oldId, finalId);
+          }
         } finally {
           inFlightRefresh = null;
         }
@@ -171,7 +177,16 @@ export function useServerSync(api: ApiInstance): void {
         if (ev.archivedAt !== undefined) patch.archivedAt = ev.archivedAt ?? null;
         if (ev.sortOrder !== undefined) patch.sortOrder = ev.sortOrder;
         if (ev.pr !== undefined) patch.pr = ev.pr ?? undefined;
+        if (ev.supersededBy !== undefined) patch.supersededBy = ev.supersededBy ?? null;
         applySessionUpdated(ev.sessionId, patch);
+        // A reset's replacement takes the archived session's place in every
+        // canvas it was tiled in — same tile id/position, just repointed.
+        // Fires for every connected client (the broadcast, not the
+        // initiator's own response), so a reset triggered from the CLI/
+        // another tab relinks here too.
+        if (ev.supersededBy) {
+          useWorkspaceStore.getState().relinkSessionTiles(ev.sessionId, ev.supersededBy);
+        }
       }
     });
     return () => {

--- a/web-ui/src/hooks/useStore.test.ts
+++ b/web-ui/src/hooks/useStore.test.ts
@@ -5,6 +5,8 @@ import {
   insertTileIntoCanvas,
   removeTileFromCanvas,
   findWorkspacesTilingSession,
+  relinkSessionInCanvas,
+  resolveSupersededChains,
   DEFAULT_WORKTREE_LAYOUT,
   type CanvasGeometry,
 } from "@/hooks/useStore";
@@ -401,6 +403,129 @@ describe("removeTileFromCanvas", () => {
     const withTile = insertTileIntoCanvas(empty, "agent", "sess-1");
     const next = removeTileFromCanvas(withTile, "nonexistent");
     expect(next.tiles).toHaveLength(1);
+  });
+});
+
+// --- relinkSessionInCanvas / relinkSessionTiles / resolveSupersededChains
+// (present-tickmark-replacement/02-reset-relink) ---
+describe("relinkSessionInCanvas", () => {
+  it("repoints a matching tile's sessionId, keeping the same tile id", () => {
+    const empty: CanvasGeometry = { mode: "free", tiles: [], tree: null, freeRects: {} };
+    const withTile = insertTileIntoCanvas(empty, "agent", "sess-old");
+    const tileId = withTile.tiles[0]!.id;
+    const next = relinkSessionInCanvas(withTile, "sess-old", "sess-new");
+    expect(next.tiles).toHaveLength(1);
+    expect(next.tiles[0]!.id).toBe(tileId);
+    expect(next.tiles[0]!.sessionId).toBe("sess-new");
+  });
+
+  it("returns the SAME canvas reference when no tile matches", () => {
+    const empty: CanvasGeometry = { mode: "free", tiles: [], tree: null, freeRects: {} };
+    const withTile = insertTileIntoCanvas(empty, "agent", "sess-other");
+    const next = relinkSessionInCanvas(withTile, "sess-old", "sess-new");
+    expect(next).toBe(withTile);
+  });
+});
+
+describe("useWorkspaceStore - relinkSessionTiles", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useWorkspaceStore.persist.clearStorage?.();
+    useWorkspaceStore.setState({
+      activeWorktreeId: W1,
+      activeDirectContextId: null,
+      layoutByWorktree: {},
+      workspaceDocs: {},
+    });
+  });
+
+  it("repoints a scratch-canvas tile referencing the old session to the new session", () => {
+    const scratch = insertTileIntoCanvas(
+      { mode: "free", tiles: [], tree: null, freeRects: {} },
+      "agent",
+      "sess-old",
+    );
+    useWorkspaceStore.setState({
+      layoutByWorktree: { [W1]: { ...DEFAULT_WORKTREE_LAYOUT, scratchCanvas: scratch } },
+    });
+    useWorkspaceStore.getState().relinkSessionTiles("sess-old", "sess-new");
+    const tiles = useWorkspaceStore.getState().layoutByWorktree[W1]!.scratchCanvas!.tiles;
+    expect(tiles[0]!.sessionId).toBe("sess-new");
+  });
+
+  it("repoints a tile in a saved workspace doc", () => {
+    const doc = {
+      id: "doc-1",
+      name: "doc-1",
+      contextKey: W1,
+      mode: "free" as const,
+      tiles: [{ id: "tile-1", kind: "agent" as const, sessionId: "sess-old" }],
+      tree: null,
+      freeRects: {},
+    };
+    useWorkspaceStore.setState({ workspaceDocs: { "doc-1": doc } });
+    useWorkspaceStore.getState().relinkSessionTiles("sess-old", "sess-new");
+    expect(useWorkspaceStore.getState().workspaceDocs["doc-1"]!.tiles[0]!.sessionId).toBe("sess-new");
+  });
+
+  it("repoints a tile present in TWO saved docs at once, in the same call", () => {
+    const mkDoc = (id: string) => ({
+      id,
+      name: id,
+      contextKey: W1,
+      mode: "free" as const,
+      tiles: [{ id: `${id}-tile`, kind: "agent" as const, sessionId: "sess-old" }],
+      tree: null,
+      freeRects: {},
+    });
+    useWorkspaceStore.setState({ workspaceDocs: { a: mkDoc("a"), b: mkDoc("b") } });
+    useWorkspaceStore.getState().relinkSessionTiles("sess-old", "sess-new");
+    const docs = useWorkspaceStore.getState().workspaceDocs;
+    expect(docs.a!.tiles[0]!.sessionId).toBe("sess-new");
+    expect(docs.b!.tiles[0]!.sessionId).toBe("sess-new");
+  });
+
+  it("is a no-op (no state churn) when nothing matches", () => {
+    const doc = {
+      id: "doc-1",
+      name: "doc-1",
+      contextKey: W1,
+      mode: "free" as const,
+      tiles: [{ id: "tile-1", kind: "agent" as const, sessionId: "sess-other" }],
+      tree: null,
+      freeRects: {},
+    };
+    useWorkspaceStore.setState({ workspaceDocs: { "doc-1": doc } });
+    const before = useWorkspaceStore.getState().workspaceDocs;
+    useWorkspaceStore.getState().relinkSessionTiles("sess-old", "sess-new");
+    expect(useWorkspaceStore.getState().workspaceDocs).toBe(before);
+  });
+});
+
+describe("resolveSupersededChains", () => {
+  it("resolves a multi-hop chain to the FINAL live id, not the intermediate hop", () => {
+    const sessions = [
+      { id: "A", supersededBy: "B" },
+      { id: "B", supersededBy: "C" },
+      { id: "C", supersededBy: null },
+    ];
+    const pairs = resolveSupersededChains(sessions);
+    // A must resolve all the way to C, never stopping at the intermediate B.
+    expect(pairs).toContainEqual({ oldId: "A", finalId: "C" });
+    expect(pairs.find((p) => p.oldId === "A")!.finalId).not.toBe("B");
+  });
+
+  it("produces no pair for a session with no supersededBy", () => {
+    const sessions = [{ id: "A", supersededBy: null }];
+    expect(resolveSupersededChains(sessions)).toEqual([]);
+  });
+
+  it("terminates instead of looping forever on a cyclic chain", () => {
+    const sessions = [
+      { id: "A", supersededBy: "B" },
+      { id: "B", supersededBy: "A" },
+    ];
+    expect(() => resolveSupersededChains(sessions)).not.toThrow();
   });
 });
 

--- a/web-ui/src/hooks/useStore.ts
+++ b/web-ui/src/hooks/useStore.ts
@@ -264,6 +264,13 @@ export interface WorkspaceState {
     sessionId?: string,
     tileWorktreeId?: string,
   ) => void;
+  /**
+   * Repoint every tile (scratch canvas + every saved workspace doc)
+   * referencing `fromSessionId` to `toSessionId` — a reset's replacement
+   * taking the archived session's exact place, same tile id/position.
+   * A no-op (identity-preserving) for canvases with no matching tile.
+   */
+  relinkSessionTiles: (fromSessionId: string, toSessionId: string) => void;
   reorderWorkspace: (scopeKey: string, orderedIds: string[]) => void;
   setActiveWorkspace: (worktreeId: string, workspaceId: string | null) => void;
   setLayoutMode: (worktreeId: string, mode: "classic" | "workspace") => void;
@@ -342,6 +349,50 @@ export function removeTileFromCanvas(canvas: CanvasGeometry, tileId: string): Ca
     nextTree = leafId ? removePane(canvas.tree, leafId) : canvas.tree;
   }
   return { ...canvas, tiles: nextTiles, freeRects: nextFreeRects, tree: nextTree };
+}
+
+/**
+ * Repoint every tile referencing `fromSessionId` to `toSessionId` — same tile
+ * id, same position/geometry, just a different session behind it (a reset's
+ * replacement taking the archived session's exact place). Returns the SAME
+ * `canvas` reference when nothing matched, so callers can skip a `set()` for
+ * canvases this reset didn't touch.
+ */
+export function relinkSessionInCanvas(
+  canvas: CanvasGeometry,
+  fromSessionId: string,
+  toSessionId: string,
+): CanvasGeometry {
+  if (!canvas.tiles.some((t) => t.sessionId === fromSessionId)) return canvas;
+  return {
+    ...canvas,
+    tiles: canvas.tiles.map((t) => (t.sessionId === fromSessionId ? { ...t, sessionId: toSessionId } : t)),
+  };
+}
+
+/**
+ * Every {oldId, finalId} pair still needing a relink, from a flat sessions
+ * list. Walks multi-hop chains (a double reset while offline produces
+ * A.supersededBy=B, B.supersededBy=C) to the FINAL live id — relinking to an
+ * intermediate hop that is itself archived would just move the bug.
+ */
+export function resolveSupersededChains(
+  sessions: Array<{ id: string; supersededBy?: string | null }>,
+): Array<{ oldId: string; finalId: string }> {
+  const supersededBy = new Map(
+    sessions.filter((s) => s.supersededBy != null).map((s) => [s.id, s.supersededBy as string]),
+  );
+  const result: Array<{ oldId: string; finalId: string }> = [];
+  for (const oldId of supersededBy.keys()) {
+    const seen = new Set<string>();
+    let finalId = oldId;
+    while (supersededBy.has(finalId) && !seen.has(finalId)) {
+      seen.add(finalId);
+      finalId = supersededBy.get(finalId)!;
+    }
+    if (finalId !== oldId) result.push({ oldId, finalId });
+  }
+  return result;
 }
 
 /**
@@ -701,6 +752,33 @@ export const useWorkspaceStore = create<WorkspaceState>()(
             const next = insertTileIntoCanvas(doc, kind, sessionId, tileWorktreeId, doc.contextKey);
             return {
               workspaceDocs: { ...s.workspaceDocs, [docId]: { ...doc, ...next } },
+            };
+          }),
+        relinkSessionTiles: (fromSessionId, toSessionId) =>
+          set((s) => {
+            let layoutChanged = false;
+            const nextLayoutByWorktree = { ...s.layoutByWorktree };
+            for (const [worktreeId, layout] of Object.entries(s.layoutByWorktree)) {
+              if (!layout.scratchCanvas) continue;
+              const relinked = relinkSessionInCanvas(layout.scratchCanvas, fromSessionId, toSessionId);
+              if (relinked !== layout.scratchCanvas) {
+                nextLayoutByWorktree[worktreeId] = { ...layout, scratchCanvas: relinked };
+                layoutChanged = true;
+              }
+            }
+            let docsChanged = false;
+            const nextWorkspaceDocs = { ...s.workspaceDocs };
+            for (const [docId, doc] of Object.entries(s.workspaceDocs)) {
+              const relinked = relinkSessionInCanvas(doc, fromSessionId, toSessionId);
+              if (relinked !== doc) {
+                nextWorkspaceDocs[docId] = { ...doc, ...relinked };
+                docsChanged = true;
+              }
+            }
+            if (!layoutChanged && !docsChanged) return s;
+            return {
+              ...(layoutChanged ? { layoutByWorktree: nextLayoutByWorktree } : {}),
+              ...(docsChanged ? { workspaceDocs: nextWorkspaceDocs } : {}),
             };
           }),
         reorderWorkspace: (scopeKey, orderedIds) =>

--- a/web-ui/src/styles/workspace-canvas.css
+++ b/web-ui/src/styles/workspace-canvas.css
@@ -214,6 +214,11 @@
   flex-shrink: 0;
 }
 
+.workspace-canvas__picker-check {
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
 /* Cross-context picker sections (saved workspaces only): project > worktree. */
 .workspace-canvas__picker-group {
   border-top: var(--border-width) solid var(--border-default);


### PR DESCRIPTION
## Summary
- The "Add tile" picker (`WorkspaceCanvas.tsx`) no longer filters out sessions/tools panes already placed on the canvas — it now shows a checkmark and clicking a checked item removes it, clicking an unchecked item adds it. Applies to own-worktree agents/terminals/tools and cross-project sessions/tools in saved workspaces.
- `releaseSessionRuntime`'s tmux kill was fire-and-forget: `killSession` swallows every error internally, so nothing ever confirmed the tmux pane actually died before the reset route archived the old session. It now verifies via `hasSession`, retries once, and logs a warning if the pane survives — never blocking the reset, just no longer failing silently.
- **Follow-up (found during user verification of the above): the client never updated after a reset.** Even with a correct kill, the old session's tab lingered forever in the classic tab strip (permanent duplicate "Archived" tab) and its canvas tile kept rendering the dead session's frozen pane while the new replacement session got no tile at all. Fixed by adding a `supersededBy` field to `SessionRecord` (persisted + broadcast, mirrors the existing `spawnedFrom` field's plumbing) so the client can identify a reset's replacement and relink every tile referencing the archived session to the new one in place (same tile id/position) — self-healing on reconnect/reload for resets that happened while offline — and filter/redirect the classic tab strip accordingly.

Both fixes went through multiple rounds of opus plan review (each round found real issues — stale line references, an untested json-channel gap, a self-superseding mock-API bug, missing reconciliation-on-load — all fixed and re-verified) plus post-implementation opus code review (clean). All tests pass (daemon: 33/33, web-ui: 461/461) and typecheck/build are clean.

## Test plan
- [x] `cd web-ui && npx tsc --noEmit` — clean
- [x] `cd web-ui && npm run build` — clean
- [x] `cd cli && npx vitest run src/daemon/__tests__/sessionRuntime.test.ts src/daemon/__tests__/sessions.reset.test.ts src/daemon/__tests__/sessions.reset.json.test.ts` — 33/33 passing
- [x] `cd web-ui && npx vitest run` (full suite) — 461/461 passing
- [x] `grep -n canAddTools web-ui/src/components/layout/WorkspaceCanvas.tsx` — zero hits (confirms full rename)
- [ ] Manual/browser verification of the picker toggle and the reset relink (tab + canvas tile, including a cross-tab saved-workspace scenario) in a dev sandbox — **not run**, no browser available in this session; left unchecked in both plan docs (`.vibekit/feature-plans/wip/present-tickmark-replacement/`) for a human to verify before merge

Plans (each with 2-3 rounds of opus review + a post-implementation opus code review):
- [`plan-present-tickmark-replacement.md`](.vibekit/feature-plans/wip/present-tickmark-replacement/plan-present-tickmark-replacement.md) — picker tickmark + kill verification
- [`02-reset-relink/plan-02-present-tickmark-replacement-reset-relink.md`](.vibekit/feature-plans/wip/present-tickmark-replacement/02-reset-relink/plan-02-present-tickmark-replacement-reset-relink.md) — tab/tile relink on reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)