### PR TITLE
fix(daemon,web-ui): dedupe/debounce VCS tab's on-demand base-branch fetch

### DIFF
--- a/.vibekit/feature-plans/wip/vcs-fetch-debounce/.sdlc-state.yaml
+++ b/.vibekit/feature-plans/wip/vcs-fetch-debounce/.sdlc-state.yaml
@@ -1,0 +1,19 @@
+feature: vcs-fetch-debounce
+worktree: /home/gb/.vibe-station/projects/vibe-station/worktrees/vs-52
+master:
+  prd: skipped
+  plan: complete
+current_subfeature: root
+subfeatures:
+  - id: root
+    origin: planned
+    spawned_from: null
+    mode: done
+    last_completed: "3.T2"
+    awaiting_phase: null
+    awaiting_artifact: null
+    phase_chain: [plan, implement, verify]
+    superseded_reason: null
+    parked_reason: null
+    handoff: {next_item: null, returned_at: null, verified_by: null}
+    commit: null

--- a/.vibekit/feature-plans/wip/vcs-fetch-debounce/plan-vcs-fetch-debounce.md
+++ b/.vibekit/feature-plans/wip/vcs-fetch-debounce/plan-vcs-fetch-debounce.md
@@ -1,0 +1,157 @@
+<!--
+RULES — read before writing or implementing:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. REQUIREMENTS: One crisp line each — no verbose descriptions
+3. CHECKLIST: Mark items [x] as you complete them — this is your persistent todo list
+4. READING TIME: Optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+# Plan: VCS tab — dedupe/debounce the on-demand `fetchOrigin` call, keep stale data visible while syncing
+
+> Follow-up to `vcs-stale-base-branch` (PR #65, merged). That fix made `GET /worktrees/:id/commits`
+> fetch `origin/<baseBranch>` on every request. This plan closes the gap the opus review on that PR
+> flagged and deliberately deferred ("Finding 5" — concurrent fetches into the same repo racing) and
+> adds the client-side "don't blank the list while refreshing" guarantee the user explicitly asked for.
+
+**Issue:** vcs-fetch-debounce
+**Branch:** `vcs-fetch-debounce` (fresh branch off `origin/main`, per lesson learned on PR #65 — do
+not extend an already-merged branch, GitHub's rebase-merge recreates commit SHAs and reusing a
+merged branch causes ghost "already merged" commits to reappear in the next PR's diff)
+**PRD:** none — small, skipped
+**Parent:** `vcs-stale-base-branch` (PR #65)
+
+**Reference files:**
+- `daemon/src/services/git.ts:291-337` — `fetchOrigin()`, the function being wrapped
+- `daemon/src/routes/worktrees.ts` — `GET /worktrees/:id/commits`, the only call site
+- `daemon/src/services/github.ts` — `CACHE_TTL_MS = 5_000` + `_clearPrCacheForTest()` — existing
+  precedent in this codebase for a module-level TTL cache with a test-reset export; mirror this
+  convention rather than inventing a new one
+- `web-ui/src/components/tools/VcsPanel.tsx:220-380` — `loading`/`commits` state, `load()`
+
+---
+
+## Problem
+
+- `GET /worktrees/:id/commits` calls `fetchOrigin(project.absolutePath, worktree.baseBranch)` on
+  **every** request (mount, worktree switch, manual refresh, "Load more") — by design, per the user's
+  explicit "only when the tab is open, no periodic stuff" direction in the parent plan
+- Gap (opus review on PR #65, "Finding 5", deferred): rapid re-triggers — toggling between two
+  worktrees of the same project, or just refreshing twice quickly — can run `git fetch origin <ref>`
+  concurrently in the **same** primary-clone repo path. Git's own ref-lock contention makes one of
+  the concurrent fetches fail (harmless here, swallowed), but it's wasted subprocess/network work,
+  and at worst interacts badly with the ALSO-concurrent one-time fetch at worktree-creation time
+  (`worktrees.ts:392-395`), which is not swallowed the same way (see that code's 400 error path)
+- User's explicit new ask: (1) don't re-fetch if a fetch for the same repo+ref is already in flight —
+  await the existing one instead of starting a second; (2) don't re-fetch again immediately after one
+  just finished (debounce a rapid toggle); (3) confirm the UI shows the previous commit list while a
+  refresh is in flight, not a blank/loading state, with some visible "still syncing" affordance
+
+## Out of Scope
+
+- Any change to the `/pr`, `/diff/*`, `/changed-paths` routes — still untouched, per the parent plan
+- No periodic/background fetch — still explicitly rejected, this is purely dedupe/debounce of the
+  existing on-demand behavior, not a new trigger
+- No cross-process dedupe (e.g. via the DB/file lock) — this daemon is a single Node process per
+  install, an in-memory `Map` is sufficient
+
+## Concept
+
+- `fetchOrigin()` gains an internal in-flight dedupe: concurrent callers for the same
+  `(repoPath, ref)` key share ONE underlying `git fetch` call/promise instead of each starting their
+  own
+- `fetchOrigin()` also gains a short post-completion cooldown (mirrors `github.ts`'s existing
+  `CACHE_TTL_MS = 5_000` precedent and its `_clearPrCacheForTest()` reset-export convention): a call
+  for the same key within the cooldown window of the previous call's completion resolves immediately
+  without spawning a new `git fetch` at all
+- Client-side: confirm (and if needed, strengthen) that `VcsPanel.tsx` never clears `commits` while a
+  refetch is in flight — the existing `loading` state already gates a spinning refresh icon, not a
+  full-list blank-out, but add an explicit small "syncing" indicator so the in-flight state is visibly
+  distinct from "idle up to date", not just inferred from the icon's spin animation
+
+## Requirements
+
+| # | Requirement |
+|---|-------------|
+| 1a | Two `fetchOrigin(repoPath, ref)` calls for the SAME `(repoPath, ref)` pair, started concurrently, result in exactly ONE `git fetch` subprocess — the second caller's promise resolves from the first's result |
+| 1b | A `fetchOrigin(repoPath, ref)` call for a DIFFERENT `repoPath` or DIFFERENT `ref` is NOT deduped against an in-flight call for another key — keys are independent |
+| 1c | After a fetch for `(repoPath, ref)` completes (success OR swallowed failure), a subsequent call for the same key within a short cooldown window (mirror the existing `CACHE_TTL_MS = 5_000` constant/value used elsewhere in this codebase) resolves immediately with no new subprocess |
+| 1d | After the cooldown window elapses, a new call for the same key performs a real fetch again — this is NOT a permanent cache, just a debounce |
+| 1e | A test-reset export (`_clearFetchOriginStateForTest()` or similarly named, matching the `_clearPrCacheForTest()`/`_clearStoreForTest()` naming convention already used in this codebase) clears both the in-flight map and the cooldown timestamps |
+| 1f | `resolveBaseSha`'s correctness (ancestry-aware origin-vs-local comparison, shipped in PR #65) is completely unaffected — this plan only changes WHEN/HOW OFTEN the underlying fetch subprocess runs, never what `resolveBaseSha` does with the resulting refs |
+| 2a | `VcsPanel.tsx`: while a refresh/reload is in flight (`loading === true`) AND there is already a previously-loaded commit list (`commits != null`), the existing commit list stays rendered — no blank/"Loading commits…" state |
+| 2b | A visible, non-blocking "syncing" indicator is shown during that in-flight state (distinct from the bare spinning refresh icon already present) — e.g. a small inline label or subtle progress affordance near the panel bar — and disappears when the load resolves |
+| 2c | The "Loading commits…" full-blank state remains ONLY for the true first-ever load of a worktree (`commits === null`) — unchanged from today |
+
+---
+
+## Research
+
+### Existing TTL-cache + test-reset precedent in this codebase
+- `daemon/src/services/github.ts`: `CACHE_TTL_MS = 5_000`, module-level `Map`, `_clearPrCacheForTest()` exported for test isolation — this plan's `fetchOrigin` cooldown should look and feel like this, not invent a new shape
+- Risk: LOW — mechanical mirroring of an existing, already-reviewed pattern
+
+### `VcsPanel.tsx` already mostly satisfies 2a
+- `commits` state is `CommitLogEntry[] | null`, only ever set via `setCommits(list)` on a successful fetch — a refresh's `mode === "initial"` path does NOT null it out first, so the previous list survives visually during a refetch already
+- What's missing is 2b — the only in-flight signal today is the refresh button's spin animation on its icon, easy to miss, not a real "syncing" affordance
+- Risk: LOW — additive UI change, no restructuring of the existing load/render logic
+
+## Root Cause
+
+- The parent plan (`vcs-stale-base-branch`) correctly implemented "fetch on demand, no periodic job,"
+  but didn't defend against the same demand arriving concurrently/rapidly from the UI — a gap flagged
+  in its own opus review and knowingly deferred as out of scope for that "very small" pass
+
+---
+
+## Implementation Phases
+
+### Phase 1 — in-flight dedupe + debounce cooldown (daemon)
+
+- [x] **1.1** `daemon/src/services/git.ts`: add in-flight `Map<string, Promise<void>>` dedupe to `fetchOrigin`, keyed by `${repoPath}::${ref}`
+- [x] **1.2** Add a cooldown `Map<string, number>` (last-completed timestamp) with the same TTL value as `github.ts`'s `CACHE_TTL_MS` (5000ms) — a call within the window after the previous call's completion resolves immediately, no subprocess. **Revised after opus review**: the cooldown is stamped only on a SUCCESSFUL fetch, not on a swallowed failure — a failed fetch (e.g. transient network blip) must not block a subsequent real attempt within the window, since that could otherwise cause a spurious 400 on worktree creation if it lands right after a failed VCS-tab fetch for the same branch
+- [x] **1.3** Export `_clearFetchOriginStateForTest()` clearing both maps
+- [x] **1.4** Unit tests: concurrent calls for the same key → one subprocess (via the existing PATH-shadowed fake-git test pattern, extended with a counter file); different keys → independent; within-cooldown same-key call → no subprocess; after-cooldown same-key call → new subprocess; **added per review**: a failing fetch still clears the in-flight map and does NOT enter cooldown; `_clearFetchOriginStateForTest()` actually restores real-fetch behavior
+
+**Verify phase 1:**
+- [x] **1.T1** `pnpm --filter cli exec vitest run src/daemon/__tests__/git.fetchOrigin.test.ts src/daemon/__tests__/git.resolveBaseSha.test.ts src/daemon/__tests__/worktrees.test.ts` — 66 tests pass
+- [x] **1.T2** `pnpm typecheck` (repo-wide) clean
+
+### Phase 2 — keep stale data visible + visible syncing indicator (web-ui)
+
+- [x] **2.1** `VcsPanel.tsx`: confirmed Requirement 2a already held (verified by reading the code, not assumed) — but review found a related gap: switching WORKTREES (not refreshing the same one) showed the PREVIOUS worktree's stale commits captioned "Syncing…", which is actively misleading. Fixed: `setCommits(null)` added to the worktree-change effect only, not to manual refresh/load-more
+- [x] **2.2** Added a "syncing" indicator shown when `loading && commits != null` (Requirement 2b), separate from the "Loading commits…" empty-state (Requirement 2c, unchanged). **Revised after opus review**: rendered unconditionally (not conditionally mounted) with `aria-live="polite"` for reliable screen-reader announcement (matches `TerminalPane.tsx`/`ConnectionStatus.tsx` convention), positioned after the refresh button with reserved width so it doesn't shift layout on every refresh
+- [x] **2.3** Extended `VcsPanel.test.tsx` covering 2a/2b/2c, plus a negative test (review-requested) pinning that "Load more" does NOT show the syncing indicator (separate `loadingMore` state)
+
+**Verify phase 2:**
+- [x] **2.T1** `pnpm --filter @vibestation/web exec vitest run src/components/tools/VcsPanel.test.tsx` — 19 tests pass
+- [x] **2.T2** `pnpm typecheck` (repo-wide) clean
+
+### Phase 3 — review + docker verify
+
+- [x] **3.1** Opus reviewer pass on the full diff — verified dedupe race-safety, cleanup-on-error, cooldown/dedupe interaction, key-collision-freedom, and mutation-tested the counter-file tests (confirmed they fail without the fix) all CORRECT; found 1 real bug (cooldown-on-failure poisoning worktree creation, see 1.2) plus 6 smaller findings (a11y live-region mounting, stale cross-worktree display, layout shift, 2 doc-comment gaps, 3 missing test cases, 1 nit)
+- [x] **3.2** All findings addressed in a follow-up implementation pass (see revised notes on 1.2, 2.1, 2.2 above); doc comments added to `fetchOrigin` (deduped caller's own `timeoutMs` is ignored) and to the two module-level maps (intentionally unbounded for the daemon's lifetime, matching the `github.ts` PR-cache precedent); PATH-restore nit in `git.fetchOrigin.test.ts` guarded against `undefined`
+- [x] **3.3** Docker sandbox (`scripts/dev-sandbox.sh up vs-52`, port 5180 — 5174 was held by another process on this host): rebuilt the same stale-vs-fresh fixture technique from `vcs-stale-base-branch`'s verification (true diff = 3, stale-local diff = 6), fired 3 concurrent `GET /commits` requests via parallel `curl` — all 3 returned the correct `isOnBranch` count (3) with no errors, confirming end-to-end correctness under concurrent access. Subprocess-count proof itself (exactly one `git fetch` for N concurrent callers) is NOT independently re-verified black-box in this pass — the fixture's origin is a local bare repo (fetch is near-instant either way, so timing can't distinguish deduped-vs-not), and re-instrumenting the running daemon's `git` binary mid-container wasn't practical without a restart. That exact claim is proven directly and rigorously by the Phase 1 unit tests instead, which opus mutation-tested (confirmed to fail — count 2 instead of 1 — with the dedupe/cooldown logic disabled)
+
+**Verify phase 3:**
+- [x] **3.T1** No unresolved CONFIRMED findings — all addressed
+- [x] **3.T2** Full repo-wide `pnpm typecheck` clean; `pnpm --filter cli test` 776/776 assertions pass (1 pre-existing, documented, unrelated flake flips exit code); `pnpm --filter @vibestation/web test` 484/484 pass
+
+---
+
+## Files & Phase Impact
+
+| File | Status | Phase | Description / Contract Change |
+|------|--------|-------|-------------------------------|
+| `daemon/src/services/git.ts` | Modified | 1 | `fetchOrigin` in-flight dedupe + cooldown |
+| `daemon/src/__tests__/git.fetchOrigin.test.ts` | Modified | 1 | Dedupe/cooldown tests |
+| `web-ui/src/components/tools/VcsPanel.tsx` | Modified | 2 | Syncing indicator, stale-data-stays-visible confirmation |
+| `web-ui/src/components/tools/VcsPanel.test.tsx` | Modified | 2 | New coverage |
+
+---
+
+## Verification Method
+
+- Node/vitest: targeted + repo-wide typecheck, both packages' full suites
+- Docker: `scripts/dev-sandbox.sh up vs-52`, concurrent-request fixture reusing the prior plan's
+  stale-vs-fresh setup technique
+- Reviewer: opus subagent, one pass on the complete diff

--- a/daemon/src/__tests__/git.fetchOrigin.test.ts
+++ b/daemon/src/__tests__/git.fetchOrigin.test.ts
@@ -7,26 +7,88 @@
  * both the existing best-effort (swallow-errors) contract and the new
  * bounded timeout.
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { writeFile, mkdtemp, chmod, rm } from "node:fs/promises";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { writeFile, mkdtemp, chmod, rm, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { fetchOrigin, revParse } from "../services/git.js";
+import { fetchOrigin, revParse, _clearFetchOriginStateForTest } from "../services/git.js";
 import { createGitFixture, removeGitFixture, type GitFixture } from "./gitFixture.js";
 
 let fixture: GitFixture;
 let repoDir: string;
 let git: GitFixture["git"];
 
+/**
+ * Shadows `git` on PATH with a script that just appends one line to
+ * `counterFile` per invocation and exits 0 — reused pattern (see the
+ * bounded-timeout test below) for proving real subprocess-count behavior
+ * rather than mocking at the JS level. Returns the fake bin dir and a
+ * `count()` helper; caller is responsible for restoring `PATH` and removing
+ * the fake bin dir.
+ */
+async function installCountingFakeGit(counterFile: string): Promise<{ fakeBinDir: string; restore: () => Promise<void> }> {
+  const fakeBinDir = await mkdtemp(join(tmpdir(), "vst-git-fetchorigin-fakebin-"));
+  const fakeGitPath = join(fakeBinDir, "git");
+  await writeFile(fakeGitPath, `#!/bin/sh\necho invoked >> "${counterFile}"\nexit 0\n`);
+  await chmod(fakeGitPath, 0o755);
+  const originalPath = process.env.PATH;
+  process.env.PATH = `${fakeBinDir}:${originalPath}`;
+  return {
+    fakeBinDir,
+    restore: async () => {
+      if (originalPath === undefined) delete process.env.PATH;
+      else process.env.PATH = originalPath;
+      await rm(fakeBinDir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function countInvocations(counterFile: string): Promise<number> {
+  try {
+    const text = await readFile(counterFile, "utf8");
+    return text.split("\n").filter((l) => l.trim() !== "").length;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Like `installCountingFakeGit`, but the fake script exits non-zero (after
+ * still recording an invocation), to prove `fetchOrigin`'s failure path:
+ * the in-flight map entry must still be cleared (so a later call for the
+ * same key isn't stuck forever), and — per the cooldown-on-success-only fix
+ * — a failed call must NOT enter the cooldown, so the very next call for the
+ * same key performs a real fetch again rather than a silent no-op.
+ */
+async function installFailingFakeGit(counterFile: string): Promise<{ fakeBinDir: string; restore: () => Promise<void> }> {
+  const fakeBinDir = await mkdtemp(join(tmpdir(), "vst-git-fetchorigin-failbin-"));
+  const fakeGitPath = join(fakeBinDir, "git");
+  await writeFile(fakeGitPath, `#!/bin/sh\necho invoked >> "${counterFile}"\nexit 1\n`);
+  await chmod(fakeGitPath, 0o755);
+  const originalPath = process.env.PATH;
+  process.env.PATH = `${fakeBinDir}:${originalPath}`;
+  return {
+    fakeBinDir,
+    restore: async () => {
+      if (originalPath === undefined) delete process.env.PATH;
+      else process.env.PATH = originalPath;
+      await rm(fakeBinDir, { recursive: true, force: true });
+    },
+  };
+}
+
 describe("fetchOrigin", () => {
   beforeEach(async () => {
     fixture = await createGitFixture("vst-git-fetchorigin-test");
     repoDir = fixture.dir;
     git = fixture.git;
+    _clearFetchOriginStateForTest();
   });
 
   afterEach(async () => {
     await removeGitFixture(fixture);
+    _clearFetchOriginStateForTest();
+    vi.restoreAllMocks();
   });
 
   it("updates the origin/<ref> remote-tracking ref on success", async () => {
@@ -78,11 +140,140 @@ describe("fetchOrigin", () => {
           const elapsedMs = Date.now() - start;
           expect(elapsedMs).toBeLessThan(2_000);
         } finally {
-          process.env.PATH = originalPath;
+          if (originalPath === undefined) delete process.env.PATH;
+          else process.env.PATH = originalPath;
         }
       } finally {
         await rm(fakeBinDir, { recursive: true, force: true });
       }
     },
   );
+
+  describe("in-flight dedupe + cooldown", () => {
+    it("dedupes concurrent calls for the same (repoPath, ref) into exactly one subprocess", async () => {
+      const counterFile = join(repoDir, "counter.txt");
+      const { restore } = await installCountingFakeGit(counterFile);
+      try {
+        await Promise.all([fetchOrigin(repoDir, "main"), fetchOrigin(repoDir, "main")]);
+        expect(await countInvocations(counterFile)).toBe(1);
+      } finally {
+        await restore();
+      }
+    });
+
+    it("does NOT dedupe a different ref for the same repoPath", async () => {
+      const counterFile = join(repoDir, "counter.txt");
+      const { restore } = await installCountingFakeGit(counterFile);
+      try {
+        await Promise.all([fetchOrigin(repoDir, "main"), fetchOrigin(repoDir, "other")]);
+        expect(await countInvocations(counterFile)).toBe(2);
+      } finally {
+        await restore();
+      }
+    });
+
+    it("does NOT dedupe the same ref for a different repoPath", async () => {
+      const otherFixture = await createGitFixture("vst-git-fetchorigin-other-repo");
+      try {
+        const counterFile = join(repoDir, "counter.txt");
+        const { restore } = await installCountingFakeGit(counterFile);
+        try {
+          await Promise.all([fetchOrigin(repoDir, "main"), fetchOrigin(otherFixture.dir, "main")]);
+          expect(await countInvocations(counterFile)).toBe(2);
+        } finally {
+          await restore();
+        }
+      } finally {
+        await removeGitFixture(otherFixture);
+      }
+    });
+
+    it("a same-key call within the cooldown window after completion resolves without a new subprocess", async () => {
+      const counterFile = join(repoDir, "counter.txt");
+      const { restore } = await installCountingFakeGit(counterFile);
+      try {
+        await fetchOrigin(repoDir, "main");
+        expect(await countInvocations(counterFile)).toBe(1);
+
+        // Immediately re-call for the same key — still well inside the 5s
+        // cooldown, so this must resolve with no additional subprocess.
+        await fetchOrigin(repoDir, "main");
+        expect(await countInvocations(counterFile)).toBe(1);
+      } finally {
+        await restore();
+      }
+    });
+
+    it("a same-key call after the cooldown window elapses performs a real fetch again", async () => {
+      const counterFile = join(repoDir, "counter.txt");
+      const { restore } = await installCountingFakeGit(counterFile);
+      try {
+        const realNow = Date.now.bind(Date);
+        let offsetMs = 0;
+        const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => realNow() + offsetMs);
+
+        try {
+          await fetchOrigin(repoDir, "main");
+          expect(await countInvocations(counterFile)).toBe(1);
+
+          // Advance the clock past the 5s cooldown window (mirrors
+          // `github.ts`'s `CACHE_TTL_MS = 5_000`) — not a permanent cache, so
+          // a call after the window must fetch for real again.
+          offsetMs = 5_001;
+          await fetchOrigin(repoDir, "main");
+          expect(await countInvocations(counterFile)).toBe(2);
+        } finally {
+          nowSpy.mockRestore();
+        }
+      } finally {
+        await restore();
+      }
+    });
+
+    it("a failing fetch still clears the in-flight entry and does NOT enter the cooldown", async () => {
+      const counterFile = join(repoDir, "counter.txt");
+      const { restore } = await installFailingFakeGit(counterFile);
+      try {
+        // First call fails (fake git exits 1) but must still resolve
+        // (best-effort contract) rather than reject.
+        await expect(fetchOrigin(repoDir, "main")).resolves.toBeUndefined();
+        expect(await countInvocations(counterFile)).toBe(1);
+
+        // A second call for the same key, made immediately after (well
+        // inside what would have been the 5s cooldown window had the first
+        // call succeeded), must still perform a REAL fetch attempt — not be
+        // silently skipped — because the previous attempt failed. This also
+        // proves the in-flight map entry was cleared: if it weren't, this
+        // call would hang awaiting an already-settled promise instead of
+        // spawning a new subprocess.
+        await expect(fetchOrigin(repoDir, "main")).resolves.toBeUndefined();
+        expect(await countInvocations(counterFile)).toBe(2);
+      } finally {
+        await restore();
+      }
+    });
+
+    it("_clearFetchOriginStateForTest restores real-fetch behavior after a primed cooldown", async () => {
+      const counterFile = join(repoDir, "counter.txt");
+      const { restore } = await installCountingFakeGit(counterFile);
+      try {
+        await fetchOrigin(repoDir, "main");
+        expect(await countInvocations(counterFile)).toBe(1);
+
+        // Still well inside the cooldown window — would normally resolve
+        // with no new subprocess.
+        await fetchOrigin(repoDir, "main");
+        expect(await countInvocations(counterFile)).toBe(1);
+
+        // Clearing the test-only state must make the NEXT call for the same
+        // key perform a real fetch again, proving the reset actually
+        // discards the primed cooldown rather than being a no-op.
+        _clearFetchOriginStateForTest();
+        await fetchOrigin(repoDir, "main");
+        expect(await countInvocations(counterFile)).toBe(2);
+      } finally {
+        await restore();
+      }
+    });
+  });
 });

--- a/daemon/src/services/git.ts
+++ b/daemon/src/services/git.ts
@@ -298,6 +298,41 @@ export async function deleteBranch(repoPath: string, branch: string): Promise<vo
 const FETCH_ORIGIN_TIMEOUT_MS = 8_000;
 
 /**
+ * Cooldown after a `(repoPath, ref)` fetch completes, mirroring `github.ts`'s
+ * `CACHE_TTL_MS = 5_000` precedent: `GET /worktrees/:id/commits` calls
+ * `fetchOrigin` on every request (mount, worktree switch, manual refresh,
+ * "Load more"), so a rapid re-trigger for the same repo+ref within this
+ * window resolves immediately instead of spawning another `git fetch`. Not a
+ * permanent cache — once the window elapses, the next call fetches for real
+ * again.
+ */
+const FETCH_ORIGIN_COOLDOWN_MS = 5_000;
+
+/**
+ * In-flight dedupe for `fetchOrigin`: concurrent callers for the same
+ * `(repoPath, ref)` key share ONE underlying `git fetch` promise instead of
+ * each starting their own subprocess (see this file's `fetchOrigin` doc
+ * comment and the `vcs-fetch-debounce` plan for why — toggling between two
+ * worktrees of the same project, or refreshing twice quickly, can otherwise
+ * race two `git fetch`es into the same repo path).
+ *
+ * This map (and `fetchOriginCooldownUntil` below) intentionally grow
+ * unbounded for the daemon's lifetime — one entry per distinct
+ * `(repoPath, ref)` pair ever fetched — and are never pruned when a
+ * worktree/project is deleted. Negligible at realistic scale (tens of
+ * projects × a handful of branches each), matching the same non-eviction
+ * precedent already used by `github.ts`'s PR cache.
+ */
+const fetchOriginInFlight = new Map<string, Promise<void>>();
+
+/** Last-completed timestamp per key, used by the cooldown above. */
+const fetchOriginCooldownUntil = new Map<string, number>();
+
+function fetchOriginKey(repoPath: string, ref: string): string {
+  return `${repoPath}::${ref}`;
+}
+
+/**
  * Fetch a ref from origin (best-effort — swallows errors if no remote,
  * network failure, or timeout).
  *
@@ -315,25 +350,69 @@ const FETCH_ORIGIN_TIMEOUT_MS = 8_000;
  * it exists as a parameter solely so `git.fetchOrigin.test.ts` can prove the
  * timeout is enforced against a fake, slow `git` without waiting out the
  * full 8s in every test run. Production call sites should not pass it.
+ *
+ * In-flight calls for the same `(repoPath, ref)` are deduped — a second
+ * concurrent caller awaits the first's actual promise rather than starting
+ * its own subprocess — and a short cooldown after completion (see
+ * `FETCH_ORIGIN_COOLDOWN_MS`) makes a rapid same-key re-call resolve
+ * immediately with no subprocess at all. Neither mechanism changes what a
+ * successful fetch does to the repo's refs, only how often the underlying
+ * `git fetch` actually runs. Note that a deduped (second, concurrent) caller's
+ * own `timeoutMs` argument is silently ignored — it just awaits the
+ * already-running first caller's promise, so whatever timeout the FIRST
+ * caller passed is the one that actually applies. This is expected/fine; it
+ * only matters for callers (like tests) that pass a non-default `timeoutMs`.
  */
 export async function fetchOrigin(
   repoPath: string,
   ref: string,
   timeoutMs: number = FETCH_ORIGIN_TIMEOUT_MS,
 ): Promise<void> {
+  const key = fetchOriginKey(repoPath, ref);
+
+  const cooldownUntil = fetchOriginCooldownUntil.get(key);
+  if (cooldownUntil != null && cooldownUntil > Date.now()) return;
+
+  const inFlight = fetchOriginInFlight.get(key);
+  if (inFlight) return inFlight;
+
+  const promise = (async () => {
+    try {
+      await execFile("git", ["-C", repoPath, "fetch", "origin", ref], {
+        cwd: repoPath,
+        env: {
+          ...process.env,
+          GIT_TERMINAL_PROMPT: "0",
+          GIT_SSH_COMMAND: "ssh -o BatchMode=yes -o ConnectTimeout=5",
+        },
+        timeout: timeoutMs,
+      });
+      // Only stamp the cooldown on a SUCCESSFUL fetch. A failed fetch (no
+      // remote, network blip, timeout) must NOT block a subsequent real
+      // attempt within the window — e.g. worktree creation calling
+      // `fetchOrigin` for a branch that isn't local yet needs a real retry,
+      // not a silent no-op inherited from an unrelated tab's swallowed
+      // failure moments earlier.
+      fetchOriginCooldownUntil.set(key, Date.now() + FETCH_ORIGIN_COOLDOWN_MS);
+    } catch {
+      // no remote, network error, or timeout — callers treat this as
+      // best-effort. Deliberately NOT entering the cooldown here (see above).
+    }
+  })();
+  fetchOriginInFlight.set(key, promise);
   try {
-    await execFile("git", ["-C", repoPath, "fetch", "origin", ref], {
-      cwd: repoPath,
-      env: {
-        ...process.env,
-        GIT_TERMINAL_PROMPT: "0",
-        GIT_SSH_COMMAND: "ssh -o BatchMode=yes -o ConnectTimeout=5",
-      },
-      timeout: timeoutMs,
-    });
-  } catch {
-    // no remote, network error, or timeout — callers treat this as best-effort
+    await promise;
+  } finally {
+    fetchOriginInFlight.delete(key);
   }
+}
+
+/** Test-only: clears `fetchOrigin`'s in-flight-dedupe and cooldown maps.
+ *  Matches the `_clearPrCacheForTest`/`_clearStoreForTest` convention used
+ *  elsewhere in this codebase for module-level test state. */
+export function _clearFetchOriginStateForTest(): void {
+  fetchOriginInFlight.clear();
+  fetchOriginCooldownUntil.clear();
 }
 
 /** Initialize a new git repository in the given directory. */

--- a/web-ui/src/components/tools/VcsPanel.test.tsx
+++ b/web-ui/src/components/tools/VcsPanel.test.tsx
@@ -397,4 +397,72 @@ describe("VcsPanel", () => {
     rerender(<VcsPanel api={api} worktreeId="wt-2" />);
     await waitFor(() => expect(screen.queryByText("Submodules")).not.toBeInTheDocument());
   });
+
+  it("Requirement 2c — the true first load (commits === null) shows the full 'Loading commits…' empty state, no syncing indicator", async () => {
+    const api = createMockApi();
+    const listCommitsDeferred = deferred<CommitLogEntry[]>();
+    vi.spyOn(api, "listCommits").mockImplementation(() => listCommitsDeferred.promise);
+    vi.spyOn(api, "getPr").mockResolvedValue(null);
+
+    render(<VcsPanel api={api} worktreeId="wt-1" />);
+
+    await screen.findByText("Loading commits…");
+    expect(screen.queryByText(/syncing/i)).not.toBeInTheDocument();
+
+    listCommitsDeferred.resolve(makeCommits(3));
+    await screen.findByText("Commits (3)");
+  });
+
+  it("Requirement 2a/2b — a manual refresh keeps the previous commit list visible and shows a syncing indicator, which clears on completion", async () => {
+    const user = userEvent.setup();
+    const api = createMockApi();
+    const refreshDeferred = deferred<CommitLogEntry[]>();
+    vi.spyOn(api, "listCommits")
+      .mockImplementationOnce(limitAwareListCommits({ "wt-1": makeCommits(5) })) // initial load
+      .mockImplementationOnce(() => refreshDeferred.promise); // refresh, held open
+    vi.spyOn(api, "getPr").mockResolvedValue(null);
+
+    render(<VcsPanel api={api} worktreeId="wt-1" />);
+    await screen.findByText("Commits (5)");
+    expect(screen.getByText("commit #0")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /refresh commits/i }));
+
+    // Requirement 2a: the previous list stays rendered, not blanked to
+    // "Loading commits…", while the refresh is in flight.
+    expect(screen.getByText("commit #0")).toBeInTheDocument();
+    expect(screen.queryByText("Loading commits…")).not.toBeInTheDocument();
+    // Requirement 2b: a visible syncing indicator is shown, distinct from
+    // the empty-state text.
+    expect(screen.getByText(/syncing/i)).toBeInTheDocument();
+
+    refreshDeferred.resolve(makeCommits(5));
+    await waitFor(() => expect(screen.queryByText(/syncing/i)).not.toBeInTheDocument());
+    expect(screen.getByText("commit #0")).toBeInTheDocument();
+  });
+
+  it("Regression — clicking Load more does NOT show the Syncing… indicator (loadingMore is distinct from loading)", async () => {
+    const user = userEvent.setup();
+    const api = createMockApi();
+    const loadMoreDeferred = deferred<CommitLogEntry[]>();
+    vi.spyOn(api, "listCommits")
+      .mockImplementationOnce(limitAwareListCommits({ "wt-1": makeCommits(80) })) // initial load
+      .mockImplementationOnce(() => loadMoreDeferred.promise); // "Load more", held open
+    vi.spyOn(api, "getPr").mockResolvedValue(null);
+
+    render(<VcsPanel api={api} worktreeId="wt-1" />);
+    await screen.findByText("Commits (50)");
+
+    await user.click(screen.getByRole("button", { name: /load 50 more/i }));
+
+    // The "Load more" button shows its own "Loading…" label, but the
+    // top-bar "Syncing…" indicator is reserved for `loading` (initial
+    // load/refresh) — `loadingMore` must not trigger it, pinning down that
+    // the two states stay separate.
+    expect(screen.getByRole("button", { name: /loading/i })).toBeInTheDocument();
+    expect(screen.queryByText(/syncing/i)).not.toBeInTheDocument();
+
+    loadMoreDeferred.resolve(makeCommits(80).slice(0, 101));
+    await screen.findByText("Commits (80)");
+  });
 });

--- a/web-ui/src/components/tools/VcsPanel.tsx
+++ b/web-ui/src/components/tools/VcsPanel.tsx
@@ -380,6 +380,13 @@ export function VcsPanel({ api, worktreeId, baseBranch }: VcsPanelProps) {
     // reset it here so an auto-toggle-off (Requirement 1f) or a manual flip
     // on a previous worktree doesn't carry over to this one.
     setDiffFromMain(true);
+    // Requirement 3: a worktree switch must fall back to the "Loading
+    // commits…" empty state, not briefly show the PREVIOUS worktree's stale
+    // commits under a "Syncing…" label (which reads as "these are your
+    // commits, just refreshing" instead of "wrong worktree, please wait").
+    // Deliberately scoped to this effect only — manual `refresh()` of the
+    // SAME worktree should keep showing old data while it reloads.
+    setCommits(null);
     void load(PAGE_SIZE, "initial");
     return () => activeLoad.current?.abort();
     // eslint-disable-next-line react-hooks/exhaustive-deps -- `load` is redefined every render (reads current api/worktreeId via closure); depending on worktreeId/api alone matches the pre-existing effect's deps.
@@ -426,6 +433,34 @@ export function VcsPanel({ api, worktreeId, baseBranch }: VcsPanelProps) {
           >
             <RefreshCw size={13} className={loading ? "vcs-panel__spin" : undefined} />
           </button>
+          {/* Requirement 2b: a visible "syncing" indicator distinct from the
+              refresh button's spin animation, shown only while a refresh is
+              in flight over a commit list already on screen (never during
+              the true first load — Requirement 2c's "Loading commits…"
+              empty state covers that case instead).
+              Rendered UNCONDITIONALLY (only its text/icon content toggles) —
+              a `role="status"` live region needs to already exist in the DOM
+              before its content changes, or some screen readers won't
+              announce it. Paired with `aria-live="polite"` per the existing
+              convention in `TerminalPane.tsx`/`ConnectionStatus.tsx`. Sits
+              AFTER the refresh button (not before) and reserves its own
+              width via CSS (`visibility: hidden` when idle, not
+              `display: none`) so its appearance/disappearance never shifts
+              the button's position. */}
+          <span
+            className={`vcs-panel__syncing${loading && commits != null ? "" : " vcs-panel__syncing--idle"}`}
+            role="status"
+            aria-live="polite"
+          >
+            {loading && commits != null ? (
+              <>
+                <RefreshCw size={11} className="vcs-panel__spin" aria-hidden />
+                Syncing…
+              </>
+            ) : (
+              ""
+            )}
+          </span>
         </div>
       </div>
       {pr ? <PrBanner pr={pr} /> : null}

--- a/web-ui/src/styles/workspace.css
+++ b/web-ui/src/styles/workspace.css
@@ -3834,6 +3834,7 @@ a.dashboard-card.dashboard-card--session {
 .vcs-panel__bar-actions {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: var(--space-3);
 }
 
@@ -3853,6 +3854,28 @@ a.dashboard-card.dashboard-card--session {
 
 .vcs-panel__spin {
   animation: vcs-spin 0.8s linear infinite;
+}
+
+/* Requirement 2b: a visible "syncing" affordance while a refresh is in
+   flight over an already-loaded commit list — distinct from the bare
+   spinning refresh-button icon, which is easy to miss.
+   Rendered unconditionally in the DOM (see VcsPanel.tsx) so it always
+   reserves its own width — `visibility: hidden` (not `display: none`) when
+   idle keeps the refresh button from jumping sideways as syncing starts and
+   stops. */
+.vcs-panel__syncing {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-width: 4.5em;
+  font-size: var(--font-size-xs);
+  color: var(--fg-muted);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.vcs-panel__syncing--idle {
+  visibility: hidden;
 }
 
 @keyframes vcs-spin {


### PR DESCRIPTION
## Summary

Follow-up to #65. That PR made `GET /worktrees/:id/commits` fetch `origin/<baseBranch>` on every request to keep the VCS tab's diff-from-main computation fresh, with explicitly no periodic background job. Its own opus review flagged and deliberately deferred a gap: nothing stopped concurrent/rapid requests for the same repo+branch from each spawning a redundant `git fetch` subprocess. User asked for this to be closed, staying within the same "on-demand only" constraint.

**Backend — `daemon/src/services/git.ts`:**
- `fetchOrigin()` now does genuine in-flight promise-sharing dedupe, keyed by `repoPath::ref` — concurrent callers share one underlying `git fetch` instead of each starting their own.
- A 5s post-completion cooldown (mirrors `github.ts`'s existing `CACHE_TTL_MS` precedent, same value) skips a redundant real fetch entirely for rapid re-triggers of the same key — but **only on a successful prior fetch**. A failed fetch does not poison the window (caught in opus review — otherwise a transient network blip on the VCS tab could silently block a legitimate retry, e.g. worktree creation needing that same branch fetched for real).
- `_clearFetchOriginStateForTest()` test-reset export, matching the `_clearPrCacheForTest()` naming convention already used in this codebase.

**Frontend — `web-ui/src/components/tools/VcsPanel.tsx`:**
- Confirmed the existing commit list already stays visible during a refresh (verified, not assumed).
- Added a visible "Syncing…" indicator (`aria-live="polite"`, unconditionally mounted so screen readers reliably announce it, no layout shift on toggle) distinct from the full "Loading commits…" empty state.
- Fixed a related gap the new indicator exposed: switching worktrees showed the *previous* worktree's stale commits under the same "Syncing…" label, reading as "these are your commits, just refreshing" instead of "wrong worktree". Now resets to the empty state on a worktree switch specifically (manual refresh of the same worktree still keeps old data visible, per spec).

## Test plan

- [x] `pnpm typecheck` (repo-wide) — clean
- [x] `pnpm --filter cli test` — 776/776 assertions pass (1 pre-existing, documented, unrelated `UnhandledRejection` flake)
- [x] `pnpm --filter @vibestation/web test` — 484/484 pass
- [x] New unit tests use a PATH-shadowed fake-`git` with a real invocation counter (not JS-level mocking) to prove actual subprocess counts: concurrent same-key calls → 1 subprocess; different repo/ref → independent; within-cooldown → 0 subprocess; after-cooldown → 1 subprocess; a *failing* fetch still clears in-flight state and does NOT enter cooldown
- [x] Opus code review — mutation-tested the new counting tests (confirmed they fail — count 2 instead of 1 — with the dedupe/cooldown logic disabled), found 1 real bug (cooldown-on-failure blocking legitimate retries, fixed) plus 6 smaller findings (a11y live-region mounting, stale cross-worktree display, layout shift, 2 doc-comment gaps, missing test coverage) — all addressed
- [x] Live docker-sandbox verification (`scripts/dev-sandbox.sh up vs-52`) against the same stale-vs-fresh fixture technique from #65's verification — fired concurrent `/commits` requests, all returned correct, consistent results with no errors