### PR TITLE
Canvas Windows popup, ghost-tile/z-order fixes, chat working indicator + composer auto-grow

### DIFF
--- a/.vibekit/feature-plans/wip/chat-working-indicator-scroll-grow/.sdlc-state.yaml
+++ b/.vibekit/feature-plans/wip/chat-working-indicator-scroll-grow/.sdlc-state.yaml
@@ -1,0 +1,19 @@
+feature: chat-working-indicator-scroll-grow
+worktree: /home/gb/.vibe-station/projects/vibe-station/worktrees/vs-54
+master:
+  prd: skipped
+  plan: complete
+current_subfeature: root
+subfeatures:
+  - id: root
+    origin: planned
+    spawned_from: null
+    mode: done
+    last_completed: "4.T2"
+    awaiting_phase: null
+    awaiting_artifact: null
+    phase_chain: [plan, implement, verify]
+    superseded_reason: null
+    parked_reason: null
+    handoff: {next_item: null, returned_at: null, verified_by: null}
+    commit: null

--- a/.vibekit/feature-plans/wip/chat-working-indicator-scroll-grow/plan-chat-working-indicator-scroll-grow.md
+++ b/.vibekit/feature-plans/wip/chat-working-indicator-scroll-grow/plan-chat-working-indicator-scroll-grow.md
@@ -1,0 +1,143 @@
+<!--
+RULES — read before writing or implementing:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. REQUIREMENTS: One crisp line each — no verbose descriptions
+3. CHECKLIST: Mark items [x] as you complete them — this is your persistent todo list
+4. READING TIME: Optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+# Plan: Rich chat — persistent last-message working indicator, reliable auto-scroll, growing composer
+
+**Issue:** chat-working-indicator-scroll-grow
+**Branch:** `option-windows-window` (continuing current worktree, separate commit)
+**PRD:** none — small, skipped
+
+**Reference files:**
+- `web-ui/src/components/chat/StatusBar.tsx` — existing spinner+Stop indicator (keep as-is)
+- `web-ui/src/components/chat/MessageList.tsx:245-249,388-390` — auto-scroll effect, message-list tail
+- `web-ui/src/components/layout/ChatPane.tsx:183-257` — footer/body flex layout
+- `web-ui/src/components/chat/Composer.tsx:107-120` — textarea, currently fixed `rows={2}`
+- `web-ui/src/styles/chat.css:701-726,905-951,1045-1058` — thinking-hint dot pulse, composer, spinner CSS
+
+---
+
+## Problem
+
+- The only "agent is working" affordance is a small spinner in the footer `StatusBar`, easy to miss when scrolled up or glancing at the message area
+- `MessageList`'s auto-scroll (`scrollIntoView` on a bottom sentinel) only re-runs on `items.length`/`pending.length`/`thinking` changes — it does NOT re-run when the footer grows taller (e.g. composer auto-grow below), so the last message can end up hidden behind the footer
+- The composer textarea has no auto-grow — fixed `rows={2}`, manual resize handle only
+
+## Concept
+
+- Add a second working indicator as the actual last item in the message feed: animated dots cycling 1→2→3→1, gated on the same busy/thinking signal `MessageList` already receives — additive, existing `StatusBar` spinner untouched
+- Make auto-scroll footer-height-aware: observe the footer's height (`ResizeObserver`) and re-trigger `scrollIntoView` when it changes, so a growing composer/indicator never leaves the last message obscured
+- Auto-grow the composer textarea on input up to a ~10-line cap, then let it scroll internally — replace the fixed `rows={2}`/manual-resize-only behavior with a JS height recalculation on each keystroke, capped
+
+## Requirements
+
+| # | Requirement |
+|---|-------------|
+| 1a | While the agent is busy (same signal driving `StatusBar`'s spinner), the message feed's last rendered item is a working indicator — 1, 2, 3 dots, cycling back to 1, looping while busy |
+| 1b | The existing `StatusBar` spinner + Stop button near the input is unchanged |
+| 1c | The new indicator disappears (not just stops animating) as soon as the agent is no longer busy |
+| 2a | After the composer/footer grows (auto-grow textarea, or anything else changing footer height) while already scrolled to bottom, the last message stays fully visible above the footer — never partially hidden |
+| 2b | Auto-scroll still fires correctly on new messages/pending/thinking changes as it does today (no regression) |
+| 3a | Typing multi-line input grows the textarea to fit content, up to ~10 lines tall |
+| 3b | Beyond ~10 lines, the textarea stops growing and scrolls internally instead |
+| 3c | Textarea shrinks back down as content is deleted (not stuck at max height) |
+
+## Out of Scope
+
+- Redesigning `StatusBar` or removing the existing spinner
+- Virtualizing/windowing the message list (unrelated to this change)
+
+**Deviation during implementation:** the manual vertical-resize handle (`resize: vertical`) was
+REMOVED rather than kept — a JS-driven auto-grow effect re-running on every keystroke would
+otherwise fight/overwrite a user's manually-dragged height on the very next character typed.
+Auto-grow-up-to-a-cap supersedes manual resize entirely (standard pattern for this kind of
+composer, e.g. Slack/Discord/ChatGPT), which is a closer match to the actual ask ("grow it
+automatically") than the original scope note assumed.
+
+---
+
+## Implementation Phases
+
+### Phase 1 — persistent dot indicator in message feed
+
+- [x] **1.1** `MessageList.tsx`: render a working-indicator element as the last child (after `pending.map`, before the `bottomRef` sentinel), gated on the same busy/thinking prop(s) already passed into `MessageList`
+- [x] **1.2** CSS: new dot-cycle animation (1→2→3→1 dots), reusing `.chat-thinking-hint__dot`'s pulse approach as a starting reference but as a 3-dot sequence, not a single pulse
+- [x] **1.3** Component/CSS test coverage for: indicator renders while busy, absent while idle, is the last DOM child of the list while present
+
+**Verify phase 1:**
+- [x] **1.T1** `pnpm --filter @vibestation/web exec vitest run src/components/chat/MessageList.test.tsx` (or nearest existing test file) passes
+- [x] **1.T2** `pnpm typecheck` clean
+
+### Phase 2 — footer-height-aware auto-scroll
+
+- [x] **2.1** `MessageList.tsx` (or `ChatPane.tsx`, whichever owns the scroll container): observe footer height via `ResizeObserver` and re-run the bottom-scroll on change, in addition to the existing `items.length`/`pending.length`/`thinking` deps
+- [x] **2.2** Only auto-re-scroll when the user was already at (or near) the bottom before the resize — don't yank the view down while the user has deliberately scrolled up to read history
+- [x] **2.3** Test coverage: footer height change while at bottom triggers scroll; footer height change while scrolled up does NOT force-scroll
+
+**Verify phase 2:**
+- [x] **2.T1** Same test file(s) as phase 1 pass
+- [x] **2.T2** `pnpm typecheck` clean
+
+### Phase 3 — composer auto-grow
+
+- [x] **3.1** `Composer.tsx`: on input, recalculate textarea height from `scrollHeight`, capped at a computed ~10-line max (derive from the textarea's actual `line-height`/padding, not a guessed pixel constant), shrink back down when content shrinks
+- [x] **3.2** `chat.css`: adjust `.chat-composer__textarea`'s `max-height`/`resize` as needed to match the new JS-driven cap (keep manual vertical resize working underneath the auto-grow, per Out of Scope)
+- [x] **3.3** Test coverage: height grows with multi-line input up to the cap, caps and scrolls beyond ~10 lines, shrinks back on delete
+
+**Verify phase 3:**
+- [x] **3.T1** `pnpm --filter @vibestation/web exec vitest run src/components/chat/Composer.test.tsx` (or nearest) passes
+- [x] **3.T2** `pnpm typecheck` clean
+
+### Phase 4 — review + verify
+
+- [x] **4.1** Opus reviewer pass on the full diff (all 3 phases together — small enough for one pass)
+- [x] **4.2** Address any CONFIRMED findings — 7 real findings, all fixed:
+  1. Composer autosize ran in `useEffect` (passive, post-paint) with the CSS safety net removed
+     (`overflow-y: hidden`) — could clip the just-typed line/caret for one frame per keystroke.
+     Fixed: `useLayoutEffect`.
+  2. `WorkingIndicator` and `ThinkingHint` could render simultaneously during the `thinking`
+     sub-state (both `turnActive`) — two competing busy indicators. Fixed: gated
+     `turnActive && !thinking`.
+  3. The dot-cycle interval had no `prefers-reduced-motion` guard (existing `ThinkingHint` dot
+     does, via CSS). Fixed: `matchMedia` check before starting the interval.
+  4. `nearBottomRef` was only refreshed by `scroll` events; streaming tokens into an existing
+     bubble grow content without moving `scrollTop`/firing `scroll`, so the flag could go
+     stale-true and yank the view down later. Fixed: removed the cached flag + scroll listener
+     entirely, compute distance-to-bottom fresh inside the `ResizeObserver` callback.
+  5. The resize-triggered rescroll used `bottomRef.current.scrollIntoView(...)`, which walks
+     every scrollable ancestor (including `overflow: hidden` boxes) — an unrelated resize
+     elsewhere (canvas divider drag) could nudge ancestor scroll positions. Fixed:
+     `container.scrollTop = container.scrollHeight` on just the one container.
+  6. `autosizeComposerTextarea` read `el.scrollHeight` twice (two forced reflows, not
+     guaranteed equal once `overflowY` flips). Fixed: cached in one variable.
+  7. The textarea's `ref` was an inline arrow function, recreated every render — React
+     detaches/reattaches (`null`) on every keystroke. Fixed: `useCallback`.
+- [x] **4.3** Full `web-ui` vitest suite + repo-wide typecheck — re-ran after fixes, all green
+
+**Verify phase 4:**
+- [x] **4.T1** No unresolved CONFIRMED findings
+- [x] **4.T2** Full `web-ui` test suite passes, typecheck clean
+
+---
+
+## Files & Phase Impact
+
+| File | Status | Phase | Description / Contract Change |
+|------|--------|-------|-------------------------------|
+| `web-ui/src/components/chat/MessageList.tsx` | Modified | 1, 2 | Dot indicator as last item; footer-resize-aware scroll |
+| `web-ui/src/components/layout/ChatPane.tsx` | Possibly modified | 2 | Footer ref/height plumbing if needed |
+| `web-ui/src/components/chat/Composer.tsx` | Modified | 3 | Auto-grow textarea logic |
+| `web-ui/src/styles/chat.css` | Modified | 1, 3 | Dot-cycle animation, textarea max-height adjustment |
+| Corresponding `*.test.tsx` files | Modified | 1, 2, 3 | New coverage |
+
+---
+
+## Verification Method
+
+- Node/vitest: targeted component tests + repo-wide `pnpm typecheck`
+- Reviewer: opus subagent, one pass on the complete diff
+- No docker/browser verification planned (no browser tool available) — static + unit-test verification only, same as the prior sub-feature in this session

--- a/daemon/src/__tests__/worktrees.test.ts
+++ b/daemon/src/__tests__/worktrees.test.ts
@@ -510,6 +510,31 @@ describe("Worktree routes", () => {
     expect(listRes.json<WorktreeRecord[]>()).toHaveLength(0);
   });
 
+  it("DELETE /worktrees/:id broadcasts session:deleted per session BEFORE worktree:deleted", async () => {
+    // Client-side tile cleanup keys off `session:deleted`; without the cascade
+    // a deleted worktree's tiles survived in every canvas as empty ghosts.
+    const createRes = await app.inject({
+      method: "POST",
+      url: "/worktrees",
+      payload: { projectId, branch: `cascade-${Date.now()}`, modeId: "bug-fix" },
+    });
+    const wt = createRes.json<{ id: string; mainSessionId: string }>();
+
+    const broadcast = await import("../broadcaster.js");
+    const spy = vi.spyOn(broadcast, "broadcastAll");
+
+    const delRes = await app.inject({ method: "DELETE", url: `/worktrees/${wt.id}` });
+    expect(delRes.statusCode).toBe(200);
+
+    const msgs = spy.mock.calls.map((c) => c[0] as { type: string; sessionId?: string });
+    const sessionDeletes = msgs.filter((m) => m.type === "session:deleted");
+    expect(sessionDeletes.map((m) => m.sessionId)).toContain(wt.mainSessionId);
+    expect(msgs.findIndex((m) => m.type === "session:deleted")).toBeLessThan(
+      msgs.findIndex((m) => m.type === "worktree:deleted"),
+    );
+    spy.mockRestore();
+  });
+
   it("DELETE /worktrees/:id 404 for unknown worktree", async () => {
     const res = await app.inject({ method: "DELETE", url: "/worktrees/wt-nonexistent-99" });
     expect(res.statusCode).toBe(404);

--- a/daemon/src/routes/projects.ts
+++ b/daemon/src/routes/projects.ts
@@ -855,6 +855,20 @@ export function registerProjectRoutes(app: FastifyInstance): void {
       return reply.status(500).send({ error: `Failed to delete project: ${String(err)}` });
     }
 
+    // Same gap as `DELETE /worktrees/:id`: client tile cleanup keys off
+    // `session:deleted`, so cascade a per-session delete for every session
+    // (direct + per-worktree) this project owned, plus a per-worktree delete,
+    // before the project-level event. Otherwise tiles referencing them survive
+    // in canvases as empty ghost windows.
+    for (const session of project.directSessions) {
+      broadcastAll({ type: "session:deleted", sessionId: session.id });
+    }
+    for (const wt of project.worktrees) {
+      for (const session of wt.sessions) {
+        broadcastAll({ type: "session:deleted", sessionId: session.id });
+      }
+      broadcastAll({ type: "worktree:deleted", worktreeId: wt.id });
+    }
     broadcastAll({ type: "project:deleted", projectId: id });
     return reply.send({ ok: true });
   });

--- a/daemon/src/routes/worktrees.ts
+++ b/daemon/src/routes/worktrees.ts
@@ -816,6 +816,15 @@ export function registerWorktreeRoutes(app: FastifyInstance): void {
       worktrees: p.worktrees.filter((w) => w.id !== wtId),
     }));
 
+    // Per-session deletes BEFORE the worktree delete: the client's tile
+    // cleanup (`removeTilesForSession`) keys off `session:deleted`, and these
+    // sessions are gone for good. Without them, tiles for this worktree's
+    // sessions survived in every canvas as empty ghost windows — a worktree
+    // delete is exactly the same event, from the client's point of view, as N
+    // individual session deletes plus the worktree itself.
+    for (const session of worktree.sessions) {
+      broadcastAll({ type: "session:deleted", sessionId: session.id });
+    }
     broadcastAll({ type: "worktree:deleted", worktreeId: wtId });
     return reply.send({ ok: true });
   });

--- a/web-ui/src/components/chat/Composer.test.tsx
+++ b/web-ui/src/components/chat/Composer.test.tsx
@@ -93,3 +93,54 @@ describe("Composer draft persistence (RA1)", () => {
     expect(localStorage.getItem("vst-chat-draft-s2")).toBe("session two draft");
   });
 });
+
+describe("Composer textarea auto-grow", () => {
+  // jsdom has no real layout, so `scrollHeight` is stubbed per-assertion.
+  // `getComputedStyle`'s line-height/padding/border resolve to jsdom's UA
+  // defaults, NOT this project's CSS (vitest doesn't apply stylesheets) —
+  // read the same computed style the component reads, rather than assuming a
+  // specific pixel cap, so this test isn't coupled to jsdom's UA defaults.
+  function expectedCapPx(textarea: HTMLTextAreaElement): number {
+    const style = window.getComputedStyle(textarea);
+    const lineHeight = parseFloat(style.lineHeight) || 20;
+    const extra =
+      (parseFloat(style.paddingTop) || 0) +
+      (parseFloat(style.paddingBottom) || 0) +
+      (parseFloat(style.borderTopWidth) || 0) +
+      (parseFloat(style.borderBottomWidth) || 0);
+    return lineHeight * 10 + extra;
+  }
+
+  it("grows to fit content up to the ~10-line cap, then caps and scrolls", () => {
+    const api = createMockApi();
+    render(<Composer api={api} sessionId="s-grow" onSend={vi.fn()} />);
+    const textarea = screen.getByLabelText("Message") as HTMLTextAreaElement;
+    const cap = expectedCapPx(textarea);
+
+    Object.defineProperty(textarea, "scrollHeight", { value: 90, configurable: true });
+    fireEvent.change(textarea, { target: { value: "line1\nline2\nline3" } });
+    expect(textarea.style.height).toBe("90px");
+    expect(textarea.style.overflowY).toBe("hidden");
+
+    Object.defineProperty(textarea, "scrollHeight", { value: cap + 300, configurable: true });
+    fireEvent.change(textarea, { target: { value: "a\n".repeat(20) } });
+    expect(textarea.style.height).toBe(`${cap}px`);
+    expect(textarea.style.overflowY).toBe("auto");
+  });
+
+  it("shrinks back down as content is deleted", () => {
+    const api = createMockApi();
+    render(<Composer api={api} sessionId="s-shrink" onSend={vi.fn()} />);
+    const textarea = screen.getByLabelText("Message") as HTMLTextAreaElement;
+    const cap = expectedCapPx(textarea);
+
+    Object.defineProperty(textarea, "scrollHeight", { value: cap + 100, configurable: true });
+    fireEvent.change(textarea, { target: { value: "a\n".repeat(15) } });
+    expect(textarea.style.height).toBe(`${cap}px`);
+
+    Object.defineProperty(textarea, "scrollHeight", { value: 40, configurable: true });
+    fireEvent.change(textarea, { target: { value: "short" } });
+    expect(textarea.style.height).toBe("40px");
+    expect(textarea.style.overflowY).toBe("hidden");
+  });
+});

--- a/web-ui/src/components/chat/Composer.tsx
+++ b/web-ui/src/components/chat/Composer.tsx
@@ -1,9 +1,31 @@
-import { useRef, useState } from "react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
 import type { ApiInstance } from "@/api";
 import type { Attachment } from "@/api/types";
 import { useAttachmentDrafts } from "@/hooks/useAttachmentDrafts";
 import { loadDraft, useComposerDraft } from "@/hooks/useComposerDraft";
 import { AttachmentChip } from "./AttachmentChip";
+
+/** Grow the textarea up to this many lines of content, then scroll internally. */
+const COMPOSER_MAX_GROW_LINES = 10;
+
+/** Resize `el` to fit its content, capped at `COMPOSER_MAX_GROW_LINES` worth
+ *  of height (derived from the element's own resolved line-height/padding/
+ *  border, not a guessed pixel constant, so it tracks the user's chat font
+ *  size setting). Toggles internal scrolling once the cap is hit. */
+function autosizeComposerTextarea(el: HTMLTextAreaElement) {
+  const style = window.getComputedStyle(el);
+  const lineHeight = parseFloat(style.lineHeight) || 20;
+  const verticalExtra =
+    (parseFloat(style.paddingTop) || 0) +
+    (parseFloat(style.paddingBottom) || 0) +
+    (parseFloat(style.borderTopWidth) || 0) +
+    (parseFloat(style.borderBottomWidth) || 0);
+  const maxHeight = lineHeight * COMPOSER_MAX_GROW_LINES + verticalExtra;
+  el.style.height = "auto";
+  const contentHeight = el.scrollHeight;
+  el.style.height = `${Math.min(contentHeight, maxHeight)}px`;
+  el.style.overflowY = contentHeight > maxHeight ? "auto" : "hidden";
+}
 
 interface ComposerProps {
   api: ApiInstance;
@@ -48,6 +70,28 @@ export function Composer({
   const [dragOver, setDragOver] = useState(false);
   const [sending, setSending] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const internalTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+  // Stable identity so React doesn't detach/reattach (null → el) on every
+  // render — an inline arrow here would re-run the ref callback on every
+  // keystroke, transiently nulling the caller's `textareaRef.current`.
+  const setTextareaRef = useCallback(
+    (el: HTMLTextAreaElement | null) => {
+      internalTextareaRef.current = el;
+      if (textareaRef) textareaRef.current = el;
+    },
+    [textareaRef],
+  );
+
+  // Re-run on every `text` change (typing, programmatic clear-on-send,
+  // initial prefill) rather than only the onChange handler — one code path
+  // covers grow AND shrink-back-down (3c) without duplicating the call site.
+  // MUST be layout-effect, not a passive effect: a passive effect runs after
+  // paint, so a keystroke that needs a taller box would paint one frame with
+  // the OLD (shorter) height while `overflow-y: hidden` is already in CSS —
+  // clipping the just-typed line/caret for that frame, every keystroke.
+  useLayoutEffect(() => {
+    if (internalTextareaRef.current) autosizeComposerTextarea(internalTextareaRef.current);
+  }, [text]);
 
   const canSend = !disabled && !sending && (text.trim().length > 0 || readyAttachments.length > 0);
 
@@ -105,7 +149,7 @@ export function Composer({
 
       <div className="chat-composer__row">
         <textarea
-          ref={textareaRef}
+          ref={setTextareaRef}
           className="chat-composer__textarea"
           aria-label="Message"
           placeholder="Type a message…"

--- a/web-ui/src/components/chat/MessageList.test.tsx
+++ b/web-ui/src/components/chat/MessageList.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import type { NormalizedEvent } from "@/api/types";
 import { MessageList, groupEvents, mergeToolRuns } from "./MessageList";
 
@@ -157,5 +157,133 @@ describe("MessageList thinking hint (Change 3)", () => {
     );
     expect(screen.getByText("just sent")).toBeTruthy();
     expect(screen.getByText("Thinking…")).toBeTruthy();
+  });
+});
+
+describe("MessageList persistent working indicator", () => {
+  it("renders as the last item in the feed while a turn is active", () => {
+    const { container } = render(
+      <MessageList events={[userEvent("t1", "do the thing")]} pending={[]} turnActive />,
+    );
+    const indicator = screen.getByRole("status", { name: "Agent is working" });
+    expect(indicator).toBeTruthy();
+    // Last item in the list's DOM order (only the invisible bottom-scroll
+    // sentinel div may follow it).
+    const list = container.querySelector(".chat-message-list")!;
+    const lastMeaningfulChild = list.children[list.children.length - 2];
+    expect(lastMeaningfulChild).toBe(indicator);
+  });
+
+  it("does not render while idle", () => {
+    render(<MessageList events={[userEvent("t1", "do the thing")]} pending={[]} />);
+    expect(screen.queryByRole("status", { name: "Agent is working" })).toBeNull();
+  });
+
+  it("cycles dot count 1 -> 2 -> 3 -> 1 on an interval", () => {
+    vi.useFakeTimers();
+    try {
+      render(<MessageList events={[]} pending={[]} turnActive />);
+      const dotOf = () => document.querySelectorAll(".chat-working-indicator__dot--on").length;
+      expect(dotOf()).toBe(1);
+      act(() => vi.advanceTimersByTime(450));
+      expect(dotOf()).toBe(2);
+      act(() => vi.advanceTimersByTime(450));
+      expect(dotOf()).toBe(3);
+      act(() => vi.advanceTimersByTime(450));
+      expect(dotOf()).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not render during the thinking sub-state (ThinkingHint already covers it)", () => {
+    render(<MessageList events={[userEvent("t1", "do the thing")]} pending={[]} turnActive thinking />);
+    expect(screen.getByText("Thinking…")).toBeTruthy();
+    expect(screen.queryByRole("status", { name: "Agent is working" })).toBeNull();
+  });
+
+  it("does not start its dot interval when the user prefers reduced motion", () => {
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = ((query: string) => ({
+      matches: true,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    })) as typeof window.matchMedia;
+    vi.useFakeTimers();
+    try {
+      render(<MessageList events={[]} pending={[]} turnActive />);
+      const dotOf = () => document.querySelectorAll(".chat-working-indicator__dot--on").length;
+      expect(dotOf()).toBe(1);
+      act(() => vi.advanceTimersByTime(2000));
+      expect(dotOf()).toBe(1);
+    } finally {
+      vi.useRealTimers();
+      window.matchMedia = originalMatchMedia;
+    }
+  });
+});
+
+describe("MessageList footer-resize-aware auto-scroll", () => {
+  // `render()`'s own mount div is the direct parent of MessageList's root
+  // (`.chat-message-list`) — exactly the "scroll container" MessageList reads
+  // via `listRef.current.parentElement`, so no extra DOM wiring is needed to
+  // simulate it here.
+  function mockResizeObserver() {
+    let captured: (() => void) | null = null;
+    class MockResizeObserver {
+      constructor(cb: () => void) {
+        captured = cb;
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    const original = globalThis.ResizeObserver;
+    globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+    return {
+      trigger: () => captured?.(),
+      restore: () => {
+        globalThis.ResizeObserver = original;
+      },
+    };
+  }
+
+  // The distance-to-bottom is computed FRESH inside the ResizeObserver
+  // callback (not from a cached scroll-listener flag — see the source
+  // comment), so these tests stub `scrollHeight`/`clientHeight` directly on
+  // the container and assert on `container.scrollTop`, not `scrollIntoView`
+  // (which the implementation deliberately does not use for this path, to
+  // avoid walking ancestor scrollables).
+  it("re-scrolls to bottom when the container resizes while currently near the bottom", () => {
+    const ro = mockResizeObserver();
+    try {
+      const { container } = render(<MessageList events={[userEvent("t1", "hi")]} pending={[]} />);
+      Object.defineProperty(container, "scrollHeight", { value: 500, configurable: true });
+      Object.defineProperty(container, "clientHeight", { value: 480, configurable: true });
+      container.scrollTop = 0; // distance = 500 - 0 - 480 = 20, < 80 → near bottom
+      act(() => ro.trigger());
+      expect(container.scrollTop).toBe(500);
+    } finally {
+      ro.restore();
+    }
+  });
+
+  it("does not force-scroll on resize when the user is currently scrolled away from the bottom", () => {
+    const ro = mockResizeObserver();
+    try {
+      const { container } = render(<MessageList events={[userEvent("t1", "hi")]} pending={[]} />);
+      Object.defineProperty(container, "scrollHeight", { value: 1000, configurable: true });
+      Object.defineProperty(container, "clientHeight", { value: 300, configurable: true });
+      container.scrollTop = 0; // distance = 1000 - 0 - 300 = 700, >= 80 → not near bottom
+      act(() => ro.trigger());
+      expect(container.scrollTop).toBe(0);
+    } finally {
+      ro.restore();
+    }
   });
 });

--- a/web-ui/src/components/chat/MessageList.tsx
+++ b/web-ui/src/components/chat/MessageList.tsx
@@ -181,6 +181,43 @@ function ThinkingHint() {
   );
 }
 
+/** Milliseconds each dot-count step of `WorkingIndicator` is shown. */
+const WORKING_INDICATOR_STEP_MS = 450;
+
+/** Persistent "agent is working" affordance pinned as the LAST item in the
+ *  feed while a turn is active — the footer `StatusBar` spinner (near Stop)
+ *  is easy to miss when scrolled up or glancing away from the composer; this
+ *  is the same `turnActive` signal, just anchored where the eye actually
+ *  lands. Dot COUNT cycles 1 → 2 → 3 → 1 (not a spinner) — only mounted
+ *  while busy (see call site), so the interval's lifetime is the busy
+ *  window, no separate start/stop wiring needed. */
+function WorkingIndicator() {
+  const [count, setCount] = useState(1);
+  useEffect(() => {
+    // Respect the same reduced-motion convention as `.chat-thinking-hint__dot`
+    // (chat.css) — that one is stoppable via a CSS media query since its
+    // motion is CSS-driven; this one's motion is a JS interval, so it needs
+    // its own explicit check to honor the same opt-out.
+    if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
+    const id = window.setInterval(() => {
+      setCount((c) => (c >= 3 ? 1 : c + 1));
+    }, WORKING_INDICATOR_STEP_MS);
+    return () => window.clearInterval(id);
+  }, []);
+  return (
+    <div className="chat-working-indicator" role="status" aria-live="polite" aria-label="Agent is working">
+      <span className="chat-working-indicator__dots" aria-hidden>
+        {[1, 2, 3].map((n) => (
+          <span
+            key={n}
+            className={`chat-working-indicator__dot${n <= count ? " chat-working-indicator__dot--on" : ""}`}
+          />
+        ))}
+      </span>
+    </div>
+  );
+}
+
 /** Loaded-turn count above which the "load all" escape hatch warns (R2.5). */
 const LOAD_ALL_WARN_TURNS = 200;
 
@@ -243,10 +280,48 @@ export function MessageList({
     return mergeToolRuns(filtered);
   }, [grouped, hiddenTurnIds]);
   const bottomRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ block: "end" });
-  }, [items.length, pending.length, thinking]);
+    // `turnActive` here so the new WorkingIndicator's own appear/disappear
+    // (it changes the feed's content height) re-triggers the scroll too.
+  }, [items.length, pending.length, thinking, turnActive]);
+
+  // Re-scroll to bottom when the SCROLL CONTAINER's own height changes (e.g.
+  // the footer below it grows/shrinks — composer auto-grow, StatusBar
+  // wrapping) — but only if the user is CURRENTLY near the bottom, so a
+  // growing footer never fights someone reading scrolled-up history.
+  // `.chat-message-list` (this component's root, via `listRef`) is unscrolled
+  // content; its parent is the `overflow-y: auto` element (`.chat-pane__body`,
+  // owned by `ChatPane.tsx`). Scoped via DOM traversal from this instance's
+  // own root rather than a global selector, since multiple chat panes can be
+  // mounted at once (canvas/workspace mode).
+  //
+  // Distance-to-bottom is computed FRESH inside the ResizeObserver callback,
+  // not cached from a scroll listener: streaming tokens into an existing
+  // assistant bubble grows content without moving `scrollTop` and without
+  // firing a `scroll` event, so a cached flag can go stale-true while the
+  // user has silently drifted away from the bottom — the observer callback
+  // always runs with current layout, so this read is free and always correct.
+  useEffect(() => {
+    const container = listRef.current?.parentElement;
+    if (!container || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(() => {
+      const distance = container.scrollHeight - container.scrollTop - container.clientHeight;
+      if (distance < 80) {
+        // Not `bottomRef.current.scrollIntoView(...)`: that walks EVERY
+        // scrollable ancestor (including `overflow: hidden` boxes, which are
+        // still programmatically scrollable), so an unrelated resize (a
+        // workspace-canvas divider drag, a sidebar collapse) could nudge
+        // ancestor scroll positions too. Scrolling just this one container
+        // keeps the effect local to the chat pane.
+        container.scrollTop = container.scrollHeight;
+      }
+    });
+    ro.observe(container);
+    return () => ro.disconnect();
+  }, []);
 
   // Anchor the thinking hint under the latest user message. When an optimistic
   // (non-queued) pending bubble exists, the newest user message is that pending
@@ -268,7 +343,7 @@ export function MessageList({
   }, [events]);
 
   return (
-    <div className="chat-message-list" role="log" aria-label="Conversation">
+    <div ref={listRef} className="chat-message-list" role="log" aria-label="Conversation">
       {hasMore && onLoadEarlier ? (
         <div className="chat-load-earlier">
           <button
@@ -386,6 +461,11 @@ export function MessageList({
       ))}
 
       {hintAfterPending ? <ThinkingHint /> : null}
+
+      {/* Not during `thinking`: `ThinkingHint` already anchors a "Thinking…"
+          affordance above for that sub-state — showing both at once would be
+          two competing busy indicators on screen simultaneously. */}
+      {turnActive && !thinking ? <WorkingIndicator /> : null}
 
       <div ref={bottomRef} />
     </div>

--- a/web-ui/src/components/layout/Layout.tsx
+++ b/web-ui/src/components/layout/Layout.tsx
@@ -302,8 +302,15 @@ export function Layout({
     </div>
   );
 
+  // Classic-mode-only — matching `mainColumnInner`'s own condition above, not
+  // just `paneLayoutMode`, since a direct-session route can have
+  // `paneLayoutMode === "workspace"` with no `workspaceCanvas` (falls back to
+  // the classic column there too). In workspace/canvas mode the canvas tile
+  // owns the `tools:<worktreeId>` pane; rendering this overlay too would
+  // mount a second outlet for the same pane key and leave one of them an
+  // empty ghost window.
   const fullscreenOverlay =
-    paneFullscreen === "tools" && hasToolPanel ? (
+    !(paneLayoutMode === "workspace" && workspaceCanvas != null) && paneFullscreen === "tools" && hasToolPanel ? (
       <div className="pane-viewport-fullscreen" key="viewport-fs-tools">
         {wrap(toolPanel, "viewport")}
       </div>

--- a/web-ui/src/components/layout/TopBar.tsx
+++ b/web-ui/src/components/layout/TopBar.tsx
@@ -382,7 +382,7 @@ export function TopBar({
                 disabled={paneLayoutMode === "workspace"}
                 title={
                   paneLayoutMode === "workspace"
-                    ? "Not applicable in canvas mode — every terminal is its own tile (use Add tile)"
+                    ? "Not applicable in canvas mode — every terminal is its own tile (use Windows)"
                     : `Toggle terminal dock (${hints.terminal})`
                 }
                 onClick={toggleTerminalDock}

--- a/web-ui/src/components/layout/WorkspaceCanvas.test.tsx
+++ b/web-ui/src/components/layout/WorkspaceCanvas.test.tsx
@@ -86,7 +86,7 @@ describe("WorkspaceCanvas - canvas toolbar disclosure", () => {
   });
 });
 
-describe("WorkspaceCanvas - Add tile picker cross-worktree note", () => {
+describe("WorkspaceCanvas - Windows picker cross-worktree note", () => {
   beforeEach(() => {
     localStorage.clear();
     useWorkspaceStore.persist.clearStorage?.();
@@ -96,7 +96,7 @@ describe("WorkspaceCanvas - Add tile picker cross-worktree note", () => {
   it("shows the cross-worktree note on an unsaved (scratch) canvas", async () => {
     const user = userEvent.setup();
     renderCanvas();
-    await user.click(screen.getByText("Add tile"));
+    await user.click(screen.getByText("Windows"));
     expect(
       screen.getByText("To add panes from other worktrees, save this canvas as a workspace."),
     ).toBeInTheDocument();
@@ -128,7 +128,7 @@ describe("WorkspaceCanvas - Add tile picker cross-worktree note", () => {
         </PaneOutletProvider>
       </MemoryRouter>,
     );
-    await user.click(screen.getByText("Add tile"));
+    await user.click(screen.getByText("Windows"));
     expect(
       screen.queryByText("To add panes from other worktrees, save this canvas as a workspace."),
     ).not.toBeInTheDocument();
@@ -182,7 +182,7 @@ describe("WorkspaceCanvas - Add tile picker cross-worktree note", () => {
         </PaneOutletProvider>
       </MemoryRouter>,
     );
-    await user.click(screen.getByText("Add tile"));
+    await user.click(screen.getByText("Windows"));
     expect(screen.getByText("Direct")).toBeInTheDocument();
     const item = screen.getByText("My Direct Agent");
     expect(item).toBeInTheDocument();
@@ -210,10 +210,98 @@ describe("WorkspaceCanvas - Add tile picker cross-worktree note", () => {
     renderCanvas();
     expect(screen.getByText("Unsaved canvas")).toBeInTheDocument();
     expect(screen.queryByText("Doc")).not.toBeInTheDocument();
-    await user.click(screen.getByText("Add tile"));
+    await user.click(screen.getByText("Windows"));
     expect(
       screen.getByText("To add panes from other worktrees, save this canvas as a workspace."),
     ).toBeInTheDocument();
+  });
+});
+
+describe("WorkspaceCanvas - Windows picker stays open", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useWorkspaceStore.persist.clearStorage?.();
+    useWorkspaceStore.setState({
+      layoutByWorktree: {
+        [W1]: {
+          ...DEFAULT_WORKTREE_LAYOUT,
+          scratchCanvas: { mode: "free", tiles: [], tree: null, freeRects: {} },
+        },
+      },
+      workspaceDocs: {},
+    });
+  });
+
+  it("keeps the popup open after adding AND after removing a tile", async () => {
+    const user = userEvent.setup();
+    const { container } = renderCanvas();
+    await user.click(screen.getByText("Windows"));
+    expect(container.querySelector("[data-workspace-canvas-picker-panel]")).toBeTruthy();
+
+    // "Tools" is always offered (hasTools). Add → popup stays open, tile added.
+    await user.click(screen.getByRole("menu").querySelector("button:last-of-type")!);
+    expect(container.querySelector("[data-workspace-canvas-picker-panel]")).toBeTruthy();
+    expect(useWorkspaceStore.getState().layoutByWorktree[W1]!.scratchCanvas!.tiles).toHaveLength(1);
+
+    // Same item again → removes, popup STILL open (symmetric with add).
+    await user.click(screen.getByRole("menu").querySelector("button:last-of-type")!);
+    expect(container.querySelector("[data-workspace-canvas-picker-panel]")).toBeTruthy();
+    expect(useWorkspaceStore.getState().layoutByWorktree[W1]!.scratchCanvas!.tiles).toHaveLength(0);
+  });
+
+  it("still closes on an outside click", async () => {
+    const user = userEvent.setup();
+    const { container } = renderCanvas();
+    await user.click(screen.getByText("Windows"));
+    expect(container.querySelector("[data-workspace-canvas-picker-panel]")).toBeTruthy();
+    await user.click(document.body);
+    expect(container.querySelector("[data-workspace-canvas-picker-panel]")).toBeFalsy();
+  });
+});
+
+describe("WorkspaceCanvas - free-mode click-to-front z-order", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useWorkspaceStore.persist.clearStorage?.();
+  });
+
+  it("raises the tapped tile above the others without reordering the tiles array", () => {
+    const canvas: CanvasGeometry = {
+      mode: "free",
+      tiles: [
+        { id: "tile-a", kind: "tools" },
+        { id: "tile-b", kind: "agent", sessionId: "sess-b" },
+        { id: "tile-c", kind: "terminal", sessionId: "sess-c" },
+      ],
+      tree: null,
+      freeRects: {
+        "tile-a": { x: 0, y: 0, w: 40, h: 40 },
+        "tile-b": { x: 10, y: 10, w: 40, h: 40, z: 5 },
+        "tile-c": { x: 20, y: 20, w: 40, h: 40, z: 9 },
+      },
+    };
+    useWorkspaceStore.setState({
+      layoutByWorktree: { [W1]: { scratchCanvas: canvas } as never },
+      workspaceDocs: {},
+    });
+    const { container } = renderCanvas();
+
+    // tile-a starts at the back (z undefined → 0). Click anywhere inside it.
+    const tiles = container.querySelectorAll(".workspace-canvas__tile");
+    const tileA = tiles[0] as HTMLElement;
+    act(() => {
+      tileA
+        .querySelector(".workspace-canvas__tile-body")!
+        .dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    });
+
+    const after = useWorkspaceStore.getState().layoutByWorktree[W1]!.scratchCanvas!;
+    expect(after.freeRects["tile-a"]!.z).toBe(10);
+    // Every other tile keeps its own z — no relative reshuffle.
+    expect(after.freeRects["tile-b"]!.z).toBe(5);
+    expect(after.freeRects["tile-c"]!.z).toBe(9);
+    // Array order is untouched.
+    expect(after.tiles.map((t) => t.id)).toEqual(["tile-a", "tile-b", "tile-c"]);
   });
 });
 

--- a/web-ui/src/components/layout/WorkspaceCanvas.tsx
+++ b/web-ui/src/components/layout/WorkspaceCanvas.tsx
@@ -2,7 +2,7 @@ import "@/styles/workspace-canvas.css";
 import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { useNavigate } from "react-router-dom";
-import { Bot, Check, Folder, FolderOpen, GitBranch, Minimize2, MoreVertical, PanelRight, Plus, Save, Search, SquareTerminal, X } from "lucide-react";
+import { Bot, Check, ChevronDown, ChevronUp, Folder, FolderOpen, GitBranch, Minimize2, MoreVertical, PanelRight, Plus, Save, Search, SquareTerminal, X } from "lucide-react";
 import type { Project, Session, Worktree } from "@/api/types";
 import {
   buildBalancedTree,
@@ -366,6 +366,56 @@ export function WorkspaceCanvas({
     }
   }, [canvas, fullscreenTileId]);
 
+  // Orphaned-tile sweep — cheap defense in depth against a tile whose backing
+  // object is gone from ANY source (a missed `session:deleted`, a worktree
+  // deleted while this client was offline, a hand-edited persisted canvas).
+  // Such a tile can't render content, so it shows up as an empty ghost window.
+  // Guarded on a non-empty `worktrees` list so the pre-bundle-load empty state
+  // never wipes a canvas.
+  useEffect(() => {
+    if (!canvas || worktrees.length === 0) return;
+    const liveSessionIds = new Set(allSessions.map((s) => s.id));
+    const liveWorktreeIds = new Set(worktrees.map((w) => w.id));
+    const orphans = canvas.tiles.filter((t) =>
+      t.kind === "tools"
+        ? !liveWorktreeIds.has(t.worktreeId ?? worktreeId)
+        : t.sessionId != null && !liveSessionIds.has(t.sessionId),
+    );
+    if (orphans.length === 0) return;
+    let next = canvas;
+    for (const tile of orphans) next = removeTileFromCanvas(next, tile.id);
+    const store = useWorkspaceStore.getState();
+    if (savedDocId) store.updateWorkspaceDoc(savedDocId, next);
+    else store.updateScratchCanvas(worktreeId, next);
+  }, [canvas, allSessions, worktrees, worktreeId, savedDocId]);
+
+  // Free-mode click-to-front. A NATIVE capture-phase listener on the canvas
+  // body, not a React `onMouseDownCapture` on the tile: pane content is
+  // PORTALED into the tile's outlet, so its React tree position is
+  // PaneHostLayer — React synthetic events from inside a pane never reach the
+  // tile's own handlers. Native DOM events do bubble through the real DOM,
+  // where the pane genuinely IS inside the tile, so this catches clicks into
+  // pane content (terminal, chat) as well as tile chrome. Capture phase so a
+  // `stopPropagation()` inside a pane can't suppress it.
+  useEffect(() => {
+    const el = canvasBodyRef.current;
+    if (!el) return;
+    const onDown = (ev: MouseEvent) => {
+      const target = ev.target as HTMLElement | null;
+      const tileEl = target?.closest?.(".workspace-canvas__tile");
+      if (!tileEl) return;
+      const entry = Object.entries(tileRefs.current).find(([, node]) => node === tileEl);
+      if (entry) raiseTile(entry[0]);
+    };
+    el.addEventListener("mousedown", onDown, true);
+    return () => el.removeEventListener("mousedown", onDown, true);
+    // `raiseTile` closes over `readCanvas`/`patchCanvas`, which close over
+    // `worktreeId`/`savedDocId` — without those in the deps, switching the
+    // viewed worktree/doc without unmounting (no `key` on this component)
+    // leaves the listener raising tiles in the PREVIOUS canvas.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [canvas != null, worktreeId, savedDocId]);
+
   if (!canvas) {
     return <div className="workspace-canvas workspace-canvas--loading" />;
   }
@@ -501,11 +551,16 @@ export function WorkspaceCanvas({
   function handleModeChange(next: "tiled" | "free") {
     if (cv.mode === next) return;
     if (next === "tiled") {
-      const order = [...cv.tiles].sort((a, b) => {
-        const ra = cv.freeRects[a.id];
-        const rb = cv.freeRects[b.id];
-        const ay = ra?.y ?? 0;
-        const by = rb?.y ?? 0;
+      // Fresh read, same discipline as addTile/removeTile: a concurrent
+      // WS-driven insert (spawned-child auto-tile) landing between this
+      // render and the click must not be rebuilt out of the tree — it has no
+      // DOM rect to sort by yet, so it sorts last rather than being dropped.
+      const freshCanvas = readCanvas() ?? cv;
+      const order = [...freshCanvas.tiles].sort((a, b) => {
+        const ra = freshCanvas.freeRects[a.id];
+        const rb = freshCanvas.freeRects[b.id];
+        const ay = ra?.y ?? Number.MAX_SAFE_INTEGER;
+        const by = rb?.y ?? Number.MAX_SAFE_INTEGER;
         if (ay !== by) return ay - by;
         return (ra?.x ?? 0) - (rb?.x ?? 0);
       });
@@ -548,9 +603,36 @@ export function WorkspaceCanvas({
   function addTile(kind: TileKind, sessionId?: string, tileWorktreeId?: string) {
     // Shared with the Phase 4c auto-insert (Decision 8) — see
     // `insertTileIntoCanvas`'s own doc comment in useStore.ts.
-    const next = insertTileIntoCanvas(cv, kind, sessionId, tileWorktreeId, worktreeId);
-    patchCanvas(next);
-    setPickerOpen(false);
+    //
+    // Read FRESH state (same discipline as startDrag/startResize below) — the
+    // render-time `cv` snapshot can already be stale by the time a click lands
+    // (a WS-driven `session:created` auto-insert, a tools-tile toggle from
+    // TopBar), and `patchCanvas` writes whole objects, so mutating off the
+    // snapshot silently reverts those concurrent updates.
+    const cur = readCanvas();
+    if (!cur) return;
+    patchCanvas(insertTileIntoCanvas(cur, kind, sessionId, tileWorktreeId, worktreeId));
+    // NOTE: deliberately does NOT close the picker — adding several tiles in a
+    // row is the common case, so the popup stays open (symmetric with remove).
+  }
+
+  /**
+   * Free-mode click-to-front: give `tileId` the highest z of any tile. Only the
+   * tapped tile's `z` changes — every other tile keeps its own number, so the
+   * rest of the stack never reshuffles relative to itself (macOS/Windows
+   * behaviour, and the reason this is a per-tile number rather than a reorder
+   * of `tiles`, which would also churn tab/render order). No-op in tiled mode
+   * (tiles can't overlap there) and when the tile is already on top.
+   */
+  function raiseTile(tileId: string) {
+    const cur = readCanvas();
+    if (!cur || cur.mode !== "free") return;
+    const rect = cur.freeRects[tileId];
+    if (!rect) return;
+    let maxZ = 0;
+    for (const r of Object.values(cur.freeRects)) maxZ = Math.max(maxZ, r.z ?? 0);
+    if ((rect.z ?? 0) === maxZ && maxZ > 0) return;
+    patchCanvas({ freeRects: { ...cur.freeRects, [tileId]: { ...rect, z: maxZ + 1 } } });
   }
 
   function removeTile(tileId: string) {
@@ -559,7 +641,9 @@ export function WorkspaceCanvas({
     // implementation. `fullscreenTileId` cleanup is handled by the
     // reconciliation effect above, not inline here, so it also covers
     // removals this component didn't itself trigger.
-    patchCanvas(removeTileFromCanvas(cv, tileId));
+    const cur = readCanvas();
+    if (!cur) return;
+    patchCanvas(removeTileFromCanvas(cur, tileId));
   }
 
   // Single toggle for every picker item — session-backed (agent/terminal) or
@@ -568,16 +652,17 @@ export function WorkspaceCanvas({
   // `t.sessionId != null` guards a "tools" call site (sessionId undefined) from
   // ever matching a tools tile, whose own `sessionId` field is also undefined.
   function togglePickerItem(kind: TileKind, sessionId?: string, tileWorktreeId?: string) {
+    // Fresh read, same reason as addTile/removeTile above.
+    const cur = readCanvas();
+    if (!cur) return;
     const existing =
       kind === "tools"
-        ? cv.tiles.find((t) => t.kind === "tools" && (t.worktreeId ?? worktreeId) === (tileWorktreeId ?? worktreeId))
-        : cv.tiles.find((t) => t.sessionId != null && t.sessionId === sessionId);
-    if (existing) {
-      removeTile(existing.id);
-      setPickerOpen(false);
-    } else {
-      addTile(kind, sessionId, tileWorktreeId);
-    }
+        ? cur.tiles.find((t) => t.kind === "tools" && (t.worktreeId ?? worktreeId) === (tileWorktreeId ?? worktreeId))
+        : cur.tiles.find((t) => t.sessionId != null && t.sessionId === sessionId);
+    // Neither branch closes the picker — toggling several panes on/off in one
+    // pass is the common case.
+    if (existing) removeTile(existing.id);
+    else addTile(kind, sessionId, tileWorktreeId);
   }
 
   /**
@@ -632,8 +717,14 @@ export function WorkspaceCanvas({
       const nextY = clamp(startRect.y + dyPct, 0, Math.max(0, 100 - startRect.h));
       const cur = readCanvas();
       if (!cur) return;
+      // `z` is read live, not from `startRect`: the click-to-front listener
+      // (mousedown, capture phase) raises `z` before this handler's own
+      // mousedown-triggered `startRect` snapshot is taken, but React hasn't
+      // re-rendered yet, so `startRect.z` is already stale — using it here
+      // would silently undo the raise on the very first drag frame.
+      const liveZ = cur.freeRects[tileId]?.z ?? startRect.z;
       patchCanvas({
-        freeRects: { ...cur.freeRects, [tileId]: { ...startRect, x: nextX, y: nextY } },
+        freeRects: { ...cur.freeRects, [tileId]: { ...startRect, x: nextX, y: nextY, z: liveZ } },
       });
     }
     function onUp() {
@@ -663,8 +754,9 @@ export function WorkspaceCanvas({
       const nextH = clamp(startRect.h + dhPct, 10, Math.max(10, 100 - startRect.y));
       const cur = readCanvas();
       if (!cur) return;
+      const liveZ = cur.freeRects[tileId]?.z ?? startRect.z;
       patchCanvas({
-        freeRects: { ...cur.freeRects, [tileId]: { ...startRect, w: nextW, h: nextH } },
+        freeRects: { ...cur.freeRects, [tileId]: { ...startRect, w: nextW, h: nextH, z: liveZ } },
       });
     }
     function onUp() {
@@ -1125,7 +1217,12 @@ export function WorkspaceCanvas({
               onClick={() => setPickerOpen((v) => !v)}
               aria-expanded={pickerOpen}
             >
-              <Plus size={14} /> Add tile
+              <Plus size={14} /> Windows
+              {pickerOpen ? (
+                <ChevronUp size={12} className="workspace-canvas__add-btn-chevron" aria-hidden />
+              ) : (
+                <ChevronDown size={12} className="workspace-canvas__add-btn-chevron" aria-hidden />
+              )}
             </button>
             {pickerOpen ? (
               <div className="workspace-canvas__picker" role="menu" data-workspace-canvas-picker-panel>
@@ -1502,6 +1599,8 @@ export function WorkspaceCanvas({
                 top: `${rect.y}%`,
                 width: `${rect.w}%`,
                 height: `${rect.h}%`,
+                // Per-tile stacking order — see FreeRect.z / raiseTile.
+                zIndex: rect.z ?? 0,
               });
             })}
           </div>

--- a/web-ui/src/components/layout/paneOutlets.test.tsx
+++ b/web-ui/src/components/layout/paneOutlets.test.tsx
@@ -1,6 +1,11 @@
 import { render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { PaneOutlet, PaneOutletProvider } from "./paneOutlets";
+import { PaneOutlet, PaneOutletProvider, usePaneOutletElement } from "./paneOutlets";
+
+function OutletProbe({ paneKey }: { paneKey: string }) {
+  const el = usePaneOutletElement(paneKey);
+  return <span data-testid="probe" data-resolved={el ? "yes" : "no"} />;
+}
 
 describe("PaneOutlet", () => {
   it("is a full-size flex column container", () => {
@@ -22,5 +27,44 @@ describe("PaneOutlet", () => {
     expect(el.style.height).toBe("100%");
     expect(el.style.minHeight).toBe("0");
     expect(el.style.minWidth).toBe("0");
+  });
+
+  it("keeps a key resolvable when one of two outlets sharing it unmounts", () => {
+    // Ghost "tools window" regression: a stale classic-mode fullscreen overlay
+    // and a canvas tile can both mount `tools:<worktreeId>` at once. With a
+    // single-slot registry, whichever unmounted first deleted the key and left
+    // the survivor permanently empty.
+    function Harness({ both }: { both: boolean }) {
+      return (
+        <PaneOutletProvider>
+          <PaneOutlet paneKey="tools:w1" />
+          {both ? <PaneOutlet paneKey="tools:w1" /> : null}
+          <OutletProbe paneKey="tools:w1" />
+        </PaneOutletProvider>
+      );
+    }
+
+    const { getByTestId, rerender } = render(<Harness both />);
+    expect(getByTestId("probe").dataset.resolved).toBe("yes");
+
+    rerender(<Harness both={false} />);
+    expect(getByTestId("probe").dataset.resolved).toBe("yes");
+  });
+
+  it("clears the key once the last outlet unmounts", () => {
+    function Harness({ mounted }: { mounted: boolean }) {
+      return (
+        <PaneOutletProvider>
+          {mounted ? <PaneOutlet paneKey="tools:w1" /> : null}
+          <OutletProbe paneKey="tools:w1" />
+        </PaneOutletProvider>
+      );
+    }
+
+    const { getByTestId, rerender } = render(<Harness mounted />);
+    expect(getByTestId("probe").dataset.resolved).toBe("yes");
+
+    rerender(<Harness mounted={false} />);
+    expect(getByTestId("probe").dataset.resolved).toBe("no");
   });
 });

--- a/web-ui/src/components/layout/paneOutlets.tsx
+++ b/web-ui/src/components/layout/paneOutlets.tsx
@@ -21,9 +21,29 @@ import {
 
 type Listener = () => void;
 
+/**
+ * A registration token. Each `<PaneOutlet>`/`<ToolbarOutlet>` instance owns one
+ * for its whole lifetime, so `unregister` can remove *that instance's* entry
+ * rather than blowing away whatever happens to be stored under the key.
+ *
+ * Without this, two components legitimately mounting the same paneKey at once
+ * (e.g. a stale classic-mode fullscreen overlay lingering next to the canvas
+ * tile that owns the same `tools:<worktreeId>` pane) collide: the second
+ * registration silently overwrites the first, and whichever unmounts first
+ * deletes the key outright — leaving the surviving outlet a permanently empty
+ * "ghost" window.
+ */
+export type OutletToken = { readonly id: number };
+
+interface Registration {
+  token: OutletToken;
+  el: HTMLElement;
+}
+
 interface RegistryValue {
-  register: (key: string, el: HTMLElement | null) => void;
-  unregister: (key: string) => void;
+  createToken: () => OutletToken;
+  register: (key: string, token: OutletToken, el: HTMLElement | null) => void;
+  unregister: (key: string, token: OutletToken) => void;
   getOutlet: (key: string) => HTMLElement | null;
   subscribe: (key: string, listener: Listener) => () => void;
 }
@@ -31,8 +51,9 @@ interface RegistryValue {
 const PaneOutletRegistryContext = createContext<RegistryValue | null>(null);
 
 export function PaneOutletProvider({ children }: { children: ReactNode }) {
-  const outletsRef = useRef<Map<string, HTMLElement | null>>(new Map());
+  const outletsRef = useRef<Map<string, Registration[]>>(new Map());
   const listenersRef = useRef<Map<string, Set<Listener>>>(new Map());
+  const nextTokenId = useRef(0);
 
   const notify = useCallback((key: string) => {
     const listeners = listenersRef.current.get(key);
@@ -40,23 +61,40 @@ export function PaneOutletProvider({ children }: { children: ReactNode }) {
     for (const listener of listeners) listener();
   }, []);
 
+  const createToken = useCallback(() => ({ id: nextTokenId.current++ }), []);
+
   const register = useCallback(
-    (key: string, el: HTMLElement | null) => {
-      outletsRef.current.set(key, el);
+    (key: string, token: OutletToken, el: HTMLElement | null) => {
+      const list = outletsRef.current.get(key) ?? [];
+      const next = list.filter((r) => r.token !== token);
+      if (el) next.push({ token, el });
+      if (next.length > 0) outletsRef.current.set(key, next);
+      else outletsRef.current.delete(key);
       notify(key);
     },
     [notify],
   );
 
   const unregister = useCallback(
-    (key: string) => {
-      outletsRef.current.delete(key);
+    (key: string, token: OutletToken) => {
+      const list = outletsRef.current.get(key);
+      if (!list) return;
+      const next = list.filter((r) => r.token !== token);
+      if (next.length === list.length) return;
+      // Only clear the key once no live instance still claims it.
+      if (next.length > 0) outletsRef.current.set(key, next);
+      else outletsRef.current.delete(key);
       notify(key);
     },
     [notify],
   );
 
-  const getOutlet = useCallback((key: string) => outletsRef.current.get(key) ?? null, []);
+  // Most recently registered live entry wins.
+  const getOutlet = useCallback((key: string) => {
+    const list = outletsRef.current.get(key);
+    if (!list || list.length === 0) return null;
+    return list[list.length - 1]?.el ?? null;
+  }, []);
 
   const subscribe = useCallback((key: string, listener: Listener) => {
     let listeners = listenersRef.current.get(key);
@@ -72,8 +110,8 @@ export function PaneOutletProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const value = useMemo<RegistryValue>(
-    () => ({ register, unregister, getOutlet, subscribe }),
-    [register, unregister, getOutlet, subscribe],
+    () => ({ createToken, register, unregister, getOutlet, subscribe }),
+    [createToken, register, unregister, getOutlet, subscribe],
   );
 
   return (
@@ -99,14 +137,17 @@ function useRegistry(): RegistryValue {
  * stays mounted elsewhere (see PaneHostLayer), it just loses its visible home.
  */
 export function PaneOutlet({ paneKey }: { paneKey: string }) {
-  const { register, unregister } = useRegistry();
+  const { createToken, register, unregister } = useRegistry();
+  const tokenRef = useRef<OutletToken | null>(null);
+  if (tokenRef.current === null) tokenRef.current = createToken();
+  const token = tokenRef.current;
 
   const refCallback = useCallback(
     (el: HTMLDivElement | null) => {
-      if (el) register(paneKey, el);
-      else unregister(paneKey);
+      if (el) register(paneKey, token, el);
+      else unregister(paneKey, token);
     },
-    [paneKey, register, unregister],
+    [paneKey, token, register, unregister],
   );
 
   // MUST be a flex column container, not a plain block. Every pane root that
@@ -151,14 +192,17 @@ export const WORKSPACE_CANVAS_TOOLBAR_KEY = "workspace-canvas-toolbar";
  * stretched to 100%/100% like `PaneOutlet`.
  */
 export function ToolbarOutlet({ paneKey }: { paneKey: string }) {
-  const { register, unregister } = useRegistry();
+  const { createToken, register, unregister } = useRegistry();
+  const tokenRef = useRef<OutletToken | null>(null);
+  if (tokenRef.current === null) tokenRef.current = createToken();
+  const token = tokenRef.current;
 
   const refCallback = useCallback(
     (el: HTMLDivElement | null) => {
-      if (el) register(paneKey, el);
-      else unregister(paneKey);
+      if (el) register(paneKey, token, el);
+      else unregister(paneKey, token);
     },
-    [paneKey, register, unregister],
+    [paneKey, token, register, unregister],
   );
 
   return (

--- a/web-ui/src/hooks/useServerSync.test.ts
+++ b/web-ui/src/hooks/useServerSync.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, beforeEach, vi } from "vitest";
 import { createMockApi } from "@/api/mock";
 import { useServerSync } from "./useServerSync";
 import { useServerStore } from "./useServerStore";
-import { useWorkspaceStore } from "./useStore";
+import { useWorkspaceStore, DEFAULT_WORKTREE_LAYOUT } from "./useStore";
 
 /**
  * 1.T4 — the daemon already broadcasts `name`/`archivedAt` (and now
@@ -129,9 +129,26 @@ describe("useServerSync — session:created auto-insert (Phase 4c)", () => {
     });
   }
 
+  /** The everyday canvas: a per-worktree TRANSIENT canvas, not a saved doc. */
+  function seedScratch(worktreeId: string) {
+    useWorkspaceStore.setState({
+      layoutByWorktree: {
+        [worktreeId]: {
+          ...DEFAULT_WORKTREE_LAYOUT,
+          scratchCanvas: {
+            mode: "free",
+            tiles: [{ id: "tile-source", kind: "agent", sessionId: SOURCE_ID }],
+            tree: null,
+            freeRects: { "tile-source": { x: 0, y: 0, w: 40, h: 40 } },
+          },
+        },
+      },
+    });
+  }
+
   beforeEach(() => {
     useServerStore.setState({ projects: [], worktrees: [], sessions: [], loaded: false });
-    useWorkspaceStore.setState({ workspaceDocs: {} });
+    useWorkspaceStore.setState({ workspaceDocs: {}, layoutByWorktree: {} });
   });
 
   it("4c.T1 — a session:created with spawnedFrom matching exactly one workspace's tile auto-inserts a new tile there", async () => {
@@ -200,7 +217,7 @@ describe("useServerSync — session:created auto-insert (Phase 4c)", () => {
     expect(doc.tiles).toHaveLength(1);
   });
 
-  it("logs and skips (no insert into either) when the source is tiled in MORE THAN ONE workspace (Risk #9/#10, not yet confirmed)", async () => {
+  it("inserts into EVERY workspace tiling the source — no skip-on-multi-match (Risk #9/#10 resolved)", async () => {
     seedOneMatchingDoc();
     useWorkspaceStore.setState((s) => ({
       workspaceDocs: {
@@ -231,10 +248,128 @@ describe("useServerSync — session:created auto-insert (Phase 4c)", () => {
       });
     });
 
-    await new Promise((r) => setTimeout(r, 50));
-    expect(useWorkspaceStore.getState().workspaceDocs[DOC_ID]!.tiles).toHaveLength(1);
-    expect(useWorkspaceStore.getState().workspaceDocs["doc-2"]!.tiles).toHaveLength(1);
-    expect(warnSpy).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(useWorkspaceStore.getState().workspaceDocs[DOC_ID]!.tiles).toHaveLength(2);
+      expect(useWorkspaceStore.getState().workspaceDocs["doc-2"]!.tiles).toHaveLength(2);
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
     warnSpy.mockRestore();
+  });
+
+  it("auto-inserts a SAME-worktree child into the source worktree's scratch canvas", async () => {
+    seedScratch("wt-1");
+    const api = createMockApi();
+    renderHook(() => useServerSync(api));
+    await waitFor(() => expect(useServerStore.getState().loaded).toBe(true));
+
+    act(() => {
+      api.__test.emit({
+        type: "session:created",
+        sessionId: "sess-new",
+        worktreeId: "wt-1",
+        sessionType: "agent",
+        spawnedFrom: SOURCE_ID,
+      });
+    });
+
+    await waitFor(() => {
+      const canvas = useWorkspaceStore.getState().layoutByWorktree["wt-1"]!.scratchCanvas!;
+      expect(canvas.tiles).toHaveLength(2);
+      const added = canvas.tiles.find((t) => t.sessionId === "sess-new")!;
+      expect(added.kind).toBe("agent");
+      // Same worktree as the canvas → left undefined, matching the existing
+      // same-context tile shape.
+      expect(added.worktreeId).toBeUndefined();
+    });
+  });
+
+  it("auto-inserts a CROSS-worktree child into the source worktree's scratch canvas, stamped with its own worktreeId", async () => {
+    seedScratch("wt-1");
+    const api = createMockApi();
+    renderHook(() => useServerSync(api));
+    await waitFor(() => expect(useServerStore.getState().loaded).toBe(true));
+
+    act(() => {
+      api.__test.emit({
+        type: "session:created",
+        sessionId: "sess-new",
+        // `vst worktree create` — the child lives in a DIFFERENT worktree, but
+        // still lands next to its parent's tile.
+        worktreeId: "wt-2",
+        sessionType: "agent",
+        spawnedFrom: SOURCE_ID,
+      });
+    });
+
+    await waitFor(() => {
+      const canvas = useWorkspaceStore.getState().layoutByWorktree["wt-1"]!.scratchCanvas!;
+      expect(canvas.tiles).toHaveLength(2);
+      expect(canvas.tiles.find((t) => t.sessionId === "sess-new")!.worktreeId).toBe("wt-2");
+    });
+  });
+
+  it("inserts into the scratch canvas AND every matching saved doc at once", async () => {
+    seedScratch("wt-1");
+    seedOneMatchingDoc();
+    const api = createMockApi();
+    renderHook(() => useServerSync(api));
+    await waitFor(() => expect(useServerStore.getState().loaded).toBe(true));
+
+    act(() => {
+      api.__test.emit({
+        type: "session:created",
+        sessionId: "sess-new",
+        worktreeId: "wt-1",
+        sessionType: "agent",
+        spawnedFrom: SOURCE_ID,
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        useWorkspaceStore.getState().layoutByWorktree["wt-1"]!.scratchCanvas!.tiles,
+      ).toHaveLength(2);
+      expect(useWorkspaceStore.getState().workspaceDocs[DOC_ID]!.tiles).toHaveLength(2);
+    });
+  });
+});
+
+// --- worktree:deleted sweeps `tools:<worktreeId>` tiles, which carry no
+// sessionId and so are unreachable by the session-keyed cleanup ---
+describe("useServerSync — worktree:deleted tools-tile cleanup", () => {
+  beforeEach(() => {
+    useServerStore.setState({ projects: [], worktrees: [], sessions: [], loaded: false });
+    useWorkspaceStore.setState({ workspaceDocs: {}, layoutByWorktree: {} });
+  });
+
+  it("drops the deleted worktree's tools tile from a scratch canvas", async () => {
+    useWorkspaceStore.setState({
+      layoutByWorktree: {
+        "wt-1": {
+          ...DEFAULT_WORKTREE_LAYOUT,
+          scratchCanvas: {
+            mode: "free",
+            tiles: [
+              { id: "tile-tools", kind: "tools" },
+              { id: "tile-agent", kind: "agent", sessionId: "sess-x" },
+            ],
+            tree: null,
+            freeRects: {},
+          },
+        },
+      },
+    });
+    const api = createMockApi();
+    renderHook(() => useServerSync(api));
+    await waitFor(() => expect(useServerStore.getState().loaded).toBe(true));
+
+    act(() => {
+      api.__test.emit({ type: "worktree:deleted", worktreeId: "wt-1" });
+    });
+
+    await waitFor(() => {
+      const canvas = useWorkspaceStore.getState().layoutByWorktree["wt-1"]!.scratchCanvas!;
+      expect(canvas.tiles.map((t) => t.id)).toEqual(["tile-agent"]);
+    });
   });
 });

--- a/web-ui/src/hooks/useServerSync.ts
+++ b/web-ui/src/hooks/useServerSync.ts
@@ -2,7 +2,12 @@ import { useEffect } from "react";
 import type { ApiInstance } from "@/api";
 import type { Session } from "@/api/types";
 import { useServerStore } from "./useServerStore";
-import { useWorkspaceStore, findWorkspacesTilingSession, resolveSupersededChains } from "./useStore";
+import {
+  useWorkspaceStore,
+  findScratchCanvasesTilingSession,
+  findWorkspacesTilingSession,
+  resolveSupersededChains,
+} from "./useStore";
 
 /**
  * Module-level in-flight guard. Collapses three refresh triggers that all
@@ -103,7 +108,13 @@ export function useServerSync(api: ApiInstance): void {
       if (ev.type === "worktree:created") applyWorktreeCreated(ev.worktree);
     });
     const offWtDeleted = api.on("worktree:deleted", (ev) => {
-      if (ev.type === "worktree:deleted") applyWorktreeDeleted(ev.worktreeId);
+      if (ev.type !== "worktree:deleted") return;
+      applyWorktreeDeleted(ev.worktreeId);
+      // The worktree's SESSION tiles are cleaned up by the per-session
+      // `session:deleted` events the daemon now cascades ahead of this one.
+      // Its `tools:<worktreeId>` tiles have no sessionId, so they need their
+      // own sweep or they linger as empty ghost windows.
+      useWorkspaceStore.getState().removeToolsTilesForWorktree(ev.worktreeId);
     });
     const offWtUpdated = api.on("worktree:updated", (ev) => {
       if (ev.type === "worktree:updated") applyWorktreeUpdated(ev.worktree);
@@ -119,24 +130,31 @@ export function useServerSync(api: ApiInstance): void {
       // splitting the source's own tile (S4/S6/Decision 8). `spawnedFrom`
       // absent or null (CUJ 6 — no source, the common case today) skips this
       // entirely — no scan, no behavior change from before Phase 4.
+      //
+      // Fan-out is "insert everywhere the source is tiled" (Risk #9/#10
+      // resolved): EVERY scratch canvas and EVERY saved workspace doc that
+      // currently tiles the source gets the child. No skip-on-multi-match —
+      // a session tiled in two places is tiled deliberately, and skipping
+      // silently produced no tile at all, which read as the feature being
+      // broken.
       if (ev.spawnedFrom) {
         const store = useWorkspaceStore.getState();
-        const matches = findWorkspacesTilingSession(ev.spawnedFrom, store.workspaceDocs);
-        if (matches.length === 1) {
-          store.insertTileIntoWorkspaceDoc(
-            matches[0]!.id,
+        // The everyday canvas mode is a scratch canvas; scanning only saved
+        // docs meant this almost never fired in normal use.
+        for (const wtId of findScratchCanvasesTilingSession(ev.spawnedFrom, store.layoutByWorktree)) {
+          store.insertTileIntoScratchCanvas(
+            wtId,
             ev.sessionType,
             ev.sessionId,
             ev.worktreeId ?? undefined,
           );
-        } else if (matches.length > 1) {
-          // Multi-workspace fan-out (S4's proposed "insert into all") is
-          // still pending user confirmation (plan Risk #9/#10) — log and
-          // skip rather than guessing which of "all" / "the active one" /
-          // "none" is correct.
-          console.warn(
-            `[workspaces] session ${ev.spawnedFrom} is tiled in ${matches.length} workspaces at once; ` +
-              `auto-insert for new session ${ev.sessionId} skipped pending Risk #9/#10 confirmation.`,
+        }
+        for (const doc of findWorkspacesTilingSession(ev.spawnedFrom, store.workspaceDocs)) {
+          store.insertTileIntoWorkspaceDoc(
+            doc.id,
+            ev.sessionType,
+            ev.sessionId,
+            ev.worktreeId ?? undefined,
           );
         }
       }

--- a/web-ui/src/hooks/useStore.ts
+++ b/web-ui/src/hooks/useStore.ts
@@ -87,6 +87,15 @@ export interface FreeRect {
   y: number;
   w: number;
   h: number;
+  /**
+   * Free-mode stacking order (higher = nearer the viewer). Optional: tiles
+   * predating this field, and tiles that have never been focused, fall back to
+   * 0. Tapping a tile raises it to `max(all z) + 1` — a per-tile number rather
+   * than an array reorder, so raising one tile never reshuffles the others
+   * relative to each other (macOS/Windows window behaviour). Meaningless in
+   * "tiled" mode, where tiles never overlap.
+   */
+  z?: number;
 }
 
 /**
@@ -265,6 +274,31 @@ export interface WorkspaceState {
     tileWorktreeId?: string,
   ) => void;
   /**
+   * `insertTileIntoWorkspaceDoc`'s scratch-canvas twin — insert into
+   * `layoutByWorktree[worktreeId].scratchCanvas`. A no-op if that worktree has
+   * no scratch canvas yet (nothing to insert next to; the seed effect in
+   * WorkspaceCanvas will build one from live panes when the canvas is opened).
+   *
+   * `tileWorktreeId` MAY differ from `worktreeId`: a child agent spawned into a
+   * NEW worktree (`vst worktree create`) still auto-inserts next to its parent's
+   * tile, in the parent's canvas. That deliberately relaxes the scratch canvas's
+   * "single-worktree only" convention for auto-inserted children, using the
+   * same cross-worktree tile rendering saved workspaces already support.
+   */
+  insertTileIntoScratchCanvas: (
+    worktreeId: string,
+    kind: TileKind,
+    sessionId?: string,
+    tileWorktreeId?: string,
+  ) => void;
+  /**
+   * Removes every `tools` tile targeting `worktreeId` from every scratch canvas
+   * and every saved workspace doc. The worktree-deletion counterpart to
+   * `removeTilesForSession` — tools tiles carry no `sessionId`, so the
+   * session-keyed sweep can never reach them.
+   */
+  removeToolsTilesForWorktree: (worktreeId: string) => void;
+  /**
    * Repoint every tile (scratch canvas + every saved workspace doc)
    * referencing `fromSessionId` to `toSessionId` — a reset's replacement
    * taking the archived session's exact place, same tile id/position.
@@ -361,11 +395,14 @@ export function removeTileFromCanvas(canvas: CanvasGeometry, tileId: string): Ca
   const nextTiles = canvas.tiles.filter((t) => t.id !== tileId);
   const nextFreeRects = { ...canvas.freeRects };
   delete nextFreeRects[tileId];
-  let nextTree = canvas.tree;
-  if (canvas.mode === "tiled") {
-    const leafId = findLeafId(canvas.tree, tileId);
-    nextTree = leafId ? removePane(canvas.tree, leafId) : canvas.tree;
-  }
+  // Prune the layout tree UNCONDITIONALLY, not just in "tiled" mode: a canvas
+  // in "free" mode can still carry a tree (from a previous tiled session), and
+  // `tiles`/`tree` are expected to stay mutually consistent regardless of
+  // current mode — anything that reads `tree` (e.g. `insertTileIntoCanvas`'s
+  // `findLeafId` lookup) shouldn't have to special-case "mode was free when
+  // this tile was removed" to avoid resolving a leaf for an already-gone tile.
+  const leafId = findLeafId(canvas.tree, tileId);
+  const nextTree = leafId ? removePane(canvas.tree, leafId) : canvas.tree;
   return { ...canvas, tiles: nextTiles, freeRects: nextFreeRects, tree: nextTree };
 }
 
@@ -442,6 +479,50 @@ export function findWorkspacesTilingSession(
   workspaceDocs: Record<string, WorkspaceDoc>,
 ): WorkspaceDoc[] {
   return Object.values(workspaceDocs).filter((doc) => doc.tiles.some((t) => t.sessionId === sessionId));
+}
+
+/**
+ * The scratch-canvas counterpart to `findWorkspacesTilingSession` — every
+ * worktree whose TRANSIENT canvas currently tiles `sessionId`. Returns
+ * worktree ids (the scratch canvas's key), not canvases.
+ *
+ * The everyday canvas mode is a scratch canvas, not a saved doc, so without
+ * this the `spawnedFrom` auto-insert only ever fired for saved workspaces —
+ * i.e. essentially never in normal use.
+ */
+export function findScratchCanvasesTilingSession(
+  sessionId: string,
+  layoutByWorktree: Record<string, WorktreeLayout>,
+): string[] {
+  const ids: string[] = [];
+  for (const [worktreeId, layout] of Object.entries(layoutByWorktree)) {
+    if (layout.scratchCanvas?.tiles.some((t) => t.sessionId === sessionId)) ids.push(worktreeId);
+  }
+  return ids;
+}
+
+/**
+ * Removes every `tools` tile targeting `worktreeId` from `canvas`. The
+ * worktree-scoped analogue of `removeTilesForSessionInCanvas` — a tools tile
+ * has no `sessionId`, so session-keyed cleanup can never reach it, and a
+ * deleted worktree's tools tile would otherwise linger as an empty ghost.
+ *
+ * `viewedWorktreeId` supplies the same `tile.worktreeId ?? <canvas's own
+ * worktree>` fallback WorkspaceCanvas uses to resolve a tools tile's pane key.
+ * Returns the SAME `canvas` reference when nothing matched.
+ */
+export function removeToolsTilesForWorktreeInCanvas(
+  canvas: CanvasGeometry,
+  worktreeId: string,
+  viewedWorktreeId: string,
+): CanvasGeometry {
+  const matching = canvas.tiles.filter(
+    (t) => t.kind === "tools" && (t.worktreeId ?? viewedWorktreeId) === worktreeId,
+  );
+  if (matching.length === 0) return canvas;
+  let next = canvas;
+  for (const tile of matching) next = removeTileFromCanvas(next, tile.id);
+  return next;
 }
 
 /**
@@ -793,9 +874,59 @@ export const useWorkspaceStore = create<WorkspaceState>()(
           set((s) => {
             const doc = s.workspaceDocs[docId];
             if (!doc) return s;
+            // Idempotency guard: a duplicate `session:created` delivery (or two
+            // auto-insert triggers racing) must not tile the same session twice
+            // in one canvas — `togglePickerItem`'s existing-tile lookup can only
+            // ever find/remove the first of a duplicate pair.
+            if (sessionId != null && doc.tiles.some((t) => t.sessionId === sessionId)) return s;
             const next = insertTileIntoCanvas(doc, kind, sessionId, tileWorktreeId, doc.contextKey);
             return {
               workspaceDocs: { ...s.workspaceDocs, [docId]: { ...doc, ...next } },
+            };
+          }),
+        insertTileIntoScratchCanvas: (worktreeId, kind, sessionId, tileWorktreeId) =>
+          set((s) => {
+            const cur = s.layoutByWorktree[worktreeId];
+            const canvas = cur?.scratchCanvas;
+            if (!cur || !canvas) return s;
+            if (sessionId != null && canvas.tiles.some((t) => t.sessionId === sessionId)) return s;
+            const next = insertTileIntoCanvas(canvas, kind, sessionId, tileWorktreeId, worktreeId);
+            return {
+              layoutByWorktree: {
+                ...s.layoutByWorktree,
+                [worktreeId]: { ...cur, scratchCanvas: next },
+              },
+            };
+          }),
+        removeToolsTilesForWorktree: (worktreeId) =>
+          set((s) => {
+            let layoutChanged = false;
+            const nextLayoutByWorktree = { ...s.layoutByWorktree };
+            for (const [viewedWorktreeId, layout] of Object.entries(s.layoutByWorktree)) {
+              if (!layout.scratchCanvas) continue;
+              const next = removeToolsTilesForWorktreeInCanvas(
+                layout.scratchCanvas,
+                worktreeId,
+                viewedWorktreeId,
+              );
+              if (next !== layout.scratchCanvas) {
+                nextLayoutByWorktree[viewedWorktreeId] = { ...layout, scratchCanvas: next };
+                layoutChanged = true;
+              }
+            }
+            let docsChanged = false;
+            const nextWorkspaceDocs = { ...s.workspaceDocs };
+            for (const [docId, doc] of Object.entries(s.workspaceDocs)) {
+              const next = removeToolsTilesForWorktreeInCanvas(doc, worktreeId, doc.contextKey);
+              if (next !== doc) {
+                nextWorkspaceDocs[docId] = { ...doc, ...next };
+                docsChanged = true;
+              }
+            }
+            if (!layoutChanged && !docsChanged) return s;
+            return {
+              ...(layoutChanged ? { layoutByWorktree: nextLayoutByWorktree } : {}),
+              ...(docsChanged ? { workspaceDocs: nextWorkspaceDocs } : {}),
             };
           }),
         relinkSessionTiles: (fromSessionId, toSessionId) =>
@@ -921,6 +1052,12 @@ export const useWorkspaceStore = create<WorkspaceState>()(
                 ...s.layoutByWorktree,
                 [worktreeId]: { ...cur, layoutMode: mode },
               },
+              // Classic-mode viewport fullscreen has no meaning in canvas mode
+              // (the canvas has its own per-tile fullscreen). Leaving it set
+              // meant switching to canvas mode kept a stale classic overlay
+              // claiming the same pane key as a canvas tile → empty ghost
+              // window. Mirrors how `toggleToolPanel` clears it on hide.
+              ...(s.workspacePaneFullscreen != null ? { workspacePaneFullscreen: null } : {}),
             };
           }),
         updateScratchCanvas: (worktreeId, patch) =>

--- a/web-ui/src/lib/tiling.test.ts
+++ b/web-ui/src/lib/tiling.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { collectTileIds, insertPane } from "./tiling";
+
+describe("insertPane — degrades instead of discarding the tree", () => {
+  it("appends at the root when targetLeafId is null (existing tiles survive)", () => {
+    const root = insertPane(null, null, "right", "a");
+    const next = insertPane(root, null, "right", "b");
+    // Regression: this used to return just the new leaf, silently dropping "a".
+    expect(collectTileIds(next).sort()).toEqual(["a", "b"]);
+  });
+
+  it("appends at the root when targetLeafId points at a leaf that no longer exists", () => {
+    const root = insertPane(null, null, "right", "a");
+    const next = insertPane(root, "leaf-that-vanished", "right", "b");
+    expect(collectTileIds(next).sort()).toEqual(["a", "b"]);
+  });
+
+  it("joins an existing same-axis root split rather than nesting a new one", () => {
+    let tree = insertPane(null, null, "right", "a");
+    tree = insertPane(tree, null, "right", "b");
+    tree = insertPane(tree, null, "right", "c");
+    expect(collectTileIds(tree).sort()).toEqual(["a", "b", "c"]);
+    expect(tree.type).toBe("split");
+    if (tree.type === "split") {
+      expect(tree.children).toHaveLength(3);
+      // Sizes stay normalized as siblings are appended.
+      const total = tree.sizes.reduce((s, v) => s + v, 0);
+      expect(total).toBeCloseTo(1, 5);
+    }
+  });
+});

--- a/web-ui/src/lib/tiling.ts
+++ b/web-ui/src/lib/tiling.ts
@@ -80,6 +80,32 @@ function clone<T>(node: T): T {
 }
 
 /**
+ * Fallback insert when no usable target leaf exists: join `root`'s top-level
+ * split if the axis matches, otherwise wrap `root` in a fresh 2-child split.
+ * `root` must already be a clone — this mutates it.
+ */
+function appendAtRoot(root: LayoutNode, newLeaf: LeafNode, side: Side): LayoutNode {
+  const axis = axisForSide(side);
+  const before = side === "left" || side === "top";
+  if (root.type === "split" && root.axis === axis) {
+    const insertAt = before ? 0 : root.children.length;
+    const share = 1 / (root.children.length + 1);
+    const scale = 1 - share;
+    root.sizes = root.sizes.map((s) => s * scale);
+    root.sizes.splice(insertAt, 0, share);
+    root.children.splice(insertAt, 0, newLeaf);
+    return root;
+  }
+  return {
+    id: nextId("split"),
+    type: "split",
+    axis,
+    children: before ? [newLeaf, root] : [root, newLeaf],
+    sizes: [0.5, 0.5],
+  };
+}
+
+/**
  * Insert a new leaf next to `targetLeafId`, on `side`. If the target's
  * parent already splits along the matching axis, the new leaf joins as a
  * sibling (halving the target's size). Otherwise the target leaf is
@@ -92,7 +118,10 @@ export function insertPane(
   newTileId: string,
 ): LayoutNode {
   const newLeaf: LeafNode = { id: nextId("leaf"), type: "leaf", tileId: newTileId };
-  if (!root || !targetLeafId) return newLeaf;
+  if (!root) return newLeaf;
+  // A missing/unknown target must NOT discard the existing tree (that silently
+  // dropped every other tile). Degrade to appending at the root instead.
+  if (!targetLeafId) return appendAtRoot(clone(root), newLeaf, side);
 
   const next = clone(root);
   const axis = axisForSide(side);
@@ -110,7 +139,9 @@ export function insertPane(
 
   // Replace the target leaf itself with a new split container.
   const target = findNode(next, targetLeafId);
-  if (!target) return next; // target vanished — no-op, caller should re-render from fresh state
+  // Target vanished (stale leaf id from a concurrent removal): still insert
+  // the new leaf, at the root, rather than dropping it on the floor.
+  if (!target) return appendAtRoot(next, newLeaf, side);
   const replacement: SplitNode = {
     id: nextId("split"),
     type: "split",

--- a/web-ui/src/routes/Workspace.tsx
+++ b/web-ui/src/routes/Workspace.tsx
@@ -297,19 +297,53 @@ export function Workspace() {
     [sessions, activeWorktreeId],
   );
   // A worktree's classic per-worktree canvas placement is ALWAYS its own
-  // transient scratch canvas now — it never binds to a saved WorkspaceDoc
-  // (see WorkspaceCanvas.tsx's module doc), so its pane-key set is just its
-  // own sessions + tools, no cross-worktree union needed. A saved doc's
-  // cross-worktree panes are handled entirely by `detachedWorkspacePaneKeys`
-  // below, for the doc's own `/workspaces/:id` route.
+  // transient scratch canvas (it never binds to a saved WorkspaceDoc — see
+  // WorkspaceCanvas.tsx's module doc), so the base of its pane-key set is its
+  // own sessions + tools.
+  //
+  // Plus any FOREIGN tile its scratch canvas happens to carry: a child agent
+  // auto-inserted next to its spawning parent (`spawnedFrom`, useServerSync)
+  // can belong to a different worktree entirely (`vst worktree create`). Those
+  // tiles render live content only if their pane is mounted here — otherwise
+  // they're empty ghost windows. Mirrors `detachedWorkspacePaneKeys` below.
+  // Select only `tiles`, not the whole canvas: `freeRects`/`tree` change on
+  // every drag/resize frame but never affect which panes should be mounted,
+  // and `updateScratchCanvas` preserves the `tiles` array reference when a
+  // patch doesn't touch it — subscribing to the whole object would re-render
+  // this route (and everything under it) on every mousemove of a drag.
+  const activeScratchCanvasTiles = useWorkspaceStore(
+    (s) => (activeWorktreeId ? (s.layoutByWorktree[activeWorktreeId]?.scratchCanvas?.tiles ?? null) : null),
+  );
   const worktreePaneKeys = useMemo<PaneKey[]>(() => {
     if (!activeWorktreeId || isDirectSession) return [];
     const keys: PaneKey[] = [];
-    for (const s of worktreeAgentSessions) keys.push(`agent:${s.id}`);
-    for (const s of worktreeTerminalSessions) keys.push(`terminal:${s.id}`);
-    keys.push(`tools:${activeWorktreeId}`);
+    const seen = new Set<string>();
+    const push = (k: PaneKey) => {
+      if (seen.has(k)) return;
+      seen.add(k);
+      keys.push(k);
+    };
+    for (const s of worktreeAgentSessions) push(`agent:${s.id}`);
+    for (const s of worktreeTerminalSessions) push(`terminal:${s.id}`);
+    push(`tools:${activeWorktreeId}`);
+    for (const tile of activeScratchCanvasTiles ?? []) {
+      if (tile.kind === "tools") {
+        const twt = tile.worktreeId ?? activeWorktreeId;
+        if (worktrees.some((w) => w.id === twt)) push(`tools:${twt}`);
+      } else if (tile.sessionId && sessions.some((s) => s.id === tile.sessionId)) {
+        push(`${tile.kind}:${tile.sessionId}`);
+      }
+    }
     return keys;
-  }, [activeWorktreeId, isDirectSession, worktreeAgentSessions, worktreeTerminalSessions]);
+  }, [
+    activeWorktreeId,
+    isDirectSession,
+    worktreeAgentSessions,
+    worktreeTerminalSessions,
+    activeScratchCanvasTiles,
+    sessions,
+    worktrees,
+  ]);
   // Whether ToolPanel instances rendered via this pane-key registry are
   // CURRENTLY live inside a workspace-canvas tile (either the classic
   // per-worktree canvas, or the detached /workspaces/:id view — both use
@@ -378,15 +412,22 @@ export function Workspace() {
   const detachedWorkspacePaneKeys = useMemo<PaneKey[]>(() => {
     if (!viewedWorkspace) return [];
     const keys: PaneKey[] = [];
+    const seen = new Set<string>();
+    const push = (k: PaneKey) => {
+      if (seen.has(k)) return;
+      seen.add(k);
+      keys.push(k);
+    };
     for (const tile of viewedWorkspace.tiles) {
       if (tile.kind === "tools") {
-        keys.push(`tools:${tile.worktreeId ?? viewedWorkspace.contextKey}`);
+        const twt = tile.worktreeId ?? viewedWorkspace.contextKey;
+        if (worktrees.some((w) => w.id === twt)) push(`tools:${twt}`);
       } else if (tile.sessionId && sessions.some((s) => s.id === tile.sessionId)) {
-        keys.push(`${tile.kind}:${tile.sessionId}`);
+        push(`${tile.kind}:${tile.sessionId}`);
       }
     }
     return keys;
-  }, [viewedWorkspace, sessions]);
+  }, [viewedWorkspace, sessions, worktrees]);
   const detachedWorkspacePaneHostLayer = (
     <PaneHostLayer paneKeys={detachedWorkspacePaneKeys} renderPane={renderWorktreePane} />
   );

--- a/web-ui/src/styles/chat.css
+++ b/web-ui/src/styles/chat.css
@@ -725,6 +725,30 @@
   .chat-thinking-hint__dot { animation: none; }
 }
 
+/* ── Persistent working indicator (last item in the feed while busy) ───────── */
+
+.chat-working-indicator {
+  display: flex;
+  align-self: flex-start;
+  padding: var(--space-1) 0;
+}
+.chat-working-indicator__dots {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.chat-working-indicator__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--chat-accent);
+  opacity: 0.15;
+  transition: opacity 0.15s ease;
+}
+.chat-working-indicator__dot--on {
+  opacity: 1;
+}
+
 /* ── Inline queued-turn editor ─────────────────────────────────────────────── */
 
 .chat-queued-editor {
@@ -938,8 +962,12 @@
 .chat-composer__textarea {
   flex: 1;
   min-height: 40px;
-  max-height: 200px;
-  resize: vertical;
+  /* Height above this is fully JS-driven (autosizeComposerTextarea) up to a
+     ~10-line cap, then internal scroll — no manual resize handle, since a
+     user-dragged height would otherwise be fought/overwritten on every
+     keystroke by the auto-grow effect. */
+  overflow-y: hidden;
+  resize: none;
   background: var(--bg-input);
   color: var(--fg-primary);
   border: var(--border-width) solid var(--border-default);

--- a/web-ui/src/styles/workspace-canvas.css
+++ b/web-ui/src/styles/workspace-canvas.css
@@ -122,6 +122,12 @@
   cursor: pointer;
 }
 
+/* Dropdown disclosure affordance on the "Windows" picker trigger. */
+.workspace-canvas__add-btn-chevron {
+  margin-left: calc(var(--space-1) * -0.5);
+  opacity: 0.6;
+}
+
 .workspace-canvas__picker {
   position: absolute;
   top: calc(100% + var(--space-1));
@@ -301,6 +307,11 @@
   min-height: 0;
   position: relative;
   overflow: hidden;
+  /* New stacking context: free-mode tiles' per-tile `z-index` (raised on
+     click-to-front, unbounded and persisted — see raiseTile) must never be
+     able to climb above sibling chrome like `.workspace-canvas__picker`
+     (z-index: 20), which lives outside this element. */
+  isolation: isolate;
 }
 
 .workspace-canvas__empty {


### PR DESCRIPTION
## Summary
- Canvas/workspace mode: "Add tile" trigger renamed to "Windows" with a dropdown chevron; picking an option no longer closes the popup (only "New agent" does, since it opens a modal); free-mode tiles now raise to front of z-order on click (including clicks into pane content) without reshuffling other tiles' relative order.
- Fixed the root cause of ghost "tools" tiles with empty content (a non-refcounted pane-outlet registry colliding with a stale classic-mode fullscreen overlay), plus related tile add/remove/mode-change race and orphaned-tile cleanup fixes.
- A session spawned by a running agent now auto-tiles into every canvas that currently tiles its source session, including cross-worktree children.
- Worktree/project deletion now cleans up their sessions' and tools tiles' canvas entries.
- Chat: a persistent "agent is working" dot-cycle indicator now shows as the last item in the message feed (in addition to the existing footer spinner), auto-scroll no longer leaves the last message hidden behind a growing composer, and the composer textarea now grows with typed content up to ~10 lines before scrolling internally.

Both pieces were implemented via `/sdlc`-style small plans and reviewed by an Opus subagent against the actual diffs before landing; findings from those review passes (registry refcounting bugs, stale-snapshot races, a one-frame text-clipping bug, a stale near-bottom scroll flag, etc.) were fixed and re-verified.

## Test plan
- [x] `pnpm --filter @vibestation/web test` — 513/513 passing
- [x] `pnpm --filter cli test` (daemon) — 791/791 passing (1 pre-existing, unrelated flaky warning)
- [x] `pnpm -r typecheck` clean
- [x] Docker dev sandbox: daemon boots cleanly, UI manually screenshotted for the canvas popup, working indicator, and composer auto-grow changes