### PR TITLE
fix(daemon): refresh stale local base-branch ref on VCS tab open, no periodic fetch

### DIFF
--- a/.vibekit/feature-plans/wip/vcs-stale-base-branch/.sdlc-state.yaml
+++ b/.vibekit/feature-plans/wip/vcs-stale-base-branch/.sdlc-state.yaml
@@ -1,0 +1,19 @@
+feature: vcs-stale-base-branch
+worktree: /home/gb/.vibe-station/projects/vibe-station/worktrees/vs-52
+master:
+  prd: skipped
+  plan: complete
+current_subfeature: root
+subfeatures:
+  - id: root
+    origin: planned
+    spawned_from: null
+    mode: done
+    last_completed: "2.T1"
+    awaiting_phase: null
+    awaiting_artifact: null
+    phase_chain: [plan, implement, verify]
+    superseded_reason: null
+    parked_reason: null
+    handoff: {next_item: null, returned_at: null, verified_by: null}
+    commit: null

--- a/.vibekit/feature-plans/wip/vcs-stale-base-branch/plan-vcs-stale-base-branch.md
+++ b/.vibekit/feature-plans/wip/vcs-stale-base-branch/plan-vcs-stale-base-branch.md
@@ -1,0 +1,148 @@
+<!--
+RULES — read before writing or implementing:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. REQUIREMENTS: One crisp line each — no verbose descriptions
+3. CHECKLIST: Mark items [x] as you complete them — this is your persistent todo list
+4. READING TIME: Optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+# Plan: VCS tab — fetch base branch on demand instead of using a stale local ref
+
+> Single follow-up bug, found while live-diagnosing the `console-home` project's `ch-64` worktree
+> right after shipping `vcs-canvas-ux-fixes`. Not a regression from that change — a pre-existing
+> gap the new "Diff from main" toggle made newly visible.
+
+**Issue:** vcs-stale-base-branch
+**Branch:** `vcs-pr-main` (current worktree branch)
+**Status:** planned
+**PRD:** none — single bug, skipped
+**Parent:** none (follow-up to `vcs-canvas-ux-fixes`, commit `16bc635`)
+
+**Reference files:**
+- `daemon/src/services/git.ts:148-172` — `resolveBaseSha()`
+- `daemon/src/services/git.ts` — `fetchOrigin(repoPath, ref)`, best-effort, already swallows errors
+- `daemon/src/routes/worktrees.ts:392-395` — the ONLY existing `fetchOrigin` call site (worktree creation, first-time-only)
+- `daemon/src/routes/worktrees.ts:1135-1152` — `GET /worktrees/:id/commits` (what `VcsPanel.tsx` calls)
+
+---
+
+## Problem
+
+- Live-diagnosed on `console-home`'s `ch-64` worktree: local `main` ref last updated 2026-08-17;
+  `origin/main` (freshly fetched) at 2026-08-20 with 11 more commits landed in between
+- `merge-base(HEAD, local main)` → 13 "unique to branch" commits; `merge-base(HEAD, origin/main)` → 2
+  (matches the real PR diff)
+- `fetchOrigin()` is only ever called once, at worktree-creation time, and only if the local branch
+  doesn't exist yet at all (`worktrees.ts:392-395`) — after that the local `baseBranch` ref is never
+  refreshed, so it silently drifts further behind actual GitHub `main` for as long as the daemon runs
+- The VCS tab's commit list, the "Diff from main" toggle, and `/changed-paths?scope=branch` are all
+  downstream of `resolveBaseSha()`, so all inherit this staleness
+
+## Out of Scope (per explicit user direction)
+
+- **No periodic/background fetch** — user explicitly rejected this ("i think its better to do only
+  when vcs tab is opened. no periodic stuff"). No `prPoller`-style interval, no cron
+- Fixing `/worktrees/:id/diff/*` (line 988, file-diff view) — different UI surface, not the VCS tab;
+  same underlying `resolveBaseSha` staleness bug, but out of scope here to keep this "very small"
+- Fixing `/changed-paths` — not called by `VcsPanel.tsx` (a different feature calls it); same bug
+  class, deliberately left for a separate pass if it turns out to matter there too
+
+## Concept
+
+- `GET /worktrees/:id/commits` (the only route `VcsPanel.tsx` hits for its base-branch-relative
+  view) does a best-effort `fetchOrigin(project.absolutePath, worktree.baseBranch)` immediately
+  before calling `resolveBaseSha` — runs exactly once per tab-open/refresh/load-more/toggle-driven
+  request, never on a timer
+- `fetchOrigin` only updates the `refs/remotes/origin/<baseBranch>` tracking ref (via plain
+  `git fetch origin <ref>`) — it does NOT fast-forward the local `<baseBranch>` branch itself (which
+  would fail anyway if that branch is checked out in the project's primary clone). So
+  `resolveBaseSha` must also change: prefer `merge-base HEAD origin/<baseBranch>` when that ref
+  resolves, falling back to the local `<baseBranch>` name (today's behavior) when it doesn't
+  (no remote, fetch failed and no remote-tracking ref ever existed, etc.)
+- `fetchOrigin` gets a bounded timeout so a network hiccup can't hang a VCS tab load — currently
+  unbounded (`execFile` with no `timeout` option)
+
+## Requirements
+
+| # | Requirement |
+|---|-------------|
+| 1a | `GET /worktrees/:id/commits` calls `fetchOrigin(project.absolutePath, worktree.baseBranch)` before `resolveBaseSha`, best-effort (errors swallowed, request proceeds regardless) |
+| 1b | The fetch has a bounded timeout (~8s) — a hung/slow network must not hang the whole `/commits` response; on timeout, proceed with whatever local refs already exist |
+| 2a | `resolveBaseSha(repoPath, baseBranch, fallbackBaseSha)`: when `origin/<baseBranch>` resolves, use `merge-base HEAD origin/<baseBranch>` |
+| 2b | `resolveBaseSha`: when `origin/<baseBranch>` does NOT resolve (no remote, never fetched, local-only project), fall back to today's `merge-base HEAD <baseBranch>` (local ref) — unchanged behavior for local-only/no-remote projects |
+| 2c | Existing `fallbackBaseSha` (cached `worktree.baseSha`) fallback, for when BOTH of the above fail, is unchanged |
+| 3a | No new periodic job, interval, or cron — the fetch only ever runs inside the `/commits` request handler |
+| 3b | `/worktrees/:id/pr`, `/worktrees/:id/diff/*`, `/worktrees/:id/changed-paths` are NOT touched by this plan (Out of Scope) |
+
+---
+
+## Research
+
+### `fetchOrigin` already exists and is already best-effort
+- `daemon/src/services/git.ts` — `fetchOrigin(repoPath, ref)`: `git fetch origin <ref>`, try/catch swallows all errors, callers already treat it as best-effort. Reused as-is; only the call site and a timeout are new.
+
+### `git fetch origin main:main` would fail
+- The project's primary clone (`project.absolutePath`) typically still has `main` checked out (worktrees are separate checkouts on separate branches) — git refuses to fetch directly into a checked-out branch ref. Fetching into the remote-tracking ref (`origin/main`) via plain `git fetch origin main` sidesteps this entirely and is the standard-safe approach.
+- Remote-tracking refs live in the shared `.git` dir, visible from every worktree of the same repo — so fetching once in `project.absolutePath` makes `origin/<baseBranch>` immediately resolvable from `wtPath` (the worktree calling `resolveBaseSha`) too.
+
+### No timeout on `execFile` today
+- `daemon/src/services/git.ts`'s `runGit()` calls `execFile` with no `timeout` option — unbounded. A hung SSH/network fetch would hang the whole `/commits` response. Needs an explicit timeout, scoped to the fetch call only (not a blanket change to every `runGit` caller).
+
+## Root Cause
+
+- `fetchOrigin` was correctly written as best-effort/non-fatal, but its only call site was designed
+  for the one-time "does this branch exist locally yet" case at worktree creation — nobody wired a
+  second call site for "keep this fresh while the tab is actually being looked at"
+
+---
+
+## Risks / Open Questions
+
+| # | Question | Resolution |
+|---|----------|------------|
+| 1 | Does fetching on every `/commits` call (including "Load more" pagination) add noticeable latency? | Accepted — user-driven, bounded by the new timeout, and it's exactly the "only when the tab is open" behavior requested. Not fetching on every request risks staleness creeping back in between the first load and a later "Load more"/refresh |
+| 2 | Could the timeout make `resolveBaseSha` silently regress to stale data indefinitely on a flaky network? | Yes, by design — best-effort was the existing contract for `fetchOrigin`; a hard-fail-the-request behavior was rejected as worse UX than "occasionally still a bit stale" |
+
+---
+
+## Implementation Phases
+
+### Phase 1 — fetch-on-demand + resolveBaseSha origin-preference
+
+- [x] **1.1** `daemon/src/services/git.ts`: add a bounded timeout to `fetchOrigin`'s underlying `execFile` call (~8s), scoped to this call only
+- [x] **1.2** `daemon/src/services/git.ts`: `resolveBaseSha` tries `merge-base HEAD origin/<baseBranch>` first (when it resolves), falls back to local `<baseBranch>`, falls back to `fallbackBaseSha` — same overall fallback shape, new preferred first branch. **Revised after opus review**: when BOTH origin and local refs resolve, compares both merge-bases via `git merge-base --is-ancestor` and picks whichever is more-advanced, instead of blindly preferring origin (a blind preference regressed the case where local is ahead of origin)
+- [x] **1.3** `daemon/src/routes/worktrees.ts`: `GET /worktrees/:id/commits` calls `fetchOrigin(project.absolutePath, worktree.baseBranch)` before `resolveBaseSha`, best-effort (don't fail the request if it throws/times out); logs the swallowed error at debug level
+- [x] **1.4** Unit tests: `resolveBaseSha` prefers `origin/<baseBranch>` when present (tmp repo with a fake "origin" remote and a manually-advanced `origin/main` ref vs. a stale local `main`); falls back correctly when no `origin/<baseBranch>` exists; `fetchOrigin`'s timeout doesn't hang the test suite (optional `timeoutMs` param lets the test exercise the bound in ~300ms instead of the real 8s); regression test for local-ahead-of-origin added per review
+- [x] **1.5** Route test: `/commits` triggers a fetch call (spy/mock) before computing `isOnBranch`; route still 200s when the fetch throws
+
+**Verify phase 1:**
+- [x] **1.T1** `pnpm --filter cli exec vitest run src/daemon/__tests__/git*.test.ts src/daemon/__tests__/worktrees.test.ts` — 77 tests pass
+- [x] **1.T2** `pnpm typecheck` (repo-wide) clean
+- [x] **1.T3** Docker sandbox (`scripts/dev-sandbox.sh up vs-52`, port 5174): built a purpose-made fixture (bare "origin" repo + a "clone" registered as the vst project, matching the real ch-64 mechanism exactly — a feature branch that merged a newer `origin/main` into itself, then the clone's local `main`/`origin/main` refs reset back to the pre-merge point to simulate "never fetched since project onboarding"). Buggy-code expectation (`HEAD..local main`): 8 "unique" commits. Hit `GET /worktrees/:id/commits` once — result: exactly 3 `isOnBranch:true` commits (2 own + the merge commit), matching the true diff against fresh `origin/main`. Confirmed via `git rev-parse origin/main` in the project's primary clone that the tracking ref itself moved from stale to fresh as a direct result of that one API call — proving the fetch is request-triggered, not periodic. Fixture torn down and project deregistered after verification.
+
+### Phase 2 — review
+
+- [x] **2.1** Opus reviewer pass on the diff — found 1 CONFIRMED (medium, the unconditional origin-preference regression), 1 CONFIRMED downstream consequence (out-of-scope routes inherit the behavior via shared `resolveBaseSha`, resolved by fixing the first), 1 CONFIRMED test-hygiene issue (leaked temp dir + 8s test), and 2 PLAUSIBLE issues (credential-prompt hang risk, orphaned grandchild processes) plus 1 observability nit
+- [x] **2.2** Addressed: ancestry-aware origin/local comparison, `GIT_TERMINAL_PROMPT`/`GIT_SSH_COMMAND` env hardening, test fixture cleanup + `timeoutMs` param, debug logging on swallowed fetch errors. Deliberately deferred (per opus's own "cheap to fold in" vs. genuinely-lower-priority split, confirmed with the user's "very small" scope in mind): in-flight fetch dedupe for concurrent requests into the same primary clone, and `detached`+process-group-kill for orphaned grandchildren beyond the `BatchMode`/`ConnectTimeout` mitigation already applied
+
+**Verify phase 2:**
+- [x] **2.T1** No unresolved CONFIRMED findings — all 3 addressed; both PLAUSIBLE findings addressed (2 of them) or accepted as documented residual risk (in-flight dedupe race, rare)
+
+---
+
+## Files & Phase Impact
+
+| File | Status | Phase | Description / Contract Change |
+|------|--------|-------|-------------------------------|
+| `daemon/src/services/git.ts` | Modified | 1 | `fetchOrigin` timeout; `resolveBaseSha` prefers `origin/<baseBranch>` |
+| `daemon/src/routes/worktrees.ts` | Modified | 1 | `/commits` calls `fetchOrigin` before `resolveBaseSha` |
+| `daemon/src/__tests__/git.commits.test.ts` or new file | Modified/New | 1 | Unit tests for the origin-preference + timeout behavior |
+| `daemon/src/__tests__/worktrees.test.ts` | Modified | 1 | Route-level fetch-triggered test |
+
+---
+
+## Verification Method
+
+- Node/vitest: targeted + repo-wide typecheck
+- Docker: `scripts/dev-sandbox.sh up vs-52`, port 5174, simulate a stale-local-main scenario against a fake local "origin" remote (demo seed repos are local-only/no-remote, so this needs a purpose-built fixture, not the default seed)
+- Reviewer: opus subagent, one pass on the complete diff

--- a/daemon/src/__tests__/git.fetchOrigin.test.ts
+++ b/daemon/src/__tests__/git.fetchOrigin.test.ts
@@ -1,0 +1,88 @@
+/**
+ * `fetchOrigin()` — best-effort `git fetch origin <ref>`, used to refresh the
+ * `origin/<baseBranch>` remote-tracking ref on demand (see
+ * `GET /worktrees/:id/commits` and `resolveBaseSha`'s doc comment for why).
+ * Was previously unbounded (`execFile` with no `timeout`) — a hung/slow
+ * network fetch could hang whatever request triggered it. These tests cover
+ * both the existing best-effort (swallow-errors) contract and the new
+ * bounded timeout.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { writeFile, mkdtemp, chmod, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fetchOrigin, revParse } from "../services/git.js";
+import { createGitFixture, removeGitFixture, type GitFixture } from "./gitFixture.js";
+
+let fixture: GitFixture;
+let repoDir: string;
+let git: GitFixture["git"];
+
+describe("fetchOrigin", () => {
+  beforeEach(async () => {
+    fixture = await createGitFixture("vst-git-fetchorigin-test");
+    repoDir = fixture.dir;
+    git = fixture.git;
+  });
+
+  afterEach(async () => {
+    await removeGitFixture(fixture);
+  });
+
+  it("updates the origin/<ref> remote-tracking ref on success", async () => {
+    const originFixture = await createGitFixture("vst-git-fetchorigin-origin-test");
+    try {
+      await writeFile(join(originFixture.dir, "seed.txt"), "seed\n");
+      originFixture.git(["add", "-A"]);
+      originFixture.git(["commit", "-q", "-m", "origin seed"]);
+      const originTip = originFixture.git(["rev-parse", "HEAD"]).trim();
+
+      git(["remote", "add", "origin", originFixture.dir]);
+
+      await fetchOrigin(repoDir, "main");
+
+      const trackingRef = await revParse(repoDir, "origin/main");
+      expect(trackingRef).toBe(originTip);
+    } finally {
+      await removeGitFixture(originFixture);
+    }
+  });
+
+  it("swallows errors and resolves without throwing when there is no remote", async () => {
+    await expect(fetchOrigin(repoDir, "main")).resolves.toBeUndefined();
+  });
+
+  it(
+    "does not hang past the bounded timeout when the underlying git process never returns",
+    async () => {
+      // Shadow `git` on PATH with a script that hangs, to prove `fetchOrigin`
+      // is actually bounded (not just "usually fast") — without this, a
+      // regression back to an unbounded `execFile` wouldn't be caught by any
+      // of the other (fast, well-behaved) tests here. Own `mkdtemp`'d dir
+      // (not a sibling of `repoDir` cleaned up implicitly) so it's guaranteed
+      // removed in `finally` regardless of `removeGitFixture`.
+      const fakeBinDir = await mkdtemp(join(tmpdir(), "vst-git-fetchorigin-fakebin-"));
+      try {
+        const fakeGitPath = join(fakeBinDir, "git");
+        await writeFile(fakeGitPath, "#!/bin/sh\nsleep 2\n");
+        await chmod(fakeGitPath, 0o755);
+
+        const originalPath = process.env.PATH;
+        process.env.PATH = `${fakeBinDir}:${originalPath}`;
+        try {
+          const start = Date.now();
+          // A short `timeoutMs` (well under the 2s the fake `git` sleeps for)
+          // proves the bound is enforced without waiting out the real
+          // production 8s default on every test run.
+          await fetchOrigin(repoDir, "main", 300);
+          const elapsedMs = Date.now() - start;
+          expect(elapsedMs).toBeLessThan(2_000);
+        } finally {
+          process.env.PATH = originalPath;
+        }
+      } finally {
+        await rm(fakeBinDir, { recursive: true, force: true });
+      }
+    },
+  );
+});

--- a/daemon/src/__tests__/git.resolveBaseSha.test.ts
+++ b/daemon/src/__tests__/git.resolveBaseSha.test.ts
@@ -86,4 +86,140 @@ describe("resolveBaseSha", () => {
     const resolved = await resolveBaseSha(repoDir, null, null);
     expect(resolved).toBeNull();
   });
+
+  // vcs-stale-base-branch: the local `<baseBranch>` ref is only ever updated
+  // once, at worktree-creation time — it silently drifts stale for as long
+  // as the daemon runs. `origin/<baseBranch>` (kept fresh by a caller that
+  // fetches it, e.g. `GET /worktrees/:id/commits`) should be preferred when
+  // it resolves, so these tests use a real second tmp repo as a fake
+  // "origin" whose `main` can be advanced independently of the "clone"'s
+  // local `main` — a mocked-only test couldn't actually distinguish
+  // stale-local from fresh-origin behavior.
+  describe("origin/<baseBranch> preference (vcs-stale-base-branch)", () => {
+    let originFixture: GitFixture;
+
+    beforeEach(async () => {
+      originFixture = await createGitFixture("vst-git-resolve-base-origin-test");
+      // Seed the origin with a first commit, then clone it into `repoDir`
+      // (the fixture's repo, freshly `git init`ed with no history yet) so
+      // `repoDir` has a real `origin` remote and a local `main` that starts
+      // out equal to the origin's `main`.
+      await writeFile(join(originFixture.dir, "seed.txt"), "seed\n");
+      originFixture.git(["add", "-A"]);
+      originFixture.git(["commit", "-q", "-m", "origin seed commit"]);
+
+      git(["remote", "add", "origin", originFixture.dir]);
+      git(["fetch", "-q", "origin"]);
+      git(["reset", "-q", "--hard", "origin/main"]);
+    });
+
+    afterEach(async () => {
+      await removeGitFixture(originFixture);
+    });
+
+    it("prefers the freshly-fetched origin/<baseBranch> over a stale local <baseBranch>", async () => {
+      // Branch off "repoDir" for the worktree's own work.
+      git(["checkout", "-q", "-b", "feature"]);
+      const seedSha = git(["rev-parse", "main"]).trim();
+      await writeFile(join(repoDir, "feature.txt"), "feature work\n");
+      git(["add", "-A"]);
+      git(["commit", "-q", "-m", "feature commit"]);
+
+      // The real GitHub main advances (in the fake "origin" repo) — but
+      // `repoDir`'s local `main` branch is never told about it, simulating
+      // the daemon's stale local ref (which is only ever updated once, at
+      // worktree-creation time).
+      await writeFile(join(originFixture.dir, "advance.txt"), "advance\n");
+      originFixture.git(["add", "-A"]);
+      originFixture.git(["commit", "-q", "-m", "origin advances"]);
+      const newOriginTip = originFixture.git(["rev-parse", "HEAD"]).trim();
+
+      // Refresh only the remote-tracking ref, exactly like `fetchOrigin`
+      // does — the local `main` branch itself is untouched (and stays at the
+      // OLD seed commit, i.e. is now stale).
+      git(["fetch", "-q", "origin", "main"]);
+      const staleLocalMain = git(["rev-parse", "main"]).trim();
+      const freshOriginMain = git(["rev-parse", "origin/main"]).trim();
+      expect(staleLocalMain).toBe(seedSha);
+      expect(freshOriginMain).toBe(newOriginTip);
+
+      // The worktree branch syncs with the real (fresh) origin main — a
+      // normal long-running-branch workflow — so its own history now
+      // contains `newOriginTip`, but the stale local `main` branch pointer
+      // never moves past the seed commit.
+      git(["merge", "-q", "-m", "sync with origin/main", "origin/main"]);
+
+      // merge-base(HEAD, local main=seed) is still the seed commit — local
+      // main never advanced, so it can't "see" newOriginTip even though HEAD
+      // now contains it.
+      const staleMergeBase = git(["merge-base", "HEAD", "main"]).trim();
+      expect(staleMergeBase).toBe(seedSha);
+
+      const resolved = await resolveBaseSha(repoDir, "main", null);
+
+      // resolveBaseSha must use origin/main (which correctly reflects that
+      // HEAD has synced past it), not the stale local main.
+      expect(resolved).toBe(newOriginTip);
+      expect(resolved).not.toBe(staleMergeBase);
+    });
+
+    it("prefers the local <baseBranch> over a stale origin/<baseBranch> when local is more advanced", async () => {
+      // The inverse of the "prefers fresh origin" case above: local `main`
+      // moved ahead of the fetched `origin/main` (e.g. someone committed
+      // directly to the local branch in the primary clone, or this daemon
+      // session simply hasn't fetched since local was last pulled). Preferring
+      // origin unconditionally here would make an already-merged-locally
+      // commit misread as "unique to this branch" — the regression this test
+      // guards against.
+      git(["checkout", "-q", "-b", "feature"]);
+      const seedSha = git(["rev-parse", "main"]).trim();
+      await writeFile(join(repoDir, "feature.txt"), "feature work\n");
+      git(["add", "-A"]);
+      git(["commit", "-q", "-m", "feature commit"]);
+
+      // Local main advances (simulating a direct local commit / manual pull)
+      // — origin/main is never told about it, so origin/main stays stale at
+      // the seed commit.
+      git(["checkout", "-q", "main"]);
+      await writeFile(join(repoDir, "advance.txt"), "advance\n");
+      git(["add", "-A"]);
+      git(["commit", "-q", "-m", "local main advances"]);
+      const newLocalMainTip = git(["rev-parse", "main"]).trim();
+
+      const staleOriginMain = git(["rev-parse", "origin/main"]).trim();
+      expect(staleOriginMain).toBe(seedSha);
+
+      // The worktree branch syncs with the advanced local main.
+      git(["checkout", "-q", "feature"]);
+      git(["merge", "-q", "-m", "sync with local main", "main"]);
+
+      const resolved = await resolveBaseSha(repoDir, "main", null);
+
+      // resolveBaseSha must prefer the more-advanced local main, not the
+      // stale origin/main.
+      expect(resolved).toBe(newLocalMainTip);
+      expect(resolved).not.toBe(staleOriginMain);
+    });
+
+    it("falls back to the local <baseBranch> when origin/<baseBranch> doesn't resolve (no remote)", async () => {
+      // A repo with no remote at all — origin/main can never resolve.
+      const noRemoteFixture = await createGitFixture("vst-git-resolve-base-noremote-test");
+      try {
+        await writeFile(join(noRemoteFixture.dir, "a.txt"), "a\n");
+        noRemoteFixture.git(["add", "-A"]);
+        noRemoteFixture.git(["commit", "-q", "-m", "commit 1"]);
+        const localMainTip = noRemoteFixture.git(["rev-parse", "main"]).trim();
+
+        noRemoteFixture.git(["checkout", "-q", "-b", "feature"]);
+        await writeFile(join(noRemoteFixture.dir, "b.txt"), "b\n");
+        noRemoteFixture.git(["add", "-A"]);
+        noRemoteFixture.git(["commit", "-q", "-m", "feature commit"]);
+
+        const resolved = await resolveBaseSha(noRemoteFixture.dir, "main", null);
+        expect(resolved).toBe(localMainTip);
+      } finally {
+        await removeGitFixture(noRemoteFixture);
+      }
+    });
+  });
 });

--- a/daemon/src/__tests__/worktrees.test.ts
+++ b/daemon/src/__tests__/worktrees.test.ts
@@ -958,6 +958,45 @@ describe("Worktree routes", () => {
       expect(top.subject).toBe("add feature.txt");
       expect(top.insertions).toBe(2);
     });
+
+    it("vcs-stale-base-branch Requirement 1a/1.5 — GET /worktrees/:id/commits fetches origin/<baseBranch> before resolving the base sha", async () => {
+      const wt = await createWorktree("vcs", "fetch-before-resolve");
+      const wtWithBase = wt as unknown as { id: string; baseBranch: string };
+
+      const git = await import("../services/git.js");
+      const callOrder: string[] = [];
+      const fetchSpy = vi.spyOn(git, "fetchOrigin").mockImplementation(async () => {
+        callOrder.push("fetchOrigin");
+      });
+      const originalResolve = git.resolveBaseSha;
+      const resolveSpy = vi
+        .spyOn(git, "resolveBaseSha")
+        .mockImplementation(async (...args: Parameters<typeof git.resolveBaseSha>) => {
+          callOrder.push("resolveBaseSha");
+          return originalResolve(...args);
+        });
+
+      const res = await app.inject({ method: "GET", url: `/worktrees/${wt.id}/commits` });
+      expect(res.statusCode).toBe(200);
+
+      expect(fetchSpy).toHaveBeenCalledWith(repoDir, wtWithBase.baseBranch);
+      expect(callOrder).toEqual(["fetchOrigin", "resolveBaseSha"]);
+
+      fetchSpy.mockRestore();
+      resolveSpy.mockRestore();
+    });
+
+    it("vcs-stale-base-branch Requirement 1a — GET /worktrees/:id/commits still succeeds when fetchOrigin throws (best-effort)", async () => {
+      const wt = await createWorktree("vcs", "fetch-throws");
+
+      const git = await import("../services/git.js");
+      const fetchSpy = vi.spyOn(git, "fetchOrigin").mockRejectedValue(new Error("network down"));
+
+      const res = await app.inject({ method: "GET", url: `/worktrees/${wt.id}/commits` });
+      expect(res.statusCode).toBe(200);
+
+      fetchSpy.mockRestore();
+    });
   });
 
   // ─── GET /worktrees/:id/submodules ──────────────────────────────────────

--- a/daemon/src/routes/worktrees.ts
+++ b/daemon/src/routes/worktrees.ts
@@ -1143,6 +1143,22 @@ export function registerWorktreeRoutes(app: FastifyInstance): void {
 
     const wtPath = getWorktreePath(project.id, wtId);
     try {
+      // Best-effort refresh of `origin/<baseBranch>` before recomputing the
+      // fork point — the local `<baseBranch>` ref is only ever updated once,
+      // at worktree-creation time, and otherwise drifts stale for as long as
+      // the daemon runs (see `resolveBaseSha`'s doc comment). Runs exactly
+      // once per `/commits` request, on tab-open/refresh/load-more — never on
+      // a timer. `fetchOrigin` already swallows its own errors/timeouts, so
+      // this can't fail the request even if it throws unexpectedly; the
+      // `.catch` below only logs at debug (not warn/error, to avoid
+      // per-request noise on a merely-flaky network) so a permanently-failing
+      // fetch is at least visible somewhere instead of being silently
+      // indistinguishable from a healthy one.
+      if (worktree.baseBranch) {
+        await fetchOrigin(project.absolutePath, worktree.baseBranch).catch((err) => {
+          req.log.debug({ err }, "fetchOrigin failed before resolveBaseSha, proceeding with local refs");
+        });
+      }
       const baseSha = await resolveBaseSha(wtPath, worktree.baseBranch, worktree.baseSha);
       const commits = await listCommits(wtPath, limit, baseSha ?? undefined);
       return reply.send({ commits });

--- a/daemon/src/services/git.ts
+++ b/daemon/src/services/git.ts
@@ -144,10 +144,38 @@ export async function revParse(repoPath: string, ref: string): Promise<string> {
 }
 
 /**
+ * Returns true if `ancestor` is an ancestor of (or equal to) `descendant`,
+ * via `git merge-base --is-ancestor` (exit code 0 = true, 1 = false). Used by
+ * `resolveBaseSha` to pick the more-advanced of two merge-base candidates.
+ * Throws (propagates) on any other failure — e.g. one of the shas doesn't
+ * resolve in this repo — so callers can distinguish "definitely not an
+ * ancestor" from "couldn't tell".
+ */
+async function isAncestor(repoPath: string, ancestor: string, descendant: string): Promise<boolean> {
+  try {
+    await execFile("git", ["-C", repoPath, "merge-base", "--is-ancestor", ancestor, descendant], {
+      cwd: repoPath,
+      env: { ...process.env },
+    });
+    return true;
+  } catch (err) {
+    // `execFile` rejects with `err.code` set to the child's exit code.
+    // Exit code 1 means "definitively not an ancestor" — a normal, expected
+    // result, not a failure. Any other exit code (or no code at all, e.g. the
+    // process was killed) means the check itself failed, so rethrow.
+    if (err && typeof err === "object" && "code" in err && (err as { code: unknown }).code === 1) {
+      return false;
+    }
+    throw err;
+  }
+}
+
+/**
  * Resolves the *current* fork point between `HEAD` and `baseBranch` in the
- * given worktree (`git merge-base HEAD <baseBranch>`), falling back to
- * `fallbackBaseSha` (the worktree's stored, creation-time `baseSha`) if
- * `baseBranch` doesn't resolve — e.g. it was deleted/renamed upstream.
+ * given worktree, preferring the remote-tracking ref (`origin/<baseBranch>`)
+ * over the local branch name, and falling back to `fallbackBaseSha` (the
+ * worktree's stored, creation-time `baseSha`) if neither resolves — e.g.
+ * `baseBranch` was deleted/renamed upstream.
  *
  * A worktree's stored `baseSha` is captured once, at creation time, and
  * never updated. If the branch is later synced/rebased onto an advancing
@@ -155,8 +183,27 @@ export async function revParse(repoPath: string, ref: string): Promise<string> {
  * true fork point moves forward but the stored value doesn't — every commit
  * the base branch picked up since creation then reads as "unique to this
  * branch" wherever `baseSha` is used for branch-scoped diffs/commit lists.
- * Recomputing the merge-base live avoids that drift. Returns null if neither
- * `baseBranch` nor the fallback resolves (e.g. a corrupted/pruned repo).
+ * Recomputing the merge-base live avoids that drift.
+ *
+ * The local `<baseBranch>` ref itself is also only ever updated once (at
+ * worktree-creation time, by `worktrees.ts`'s call to `fetchOrigin`) — after
+ * that it silently drifts stale for as long as the daemon runs, even though
+ * `origin/<baseBranch>` may be kept fresh by a caller that fetches it (see
+ * `GET /worktrees/:id/commits`). So when both `origin/<baseBranch>` and the
+ * local `baseBranch` resolve, their merge-bases are compared and the more
+ * advanced one (the one that is a *descendant* of the other) wins — NOT
+ * origin unconditionally. Origin is usually the fresher one (that's the
+ * common case this whole mechanism exists for), but not always: someone may
+ * have committed directly to the local branch in the primary clone bypassing
+ * GitHub, or `origin/<baseBranch>`'s tracking ref may simply not have been
+ * fetched yet this daemon session while the local branch was manually pulled
+ * more recently. Blindly preferring origin in that situation would make
+ * already-merged-locally commits misread as "unique to this branch" — the
+ * exact bug this mechanism exists to prevent, just triggered from the other
+ * direction. The local branch name is still the sole fallback for repos with
+ * no remote, or where a fetch has never succeeded. Returns null if none of
+ * `origin/<baseBranch>`, `baseBranch`, nor the fallback resolves (e.g. a
+ * corrupted/pruned repo).
  */
 export async function resolveBaseSha(
   repoPath: string,
@@ -164,11 +211,48 @@ export async function resolveBaseSha(
   fallbackBaseSha?: string | null,
 ): Promise<string | null> {
   if (baseBranch) {
+    let originMergeBase: string | null = null;
+    let localMergeBase: string | null = null;
     try {
-      return await runGit(["-C", repoPath, "merge-base", "HEAD", baseBranch], repoPath);
+      originMergeBase = await runGit(
+        ["-C", repoPath, "merge-base", "HEAD", `origin/${baseBranch}`],
+        repoPath,
+      );
+    } catch {
+      // origin/<baseBranch> doesn't resolve (no remote, never fetched) —
+      // fall through to the local branch name.
+    }
+    try {
+      localMergeBase = await runGit(["-C", repoPath, "merge-base", "HEAD", baseBranch], repoPath);
     } catch {
       // baseBranch ref doesn't resolve (deleted/renamed) — fall through.
     }
+
+    if (originMergeBase && localMergeBase) {
+      if (originMergeBase === localMergeBase) return originMergeBase;
+      // Whichever merge-base is the more-advanced fork point is the one that
+      // is NOT an ancestor of the other (i.e. the other one IS an ancestor of
+      // it). Check both directions explicitly rather than assuming either
+      // side wins by default.
+      try {
+        const localIsAncestorOfOrigin = await isAncestor(repoPath, localMergeBase, originMergeBase);
+        if (localIsAncestorOfOrigin) return originMergeBase;
+      } catch {
+        // fall through to the other direction check
+      }
+      try {
+        const originIsAncestorOfLocal = await isAncestor(repoPath, originMergeBase, localMergeBase);
+        if (originIsAncestorOfLocal) return localMergeBase;
+      } catch {
+        // fall through
+      }
+      // Neither is an ancestor of the other — divergent histories with no
+      // ancestor relationship. Should be rare/impossible for two merge-base
+      // results against the same HEAD, but fall back to origin defensively.
+      return originMergeBase;
+    }
+    if (originMergeBase) return originMergeBase;
+    if (localMergeBase) return localMergeBase;
   }
   if (fallbackBaseSha) {
     try {
@@ -204,12 +288,51 @@ export async function deleteBranch(repoPath: string, branch: string): Promise<vo
   await runGit(["-C", repoPath, "branch", "-D", branch]);
 }
 
-/** Fetch a ref from origin (best-effort — swallows errors if no remote). */
-export async function fetchOrigin(repoPath: string, ref: string): Promise<void> {
+/**
+ * Bounded timeout for `fetchOrigin`'s underlying `execFile` call — a hung or
+ * slow network fetch must not hang whatever request triggered it (e.g.
+ * `GET /worktrees/:id/commits`, which calls this synchronously on every
+ * tab-open/refresh). Scoped to this one call, not a blanket change to
+ * `runGit`/`execFile` elsewhere in this file.
+ */
+const FETCH_ORIGIN_TIMEOUT_MS = 8_000;
+
+/**
+ * Fetch a ref from origin (best-effort — swallows errors if no remote,
+ * network failure, or timeout).
+ *
+ * `GIT_TERMINAL_PROMPT: "0"` and a `BatchMode`/bounded-`ConnectTimeout`
+ * `GIT_SSH_COMMAND` keep this from ever blocking on an interactive
+ * credential/host-key prompt — without them, a remote that needs credentials
+ * can hang for the *entire* `timeoutMs` on every single call (e.g. every
+ * `/commits` request) if the daemon process has a TTY attached, and an
+ * SSH-side hang in particular wouldn't even be bounded by `timeoutMs` until
+ * SSH itself gives up. The 5s SSH connect timeout is comfortably inside the
+ * default 8s outer timeout so the outer bound is still what actually fires in
+ * the common case.
+ *
+ * `timeoutMs` defaults to the production value (`FETCH_ORIGIN_TIMEOUT_MS`);
+ * it exists as a parameter solely so `git.fetchOrigin.test.ts` can prove the
+ * timeout is enforced against a fake, slow `git` without waiting out the
+ * full 8s in every test run. Production call sites should not pass it.
+ */
+export async function fetchOrigin(
+  repoPath: string,
+  ref: string,
+  timeoutMs: number = FETCH_ORIGIN_TIMEOUT_MS,
+): Promise<void> {
   try {
-    await runGit(["-C", repoPath, "fetch", "origin", ref]);
+    await execFile("git", ["-C", repoPath, "fetch", "origin", ref], {
+      cwd: repoPath,
+      env: {
+        ...process.env,
+        GIT_TERMINAL_PROMPT: "0",
+        GIT_SSH_COMMAND: "ssh -o BatchMode=yes -o ConnectTimeout=5",
+      },
+      timeout: timeoutMs,
+    });
   } catch {
-    // no remote or network error — callers treat this as best-effort
+    // no remote, network error, or timeout — callers treat this as best-effort
   }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #64, found while live-diagnosing the `console-home` project's `ch-64` worktree right after that PR shipped the "Diff from main" toggle.

**Root cause:** `resolveBaseSha()` in `daemon/src/services/git.ts` computes "commits unique to this branch" via `git merge-base HEAD <baseBranch>` against the LOCAL `<baseBranch>` git ref. That local ref is only ever fetched once — at worktree-creation time, and only if the branch doesn't exist locally yet — then never refreshed again for as long as the daemon runs. Confirmed live: `ch-64`'s local `main` was 3 days stale, so the VCS tab showed 13 "unique" commits when the real PR diff (against fresh `origin/main`) was only 2.

**Fix**, per explicit direction to fetch on demand only (no background/periodic job):
- `GET /worktrees/:id/commits` (the only route the VCS tab hits for this) does a best-effort `git fetch origin <baseBranch>` immediately before resolving the merge-base — runs once per tab-open/refresh/load-more, never on a timer. Bounded by an 8s timeout so a network hiccup can't hang the tab.
- `resolveBaseSha()` now compares the local and `origin/<baseBranch>` refs by ancestry (`git merge-base --is-ancestor`) and picks whichever is more advanced, instead of blindly preferring origin — avoids regressing a project where local is legitimately ahead of a not-yet-fetched origin ref (caught in opus review).
- `GIT_TERMINAL_PROMPT=0` / `GIT_SSH_COMMAND` with `BatchMode=yes -o ConnectTimeout=5` added so a credential prompt can't silently eat the whole timeout budget on every tab load.
- Swallowed fetch errors now logged at debug level instead of being completely invisible.

Explicitly out of scope (same "very small" philosophy as #64): no periodic/cron fetch, `/pr` `/diff/*` `/changed-paths` routes left untouched, in-flight fetch dedupe for concurrent requests not added.

## Test plan

- [x] `pnpm typecheck` (repo-wide) — clean
- [x] `pnpm --filter cli test` — 769/769 assertions pass (1 pre-existing, unrelated `UnhandledRejection` flake flips exit code, documented in prior PR too)
- [x] New/extended tests: `git.resolveBaseSha.test.ts` (real tmp "clone" + real tmp "origin" fixture, proves origin-preference AND the local-ahead-of-origin regression case), `git.fetchOrigin.test.ts` (new — proves the bounded timeout actually works, via a fast `timeoutMs` override), `worktrees.test.ts` (route triggers fetch before resolveBaseSha, route still 200s if fetch throws)
- [x] Opus code review — 1 CONFIRMED medium finding (unconditional origin-preference regression) + 2 more CONFIRMED/PLAUSIBLE fixed in a follow-up pass
- [x] Live docker-sandbox verification (`scripts/dev-sandbox.sh up vs-52`, port 5174) against a purpose-built fixture reproducing the real `ch-64` mechanism (a feature branch synced with a newer main than the primary clone's frozen local `main`) — confirmed the fix reports the true commit count (3, not the buggy 8) and that `origin/main`'s tracking ref only moves as a direct result of the API call, proving the fetch is request-triggered, not periodic