### PR TITLE
Allow terminating a worktree's main session; speed up SendMessage name resolution

### DIFF
--- a/cli/src/__tests__/session-ls.test.ts
+++ b/cli/src/__tests__/session-ls.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Command } from "commander";
+import { registerSessionLs } from "../commands/session/ls.js";
+import { buildProgram } from "../program.js";
+
+/**
+ * `vst session ls` — `--worktree`/`--name` filters + `--json` output.
+ * Deep-test harness mirrors `session-terminate.test.ts` EXACTLY (M3): fetch
+ * stubbed directly via `vi.stubGlobal("fetch", ...)` (NOT a `daemonGet`
+ * mock), `process.exit` stubbed to throw so `die()`/`printJson()`'s internal
+ * `process.exit(...)` calls are catchable instead of killing the worker.
+ * Unlike session-terminate.test.ts, `console.log` is SPIED (not silenced) so
+ * `--json` output can be captured and asserted on (M4) — `printJson`/
+ * `printTable` both write via `console.log` directly (output.ts:3-31), not
+ * through commander's configured output stream.
+ */
+
+class ExitError extends Error {
+  constructor(public code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+interface Captured {
+  url: string;
+  method: string;
+}
+
+let captured: Captured[] = [];
+let loggedArgs: unknown[][] = [];
+let daemonSessions: unknown[] = [];
+
+async function run(argv: string[]): Promise<number | null> {
+  const program = buildProgram();
+  program.exitOverride();
+  program.configureOutput({ writeOut: () => {}, writeErr: () => {} });
+  try {
+    await program.parseAsync(["node", "vst", ...argv]);
+    return null;
+  } catch (err) {
+    if (err instanceof ExitError) return err.code;
+    const code = (err as { exitCode?: number }).exitCode;
+    if (typeof code === "number") return code;
+    throw err;
+  }
+}
+
+beforeEach(() => {
+  captured = [];
+  loggedArgs = [];
+  daemonSessions = [];
+  process.env.VST_DAEMON_URL = "http://127.0.0.1:9";
+
+  vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new ExitError(code ?? 0);
+  }) as never);
+
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    loggedArgs.push(args);
+  });
+
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string, init?: { method?: string }) => {
+      if (url.endsWith("/health")) {
+        return { ok: true, status: 200, json: async () => ({}) };
+      }
+      captured.push({ url, method: init?.method ?? "GET" });
+      return { ok: true, status: 200, json: async () => daemonSessions };
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  delete process.env.VST_DAEMON_URL;
+});
+
+describe("session ls command registration", () => {
+  it("B1.T1 — registers ls with --worktree, --name, --json options", () => {
+    const session = new Command();
+    registerSessionLs(session);
+
+    const lsCommand = session.commands.find((cmd) => cmd.name() === "ls");
+    expect(lsCommand).toBeDefined();
+    const flags = (lsCommand?.options ?? []).map((o) => o.long);
+    expect(flags).toContain("--worktree");
+    expect(flags).toContain("--name");
+    expect(flags).toContain("--json");
+  });
+});
+
+describe("vst session ls", () => {
+  it("B1.T2 — --worktree <id> results in a fetch to /sessions?worktree=<id>", async () => {
+    daemonSessions = [];
+    await run(["session", "ls", "--worktree", "vs-19", "--json"]);
+
+    const get = captured.find((c) => c.url.includes("/sessions?worktree=vs-19"));
+    expect(get, "expected a GET to /sessions?worktree=vs-19").toBeDefined();
+    expect(get!.method).toBe("GET");
+  });
+
+  it("no --worktree — fetch hits /sessions with no query", async () => {
+    daemonSessions = [];
+    await run(["session", "ls", "--json"]);
+
+    const get = captured.find((c) => c.url.endsWith("/sessions"));
+    expect(get, "expected a GET to /sessions with no query").toBeDefined();
+  });
+
+  it("B1.T3 — --name filters the response to only sessions whose .name matches", async () => {
+    daemonSessions = [
+      { id: "vs-19-a", worktreeId: "vs-19", type: "agent", state: "idle", name: "reviewer" },
+      { id: "vs-19-b", worktreeId: "vs-19", type: "agent", state: "idle", name: "other" },
+      { id: "vs-19-c", worktreeId: "vs-19", type: "agent", state: "idle", name: "reviewer" },
+    ];
+    await run(["session", "ls", "--worktree", "vs-19", "--name", "reviewer", "--json"]);
+
+    const printed = loggedArgs[0]?.[0];
+    expect(typeof printed).toBe("string");
+    const parsed = JSON.parse(printed as string) as Array<{ id: string; name: string }>;
+    expect(parsed.map((s) => s.id).sort()).toEqual(["vs-19-a", "vs-19-c"]);
+    expect(parsed.every((s) => s.name === "reviewer")).toBe(true);
+  });
+
+  it("B1.T4 — --json prints a single JSON-parseable array matching the filtered set", async () => {
+    daemonSessions = [
+      { id: "vs-19-a", worktreeId: "vs-19", type: "agent", state: "idle", name: "reviewer" },
+      { id: "vs-19-b", worktreeId: "vs-19", type: "agent", state: "idle", name: "other" },
+    ];
+    const code = await run(["session", "ls", "--worktree", "vs-19", "--name", "reviewer", "--json"]);
+
+    // printJson() calls process.exit(0) internally, which the stub converts
+    // into an ExitError caught by run() and returned as its exit code — this
+    // IS the expected control flow, not a failure.
+    expect(code).toBe(0);
+    expect(loggedArgs).toHaveLength(1);
+    const parsed = JSON.parse(loggedArgs[0]?.[0] as string) as unknown[];
+    expect(parsed).toHaveLength(1);
+    expect((parsed[0] as { id: string }).id).toBe("vs-19-a");
+  });
+
+  it("B1.T5-adjacent — no --name returns the full (worktree-scoped) set unfiltered", async () => {
+    daemonSessions = [
+      { id: "vs-19-a", worktreeId: "vs-19", type: "agent", state: "idle", name: "reviewer" },
+      { id: "vs-19-b", worktreeId: "vs-19", type: "agent", state: "idle", name: "other" },
+    ];
+    await run(["session", "ls", "--worktree", "vs-19", "--json"]);
+
+    const parsed = JSON.parse(loggedArgs[0]?.[0] as string) as unknown[];
+    expect(parsed).toHaveLength(2);
+  });
+});

--- a/cli/src/commands/session/ls.ts
+++ b/cli/src/commands/session/ls.ts
@@ -8,6 +8,7 @@ interface Session {
   worktreeId: string;
   type: string;
   state: string;
+  name?: string | null;
   createdAt?: string;
 }
 
@@ -15,22 +16,27 @@ export function registerSessionLs(session: Command): void {
   session
     .command("ls")
     .description("List all sessions")
+    .option("--worktree <id>", "Filter by worktree")
+    .option("--name <name>", "Filter by exact session name")
     .option("--json", "Output JSON")
-    .action(async (opts: { json?: boolean }) => {
+    .action(async (opts: { worktree?: string; name?: string; json?: boolean }) => {
       await preflight();
 
-      const result = await daemonGet<Session[]>("/sessions");
+      const query = opts.worktree ? `?worktree=${encodeURIComponent(opts.worktree)}` : "";
+      const result = await daemonGet<Session[]>(`/sessions${query}`);
 
       if (!result.ok) {
         die(result.error, 1);
       }
 
+      const filtered = opts.name ? result.data.filter((s) => s.name === opts.name) : result.data;
+
       if (opts.json) {
-        printJson(result.data);
+        printJson(filtered); // never returns — process.exit(0) inside (output.ts:3-6)
+        return; // unreachable at runtime; kept for readable control flow / lint-friendliness
       }
 
-      const rows = result.data.map((s) => [s.id, s.worktreeId, s.type, s.state]);
-
+      const rows = filtered.map((s) => [s.id, s.worktreeId, s.type, s.state]);
       printTable(["ID", "Worktree", "Type", "State"], rows);
     });
 }

--- a/daemon/src/__tests__/prPoller.test.ts
+++ b/daemon/src/__tests__/prPoller.test.ts
@@ -492,4 +492,101 @@ describe("PR poller behavior", () => {
     await expect(pollAllPrs()).resolves.toBeUndefined();
     expect(github.fetchPrsForBranches).not.toHaveBeenCalled();
   });
+
+  it("A1.T6 — after a main-session promotion, polling resolves PR against the NEW isMain session, not a former/non-main sibling", async () => {
+    // Simulates the post-promotion state a Fix 1 `DELETE /sessions/:id`
+    // would leave behind: the old main is gone (deleted), and the promoted
+    // sibling already carries the old main's `pr` forward (M1 fix, asserted
+    // structurally in sessions.test.ts) — here we only need to confirm
+    // `prPoller` needs no code change: it must re-derive `isMain` fresh and
+    // target whichever session holds it now, regardless of array position
+    // or prior role, and must never write to a non-main sibling.
+    const { _clearStoreForTest, addProject } = await import("../state/project-store.js");
+    _clearStoreForTest();
+    const carriedPr: PrStatus = {
+      state: "open",
+      number: 7,
+      url: "https://github.com/acme/widgets/pull/7",
+      prBranch: "feature-branch-0",
+      checkedAt: new Date(0).toISOString(),
+    };
+    const record: ProjectRecord = {
+      id: "proj-pr",
+      absolutePath: join(tempDir, "repo"),
+      prefix: "pfx",
+      isGit: true,
+      defaultBranch: "main",
+      createdAt: new Date().toISOString(),
+      directSessions: [],
+      worktrees: [
+        {
+          id: "wt-pr-0",
+          branch: "feature-branch-0",
+          baseBranch: "main",
+          baseSha: "a".repeat(40),
+          createdAt: new Date().toISOString(),
+          sortOrder: 0,
+          sessions: [
+            // A non-main sibling (never touched by prPoller — the OLD main
+            // is gone entirely post-promotion, but a second, ineligible
+            // sibling like a terminal could still be present).
+            {
+              id: "sess-pr-sibling",
+              isMain: false,
+              sortOrder: 1,
+              type: "terminal" as const,
+              tmuxName: "pane-pr-sibling",
+              useTmux: true,
+              lifecycle: { state: "idle", lastTransitionAt: new Date().toISOString() },
+            },
+            // The PROMOTED session — isMain now, already carrying the old
+            // main's `pr` forward, and NOT at array index 0.
+            {
+              id: "sess-pr-promoted",
+              isMain: true,
+              sortOrder: 0,
+              type: "agent" as const,
+              modeId: "mode",
+              tmuxName: "pane-pr-promoted",
+              useTmux: true,
+              lifecycle: { state: "idle", lastTransitionAt: new Date().toISOString() },
+              pr: carriedPr,
+            },
+          ],
+        },
+      ],
+    };
+    await addProject(record);
+
+    // Next 30s tick finds a newer PR state — must land on the promoted
+    // session's id, never the (nonexistent) old main or the terminal sibling.
+    github.fetchPrsForBranches.mockResolvedValue(
+      new Map([
+        [
+          "acme/widgets#feature-branch-0",
+          {
+            kind: "pr" as const,
+            pr: {
+              number: 7,
+              url: "https://github.com/acme/widgets/pull/7",
+              title: "Add widget",
+              state: "closed" as const,
+              merged: true,
+              draft: false,
+              author: "octocat",
+            },
+          },
+        ],
+      ]),
+    );
+
+    await pollAllPrs();
+
+    const { getProject } = await import("../state/project-store.js");
+    const worktree = getProject("proj-pr")!.worktrees[0]!;
+    const promoted = worktree.sessions.find((s) => s.id === "sess-pr-promoted")!;
+    const sibling = worktree.sessions.find((s) => s.id === "sess-pr-sibling")!;
+    expect(promoted.pr?.state).toBe("merged");
+    expect(sibling.pr).toBeUndefined();
+  });
 });

--- a/daemon/src/__tests__/sessions.test.ts
+++ b/daemon/src/__tests__/sessions.test.ts
@@ -235,6 +235,221 @@ describe("Session routes", () => {
     expect(sessions.find((s) => s.id === sessionId)).toBeUndefined();
   });
 
+  it("DELETE /sessions/:id on main session with an eligible agent sibling promotes it and deletes the old main", async () => {
+    const listRes = await app.inject({ method: "GET", url: `/sessions?worktree=${worktreeId}` });
+    const mainId = listRes.json<SessionRecord[]>()[0]?.id;
+
+    const createRes = await app.inject({
+      method: "POST",
+      url: "/sessions",
+      payload: { worktreeId, type: "agent", modeId: "bugfix" },
+    });
+    const siblingId = createRes.json<SessionRecord>().id;
+
+    const delRes = await app.inject({ method: "DELETE", url: `/sessions/${mainId}` });
+    expect(delRes.statusCode).toBe(200);
+    expect(delRes.json().ok).toBe(true);
+
+    const afterRes = await app.inject({ method: "GET", url: `/sessions?worktree=${worktreeId}` });
+    const after = afterRes.json<SessionRecord[]>();
+    expect(after).toHaveLength(1);
+    expect(after[0]?.id).toBe(siblingId);
+    expect(after[0]?.isMain).toBe(true);
+    expect(after.find((s) => s.id === mainId)).toBeUndefined();
+  });
+
+  it("M1 — promotion carries the old main's pr forward immediately, no 30s gap", async () => {
+    const listRes = await app.inject({ method: "GET", url: `/sessions?worktree=${worktreeId}` });
+    const mainId = listRes.json<SessionRecord[]>()[0]?.id as string;
+
+    const createRes = await app.inject({
+      method: "POST",
+      url: "/sessions",
+      payload: { worktreeId, type: "agent", modeId: "bugfix" },
+    });
+    const siblingId = createRes.json<SessionRecord>().id as string;
+
+    // Seed a `pr` on the main session directly via the store, simulating a
+    // prior prPoller write, before triggering promotion.
+    const { mutateProject } = await import("../state/project-store.js");
+    await mutateProject(projectId, (p) => ({
+      ...p,
+      worktrees: p.worktrees.map((w) =>
+        w.id === worktreeId
+          ? {
+              ...w,
+              sessions: w.sessions.map((s) =>
+                s.id === mainId
+                  ? {
+                      ...s,
+                      pr: {
+                        state: "open" as const,
+                        number: 42,
+                        url: "https://github.com/acme/widgets/pull/42",
+                        checkedAt: new Date().toISOString(),
+                        prBranch: "feat-sessions",
+                      },
+                    }
+                  : s,
+              ),
+            }
+          : w,
+      ),
+    }));
+
+    await app.inject({ method: "DELETE", url: `/sessions/${mainId}` });
+
+    // No delay, no waiting for a poll tick — the promoted session must
+    // already carry the old main's `pr` in the very next read.
+    const afterRes = await app.inject({ method: "GET", url: `/sessions/${siblingId}` });
+    const after = afterRes.json<SessionRecord>();
+    expect(after.isMain).toBe(true);
+    expect(after.pr?.state).toBe("open");
+    expect(after.pr?.number).toBe(42);
+  });
+
+  it("DELETE /sessions/:id on main session with only a terminal sibling still 400s (terminal ineligible)", async () => {
+    const listRes = await app.inject({ method: "GET", url: `/sessions?worktree=${worktreeId}` });
+    const mainId = listRes.json<SessionRecord[]>()[0]?.id;
+
+    await app.inject({
+      method: "POST",
+      url: "/sessions",
+      payload: { worktreeId, type: "terminal" },
+    });
+
+    const delRes = await app.inject({ method: "DELETE", url: `/sessions/${mainId}` });
+    expect(delRes.statusCode).toBe(400);
+    expect(delRes.json().error).toContain("no other agent session");
+  });
+
+  it("DELETE /sessions/:id on main session with only an archived agent sibling still 400s (archived ineligible)", async () => {
+    const listRes = await app.inject({ method: "GET", url: `/sessions?worktree=${worktreeId}` });
+    const mainId = listRes.json<SessionRecord[]>()[0]?.id;
+
+    const createRes = await app.inject({
+      method: "POST",
+      url: "/sessions",
+      payload: { worktreeId, type: "agent", modeId: "bugfix" },
+    });
+    const siblingId = createRes.json<SessionRecord>().id;
+
+    // Archive the sibling directly via the store so it's excluded from
+    // promotion eligibility, without depending on the reset-flow route.
+    const { mutateProject } = await import("../state/project-store.js");
+    await mutateProject(projectId, (p) => ({
+      ...p,
+      worktrees: p.worktrees.map((w) =>
+        w.id === worktreeId
+          ? {
+              ...w,
+              sessions: w.sessions.map((s) =>
+                s.id === siblingId ? { ...s, archivedAt: new Date().toISOString() } : s,
+              ),
+            }
+          : w,
+      ),
+    }));
+
+    const delRes = await app.inject({ method: "DELETE", url: `/sessions/${mainId}` });
+    expect(delRes.statusCode).toBe(400);
+    expect(delRes.json().error).toContain("no other agent session");
+  });
+
+  it("DELETE /sessions/:id promotion leaves the promoted sibling's name/nameSource unchanged", async () => {
+    const listRes = await app.inject({ method: "GET", url: `/sessions?worktree=${worktreeId}` });
+    const mainId = listRes.json<SessionRecord[]>()[0]?.id;
+
+    const createRes = await app.inject({
+      method: "POST",
+      url: "/sessions",
+      payload: { worktreeId, type: "agent", modeId: "bugfix" },
+    });
+    const sibling = createRes.json<SessionRecord>();
+    expect(sibling.name).toBe("Agent 1");
+
+    await app.inject({ method: "DELETE", url: `/sessions/${mainId}` });
+
+    const afterRes = await app.inject({ method: "GET", url: `/sessions/${sibling.id}` });
+    const after = afterRes.json<SessionRecord>();
+    expect(after.name).toBe("Agent 1");
+    expect(after.nameSource).toBe(sibling.nameSource);
+    expect(after.isMain).toBe(true);
+  });
+
+  // M3 (reviewer): tightened from a single loosely-asserted race test into
+  // two deterministic sub-tests. `app.inject()` calls dispatch (and their
+  // `mutateProject` callbacks acquire the per-project lock) in the order
+  // they're invoked in this test harness — confirmed empirically (10 runs
+  // each direction, zero flakes) — so listing one request before the other
+  // in the `Promise.all` array deterministically makes that one's commit win
+  // the race, letting each ordering be asserted exactly rather than loosely.
+  //
+  // This test previously exposed a REAL bug during this revision: the plain
+  // (non-main) delete path used to filter a session out by id unconditionally,
+  // using only the `session.isMain` snapshot captured at the top of the
+  // handler (BEFORE the lock). When session B raced session A's promotion —
+  // B was not main when B's handler started, but became main via A's commit
+  // before B's own commit ran — B's stale-snapshot-driven plain delete still
+  // fired, removing the worktree's only main session and leaving ZERO live
+  // sessions. Fixed by re-deriving "is this session main, and if so is there
+  // an eligible sibling" fresh inside B's own locked `mutateProject`
+  // callback too (`daemon/src/routes/sessions.ts`), not just inside the
+  // already-flagged-as-main request's callback.
+  async function seedMainPlusOneSibling(): Promise<{ mainId: string; siblingId: string }> {
+    const listRes = await app.inject({ method: "GET", url: `/sessions?worktree=${worktreeId}` });
+    const mainId = listRes.json<SessionRecord[]>()[0]?.id as string;
+    const createRes = await app.inject({
+      method: "POST",
+      url: "/sessions",
+      payload: { worktreeId, type: "agent", modeId: "bugfix" },
+    });
+    const siblingId = createRes.json<SessionRecord>().id as string;
+    return { mainId, siblingId };
+  }
+
+  it("A1.T7 — concurrent DELETE, main-delete's commit wins: main promotes+deletes (200), sibling-delete then 400s (no sibling of its own)", async () => {
+    const { mainId, siblingId } = await seedMainPlusOneSibling();
+
+    const [mainDel, siblingDel] = await Promise.all([
+      app.inject({ method: "DELETE", url: `/sessions/${mainId}` }),
+      app.inject({ method: "DELETE", url: `/sessions/${siblingId}` }),
+    ]);
+
+    expect(mainDel.statusCode).toBe(200);
+    expect(mainDel.json().ok).toBe(true);
+    expect(siblingDel.statusCode).toBe(400);
+    expect(siblingDel.json().error).toContain("no other agent session");
+
+    const finalRes = await app.inject({ method: "GET", url: `/sessions?worktree=${worktreeId}` });
+    const final = finalRes.json<SessionRecord[]>();
+    const live = final.filter((s) => s.archivedAt == null);
+    expect(live).toHaveLength(1);
+    expect(live[0]?.id).toBe(siblingId);
+    expect(live[0]?.isMain).toBe(true);
+  });
+
+  it("A1.T7 — concurrent DELETE, sibling-delete's commit wins: sibling deletes plainly (200), main-delete then 400s (its sibling is already gone)", async () => {
+    const { mainId, siblingId } = await seedMainPlusOneSibling();
+
+    const [siblingDel, mainDel] = await Promise.all([
+      app.inject({ method: "DELETE", url: `/sessions/${siblingId}` }),
+      app.inject({ method: "DELETE", url: `/sessions/${mainId}` }),
+    ]);
+
+    expect(siblingDel.statusCode).toBe(200);
+    expect(siblingDel.json().ok).toBe(true);
+    expect(mainDel.statusCode).toBe(400);
+    expect(mainDel.json().error).toContain("no other agent session");
+
+    const finalRes = await app.inject({ method: "GET", url: `/sessions?worktree=${worktreeId}` });
+    const final = finalRes.json<SessionRecord[]>();
+    const live = final.filter((s) => s.archivedAt == null);
+    expect(live).toHaveLength(1);
+    expect(live[0]?.id).toBe(mainId);
+    expect(live[0]?.isMain).toBe(true);
+  });
+
   it("3.T6 — PATCH /sessions/:id/rename { name: \"\" } clears to null", async () => {
     const listRes = await app.inject({ method: "GET", url: `/sessions?worktree=${worktreeId}` });
     const mainId = listRes.json<SessionRecord[]>()[0]?.id;

--- a/daemon/src/assets/agent-system-prompt.md
+++ b/daemon/src/assets/agent-system-prompt.md
@@ -57,7 +57,13 @@ vst worktree info $VST_WORKTREE --json
 # All sessions in your worktree
 vst session ls --worktree=$VST_WORKTREE --json
 
-# Your own session details (slot, type, mode, state)
+# Resolve a UI-set session name to its id (e.g. before sending it a message —
+# see "Send a message to a session" below). Names are set by users in the web
+# UI and are not guaranteed unique; `.[0]` picks the first match.
+vst session ls --worktree=$VST_WORKTREE --name="<name>" --json | jq -r '.[0].id'
+
+# Your own session details (id, type, mode, state — ids are opaque strings
+# returned by vst, not something to construct yourself)
 vst session info $VST_SESSION --json
 
 # Recent output from another session
@@ -74,7 +80,7 @@ There are two distinct operations. Pick the right one — they are not interchan
 #### Case A — a NEW worktree (separate branch, isolated checkout)
 
 ```bash
-# Creates the worktree AND its main agent session (slot `m`) in ONE command.
+# Creates the worktree AND its main agent session in ONE command.
 vst worktree create $VST_PROJECT --mode=<modeId> --branch=<name> --prompt="the task"
 ```
 
@@ -88,10 +94,10 @@ with `vst project ls --json`.
 #### Case B — an extra session in the PROVIDED worktree (same branch/checkout; worktree sessions only)
 
 ```bash
-# Adds a sibling agent tab to the given worktree (slots a1, a2, …).
+# Adds a sibling agent tab to the given worktree.
 vst session create $VST_WORKTREE --type=agent --mode=<modeId> --prompt="your sub-task"
 
-# Add a plain terminal tab (slots t1, t2, …).
+# Add a plain terminal tab.
 vst session create $VST_WORKTREE --type=terminal
 ```
 
@@ -99,6 +105,21 @@ Use this only when the work should share an existing git checkout. Sibling
 sessions coordinate via files (e.g. write a spec file, let the sibling implement it).
 
 ### Send a message to a session
+
+If you only know a session by its UI-set display name (e.g. "send a message
+to reviewer"), resolve it to an id first — don't guess or construct one:
+
+```bash
+# Resolve name -> id (jq is available in these sandboxes)
+SESSION_ID=$(vst session ls --worktree=$VST_WORKTREE --name="reviewer" --json | jq -r '.[0].id')
+```
+
+- No match → the filtered array is empty and `.[0].id` is `null`/empty. Don't
+  assume the target doesn't exist — re-run `vst session ls --worktree=$VST_WORKTREE --json`
+  (unfiltered) and check for a typo before giving up.
+- More than one match → names are not guaranteed unique; `.[0]` picks an
+  arbitrary one. If that matters, list the unfiltered `--json` output and
+  disambiguate by hand (e.g. by `state`/`type`/`id`).
 
 ```bash
 # Send a message and wait for the session to go idle
@@ -132,7 +153,7 @@ If you hit a blocker you cannot resolve (missing credentials, ambiguous requirem
 ## Ending your session
 
 - `vst session terminate` — ends **this** session (defaults to `$VST_SESSION` when no id is given); deletes the session record and its data dir. Use this when asked to end/finish/stop yourself, or when you spawned a sibling/child session that's no longer needed.
-- Caveat: if you are a worktree's **main** agent, this is rejected (400) — the daemon requires `vst worktree rm` for that case instead. This is out of scope for a mid-task agent to run unprompted; surface the 400 to the user rather than escalating to a worktree removal.
+- Caveat: if you are a worktree's **main** agent and another agent session already exists in the same worktree, terminating yourself PROMOTES that other session to main (it keeps its own name) and then ends your session as normal — a real side effect another agent/user may not expect, so avoid triggering it unprompted. If you are the worktree's **only** session, this is rejected (400) — the daemon requires `vst worktree rm` for that case instead; this is out of scope for a mid-task agent to run unprompted, surface the 400 to the user rather than escalating to a worktree removal.
 
 ---
 

--- a/daemon/src/routes/sessions.ts
+++ b/daemon/src/routes/sessions.ts
@@ -803,44 +803,120 @@ export function registerSessionRoutes(app: FastifyInstance): void {
 
     const { project, session } = ctx;
 
-    // Main session cannot be killed (worktree sessions only)
-    if (session.isMain) {
-      return reply.status(400).send({
-        error: "Cannot delete the main session. Use DELETE /worktrees/:id instead.",
-      });
-    }
-
-    // Release every live resource BEFORE purge (Decision 13): the JSON turn's
-    // process group (so no orphaned child keeps mutating the checkout), its
-    // SQLite handle, the tmux pane / direct-pty child, and the idle tracker.
-    // Delete is destructive, so staged attachments go too.
-    await releaseSessionRuntime(session, { clearAttachments: true });
-
-    if (ctx.kind === "worktree") {
-      // Worktree session: cleanup worktree-scoped data dir
-      cleanupSessionDataDir(project.id, ctx.worktree.id, id);
-      // Remove from worktree's sessions array. `agentSeq` no longer needs any
-      // recomputation here (Decision 5): now that ids are independently
-      // generated (not slot-derived), the counter only ever needs to
-      // monotonically increase for the NEXT default "Agent N" label — it's
-      // bumped once at agent creation and never touched again, so a deleted
-      // agent's number is naturally never reused without any high-water scan.
-      await mutateProject(project.id, (p) => ({
-        ...p,
-        worktrees: p.worktrees.map((w) =>
-          w.id === ctx.worktree.id ? { ...w, sessions: w.sessions.filter((s) => s.id !== id) } : w,
-        ),
-      }));
-    } else {
-      // Direct session: cleanup project-scoped data dir
+    if (ctx.kind !== "worktree") {
+      // Direct session: isMain is impossible (DB CHECK), so no promotion
+      // logic applies — plain delete only.
+      await releaseSessionRuntime(session, { clearAttachments: true });
       cleanupDirectSessionDataDir(project.id, id);
-      // Remove from project's directSessions array
       await mutateProject(project.id, (p) => ({
         ...p,
         directSessions: p.directSessions.filter((s) => s.id !== id),
       }));
+      broadcastAll({ type: "session:deleted", sessionId: id });
+      return reply.send({ ok: true });
     }
 
+    const NO_SIBLING_ERROR =
+      "Cannot delete the main session: no other agent session exists in this worktree " +
+      "to promote to main. Use DELETE /worktrees/:id to remove the whole worktree.";
+
+    // Fast-path pre-check OUTSIDE the lock — pure optimization so the common
+    // "main session, sole session in the worktree" case 400s immediately
+    // without an extra DB round trip. Based on `session`/`ctx.worktree`
+    // captured at the very top of the handler, so NOT authoritative: it can
+    // only ever short-circuit to the SAME outcome the in-lock check below
+    // would reach anyway (a false negative here just skips the optimization,
+    // never skips the real check) — see the unified in-lock logic for why.
+    if (session.isMain) {
+      const hasAnyEligibleSibling = ctx.worktree.sessions.some(
+        (s) => s.id !== session.id && s.type === "agent" && s.archivedAt == null,
+      );
+      if (!hasAnyEligibleSibling) {
+        return reply.status(400).send({ error: NO_SIBLING_ERROR });
+      }
+    }
+
+    class SessionGoneAtCommit extends Error {}
+    class NoEligibleSiblingAtCommit extends Error {}
+    let promotedId: string | undefined;
+    let promotedPr: SessionRecord["pr"];
+    let promotedAtCommit = false;
+
+    try {
+      // Whether THIS delete is "the main session, needs promotion" or "just
+      // remove it" is decided fresh, INSIDE this one locked callback, off the
+      // `p`/`w` mutateProject hands in — never off `session`/`ctx.worktree`
+      // captured before this call. This closes the race in BOTH directions
+      // (not just "promotion candidate went stale," Decision 1's original
+      // scope): a concurrent request can also PROMOTE this exact session to
+      // main between this handler's start and the lock being acquired — a
+      // stale `session.isMain === false` read would otherwise let a plain
+      // unconditional-filter delete remove the worktree's only main session
+      // out from under a racing promotion, leaving zero live sessions
+      // (confirmed empirically before this fix — see M3/A1.T7's test).
+      await mutateProject(project.id, (p) => {
+        const w = p.worktrees.find((x) => x.id === ctx.worktree.id);
+        if (!w) throw new Error(`Worktree '${ctx.worktree.id}' not found`);
+        const fresh = w.sessions.find((s) => s.id === id);
+        if (!fresh) throw new SessionGoneAtCommit(); // a concurrent request already removed it
+        if (!fresh.isMain) {
+          // Not main at commit time (whether or not it looked main at
+          // request start) — plain delete.
+          return {
+            ...p,
+            worktrees: p.worktrees.map((ww) =>
+              ww.id === ctx.worktree.id ? { ...ww, sessions: ww.sessions.filter((s) => s.id !== id) } : ww,
+            ),
+          };
+        }
+        const siblings = w.sessions
+          .filter((s) => s.id !== id && s.type === "agent" && s.archivedAt == null)
+          .sort((a, b) => a.sortOrder - b.sortOrder);
+        const promoted = siblings[0];
+        if (!promoted) throw new NoEligibleSiblingAtCommit();
+        promotedId = promoted.id;
+        // Carry the OLD main's `pr` onto the promoted session so PR-colored
+        // surfaces don't blank for up to 30s until the next prPoller tick.
+        promotedPr = fresh.pr;
+        promotedAtCommit = true;
+        return {
+          ...p,
+          worktrees: p.worktrees.map((ww) =>
+            ww.id === ctx.worktree.id
+              ? {
+                  ...ww,
+                  sessions: ww.sessions
+                    .filter((s) => s.id !== id)
+                    .map((s) => (s.id === promoted.id ? { ...s, isMain: true, pr: fresh.pr } : s)),
+                }
+              : ww,
+          ),
+        };
+      });
+    } catch (err) {
+      if (err instanceof SessionGoneAtCommit) {
+        return reply.status(404).send({ error: `Session '${id}' not found` });
+      }
+      if (err instanceof NoEligibleSiblingAtCommit) {
+        // Lost a race: every eligible sibling was removed/reset between the
+        // fast-path check above (or this session becoming main after it)
+        // and this locked commit. mutateProject never called
+        // writeProjectFull (fn is invoked BEFORE the try/writeProjectFull
+        // block), so nothing persisted and the cache is untouched.
+        return reply.status(400).send({ error: NO_SIBLING_ERROR });
+      }
+      throw err; // genuine unexpected failure — surfaces as a 500, not swallowed
+    }
+
+    // Persisted state now has the delete (and, if applicable, the promotion)
+    // committed. Runtime teardown uses the `session` object fetched at the
+    // top of the handler, which is still valid regardless of DB state.
+    await releaseSessionRuntime(session, { clearAttachments: true });
+    cleanupSessionDataDir(project.id, ctx.worktree.id, id);
+
+    if (promotedAtCommit) {
+      broadcastAll({ type: "session:updated", sessionId: promotedId!, isMain: true, pr: promotedPr ?? null });
+    }
     broadcastAll({ type: "session:deleted", sessionId: id });
     return reply.send({ ok: true });
   });

--- a/daemon/src/ws/protocol.ts
+++ b/daemon/src/ws/protocol.ts
@@ -336,6 +336,9 @@ const SessionUpdatedEvent = z.object({
   /** Set on the archived session by a reset (POST .../reset) — the
    *  replacement session's id (present-tickmark-replacement/02-reset-relink). */
   supersededBy: z.string().nullable().optional(),
+  /** Set true when a main-session promotion (DELETE /sessions/:id on the old
+   *  main, Fix 1) flips this session to the worktree's new main. */
+  isMain: z.boolean().optional(),
 });
 
 /**

--- a/docs/HIGH-LEVEL-DESIGN.md
+++ b/docs/HIGH-LEVEL-DESIGN.md
@@ -345,10 +345,12 @@ The branch name is **immutable for the worktree's lifetime** in v1 — to rename
 
 ### Worktree ↔ main-session invariant
 
-A worktree **always** has exactly one main session (slot `m`).
+A worktree **always** has exactly one main session, though *which* session holds that
+role can change at runtime (see promotion below) — it is not pinned to the session
+created alongside the worktree.
 
 - **Creation is atomic**: `POST /worktrees` (and `vst worktree create`) always provisions the git worktree AND spawns the main session in the same operation. There is no "worktree without sessions" state.
-- The main session cannot be terminated via `DELETE /sessions/:id` — that's rejected with `400`. The only way to end a main session is `DELETE /worktrees/:id`, which terminates all sessions including main and removes the checkout.
+- The main session CAN be terminated via `DELETE /sessions/:id` when another eligible agent session exists in the worktree: that sibling is atomically promoted to main (its own name preserved) before the old main is deleted. It is rejected with `400` only when the main session is the worktree's sole session — the only way to end a main session with no siblings is `DELETE /worktrees/:id`, which terminates all sessions including main and removes the checkout.
 - After tmux death, the main session moves to `exited` state but the record persists; the worktree still has its main session, just paused. Resume re-spawns the tmux session in place.
 
 **Rollback on creation failure** (atomicity guarantee):

--- a/docs/STATUS-INDICATORS.md
+++ b/docs/STATUS-INDICATORS.md
@@ -146,6 +146,14 @@ done.
   - A direct (worktree-less) session has no worktree to resolve a PR against, so it can **never**
     show a PR — its card is always lifecycle-only, regardless of what `session.pr` holds.
   - Archived sessions (`archivedAt != null`) produce no card at all.
+  - **Which session holds `isMain` for a worktree can change at runtime** (main-session
+    promotion — `DELETE /sessions/:id` on the main session promotes an eligible sibling to
+    `isMain` before deleting the old main, `daemon/src/routes/sessions.ts`). This does not weaken
+    the invariant above: at every instant exactly one session is `isMain` and `prPoller`/
+    `worktreePrStatus()` still read/write only that one — promotion just means "that one" can be a
+    different session than a moment ago. The promotion itself carries the old main's `pr` forward
+    onto the promoted session in the same atomic step, so there is no gap where the worktree's PR
+    colour blanks while waiting for the next poll tick.
 - **The sidebar's worktree rows roll up per worktree** (unchanged by Phase 6) — see
   `worktreeRolledUpStatus()` in `web-ui/src/lib/worktreeStatus.ts`, used by `LeftSidebar.tsx`'s
   worktree-row `<StatusDot>` sites. There, the rolled-up worktree PR colour comes from

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -93,11 +93,23 @@ curl -X POST http://127.0.0.1:7421/worktrees \
 
 **Modes** (`GET /modes` returns the list) bind an agent CLI (`claude`, `cursor`, `opencode`) + mode-specific system-prompt context. Use `vst mode ls --json` to discover available modes.
 
-**Slots** — the main session is slot `m`; additional sessions in the same worktree get slots `a2`, `a3`, … for agents and `t2`, `t3`, … for terminals.
+**Session identity** — each session has an opaque `id` (returned by `vst worktree create`/`vst session create`, or looked up via `vst session ls`) and an `isMain` flag marking the worktree's single main agent session. Session ids are not something to construct yourself — always look them up.
 
 ---
 
 ## 5. Send a message and wait
+
+If you only have a session's UI-set display name (not its id), resolve it first:
+
+```bash
+# Resolve a UI-set name to its id within a worktree (jq is available)
+vst session ls --worktree=<worktreeId> --name="<name>" --json | jq -r '.[0].id'
+```
+
+No match → the filtered array is empty; re-check with the unfiltered
+`vst session ls --worktree=<worktreeId> --json` before assuming the session
+doesn't exist. Names aren't guaranteed unique — `.[0]` picks an arbitrary
+match among duplicates.
 
 ```bash
 # CLI — send message and wait for agent to go idle
@@ -180,8 +192,10 @@ Returns sessions for a worktree (omit query to return all).
 ### GET /sessions/:id
 ```
 → 200 {
-    id, worktreeId, slot, type, modeId,
-    label, tmuxName, state, lifecycleState, createdAt
+    id, worktreeId, isMain, sortOrder, type, modeId,
+    name, nameSource, channel, tmuxName, state, lifecycleState,
+    createdAt, pinnedAt, archivedAt, handoffSummary, spawnedFrom,
+    supersededBy, pr
   }
 → 404 { error: "Session '…' not found" }
 ```
@@ -206,10 +220,14 @@ Create an additional agent or terminal session inside an existing worktree.
 ```
 
 ### DELETE /sessions/:id
-Terminate a non-main session.
+Terminate a session. A worktree's main session is terminated by promoting an eligible
+sibling agent session to main (its own name is preserved); rejected only when it is the
+worktree's sole session.
 ```
 → 200 { ok: true }
-→ 400 { error: "Cannot delete the main session. Use DELETE /worktrees/:id instead." }
+→ 400 { error: "Cannot delete the main session: no other agent session exists in this
+                 worktree to promote to main. Use DELETE /worktrees/:id to remove the
+                 whole worktree." }
 → 404 { error: "Session '…' not found" }
 ```
 
@@ -273,7 +291,7 @@ WORKTREE=$(curl -s -X POST http://127.0.0.1:7421/worktrees \
     \"modeId\":    \"<your-claude-modeId>\",
     \"prompt\":    \"Review the diff at /tmp/pr.diff and summarise findings.\"
   }")
-SESSION_ID=$(echo "$WORKTREE" | jq -r '.id')-m
+SESSION_ID=$(echo "$WORKTREE" | jq -r '.mainSessionId')
 
 # 4. Poll until session is idle or exited
 while true; do
@@ -372,13 +390,15 @@ Do not ask the user for the current id — you already have it. Do not ask wheth
 Both arguments are required. The first is the existing id, the second is the new name:
 
 ```bash
-vst worktree rename vs-19 my-feature   # rename worktree vs-19 → my-feature
-vst session rename vs-19-m my-session  # rename session vs-19-m → my-session
+vst worktree rename vs-19 my-feature               # rename worktree vs-19 → my-feature
+vst session rename vs-19-a-3f9c2b7a my-session      # rename a session by its id → my-session
 ```
 
 **ID patterns** (to distinguish existing ids from new names):
 - **Worktree IDs** — `<prefix>-<number>`, e.g. `direct-2`, `myap-1`, `vs-19`
-- **Session IDs** — `<worktreeId>-<slot>`, e.g. `direct-2-m`, `vs-19-a2`, `vs-19-t3`
+- **Session IDs** — `<worktreeId>-<a|t>-<random>`, e.g. `vs-19-a-3f9c2b7a` (generated
+  independently per session, not from a slot/position — don't construct one by hand;
+  look it up via `vst session ls` or `vst session info $VST_SESSION`)
 
 **Via HTTP:**
 ```bash

--- a/web-ui/src/api/mock.test.ts
+++ b/web-ui/src/api/mock.test.ts
@@ -213,4 +213,55 @@ describe("mock api contract", () => {
     const api = createMockApi();
     await expect(api.handoffSession("sess-term1")).rejects.toThrow();
   });
+
+  // M4 (A2.8) — mock's terminateSession promotion-selection logic. wt-1
+  // seeds sess-main (isMain, sortOrder 1), sess-agent2 (agent, sortOrder 2),
+  // sess-term1 (terminal, sortOrder 3) — the terminal must never be picked.
+  it("terminateSession on a main session with an eligible sibling promotes it (isMain flips, pr carried) instead of throwing", async () => {
+    const api = createMockApi();
+    const updated = vi.fn();
+    const off = api.on("session:updated", updated);
+
+    const res = await api.terminateSession("sess-main");
+    expect(res).toEqual({ ok: true });
+
+    const sessions = await api.listSessions("wt-1");
+    expect(sessions.find((s) => s.id === "sess-main")).toBeUndefined();
+    const promoted = sessions.find((s) => s.id === "sess-agent2");
+    expect(promoted?.isMain).toBe(true);
+    // The terminal sibling (sortOrder 3, ineligible) must never be promoted
+    // even though it's still "closer" in id/creation order than nothing.
+    const terminal = sessions.find((s) => s.id === "sess-term1");
+    expect(terminal?.isMain).toBeFalsy();
+
+    expect(updated).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "session:updated", sessionId: "sess-agent2", isMain: true }),
+    );
+    off();
+  });
+
+  it("terminateSession on a main session with only a terminal sibling still throws (no eligible agent to promote)", async () => {
+    const api = createMockApi();
+    // wt-2's only session is its main agent (sess-wt2-main) — no sibling at
+    // all, agent or otherwise, so this must still reject.
+    await expect(api.terminateSession("sess-wt2-main")).rejects.toThrow();
+  });
+
+  it("terminateSession promotion emits the carried pr value on the session:updated event", async () => {
+    // No public/test hook seeds a `pr` onto the base fixture's sess-main
+    // (it's a pure lifecycle-only fixture, no PR state), so this asserts the
+    // carry-forward CODE PATH runs and emits a defined `pr` key on the event
+    // (present, even if `undefined`-valued) rather than omitting it — proving
+    // `victim.pr` is read and threaded through, not silently dropped. The
+    // real (daemon-side, non-empty) carry-forward value is covered by
+    // `daemon/src/__tests__/sessions.test.ts`'s "M1 — promotion carries the
+    // old main's pr forward immediately" test.
+    const api = createMockApi();
+    const updated = vi.fn();
+    const off = api.on("session:updated", updated);
+    await api.terminateSession("sess-main");
+    const call = updated.mock.calls.find((c) => c[0]?.sessionId === "sess-agent2");
+    expect(call?.[0]).toHaveProperty("pr");
+    off();
+  });
 });

--- a/web-ui/src/api/mock.ts
+++ b/web-ui/src/api/mock.ts
@@ -561,7 +561,34 @@ export function createMockApi() {
       if (idx === -1) throw new ApiError("not found", 404);
       const victim = sessions[idx];
       if (!victim) throw new ApiError("not found", 404);
-      if (victim.isMain) throw new ApiError("cannot delete main", 400);
+      if (victim.isMain) {
+        // Mirrors the daemon's promotion behavior (Fix 1): promote the
+        // eligible (type "agent", not archived) sibling with the lowest
+        // sortOrder in the same worktree, carrying the old main's `pr`
+        // forward, instead of always rejecting.
+        const siblings = sessions
+          .filter(
+            (s) =>
+              s.id !== victim.id &&
+              s.worktreeId === victim.worktreeId &&
+              s.type === "agent" &&
+              s.archivedAt == null,
+          )
+          .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0));
+        const promoted = siblings[0];
+        if (!promoted) throw new ApiError("cannot delete main", 400);
+        promoted.isMain = true;
+        promoted.pr = victim.pr;
+        sessions.splice(idx, 1);
+        // Unlike the daemon, this mock emits NO event for the delete itself
+        // (matches its existing convention — no `emit(...)` call here today).
+        // It DOES emit for the promoted sibling's isMain flip: other open
+        // surfaces (sidebar rollup, other tabs) have no other way to learn
+        // about it in mock/dev mode, since the caller's own refetch only
+        // refreshes its own worktree-scoped list, not every mounted component.
+        emit({ type: "session:updated", sessionId: promoted.id, isMain: true, pr: promoted.pr ?? undefined });
+        return { ok: true };
+      }
       sessions.splice(idx, 1);
       return { ok: true };
     },

--- a/web-ui/src/api/types.ts
+++ b/web-ui/src/api/types.ts
@@ -365,6 +365,9 @@ export type WSEvent =
       pr?: PrStatus | null;
       /** Set on the archived session by a reset — the replacement session's id. */
       supersededBy?: string | null;
+      /** Set true when a main-session promotion (DELETE /sessions/:id on the
+       *  old main) flips this session to the worktree's new main. */
+      isMain?: boolean;
     }
   | {
       type: "session:error";

--- a/web-ui/src/components/layout/LeftSidebar.test.tsx
+++ b/web-ui/src/components/layout/LeftSidebar.test.tsx
@@ -703,6 +703,66 @@ describe("LeftSidebar", () => {
       expect(row).toHaveAttribute("data-archived", "true");
       expect(within(row).getByText(/archived/i)).toBeInTheDocument();
     });
+
+    it("A2.T4 — a failed terminate surfaces the daemon's error instead of failing silently", async () => {
+      // NOTE: LeftSidebar's session-actions menu only ever operates on
+      // DIRECT sessions (filtered via `worktreeId === null`, LeftSidebar.tsx
+      // :213) — a direct session can never be `isMain` (daemon CHECK
+      // constraint), so the specific "worktree's only session" 400 that Fix 1
+      // introduces cannot be reproduced through THIS file's UI. This test
+      // instead verifies the actual code change generically: any
+      // `terminateSession` failure now surfaces to the user via `window.alert`
+      // rather than the previous bare `catch { /* surface errors later */ }`.
+      const user = userEvent.setup();
+      const localApi = createMockApi();
+      const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+      vi.spyOn(localApi, "terminateSession").mockRejectedValue(
+        new Error("Cannot delete the main session: no other agent session exists in this worktree to promote to main."),
+      );
+      try {
+        render(
+          <MemoryRouter>
+            <Harness api={localApi}>
+              <LeftSidebar api={localApi} />
+            </Harness>
+          </MemoryRouter>,
+        );
+        await screen.findByText("Proj A");
+        localApi.__test.emit({
+          type: "session:created",
+          sessionId: "proj-a-d4",
+          worktreeId: null,
+          projectId: "proj-a",
+          sessionType: "agent",
+          snapshot: {
+            id: "proj-a-d4",
+            worktreeId: null,
+            projectId: "proj-a",
+            modeId: "mode-1",
+            type: "agent",
+            name: "sole direct agent",
+            isMain: false,
+            state: "idle",
+            lifecycleState: "idle",
+            tmuxName: "tm-proj-a-d4",
+            createdAt: new Date().toISOString(),
+          },
+        });
+
+        const trigger = await screen.findByRole("button", { name: /Session actions for sole direct agent/i });
+        await user.click(trigger);
+        await user.click(await screen.findByRole("menuitem", { name: /^Terminate$/i }));
+        await user.click(await screen.findByRole("button", { name: /^Terminate$/i }));
+
+        await waitFor(() => {
+          expect(alertSpy).toHaveBeenCalledWith(
+            expect.stringContaining("no other agent session exists in this worktree"),
+          );
+        });
+      } finally {
+        alertSpy.mockRestore();
+      }
+    });
   });
 
   // ─── Inline rename (Part 03 Phase 3 — double-click, no modal fallback) ──

--- a/web-ui/src/components/layout/LeftSidebar.tsx
+++ b/web-ui/src/components/layout/LeftSidebar.tsx
@@ -745,8 +745,16 @@ export function LeftSidebar({
       // Removes the session record + kills the process + removes its data dir.
       // The daemon NEVER deletes the project's own files (guarded server-side).
       await api.terminateSession(sess.id);
-    } catch {
-      /* surface errors later */
+    } catch (err) {
+      // The only remaining failure for this call is "main session, no
+      // eligible sibling to promote" (Fix 1) — the one case a user must be
+      // told about, since it's no longer the default outcome for every
+      // main-session terminate. No toast/error-banner mechanism exists
+      // anywhere in web-ui (grepped this file, WorkspaceCanvas.tsx,
+      // DashboardPanel.tsx — all use the same bare "surface errors later"
+      // catch), so this uses the browser-native alert() rather than
+      // inventing new UI infra, per the plan's explicit instruction.
+      window.alert(err instanceof Error ? err.message : "Failed to terminate session.");
     }
   }
 

--- a/web-ui/src/components/layout/TabsStrip.test.tsx
+++ b/web-ui/src/components/layout/TabsStrip.test.tsx
@@ -77,17 +77,30 @@ describe("TabsStrip", () => {
     });
   });
 
-  it("main tab has no close control", async () => {
+  it("A2.T2 — main tab has no close control when it is the only agent session (wt-2, sole session)", async () => {
+    render(
+      <MemoryRouter>
+        <TabsStrip api={api} worktreeId="wt-2" kind="agent" />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /^main\b/i })).toBeInTheDocument();
+    });
+    const mainTab = screen.getByRole("tab", { name: /^main\b/i });
+    expect(mainTab.querySelector('[aria-label^="Terminate"]')).toBeNull();
+  });
+
+  it("A2.T1 — main tab shows a closeable '×' when a sibling agent session exists (wt-1)", async () => {
     render(
       <MemoryRouter>
         <TabsStrip api={api} worktreeId="wt-1" kind="agent" />
       </MemoryRouter>,
     );
     await waitFor(() => {
-      expect(screen.getByRole("tab", { name: /^main$/i })).toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: /^main\b/i })).toBeInTheDocument();
     });
-    const mainTab = screen.getByRole("tab", { name: /^main$/i });
-    expect(mainTab.querySelector('[aria-label^="Terminate"]')).toBeNull();
+    const mainTab = screen.getByRole("tab", { name: /^main\b/i });
+    expect(mainTab.querySelector('[aria-label^="Terminate"]')).not.toBeNull();
   });
 
   it("non-main tab exposes close via aria-label", async () => {
@@ -113,6 +126,73 @@ describe("TabsStrip", () => {
     expect(screen.getByRole("dialog")).toBeInTheDocument();
   });
 
+  it("A2.T3 — confirm dialog for a main-session terminate names the predicted promoted sibling", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <TabsStrip api={api} worktreeId="wt-1" kind="agent" />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /^main\b/i })).toBeInTheDocument();
+    });
+    const mainTab = screen.getByRole("tab", { name: /^main\b/i });
+    const closeButton = mainTab.querySelector('[aria-label^="Terminate"]') as HTMLElement;
+    expect(closeButton).not.toBeNull();
+    await user.click(closeButton);
+    const dialog = screen.getByRole("dialog");
+    // wt-1's only other non-archived agent session is "agent-2"
+    // (sortOrder 2, the lowest among eligible siblings) — same rule the
+    // daemon uses for authoritative selection (Decision 1).
+    expect(within(dialog).getByText(/agent-2.*will become the new main session/i)).toBeInTheDocument();
+  });
+
+  it("M4 — a session:updated{isMain:true} WS event propagates through TabsStrip's local reconciliation (A2.3) and is read by dependent UI (A2.5's dialog naming)", async () => {
+    // Direct test of the isMain patch added at TabsStrip.tsx's own
+    // `session:updated` handler (`:415-432`) — NOT routed through the global
+    // `useServerSync`/`useServerStore` (A2.2, covered separately), since this
+    // component reads its OWN local `sessions` state for `closeable` and the
+    // confirm-dialog message. Reassigns "main" to "agent-2" purely via WS
+    // events (isMain flips on both, no session added/removed) and confirms
+    // the dialog naming (which reads `s.isMain` from local state) reflects
+    // the swap — proving the patch actually took effect, not just that no
+    // error was thrown. (Note: this cannot exercise a "closeable → not
+    // closeable" transition purely from an isMain flip while holding
+    // membership fixed — `closeable` is `!s.isMain || siblingCount > 1`, so a
+    // main tab is only ever non-closeable when it's the SOLE session, a case
+    // already covered by A2.T2; the isMain field itself doesn't gate
+    // closeability when a sibling exists, in either direction.)
+    const user = userEvent.setup();
+    const localApi = createMockApi();
+    render(
+      <MemoryRouter>
+        <TabsStrip api={localApi} worktreeId="wt-1" kind="agent" />
+      </MemoryRouter>,
+    );
+    await screen.findByRole("tab", { name: /^main\b/i });
+    await screen.findByRole("tab", { name: /agent-2/i });
+
+    await act(async () => {
+      localApi.__test.emit({ type: "session:updated", sessionId: "sess-main", isMain: false });
+      localApi.__test.emit({ type: "session:updated", sessionId: "sess-agent2", isMain: true });
+    });
+
+    // "agent-2" is now the main session — click ITS terminate control and
+    // confirm the predicted promotion candidate is sess-main (sortOrder 1,
+    // the only other eligible non-archived agent sibling). sess-main has no
+    // explicit `name`, and `sessionLabel()` only falls back to "main" while
+    // `isMain` is true — since our event just flipped it to `false`, its
+    // computed label is now "Agent" (the type-based default), which is
+    // itself further proof the isMain patch took effect on THIS session too
+    // (not just sess-agent2).
+    const agentTwoTab = screen.getByRole("tab", { name: /agent-2/i });
+    const closeButton = agentTwoTab.querySelector('[aria-label^="Terminate"]') as HTMLElement;
+    expect(closeButton).not.toBeNull();
+    await user.click(closeButton);
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByText(/Agent.*will become the new main session/i)).toBeInTheDocument();
+  });
+
   it("click + opens NewTab dialog", async () => {
     const user = userEvent.setup();
     render(
@@ -131,7 +211,7 @@ describe("TabsStrip", () => {
       </MemoryRouter>,
     );
     await waitFor(() => {
-      expect(screen.getByRole("tab", { name: /^main$/i })).toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: /^main\b/i })).toBeInTheDocument();
     });
     expect(screen.queryByRole("button", { name: /Close terminal dock/i })).toBeNull();
   });
@@ -278,7 +358,7 @@ describe("TabsStrip", () => {
         <TabsStrip api={api} worktreeId="wt-1" kind="agent" />
       </MemoryRouter>,
     );
-    await screen.findByRole("tab", { name: /^main$/i });
+    await screen.findByRole("tab", { name: /^main\b/i });
     expect(capturedOnDragEnd).toBeTypeOf("function");
 
     // Mock fixtures: sess-main sortOrder=1, sess-agent2 sortOrder=2. Dragging
@@ -300,7 +380,7 @@ describe("TabsStrip", () => {
         <TabsStrip api={api} worktreeId="wt-1" kind="agent" />
       </MemoryRouter>,
     );
-    await screen.findByRole("tab", { name: /^main$/i });
+    await screen.findByRole("tab", { name: /^main\b/i });
     act(() => {
       capturedOnDragEnd!({
         active: { id: "sess-agent2" },
@@ -393,7 +473,7 @@ describe("TabsStrip", () => {
         <TabsStrip api={localApi} worktreeId="wt-1" kind="agent" />
       </MemoryRouter>,
     );
-    await screen.findByRole("tab", { name: /^main$/i });
+    await screen.findByRole("tab", { name: /^main\b/i });
     act(() => {
       capturedOnDragEnd!({
         active: { id: "sess-agent2" },
@@ -435,7 +515,7 @@ describe("TabsStrip", () => {
         <TabsStrip api={localApi} worktreeId="wt-1" kind="agent" />
       </MemoryRouter>,
     );
-    await screen.findByRole("tab", { name: /^main$/i });
+    await screen.findByRole("tab", { name: /^main\b/i });
     expect(document.querySelector("[data-tab-menu-trigger]")).toBeNull();
     expect(screen.queryByRole("button", { name: /Session actions for/i })).toBeNull();
   });

--- a/web-ui/src/components/layout/TabsStrip.tsx
+++ b/web-ui/src/components/layout/TabsStrip.tsx
@@ -423,6 +423,7 @@ export function TabsStrip({ api, worktreeId, kind, scope = "worktree" }: TabsStr
           if (ev.sortOrder !== undefined) patch.sortOrder = ev.sortOrder;
           if (ev.pinnedAt !== undefined) patch.pinnedAt = ev.pinnedAt ?? null;
           if (ev.supersededBy !== undefined) patch.supersededBy = ev.supersededBy ?? null;
+          if (ev.isMain !== undefined) patch.isMain = ev.isMain;
           if (ev.channel !== undefined) {
             patch.channel = ev.channel;
             patch.useTmux = ev.channel === "tmux";
@@ -551,7 +552,13 @@ export function TabsStrip({ api, worktreeId, kind, scope = "worktree" }: TabsStr
           >
             {orderedSessions.map((s) => {
               const active = s.id === activeSessionId;
-              const closeable = !s.isMain;
+              // A main session can be terminated too, as long as another
+              // live agent session in this worktree exists to be promoted
+              // (Fix 1) — `orderedSessions` here is already scoped to this
+              // bar's kind ("agent"), so counting non-archived siblings
+              // mirrors the daemon's own eligibility check exactly.
+              const closeable =
+                !s.isMain || orderedSessions.filter((x) => x.archivedAt == null).length > 1;
               const label = sessionLabel(s);
               const isRenaming = renamingId === s.id;
               const archived = s.archivedAt != null;
@@ -744,11 +751,41 @@ export function TabsStrip({ api, worktreeId, kind, scope = "worktree" }: TabsStr
       <ConfirmDialog
         open={!!terminateTarget}
         title={isAgent ? "Terminate agent?" : "Terminate terminal?"}
-        message={isAgent ? "Terminate this agent session?" : "Terminate this terminal?"}
+        message={
+          isAgent && terminateTarget?.isMain
+            ? // Client-side prediction only (display purposes) — mirrors the
+              // daemon's own eligibility rule (lowest sortOrder, type "agent",
+              // not archived); the daemon's own selection at commit time is
+              // authoritative and may differ in a rare race (Risk 3).
+              (() => {
+                const candidate = orderedSessions
+                  .filter((s) => s.id !== terminateTarget.id && s.archivedAt == null)
+                  .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0))[0];
+                return candidate
+                  ? `Terminate this agent session? "${sessionLabel(candidate)}" will become the new main session.`
+                  : "Terminate this agent session?";
+              })()
+            : isAgent
+              ? "Terminate this agent session?"
+              : "Terminate this terminal?"
+        }
         confirmLabel="Terminate"
         onCancel={() => setTerminateTarget(null)}
         onConfirm={() => {
-          if (terminateTarget) void api.terminateSession(terminateTarget.id).then(() => void refreshTabs());
+          if (terminateTarget) {
+            void api
+              .terminateSession(terminateTarget.id)
+              .then(() => void refreshTabs())
+              .catch((err: unknown) => {
+                // No existing toast/error-banner mechanism was found anywhere
+                // in web-ui (grepped LeftSidebar.tsx, WorkspaceCanvas.tsx,
+                // DashboardPanel.tsx — all use the same bare
+                // `catch { /* surface errors later */ }`), so this uses the
+                // browser-native alert() rather than inventing new UI infra,
+                // per the plan's explicit "don't invent a new mechanism" rule.
+                window.alert(err instanceof Error ? err.message : "Failed to terminate session.");
+              });
+          }
           setTerminateTarget(null);
         }}
       />

--- a/web-ui/src/components/layout/WorkspaceCanvas.tsx
+++ b/web-ui/src/components/layout/WorkspaceCanvas.tsx
@@ -1473,7 +1473,17 @@ export function WorkspaceCanvas({
           const target = terminateTarget;
           setTerminateTarget(null);
           if (target) {
-            void api.terminateSession(target.session.id).then(() => removeTile(target.tileId));
+            void api
+              .terminateSession(target.session.id)
+              .then(() => removeTile(target.tileId))
+              .catch((err: unknown) => {
+                // Only remaining failure: "main session, no eligible sibling
+                // to promote" (Fix 1). No toast/error-banner mechanism exists
+                // anywhere in web-ui — see TabsStrip.tsx's identical catch for
+                // the full rationale — so this uses the browser-native
+                // alert() rather than inventing new UI infra.
+                window.alert(err instanceof Error ? err.message : "Failed to terminate session.");
+              });
           }
         }}
       />

--- a/web-ui/src/hooks/useServerSync.test.ts
+++ b/web-ui/src/hooks/useServerSync.test.ts
@@ -68,6 +68,24 @@ describe("useServerSync — session:updated reconciliation", () => {
     });
   });
 
+  it("M4 (A2.2) — applies isMain from a session:updated event (main-session promotion, Fix 1)", async () => {
+    const api = createMockApi();
+    renderHook(() => useServerSync(api));
+    await waitFor(() => expect(useServerStore.getState().loaded).toBe(true));
+
+    const before = useServerStore.getState().sessions.find((x) => x.id === "sess-agent2");
+    expect(before?.isMain).toBeFalsy();
+
+    act(() => {
+      api.__test.emit({ type: "session:updated", sessionId: "sess-agent2", isMain: true });
+    });
+
+    await waitFor(() => {
+      const s = useServerStore.getState().sessions.find((x) => x.id === "sess-agent2");
+      expect(s?.isMain).toBe(true);
+    });
+  });
+
   it("leaves unrelated fields untouched when only pinnedAt is present", async () => {
     const api = createMockApi();
     renderHook(() => useServerSync(api));

--- a/web-ui/src/hooks/useServerSync.ts
+++ b/web-ui/src/hooks/useServerSync.ts
@@ -197,6 +197,7 @@ export function useServerSync(api: ApiInstance): void {
         if (ev.sortOrder !== undefined) patch.sortOrder = ev.sortOrder;
         if (ev.pr !== undefined) patch.pr = ev.pr ?? undefined;
         if (ev.supersededBy !== undefined) patch.supersededBy = ev.supersededBy ?? null;
+        if (ev.isMain !== undefined) patch.isMain = ev.isMain;
         applySessionUpdated(ev.sessionId, patch);
         // A reset's replacement takes the archived session's place in every
         // canvas it was tiled in — same tile id/position, just repointed.


### PR DESCRIPTION
## Summary
- **Main-session promotion**: `DELETE /sessions/:id` on a worktree's main session now promotes an eligible sibling agent session (atomically, inside one locked `mutateProject` callback re-derived at commit time — closes a TOCTOU race found and fixed during implementation, including in the plain non-main delete path) instead of unconditionally rejecting. The promoted session's `name` and `pr` are preserved/carried forward; it's still rejected with 400 only when the main session is the worktree's sole session. Web-UI enables the terminate control on main tabs, discloses the promotion side effect in the confirm dialog, and surfaces errors instead of silently swallowing them.
- **SendMessage name resolution**: `vst session ls` gains `--worktree`/`--name` filters so an agent can resolve a UI-set session display name to an id in one call instead of manually scanning unfiltered output. `agent-system-prompt.md` and `skill/SKILL.md` document the resolution one-liner and drop stale slot-based session-id wording that could otherwise cause an agent to fabricate a nonexistent id.

Full plan + research: `.vibekit/feature-plans/wip/ui-allow-daemon/plan-ui-allow-daemon.md` (went through 2 rounds of plan review and 2 rounds of post-implementation code review — all opus).

## Test plan
- [x] `pnpm typecheck` (cli + web-ui) — clean
- [x] `eslint web-ui/src cli/src` — 0 new errors/warnings (3 pre-existing errors in an untouched file)
- [x] `cli` vitest — 790/790 passed, including new `session-ls.test.ts` and concurrency tests in `sessions.test.ts`
- [x] `web-ui` vitest — 492/492 passed, including new coverage for the WS `isMain` plumbing and mock promotion logic
- [x] Concurrency correctness independently re-verified (project-locked `mutateProject` semantics, promotion candidate selected fresh inside the lock, teardown after commit, broadcast ordering)