### PR TITLE
fix(web-ui): consolidate Rich Chat thinking indicator, fix scroll-lock, composer send-while-busy

### DIFF
--- a/.vibekit/.gitignore
+++ b/.vibekit/.gitignore
@@ -1,0 +1,2 @@
+config.yaml
+**/screenshots/

--- a/.vibekit/feature-plans/done/chat-thinking-scroll-send/.sdlc-state.yaml
+++ b/.vibekit/feature-plans/done/chat-thinking-scroll-send/.sdlc-state.yaml
@@ -1,0 +1,19 @@
+feature: chat-thinking-scroll-send
+worktree: /home/gb/.vibe-station/projects/vibe-station/worktrees/vs-55
+master:
+  prd: skipped
+  plan: complete
+current_subfeature: root
+subfeatures:
+  - id: root
+    origin: planned
+    spawned_from: null
+    mode: done
+    last_completed: "post-review fix pass: 8/8 findings resolved"
+    awaiting_phase: null
+    awaiting_artifact: null
+    phase_chain: [plan, implement]
+    superseded_reason: null
+    parked_reason: null
+    handoff: {next_item: null, returned_at: null, verified_by: null}
+    commit: null

--- a/.vibekit/feature-plans/done/chat-thinking-scroll-send/plan-chat-thinking-scroll-send.md
+++ b/.vibekit/feature-plans/done/chat-thinking-scroll-send/plan-chat-thinking-scroll-send.md
@@ -1,0 +1,479 @@
+<!--
+RULES — read before writing or implementing:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. REQUIREMENTS: One crisp line each — no verbose descriptions
+3. CHECKLIST: Mark items [x] as you complete them — this is your persistent todo list
+4. READING TIME: Optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+# Plan: Rich chat — consolidated thinking indicator, scroll-lock fix, dot/spinner polish, composer send-while-busy
+
+> Bundles all 6 issues from the source investigation report into one plan (small, related UI-polish fixes — same convention as `chat-working-indicator-scroll-grow`).
+
+**Issue:** chat-thinking-scroll-send
+**Branch:** `issues-block-dots` (current branch)
+**Status:** Pending
+**PRD:** none — small, skipped
+**Source report:** `.vibekit/reports/2026-08-24-rich-chat-block-indicators-and-scroll.md` (commit `13daa00` — current `HEAD`, all cited line numbers verified against it)
+
+**Reference files:**
+- `web-ui/src/components/chat/MessageList.tsx:12-19` (`RenderItem`), `:77-170` (`groupEvents`), `:172-219` (`ThinkingHint`/`WorkingIndicator`), `:285-289` (primary scroll effect), `:307-324` (resize-scroll effect), `:452-468` (render/mount points)
+- `web-ui/src/components/chat/ThinkingBlock.tsx:13-43`
+- `web-ui/src/components/layout/ChatPane.tsx:84-88` (`turnActive`/`thinking`), `:197-211` (`MessageList` props), `:242-256` (`Composer` props)
+- `web-ui/src/components/chat/Composer.tsx:96` (`canSend`), `:188-202` (Send/Stop branch)
+- `web-ui/src/components/chat/StatusBar.tsx:22-39` (`turnLabel`), `:103-104` (spinner)
+- `web-ui/src/styles/chat.css:701-751` (`.chat-thinking-hint`/`.chat-working-indicator`), `:344-368` (`.chat-thinking`), `:912-918` (`.chat-statusbar__state`), `:1073-1082` (`.chat-spinner`)
+- `daemon/src/services/jsonAgent.ts` — unchanged, reference only (see Root Cause)
+- `web-ui/src/api/types.ts:188-215` (`NormalizedEvent.ts`, `logSeq`)
+
+---
+
+## Problem
+
+- "Thinking…" flickers and duplicates: `turnState` recomputes per-event and two different components (`ThinkingHint`, `ThinkingBlock`) both render a "Thinking…" label that mount/unmount independently — `MessageList.tsx:126-134,175-182,336,452-468`
+- The live "Thinking…" label never resolves to a completed "Thought for Xs" summary — no timestamp reaches the renderer — `MessageList.tsx:12-19`
+- Auto-scroll yanks the view to bottom on every content change even when the user has scrolled up to read history — `MessageList.tsx:285-289` (only the resize path has a near-bottom guard, `:307-324`)
+- Working-indicator dots are oversized (6px/4px gap) — `chat.css:730-750`
+- A redundant circular spinner duplicates the in-feed working indicator in the footer `StatusBar` — `StatusBar.tsx:104`
+- Composer hides the Send button behind Stop whenever the agent is busy, even with text ready to send/queue — `Composer.tsx:188-201`
+
+## Out of Scope
+
+- Virtualizing/windowing the message list
+- Redesigning `StatusBar` beyond removing the spinner (token/model/mode row, channel toggle untouched)
+- Changing the queue/tray UI itself (`QueuedTray.tsx`) beyond the Composer button affordance
+- `daemon/src/services/jsonAgent.ts` — unchanged, reference only; the anti-flicker fix (Decision 2) is entirely client-side in `ChatPane.tsx`, no provider-cadence or event-mapping change
+- Browser/device verification — no browser tool available this session (same constraint as the precedent plan); vitest + typecheck only
+
+## Concept
+
+- One live "working" affordance at a time: drop `ThinkingHint` entirely; `ThinkingBlock` (per-block) and the trailing `WorkingIndicator` (turn-level) are the only busy affordances, and `WorkingIndicator` now carries the turn-state label text
+- `thinking`/turn-state display values are debounced client-side so rapid `turnState` oscillation no longer flickers the UI (raw `turnActive` stays undebounced for gating Composer/Stop)
+- Consecutive same-turn thinking bursts merge into one `RenderItem` across intervening tool calls, and gain `startedTs`/`endedTs` so the block can show "Thought for Xs" once done
+- Auto-scroll respects a near-bottom guard on every content-change trigger (not just resize), plus a floating jump-to-bottom button when the user has scrolled away
+- Dots shrink to 4px/3px gap; the footer spinner is removed since the in-feed indicator now carries the same information
+- Composer branches on `canSend`, not raw `busy` — Send stays visible and queues while busy, Stop only shows when busy with an empty box
+
+## Requirements
+
+| # | Requirement |
+|---|-------------|
+| 1 | Exactly one live "Thinking…"/working affordance renders at any moment — no simultaneous `ThinkingHint` + `ThinkingBlock` + `WorkingIndicator` |
+| 2 | Rapid `turnState` oscillation (thinking→tool→thinking within one turn) does not visibly flicker the label or swap components |
+| 3 | A tool call between two same-turn thinking bursts does not create two separate "Thinking…" blocks |
+| 4 | A completed thinking block shows "Thought for Xs" (rounded seconds); a still-live block keeps showing "Thinking…" |
+| 5 | Auto-scroll only force-scrolls to bottom when the user is already within 80px of bottom, OR the scroll is caused by the user's own send; a floating jump-to-bottom button appears otherwise |
+| 6 | Working-indicator dots are 4px with 3px gap |
+| 7 | `StatusBar` no longer renders a circular spinner; `.chat-spinner` remains available to `ToolRunSummary` and `ChatPane`'s history-loading state |
+| 8 | The in-feed `WorkingIndicator` shows `<turn-state label> •••`, label and dots bottom/baseline-aligned (`align-items: last baseline`, fallback `baseline`) — not center-aligned |
+| 9 | Composer shows Send (queues) whenever `canSend` is true, even while busy; Stop shows only when `busy && !canSend` (busy with no text/attachment ready — includes disabled/mid-`sending`) |
+| 10 | While busy and `canSend`, the Send affordance is visually distinct from idle Send (signals "will queue" rather than "sends now") |
+
+---
+
+## Research
+
+### Thinking flicker/duplication (issues 1+2)
+
+- **File:** `daemon/src/services/jsonAgent.ts:968-969` (`updateTurnState` + `emitMeta` run per persisted event), `:1000-1024` (`updateTurnState` switches per `NormalizedEventKind`)
+- **Trigger:** every `thinking`/`text`/`tool_use` event flips `turnState`; `ChatPane.tsx:88` maps this straight into the `thinking` boolean
+- **Risk:** HIGH — root cause of both the flicker and the duplicate-label issues
+
+- **File:** `MessageList.tsx:126-134` (`groupEvents`, `thinking` case) — only merges an event into the *immediately preceding* item; a `tool_use`/`tool_result` in between starts a new `thinking` `RenderItem`
+- **File:** `MessageList.tsx:175-182` (`ThinkingHint`, global) vs `ThinkingBlock.tsx:18-24,32` (per-block) — two independently-mounted "Thinking…" labels
+- **File:** `MessageList.tsx:329-336,452-453,463,468` — `ThinkingHint` mount points; `WorkingIndicator` gated `turnActive && !thinking` at `:468` (widens to plain `turnActive` per Decision 1 — see that decision for why the narrower gate is a latent regression once `ThinkingHint` is deleted)
+
+### No elapsed-time data (issue 2)
+
+- **File:** `MessageList.tsx:12-19` — `RenderItem` union carries no timestamp for any variant
+- **File:** `web-ui/src/api/types.ts:191` — `NormalizedEvent.ts: string` (ISO) exists on every raw event, discarded during grouping
+
+### Scroll-stealing (issue 3)
+
+- **File:** `MessageList.tsx:285-289` — unconditional `bottomRef.current?.scrollIntoView(...)` on `[items.length, pending.length, thinking, turnActive]`
+- **File:** `MessageList.tsx:307-324` — the *only* near-bottom guard (`distance < 80`) lives in the ResizeObserver-driven footer-resize path, added by the precedent plan; it does not cover the primary content-change path
+- **Risk:** HIGH — `thinking`/`turnActive` in the primary effect's deps flip constantly per issue 1, so the yank fires repeatedly mid-turn
+
+### Dot sizing (issue 4)
+
+- **File:** `chat.css:713-719` (`.chat-thinking-hint__dot`, 6px, deleted alongside `ThinkingHint` — see Decision 1) and `:740-750` (`.chat-working-indicator__dot`, 6px/4px gap, kept and resized)
+
+### Footer spinner + label plumbing (issue 5)
+
+- **File:** `StatusBar.tsx:22-39` (`turnLabel`, the only source of the "Thinking…"/"Responding…"/"Running tool…" strings today), `:104` (spinner span to delete)
+- **File:** `ToolRunSummary.tsx:113,177`, `ChatPane.tsx:188` — other `.chat-spinner` consumers, must NOT be touched
+- **Risk:** LOW for the spinner deletion (no test asserts it — `grep -n "spinner" web-ui/src/components/chat/*.test.tsx` → no output); MEDIUM for the label plumbing (new prop threading `ChatPane` → `MessageList` → `WorkingIndicator`)
+
+### Composer Send/Stop (issue 6)
+
+- **File:** `Composer.tsx:96` (`canSend`, computed but unused while `busy`), `:188-201` (branch), `:98-118` (`handleSend`/`onKeyDown` — Enter already silently queues while busy, just with no button feedback)
+- **File:** `ChatPane.tsx:217` (`queueDepth={trayRows.length}` already computed for `StatusBar`, reusable for a queue-count badge), `:252` (`busy={turnActive}` passed to `Composer`)
+
+## Root Cause
+
+- Issues 1–2: `turnState` is recomputed and re-broadcast per raw event with no debounce, and two independent components both key off it as a boolean/absence signal instead of sharing one owned "working" affordance
+- Issue 3: the primary scroll effect predates the near-bottom guard added for the (unrelated) resize path in the precedent plan and was never retrofitted
+- Issues 4–6: sizing/spinner/branching gaps explicitly left out of scope by the precedent plan, not new regressions
+
+---
+
+## Architecture Diagram
+
+- Single-module change within `web-ui`'s chat component tree — no new service boundary. One diagram covers the new prop flow for the label (issue 5) and timestamps (issue 2):
+
+```mermaid
+flowchart LR
+    jsonAgent["jsonAgent.ts\n(turnState, unchanged)"] -->|WS meta| ChatPane
+    ChatPane -->|"debounced thinking + raw turnActive\n+ workingLabel: string"| MessageList
+    MessageList -->|"RenderItem.startedTs/endedTs"| ThinkingBlock
+    MessageList -->|"workingLabel prop"| WorkingIndicator
+    Composer -->|"canSend, busy, queueDepth"| SendButton["Send / Stop / Queue affordance"]
+    ChatPane -->|"queueDepth"| Composer
+```
+
+---
+
+## Design Details
+
+### Critical User Journeys (CUJs)
+
+#### CUJ 1 — Agent thinks through a tool-heavy turn
+
+```
+User sends a message
+  → Agent emits thinking → tool_use → tool_result → thinking → text (same turnId)
+  → MessageList renders ONE thinking block, label "Thinking…" while live
+  → Turn completes → label flips to "Thought for 6s" (no flicker, no duplicate block)
+  → WorkingIndicator disappears once turnActive goes false
+```
+
+- **Edge case:** turn ends (idle/error) with an open thinking block and no trailing `text` event → the turn's `result`/`error`/`status` event closes the group inside `groupEvents` itself (Decision 3), so the block still resolves to "Thought for Xs" instead of staying stuck on "Thinking…" — this also works correctly for a COLD-LOADED/replayed transcript, since `groupEvents` re-derives closes from the persisted event stream, not from a live effect
+
+#### CUJ 2 — User scrolls up mid-stream, then sends a new message
+
+```
+User scrolls up to re-read earlier history while a turn streams
+  → New tokens/tool events arrive → distance-to-bottom > 80px → no forced scroll
+  → Floating jump-to-bottom button appears (bottom-right of the scroll viewport)
+  → User clicks the button → scrolls to bottom, button hides
+  → User instead types and sends a new message → composer send scrolls to bottom unconditionally (pending bubble growth), independent of the 80px guard
+```
+
+- **Error path:** `ResizeObserver`/ scroll container unavailable (SSR/test env) → guard degrades to no-op, no crash (same fallback pattern as the existing resize effect at `MessageList.tsx:309`)
+
+### Data Model
+
+- None — nothing persisted. `startedTs`/`endedTs` (Decision 3/4) are derived in-memory from existing `NormalizedEvent.ts` values on every `groupEvents` call, not stored; `displayTurnState`/`atBottom` (Decisions 2, 5) are ephemeral component state.
+
+### Key Decisions
+
+#### Decision 1: Drop `ThinkingHint`, consolidate into `ThinkingBlock` + `WorkingIndicator`
+
+- **Decision:** delete the `ThinkingHint` component and both its mount points, rather than suppressing it conditionally; **also** widen the `WorkingIndicator` gate from `turnActive && !thinking` to plain `turnActive` — the `!thinking` exclusion existed ONLY to avoid double-rendering against `ThinkingHint`, and deleting `ThinkingHint` without this change leaves NO busy affordance during the `thinking` sub-state (a regression, not neutral)
+- **Rationale:** two live components tracking the same signal is the actual duplication bug (Req 1); a single owned affordance per level (per-block vs per-turn) is simpler than a suppression flag and removes an `aria-live` region we'd otherwise have to keep in sync; widening the gate restores continuous coverage across the whole busy window (thinking → tool → responding)
+- **Where:** `MessageList.tsx:172-182` (delete `ThinkingHint`), `:326-336` (`hintAfterPending`/`hintAfterItem` computations — delete), `:452-453,463` (mount points — delete), `:465-467` (delete the comment justifying the old `!thinking` exclusion — no longer true), `:468` (gate becomes `{turnActive ? <WorkingIndicator label={workingLabel} /> : null}`); `chat.css:701-726` (`.chat-thinking-hint*` rules + keyframes — delete, dead after component removal)
+- Accessibility: `WorkingIndicator` already has `role="status" aria-live="polite"` (`MessageList.tsx:208`) — this becomes the sole live-region for turn-level busy state, preserving the announcement `ThinkingHint` provided
+
+#### Decision 2: Client-side debounce of display-facing turn state, raw `turnActive` untouched
+
+- **Decision:** in `ChatPane.tsx`, derive a debounced `displayTurnState` (trailing ~250ms: only commit a new `meta?.turnState` value to display state after it holds for the debounce window) and use it for `thinking` and the new `workingLabel`; keep the existing undebounced `turnActive` (`ChatPane.tsx:84-87`) as-is for Composer/Stop gating
+- **Rationale:** Composer's busy/Stop button must reflect real busy state instantly (a debounced `turnActive` could let a user click Send mid-turn right as it ends); only the *display* label/thinking-block swap needs smoothing — narrower blast radius than debouncing meta emission in `jsonAgent.ts`, and other untraced meta consumers (see report "Not checked") aren't touched
+- **Where:** `ChatPane.tsx:84-88`
+- **Implementer note:** `ChatPane.tsx:1` currently imports `{ useCallback, useMemo, useRef, useState }` from `"react"` — no `useEffect` yet; add it to this import line, the snippet below depends on it
+
+```ts
+// ChatPane.tsx — debounce ONLY the value used for display (label, thinking-block
+// swap); turnActive stays raw so Stop/Composer react to real busy state immediately.
+const [displayTurnState, setDisplayTurnState] = useState(meta?.turnState);
+useEffect(() => {
+  const id = setTimeout(() => setDisplayTurnState(meta?.turnState), 250);
+  return () => clearTimeout(id);
+}, [meta?.turnState]);
+const thinking = displayTurnState === "thinking"; // was: meta?.turnState === "thinking"
+```
+
+#### Decision 3: Merge same-turn thinking bursts across tool calls via an open-group map, closed DETERMINISTICALLY INSIDE `groupEvents`
+
+- **Decision:** track `thinkingOpenByTurnId: Map<turnId, itemIndex>` in `groupEvents`, mirroring the existing `toolIndexById` pattern (`MessageList.tsx:79,136-138`); a `thinking` event with non-empty trimmed text, for a turn with an open entry, appends to that item (even after intervening `tool_use`/`tool_result`); the open entry is closed (sets `endedTs`, deletes the map entry) by whichever of these happens FIRST: (a) a `text` event for that turn, (b) a `result`/`error`/`status` event for that turn (the existing `default:` branch at `MessageList.tsx:164-166` already receives these — add the close there too), or (c) the first event for a DIFFERENT `turnId` (a new turn starting always implies the prior turn's reasoning is over)
+- **Why NOT the effect-based approach (rejected):** `items` is `useMemo(() => groupEvents(events), [events])` (`MessageList.tsx:272`) — mutating a memoized item from a `useEffect` after the fact triggers no re-render and is discarded on the next `events` change (a trailing `usage`/`result` event guarantees one happens almost immediately), so the label would revert to "Thinking…" permanently. It also does nothing for a REPLAYED/reloaded transcript, since no live turn-transition effect ever runs for history that loads already-idle — any thinking block not followed by a `text` event in the persisted log would show "Thinking…" forever after a page refresh. Closing the group inside the pure `groupEvents` function fixes both: it's re-derived correctly on every `events` change, and it works identically for live streams and replayed history
+- **Empty-text guard (regression fix):** only `thinking` events with `ev.text.trim().length > 0` open or append to a group; an empty/signature-only thinking event does NOT open a group and does NOT get appended into an open one. Without this guard, the existing `mergeToolRuns` drop-rule at `MessageList.tsx:44-47` (which drops an empty `thinking` item sitting between two tool calls so they merge into one `toolRun`) breaks: under a naive open-group merge, that empty item would get thinking text appended into it by a LATER same-turn thinking event, so it's no longer empty by the time `mergeToolRuns` runs — `mergeToolRuns` stops dropping it, and two tool calls that previously merged into one run now render as two separate runs with reasoning wedged in between. Skipping empty-text events entirely in the grouping step (they contribute no content and no timing) avoids ever putting text into what should stay a drop candidate
+- **Rationale:** matches the requirement ("merge … across intervening tool calls") while still treating a real reply, a terminal turn event, or a new turn as the natural end of a reasoning burst; closing inside `groupEvents` avoids the stale-memo bug and handles cold-loaded history for free
+- **Where:** `MessageList.tsx:126-134` (thinking case), `:77-83` (map declarations), `:114-124` (`text` case — add close), `:151-163` (`error`/`status` cases — add close), `:164-166` (`default:` branch, i.e. `session_init`/`usage`/`result` — add close), `:44-47` (empty-item drop rule in `mergeToolRuns` — now only ever sees empty items, since Decision 3 never creates a non-empty one from a formerly-empty entry)
+
+```ts
+// groupEvents — replaces the "only merge into the immediately-preceding item" rule.
+// Closing happens INSIDE this pure function (text / result-error-status / new-turnId),
+// never via a post-hoc effect — see "Why NOT the effect-based approach" above.
+function closeOpenThinking(turnId: string | undefined, ts: string) {
+  if (!turnId) return;
+  const openIdx = thinkingOpenByTurnId.get(turnId);
+  const open = openIdx != null ? items[openIdx] : undefined;
+  if (open && open.type === "thinking" && !open.endedTs) open.endedTs = ts;
+  thinkingOpenByTurnId.delete(turnId);
+}
+
+// At the TOP of the per-event loop: any event for a turnId different from the
+// currently-open one closes that prior turn's thinking group first.
+for (const [openTurnId] of thinkingOpenByTurnId) {
+  if (ev.turnId && ev.turnId !== openTurnId) closeOpenThinking(openTurnId, ev.ts);
+}
+
+case "thinking": {
+  if ((ev.text ?? "").trim().length === 0) break; // empty/signature-only: never opens or appends (mergeToolRuns drop rule)
+  const openIdx = ev.turnId ? thinkingOpenByTurnId.get(ev.turnId) : undefined;
+  const open = openIdx != null ? items[openIdx] : undefined;
+  if (open && open.type === "thinking" && !open.endedTs) {
+    open.text += ev.text ?? "";
+  } else {
+    items.push({ type: "thinking", id: ev.id, text: ev.text ?? "", turnId: ev.turnId, startedTs: ev.ts });
+    if (ev.turnId) thinkingOpenByTurnId.set(ev.turnId, items.length - 1);
+  }
+  break;
+}
+case "text":
+  closeOpenThinking(ev.turnId, ev.ts);
+  // ...existing merge logic unchanged...
+  break;
+case "error":
+  closeOpenThinking(ev.turnId, ev.ts);
+  // ...existing push unchanged...
+  break;
+case "status":
+  closeOpenThinking(ev.turnId, ev.ts);
+  // ...existing conditional push unchanged...
+  break;
+default:
+  // session_init / usage / result — also close any open group for this turn.
+  closeOpenThinking(ev.turnId, ev.ts);
+  break;
+```
+
+#### Decision 4: `RenderItem` gains `startedTs`/`endedTs`, `ThinkingBlock` renders "Thought for Xs" as a footer row
+
+- **Decision:** add `startedTs: string; endedTs?: string` to the `thinking` variant of `RenderItem`; `ThinkingBlock` accepts them as props and renders a second, smaller footer line below `__body` (open state) or replaces "Thinking…" with "Thought for Xs" in the toggle label once `endedTs` is set (closed/static state) — per report §2, "or a second footer row" is the lower-risk option since the toggle button itself must stay usable while collapsed
+- **Rationale:** avoids restructuring the click target; the toggle label switches text on completion (always visible, closed or open), the footer row is additive only when open
+- **Where:** `MessageList.tsx:12-19` (add fields, computed via Decision 3), `ThinkingBlock.tsx:4-8` (props), `:18-24` (static/no-content label text), `:34` (toggle label text), `:36-40` (add footer row when `open && endedTs`)
+
+```tsx
+// ThinkingBlock.tsx — label text is the only place elapsed time renders.
+const label = endedTs
+  ? `Thought for ${Math.round((Date.parse(endedTs) - Date.parse(startedTs)) / 1000)}s`
+  : "Thinking…";
+// ...__toggle uses {label} instead of the literal "Thinking…" (both static and interactive cases)
+// ...when open: <div className="chat-thinking__summary">{label}</div> rendered AFTER __body
+```
+
+#### Decision 5: Near-bottom guard on the primary scroll effect + jump-to-bottom button
+
+- **Decision:** replace the unconditional `scrollIntoView` at `MessageList.tsx:285-289` with an `atBottomRef`-guarded check (pre-render at-bottom state captured by the scroll listener below), NOT a fresh post-render `distance` measurement like `:311` — see the implementer note below for why; scoped to `listRef.current?.parentElement`; add an explicit "own send" bypass so the guard never blocks the snap-to-bottom a user expects right after sending; **in scope** for this plan alongside the guard itself, decided explicitly below (not silently added)
+- **Rationale:** matches Req 5; "own send" bypass keeps the one case (`pending.length` growing from the user's own optimistic bubble) where a forced scroll is always correct
+- **Scope call (issue 3 didn't ask for this, addressing reviewer note):** none of the 6 source issues requested a jump-to-bottom button — issue 3 only asked to stop the unwanted yank. It's included anyway because the guard alone is a regression on its own: today the view ALWAYS reaches bottom eventually (annoying but never stuck); once the guard suppresses auto-scroll while scrolled up, a user who scrolls away during a long/streaming turn has NO way back to the live edge without manually dragging the scrollbar past fast-arriving content — a plain scroll gesture competing with new DOM height is unreliable. The button is the minimum companion affordance, not scope creep for its own sake; it stays IN SCOPE. Visual placement is unverified this session (Risk #3) but the interaction logic (2.T4) is fully unit-testable
+- **Where:** `MessageList.tsx:285-289`
+- **Implementer note:** `MessageList.tsx:1` currently imports `{ useEffect, useMemo, useRef, useState }` — add `useLayoutEffect` to this line for the snippet below
+
+```ts
+// MessageList.tsx — primary content-change scroll, now guarded.
+// MUST be useLayoutEffect, not useEffect: the distance check needs to read
+// layout BEFORE the browser paints the just-added content, and the decision
+// of whether to measure "was near bottom" must be made from state captured
+// BEFORE this render's DOM mutation, not after — see the `atBottomRef`
+// note below for why a plain post-render measurement is unsound.
+const prevPendingLen = useRef(pending.length);
+useLayoutEffect(() => {
+  const container = listRef.current?.parentElement;
+  const ownSend = pending.length > prevPendingLen.current; // user just sent → always snap
+  prevPendingLen.current = pending.length;
+  if (!container) { bottomRef.current?.scrollIntoView({ block: "end" }); return; }
+  // Distance is measured AFTER this render's new content is already in the DOM
+  // (unavoidable — the content that determines new scrollHeight must exist to
+  // measure it) — so a single render that appends a lot of height (a large
+  // tool card, a batched token flush) could read distance >= 80 even though
+  // the user was following along right up to that append, silently dropping
+  // them out of follow-mode mid-stream. Mitigation: reuse the `atBottom`
+  // scroll-listener state (below) as the decision input instead of a fresh
+  // measurement here — `atBottom` reflects whether the user was at bottom
+  // BEFORE this render's content landed, which is the intent-preserving check.
+  if (ownSend || atBottomRef.current) container.scrollTop = container.scrollHeight;
+}, [items.length, pending.length, thinking, turnActive]);
+```
+
+- Jump-to-bottom button: new `atBottom` state (mirrored into `atBottomRef` for the layout effect above to read without adding it as a dependency) driven by a `scroll` listener on the same `container` (recomputing `distance < 80` on scroll — separate concern from the ResizeObserver path, which already avoids caching per the precedent plan's Decision 4 fix); button renders inside `.chat-message-list`'s parent wrapper, `position: absolute; bottom: <above footer>; right: var(--space-3)`, shown only when `!atBottom`, `onClick` sets `container.scrollTop = container.scrollHeight`
+- **Initial value:** `atBottom`/`atBottomRef` MUST initialize to `true` (`useState(true)`/`useRef(true)`) — no `scroll` event has fired at mount, so a `false` default would make a freshly opened chat render at the top of history instead of snapping to the live edge, a regression against today's unconditional `scrollIntoView` at mount
+- Multi-pane safety: scoped via `listRef` DOM traversal exactly like the existing resize effect (`MessageList.tsx:296-306` comment) — no global selectors
+
+#### Decision 6: Dot sizing + dead CSS cleanup
+
+- **Decision:** `.chat-working-indicator__dot` → `width/height: 4px`, `.chat-working-indicator__dots` → `gap: 3px`; `.chat-working-indicator` padding stays (still needed once the label sits inline, per Decision 8); delete `.chat-thinking-hint`, `.chat-thinking-hint__dot`, `@keyframes chat-thinking-pulse`, and its `prefers-reduced-motion` override (dead after Decision 1)
+- **Rationale:** Req 6; the `ThinkingHint` CSS has no remaining consumer once the component is deleted
+- **Where:** `chat.css:701-726` (delete), `:740-750` (resize)
+
+#### Decision 7: Remove `StatusBar` spinner only
+
+- **Decision:** delete `StatusBar.tsx:104` (`{busy ? <span className="chat-spinner" ... /> : null}`); leave `.chat-statusbar__state` flex rules and the `.chat-spinner` CSS class untouched (still used by `ToolRunSummary.tsx:113,177`, `ChatPane.tsx:188`)
+- **Rationale:** Req 7; no test asserts the spinner (`grep -n "spinner" web-ui/src/components/chat/*.test.tsx` → no output)
+- **Where:** `StatusBar.tsx:104`
+
+#### Decision 8: Share `turnLabel`, plumb into `WorkingIndicator`, bottom/baseline-align
+
+- **Decision:** export `turnLabel` from `StatusBar.tsx` (`:24-39`, unchanged logic) and import it in `ChatPane.tsx`; compute `workingLabel = turnLabel(displayTurnState, trayRows.length)` and pass as a new `workingLabel?: string` prop through `MessageList` into `WorkingIndicator({ label })`, which renders `<span className="chat-working-indicator__label">{label}</span>` before the existing dots span
+- **Rationale:** Req 8, one source of truth for the label strings instead of duplicating the switch statement; `StatusBar` keeps computing its own copy from `meta` directly (unaffected — its label is NOT debounced, since it renders next to Stop and must stay accurate), `WorkingIndicator`'s label uses the debounced `displayTurnState` for consistency with `thinking`
+- **Where:** `StatusBar.tsx:24` (`export function turnLabel`), `ChatPane.tsx:88` (add `workingLabel` const), `:197-211` (pass prop), `MessageList.tsx:194-219` (`WorkingIndicator` signature + JSX), `:468` (pass `label={workingLabel}`)
+
+```css
+/* chat.css — bottom-align label text and dots, NOT center. Fallback FIRST,
+   enhancement LAST: CSS cascade means the LAST valid declaration for a
+   property wins, so the fallback must come before the preferred value,
+   not after — reversing this order would make `last baseline` dead code
+   even on browsers that support it, since the later `baseline` line would
+   always override it back. */
+.chat-working-indicator {
+  display: flex;
+  align-items: baseline;      /* fallback: applied first, then overridden below where supported */
+  align-items: last baseline; /* wins on browsers that support it — must be the LAST declaration */
+  gap: var(--space-1);
+}
+```
+- Rule order matters: an unsupported `align-items: last baseline` line is dropped as an invalid declaration by CSS parsers, leaving whatever was declared BEFORE it (the `baseline` fallback) in effect; a SUPPORTED `last baseline` line, being declared last, wins the cascade over the earlier fallback — the two lines are NOT redundant, and their order is load-bearing
+
+#### Decision 9: Composer branches on `canSend`, distinct "will queue" affordance
+
+- **Decision:** button branch becomes `busy && !canSend ? <Stop> : <SendOrQueue disabled={!canSend} queued={busy && canSend} />`; the queued variant gets a distinct class (`chat-composer__send--queue`) and `title="Sends after the current turn finishes"` (icon/copy left as `▤` or reuse `▶` with the class-driven visual diff — CSS-only distinction is sufficient, no new icon asset required)
+- **Rationale:** Req 9/10; matches the report's exact boundary — Stop is reachable only in today's one real busy-with-empty-box case
+- **Where:** `Composer.tsx:188-202`
+
+```tsx
+// Composer.tsx — was: {busy ? <Stop/> : <Send disabled={!canSend}/>}
+{busy && !canSend ? (
+  <button type="button" className="chat-composer__stop" onClick={onStop} aria-label="Stop turn">Stop</button>
+) : (
+  <button
+    type="button"
+    className={`chat-composer__send${busy ? " chat-composer__send--queue" : ""}`}
+    aria-label={busy ? "Send message (queues after current turn)" : "Send message"}
+    title={busy ? "Sends after the current turn finishes" : undefined}
+    disabled={!canSend}
+    onClick={() => void handleSend()}
+  >▶</button>
+)}
+```
+- `queueDepth` (already computed at `ChatPane.tsx:217`) is available for an optional count badge on the queue variant but not required to satisfy Req 10 — CSS-only distinction ships first; a badge is a follow-up, not blocking
+
+---
+
+## Risks / Open Questions
+
+| # | Question | Notes |
+|---|----------|-------|
+| 1 | **Does the 250ms display debounce (Decision 2) make "Responding…" visibly lag behind the first streamed token?** | Acceptable tradeoff per report — flicker elimination outweighs a sub-300ms label lag; no test can catch perceived lag without a browser, flag for later device check |
+| 2 | **Does closing an open thinking group on ANY differing-turnId event (Decision 3) ever close prematurely?** | No — turns are strictly sequential in this codebase (one active `turnId` at a time per session), so a differing `turnId` always means the prior turn is fully done; no artificial "now" timestamp is needed since closing uses the actual next event's `ts` |
+| 3 | **Jump-to-bottom button z-index/overlap with the footer in canvas/workspace mode** | No browser available to verify visually this session — implement with a generous bottom offset, flag for manual check post-merge |
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Consolidate + latch the thinking affordance (issues 1+2)
+
+- [x] **1.1** `ChatPane.tsx`: add `useEffect` to the react import (see Decision 2 implementer note); add debounced `displayTurnState` (Decision 2); `thinking` derives from it, `turnActive` stays raw
+- [x] **1.2** `MessageList.tsx`: delete `ThinkingHint` component, its mount points (`:452-453,463`), and `hintAfterPending`/`hintAfterItem`/`lastUserIdx` computations that only existed to place it; delete the `:465-467` comment justifying the old exclusion; **widen the `WorkingIndicator` gate from `turnActive && !thinking` to plain `turnActive`** at `:468` (the `label={workingLabel}` pass-through is deferred to Phase 3, 3.4/3.5, where the `workingLabel` prop is actually introduced — implementing it here would reference a prop that doesn't exist yet) (Decision 1 — without this sub-item, no busy affordance renders during the `thinking` sub-state, a regression)
+- [x] **1.3** `MessageList.tsx`: add `thinkingOpenByTurnId` map + `closeOpenThinking` helper to `groupEvents`; empty-text thinking events never open/append a group (mergeToolRuns regression guard); merge non-empty same-turn thinking across intervening tool calls; close the open group inside `groupEvents` on `text`/`error`/`status`/`default` (session_init/usage/result) events for that turn, and on the first event of a DIFFERENT turnId (Decision 3 — closing lives inside the pure function, NOT in a `useEffect`)
+- [x] **1.4** `MessageList.tsx`: add `startedTs: string; endedTs?: string` to the `thinking` `RenderItem` variant, populated entirely by the `groupEvents` logic in 1.3 — no separate effect/state needed (Decision 3)
+- [x] **1.5** `ThinkingBlock.tsx`: accept `startedTs`/`endedTs` props, compute/render "Thinking…" vs "Thought for Xs" label, add footer summary row when open + ended (Decision 4)
+- [x] **1.6** `chat.css`: delete `.chat-thinking-hint*` rules + `@keyframes chat-thinking-pulse` (dead code, Decision 1); add `.chat-thinking__summary` footer-row styling
+
+**Verify phase 1:**
+- [x] **1.T1** Unit — `MessageList.test.tsx`: `groupEvents` merges thinking→tool_use→thinking (same turnId, non-empty text) into one item; a `tool_use` from a DIFFERENT turnId does not merge into the still-open group (and closes it)
+- [x] **1.T2** Unit — `MessageList.test.tsx`: a `text` event after thinking sets `endedTs` on the thinking item (using that event's `ts`, not a synthetic "now"); a second thinking burst after that `text` (same turnId) starts a NEW item
+- [x] **1.T3** Unit — `MessageList.test.tsx`: regression for the `mergeToolRuns` drop rule — `thinking(empty) → tool_use → thinking(empty) → tool_use` (same turnId) still merges into ONE `toolRun` with no `thinking` `RenderItem` in between (empty-text guard from 1.3 must not let the open-group merge inject text into the empty item)
+- [x] **1.T4** Unit — `ThinkingBlock` (new test file `ThinkingBlock.test.tsx`): `startedTs`/`endedTs` 6400ms apart renders "Thought for 6s"; `startedTs`/`endedTs` <500ms apart renders "Thought for 0s" (no suppression — matches `Math.round`); `endedTs` unset renders "Thinking…"
+- [x] **1.T5** Unit/component — `MessageList.test.tsx`: `ThinkingHint` no longer renders under any prop combination (no `.chat-thinking-hint` in the rendered tree); `turnActive: true, thinking: true` renders `WorkingIndicator` (was previously suppressed by the `!thinking` gate — this is the regression test for the 1.2 gate widening)
+- [x] **1.T6** Regression — `MessageList.test.tsx:199-203` ("does not render during the thinking sub-state (ThinkingHint already covers it)") — INVERT this test: it currently asserts `getByText("Thinking…")` present via `ThinkingHint` and `WorkingIndicator`'s `role="status"`/name "Agent is working" ABSENT; both assumptions are now wrong post-1.2/1.5 (label text may read "Thought for Xs", and `WorkingIndicator` DOES render during `thinking`) — rewrite to assert `WorkingIndicator` (`role="status"`, name "Agent is working") IS present while `thinking: true, turnActive: true`
+- [x] **1.T7** Unit — `ChatPane.test.tsx` (fake timers): `meta.turnState` flipping `thinking → tool → thinking` within the 250ms debounce window does NOT change the `thinking` prop passed to `MessageList` (assert `MessageList` receives `thinking={true}` throughout, no intermediate `false`); a value held longer than 250ms DOES commit and update the prop
+- [x] **1.T8** `pnpm --filter @vibestation/web exec vitest run src/components/chat/MessageList.test.tsx src/components/layout/ChatPane.test.tsx` passes (32/32 green; `ThinkingBlock.test.tsx` also added/passing, 4/4)
+- [x] **1.T9** `pnpm typecheck` clean
+
+### Phase 2 — Scroll-lock fix + jump-to-bottom (issue 3)
+
+- [x] **2.1** `MessageList.tsx`: add `useLayoutEffect` to the react import (see Decision 5 implementer note); add `atBottom` state + `atBottomRef` — both initialized to `true` (no `scroll` event has fired at mount; see Decision 5 "Initial value") — kept in sync, read by the layout effect without adding it as a dependency, driven by a `scroll` listener on the scroll container; replace the unconditional primary scroll effect with the `useLayoutEffect`-based, `atBottomRef`-guarded version, including the own-send bypass (Decision 5)
+- [x] **2.2** `MessageList.tsx`: render a floating jump-to-bottom button, hidden when `atBottom`, `onClick` sets `container.scrollTop = container.scrollHeight`
+- [x] **2.3** `chat.css`: jump-to-bottom button styling (absolute positioning within the scroll viewport wrapper, above the footer)
+
+**Verify phase 2:**
+- [x] **2.T1** Unit — `MessageList.test.tsx`: content change while `atBottom` is false (simulated via the scroll listener / initial state) does NOT set `scrollTop`
+- [x] **2.T2** Unit — `MessageList.test.tsx`: content change while `atBottom` is true DOES set `scrollTop = scrollHeight`
+- [x] **2.T3** Unit — `MessageList.test.tsx`: `pending.length` growing (own send) forces scroll even when `atBottom` is false
+- [x] **2.T4** Unit — `MessageList.test.tsx`: jump-to-bottom button is absent when `atBottom` is true; when `atBottom` is false the button renders, and clicking it sets `container.scrollTop === container.scrollHeight` and (after the resulting `scroll` event flips `atBottom` back to true) the button unmounts
+- [x] **2.T5** Unit — `MessageList.test.tsx`: first render with no prior `scroll` event (fresh mount, no user scroll yet) sets `scrollTop = scrollHeight` — confirms the `true` initial value, guards against the mount-regression the reviewer flagged
+- [x] **2.T6** `pnpm --filter @vibestation/web exec vitest run src/components/chat/MessageList.test.tsx` passes (28/28 green)
+- [x] **2.T7** `pnpm typecheck` clean
+
+### Phase 3 — Dot sizing, spinner removal, label plumbing (issues 4+5)
+
+- [x] **3.1** `chat.css`: resize `.chat-working-indicator__dot`/`__dots` to 4px/3px gap (Decision 6)
+- [x] **3.2** `StatusBar.tsx`: `export function turnLabel(...)`; delete the spinner span at `:104` (Decisions 7, 8)
+- [x] **3.3** `ChatPane.tsx`: import `turnLabel`, compute `workingLabel`, pass through to `MessageList` (Decision 8)
+- [x] **3.4** `MessageList.tsx`: accept `workingLabel` prop, forward to `WorkingIndicator({ label })`
+- [x] **3.5** `WorkingIndicator`: render `__label` span before `__dots`; `chat.css`: `.chat-working-indicator` → `align-items: last baseline` + `baseline` fallback (Decision 8)
+
+**Verify phase 3:**
+- [x] **3.T1** Unit — `StatusBar.test.tsx`: no `.chat-spinner` element renders while busy; `turnLabel` export still produces the same strings as before (Thinking…/Responding…/Running tool…/Queued (n)/Error/Ready)
+- [x] **3.T2** Unit — `MessageList.test.tsx`: `WorkingIndicator` renders the passed `label` text and the dot count classes (`.chat-working-indicator__dot--on`) as before
+- [x] **3.T3** `pnpm --filter @vibestation/web exec vitest run src/components/chat/StatusBar.test.tsx src/components/chat/MessageList.test.tsx` passes (46/46 green)
+- [x] **3.T4** `pnpm typecheck` clean
+
+### Phase 4 — Composer send-while-busy (issue 6)
+
+- [x] **4.1** `Composer.tsx`: rebranch button on `busy && !canSend` vs `canSend` (Decision 9)
+- [x] **4.2** `Composer.tsx`: add `chat-composer__send--queue` class + `title`/`aria-label` variants for the busy+canSend case
+- [x] **4.3** `chat.css`: `.chat-composer__send--queue` visual distinction (e.g. accent-color shift or a small badge dot) from idle Send
+
+**Verify phase 4:**
+- [x] **4.T1** Unit — `Composer.test.tsx`: `busy=true, text=""` → Stop button renders
+- [x] **4.T2** Unit — `Composer.test.tsx`: `busy=true, text="hi"` → Send (queue-variant class) renders, NOT Stop; clicking it calls `onSend`
+- [x] **4.T3** Unit — `Composer.test.tsx`: `busy=false, text="hi"` → plain Send renders (no queue class)
+- [x] **4.T4** Regression — `Composer.test.tsx`: `busy=false, text=""` → Send renders disabled (unchanged existing behavior)
+- [x] **4.T5** `pnpm --filter @vibestation/web exec vitest run src/components/chat/Composer.test.tsx` passes (12/12 green)
+- [x] **4.T6** `pnpm typecheck` clean
+
+### Phase 5 — Review + verify
+
+- [x] **5.1** Opus reviewer subagent pass on the full diff (all 4 phases together) — dispatched by the coordinator; verdict NOT CLEAN, 4 confirmed + 2 plausible findings
+- [x] **5.2** Addressed all 6 findings:
+  1. `ChatPane.tsx` — `workingLabel` flashed "Ready •••" on idle→busy (debounced state lagging raw `turnActive`) — now falls back to raw `meta?.turnState` whenever the debounced value isn't itself a busy state
+  2. `Composer.tsx` — mid-send, `sending=true` alone flipped the button branch to Stop at the same screen position (queue-Send → Stop swap risked aborting the wrong turn) — branch now gated on a separate `hasContent` flag, independent of `sending`
+  3. `MessageList.tsx` `status` case — closed an open thinking group even for benign rate-limit heartbeats that render nothing, splitting a burst with no visible cause — close call moved inside the same `if (ev.text && !isBenignRateLimit(ev.text))` guard as the push
+  4. Stale comments (`WorkingIndicator`'s reduced-motion note referencing deleted `.chat-thinking-hint__dot`; `thinking` prop doc still saying "(Change 3)") — both reworded to match current code
+  5. `ThinkingBlock.tsx` — `Math.round(NaN)` from an empty/malformed timestamp rendered "Thought for NaNs" — added an `Number.isFinite` guard, falls back to "Thinking…"
+  6. Strengthened two tests: `ChatPane.test.tsx` 1.T7 now asserts recorded-call count `> 0` (was vacuously true if the mock never fired); `MessageList.test.tsx` 2.T4 now also fires a real `scroll` event post-click to exercise the scroll-listener path itself, not just the click handler's direct state set
+- [x] **5.3** Full `web-ui` vitest suite + repo-wide typecheck, re-run after fixes (green: 64 files / 535 tests, typecheck clean)
+
+**Verify phase 5:**
+- [x] **5.T1** No unresolved CONFIRMED findings — all 6 (4 confirmed + 2 plausible) fixed
+- [x] **5.T2** `pnpm --filter @vibestation/web exec vitest run` (full suite) passes — 64 passed / 535 passed, 0 failed
+- [x] **5.T3** `pnpm typecheck` clean (repo-wide) — `cli` + `web-ui` both clean (`daemon` has no `typecheck` script, pre-existing/unrelated to this change)
+
+---
+
+## Files & Phase Impact
+
+| File | Status | Phase | Description / Contract Change |
+|------|--------|-------|-------------------------------|
+| `web-ui/src/components/chat/MessageList.tsx` | Modified | 1, 2, 3 | Remove `ThinkingHint`; `groupEvents` open-group merge + `startedTs`/`endedTs`; guarded primary scroll effect + jump-to-bottom; `WorkingIndicator` accepts `label` prop |
+| `web-ui/src/components/chat/ThinkingBlock.tsx` | Modified | 1 | Contract: `ThinkingBlockProps` gains `startedTs: string; endedTs?: string`; renders "Thought for Xs" + footer summary row |
+| `web-ui/src/components/layout/ChatPane.tsx` | Modified | 1, 3 | Debounced `displayTurnState`; computes + passes `workingLabel` to `MessageList` |
+| `web-ui/src/components/chat/StatusBar.tsx` | Modified | 3 | `turnLabel` exported; spinner span removed |
+| `web-ui/src/components/chat/Composer.tsx` | Modified | 4 | Send/Stop branch on `canSend`; queue-variant class + labels |
+| `web-ui/src/styles/chat.css` | Modified | 1, 2, 3, 4 | Delete `.chat-thinking-hint*`; resize working-indicator dots; jump-to-bottom button; `last baseline` label+dots row; `.chat-composer__send--queue` |
+| `web-ui/src/components/chat/MessageList.test.tsx` | Modified | 1, 2, 3 | New/updated coverage per phase verify blocks; `:199-203` inverted (1.T6) |
+| `web-ui/src/components/layout/ChatPane.test.tsx` | Modified | 1 | Fake-timer coverage for the `displayTurnState` debounce (1.T7) |
+| `web-ui/src/components/chat/StatusBar.test.tsx` | Modified | 3 | Spinner-absence + `turnLabel` export coverage |
+| `web-ui/src/components/chat/Composer.test.tsx` | Modified | 4 | Send/Stop/queue branch coverage |
+
+---
+
+## Verification Method
+
+- Node/vitest: targeted component tests per phase + full `web-ui` suite in phase 5
+- `pnpm typecheck`: repo-wide, run at the end of every phase
+- Reviewer: opus subagent, one pass on the complete 4-phase diff
+- No browser/device verification available this session (same constraint as `chat-working-indicator-scroll-grow`) — static + unit-test verification only; flicker cadence, dot sizing, and jump-button placement are visually unconfirmed (see Risks #1, #3)

--- a/.vibekit/reports/2026-08-24-mobile-agent-tools-split-not-responsive/report.md
+++ b/.vibekit/reports/2026-08-24-mobile-agent-tools-split-not-responsive/report.md
@@ -1,0 +1,71 @@
+<!--
+RULES — read before writing this report:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. ANSWER FIRST: the finding goes at the top, before any evidence
+3. EVERY CLAIM CITED: file:line, a command + its output, or a screenshot
+4. READING TIME: optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+# Report: Mobile — agent pane / tools panel split isn't responsive, reads as a stray scrollable strip
+
+**Date:** 2026-08-24 · **Commit:** `13daa0042309ecadbb7a914b81dc7d2a2bb6e974` (unrelated to the `chat-thinking-scroll-send` working-tree changes on this branch — pre-existing bug) · **Scope:** `web-ui` mobile layout (`Layout.tsx`, agent-pane/tools-panel split) · **Method:** Docker dev sandbox (`scripts/dev-sandbox.sh up vs-55 5180`) + Playwright headless Chromium at a 390×844 mobile viewport (`isMobile: true, hasTouch: true`), against the demo-seeded dataset
+
+## Answer
+
+- Not a border bug: `Layout.tsx:238` (`toolsInSplit = showToolPanel && paneFullscreen !== "tools"`) never checks `isMobile`, so the desktop agent-pane/tools-panel `PanelGroup` split (58%/42%) still renders side-by-side on a 390px-wide phone screen whenever the Files/tools panel happens to be toggled on (its visibility persists per-worktree, so it can be "on" from a prior desktop session)
+- Both panes get squeezed to ~227px / ~163px; text overlaps, the file tree wraps to one word per line, and several inner elements (tab strip, file tree, breadcrumb tabs) become independently horizontally-scrollable within their own cramped width — that's the "small area that's scrollable both directions"
+- The colored status border (`chat.css:33-35`, `.agent-pane-slot--waiting_for_human`) is incidental — it outlines the squeezed left sliver, which is what made the bug visible
+- The whole page/document does NOT overflow (`document.documentElement.scrollWidth` stays `390` — confirmed below), so this isn't a global viewport-overflow bug, it's several sub-regions independently overflowing inside their own too-narrow box
+- `isMobile` is already plumbed into `Layout.tsx` and used for the left sidebar (`:186,328`) — it was just never wired into this second split, unlike the sidebar which correctly collapses to an overlay on mobile
+
+## Evidence
+
+| Claim | Source |
+|-------|--------|
+| `isMobile` computed once per route, from a real media query | `web-ui/src/routes/Workspace.tsx:75` — `const isMobile = useMediaQuery("(max-width: 768px)");` |
+| `isMobile` passed into `Layout` and used for the sidebar only | `web-ui/src/components/layout/Layout.tsx:32,49,186,328` |
+| The agent/tools split has no `isMobile` check anywhere | `web-ui/src/components/layout/Layout.tsx:238` — `const toolsInSplit = showToolPanel && paneFullscreen !== "tools";` |
+| `PanelGroup` renders the 58/42 horizontal split unconditionally when `toolsInSplit` is true | `web-ui/src/components/layout/Layout.tsx:240-269` |
+| Colored border is a separate, correctly-implemented feature (not the bug) | `web-ui/src/styles/chat.css:4-11,29-45` (`.agent-pane-slot`, `box-sizing: border-box` already set) |
+| Reproduced at 390×844 mobile viewport: agent pane and files panel both squeezed side-by-side | `screenshots/02-mobile-agent-view-squeezed-split.png` |
+| Mobile dashboard (list view, no split) renders correctly at the same viewport — confirms this is specific to the agent/tools split, not a global mobile-layout bug | `screenshots/01-mobile-dashboard-ok.png` |
+| Document itself does not overflow — the bug is several inner regions each overflowing within their own squeezed box, not the whole page | `$ page.evaluate(() => document.documentElement.scrollWidth)` → `390` (viewport width, no page-level overflow) |
+| Four inner elements independently horizontally-scrollable at the squeezed width: `.tabs-strip__scroll` (101px box, 353px content), `.tool-panel__tabs-scroll` (99px box, 304px content), `.files-topbar__tabs` (39px box, 154px content), and the unlabeled file-tree `[role=tree]` container (54px box, 156px content) inside `.files-panel > .tool-panel__body` | Playwright DOM query over `body *`, filtering `scrollWidth > clientWidth` elements with `overflow(-x): auto\|scroll` |
+
+## Detail
+
+### Root cause
+- `Layout.tsx:238-269` builds `topRow` as a `PanelGroup` split between `agentWrapper()` (58%, min 25%) and `wrap(toolPanel)` (42%, min 18%) whenever `toolsInSplit` is true
+- `toolsInSplit`'s only gates are `showToolPanel` (persisted visibility, not screen-size-aware) and `paneFullscreen !== "tools"` — no `isMobile` term
+- Contrast with the sidebar just above it, which DOES branch: `{isMobile ? sidebarMobile : sidebarDesktop}` (`:186,328`) — collapses to a slide-over overlay instead of squeezing into the row
+- Net effect: opening an agent session on a phone with the Files panel toggled on renders the full desktop IDE-style split, just proportionally shrunk, instead of one full-width pane
+
+### What the squeeze does downstream
+- Agent pane (`.agent-pane-slot`, ~227px wide): the `⇌ Rich Chat` channel-toggle overlay (`chat.css:50-56`, `position: absolute; top; right`) collides with the `📎 Attach files` button and the terminal's "[Agent paused, waiting for input]" banner text, all fighting for the same ~227px
+- Files panel (`.files-panel`, ~163px wide): `[role=tree]` file names wrap to one word per line and the tree container itself picks up its own horizontal scrollbar (54px visible / 156px content) because tree-row indentation (`min-width: max-content` on the row wrapper) can't shrink further
+- Both tab strips (`.tabs-strip__scroll`, `.tool-panel__tabs-scroll`) and the Files breadcrumb tabs (`.files-topbar__tabs`) also pick up independent horizontal scrollbars at their squeezed width — these are legitimate horizontal-scroll UI patterns at normal width, but at ~40-100px they read as broken/stray scrollable slivers
+
+### Screenshots
+
+**Mobile dashboard (390×844) — correct, no split, single column:**
+
+![Mobile dashboard renders correctly](./screenshots/01-mobile-dashboard-ok.png)
+
+**Mobile agent view (390×844) — agent pane + Files panel squeezed side-by-side, text overlapping, colored border outlining the narrow left sliver:**
+
+![Agent pane and Files panel squeezed into a desktop-style split on a phone viewport](./screenshots/02-mobile-agent-view-squeezed-split.png)
+
+## Not checked
+
+- Whether other split surfaces have the same gap — `toolSplitOrientation === "vertical"` (stacked instead of side-by-side) was not tested at mobile width; a vertical split might already be less broken since both panes would at least span the full width
+- The terminal dock split (`Layout.tsx:270-282`, agent/tools row stacked with the terminal dock) was not separately reproduced at mobile width — likely has the same missing-`isMobile` gap by the same pattern, not confirmed
+- No fix implemented — this report is investigation only, per the user's request to identify the root cause, not to change code
+- Real device testing (iOS Safari / Android Chrome) not done — Chromium headless only; touch-drag behavior on the resize handles at this width wasn't exercised
+
+## Follow-ups
+
+| # | Question | Why it matters |
+|---|----------|-----------------|
+| 1 | Should mobile force `toolsInSplit`/`showTerminalDock` to `false` and instead render one full-width pane at a time (agent XOR tools, likely via a tab switcher), mirroring how the sidebar already collapses to an overlay via `isMobile`? | This is the actual fix — the split itself, not the border, is the bug; scope + UX (tabs vs. a toggle button) needs a decision before implementing |
+| 2 | Does the terminal dock split (`Layout.tsx:270-282`) have the same missing-`isMobile` gap? | Not reproduced in this report — worth checking before scoping a fix, so one plan covers all affected splits instead of a second bug report later |
+| 3 | Is `showToolPanel`'s persisted-per-worktree visibility itself mobile-appropriate, or should mobile always start with tools panel closed regardless of the desktop-set preference? | Affects whether the fix is purely layout (still splits, just responsively) or also touches what state mobile inherits from a desktop session |

--- a/.vibekit/reports/2026-08-24-rich-chat-block-indicators-and-scroll.md
+++ b/.vibekit/reports/2026-08-24-rich-chat-block-indicators-and-scroll.md
@@ -1,0 +1,149 @@
+<!--
+RULES — read before writing this report:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. ANSWER FIRST: the finding goes at the top, before any evidence
+3. EVERY CLAIM CITED: file:line, a command + its output, or a screenshot
+4. READING TIME: optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+# Report: Rich Chat block "Thinking..." indicator, scroll-lock, dot-sizing, and composer send/stop bugs
+
+**Date:** 2026-08-24 · **Commit:** 13daa0042309ecadbb7a914b81dc7d2a2bb6e974 · **Scope:** web-ui rich chat (json channel) message rendering, agent block header, auto-scroll, StatusBar, Composer · **Method:** code reading, no device/browser available
+
+## Answer
+
+- **One root cause drives issues 1 + 2:** the daemon recomputes `turnState` from the kind of *every single normalized event* and re-emits meta each time (`daemon/src/services/jsonAgent.ts:1000-1019`, `:966-969`), so `thinking` flips `true→false→true` many times per turn. The UI mounts/unmounts `ThinkingHint` on that boolean (`MessageList.tsx:336,452-453,463`) and swaps it against `WorkingIndicator` (`MessageList.tsx:468`) → visible flicker. The *second* stacked "Thinking…" is a different component: every `thinking` event group also renders its own `ThinkingBlock` label (`ThinkingBlock.tsx:18-24,32`), and a turn emits many separate thinking groups because `groupEvents` only merges *adjacent* same-turn thinking events (`MessageList.tsx:126-134`).
+- **No elapsed-time data model exists client-side:** `RenderItem` carries no timestamps (`MessageList.tsx:12-20`) even though every raw event has `ts` (`web-ui/src/api/types.ts:191`), so there is nothing today that could render "Thought for Xs" — it needs a new `startedTs`/`endedTs` on the thinking render item. Placement is also wrong-by-design: the hint is anchored *under the last user message*, i.e. above everything the agent then streams (`MessageList.tsx:329-336,452-453`).
+- **Issues 3/4/5 are gaps left by the prior sub-feature, not new bugs:** the unconditional `scrollIntoView` on every content change was never made near-bottom-aware (only the *ResizeObserver* path was — `MessageList.tsx:285-288` vs `:307-325`); there is no jump-to-bottom control anywhere in the repo; dots are 6px/4px-gap (`chat.css:740-750`); and the `StatusBar` circular spinner was explicitly out of scope in the prior plan and still renders (`StatusBar.tsx:104`, `chat.css:1073-1082`).
+- **Issue 6 (new): Composer hides Send while busy, even with text ready to send.** `busy` unconditionally swaps the button to `Stop` (`Composer.tsx:188-201`) — but sending while busy is a real, working action (it enqueues a turn into the tray, `ChatPane.tsx:217-218,243-253`), not a no-op. There is no queue-depth affordance on the button itself today.
+
+## Evidence
+
+| Claim | Source |
+|-------|--------|
+| `turnState` derived per-event kind, so it oscillates thinking→tool→responding→thinking within one turn | `daemon/src/services/jsonAgent.ts:1000-1019` |
+| Every persisted event triggers `updateTurnState` + `emitMeta` (one meta push per token/tool event) | `daemon/src/services/jsonAgent.ts:966-969` |
+| `thinking` prop is literally `turnState === "thinking"`; `turnActive` is the 3-state busy union | `web-ui/src/components/layout/ChatPane.tsx:84-88`, passed at `:200-201` |
+| `ThinkingHint` renders only while `thinking` is true → unmounts on every flip | `MessageList.tsx:335-336`, `:452-453`, `:463` |
+| `WorkingIndicator` is mutually exclusive with `ThinkingHint`, so the two swap on each flip | `MessageList.tsx:468` (`turnActive && !thinking`) |
+| Per-block "Thinking…" label is `ThinkingBlock`, a *separate* component from `ThinkingHint` | `ThinkingBlock.tsx:18-24` (static, no-text case), `:32` (toggle case) |
+| Thinking events merge into one item only when *immediately adjacent* and same `turnId` — a tool_use between them splits a new block | `MessageList.tsx:126-134` |
+| Empty/signature-only thinking items are dropped only when a tool run is open, otherwise they render as a bare "Thinking…" | `MessageList.tsx:45-47` + `ThinkingBlock.tsx:18-24` |
+| No elapsed/duration tracking: `RenderItem` union has no timestamp field | `MessageList.tsx:12-20` |
+| Raw events *do* carry `ts` (ISO string) — the data exists, it's discarded at grouping | `web-ui/src/api/types.ts:188-215` |
+| Unconditional scroll-to-bottom fires on items/pending/thinking/turnActive changes with no near-bottom guard | `MessageList.tsx:285-288` |
+| The near-bottom guard (`distance < 80`) exists **only** in the ResizeObserver path | `MessageList.tsx:307-325` |
+| No jump-to-bottom affordance exists | `$ grep -rn "jump-to-bottom\|scrollToBottom\|jumpTo" web-ui/src` → only `TerminalPane.tsx:451: term.scrollToBottom();` |
+| Prior plan scoped only footer-resize-awareness; user-scroll respect covered only requirement 2a/2b, no jump button | `.vibekit/feature-plans/wip/chat-working-indicator-scroll-grow/plan-chat-working-indicator-scroll-grow.md` (Requirements table, Out of Scope) |
+| Working dots are 6px with 4px gap + `--space-1` vertical padding | `web-ui/src/styles/chat.css:730-750` |
+| Circular spinner rendered left of the Stop button in the status bar | `StatusBar.tsx:103-111` |
+| Spinner is a 12px 2px-border rotating ring | `web-ui/src/styles/chat.css:1073-1082` |
+| `.chat-statusbar__state` centers spinner against label (flex, `align-items: center`) | `web-ui/src/styles/chat.css:912-918` |
+| Same `chat-spinner` class is reused elsewhere — removal must be scoped to StatusBar only | `ToolRunSummary.tsx:113,177`, `ChatPane.tsx:189` |
+| No test asserts the StatusBar spinner (safe to remove) | `$ grep -n "spinner" web-ui/src/components/chat/*.test.tsx` → no output |
+| Existing tests do assert working-indicator dots (will need updating if markup changes) | `MessageList.test.tsx:186,220` |
+| `.chat-pane` is already a positioning context (usable for an overlay button) | `web-ui/src/styles/chat.css:146,165` |
+| Scroll container is `.chat-pane__body` (`overflow-y:auto`), the list itself is unscrolled | `web-ui/src/styles/chat.css:171-175`, `:204-209` |
+| Composer button is `Stop` whenever `busy`, regardless of textarea content | `Composer.tsx:188-201` |
+| `canSend` (text or ready attachment present) is computed but only gates the `Send` branch — never consulted while `busy` | `Composer.tsx:96` |
+| Sending while busy enqueues a real turn (queue tray), it is not blocked/ignored | `ChatPane.tsx:217-218` (`queueDepth={trayRows.length}`), `:243-253` (`onSend`) |
+| `onKeyDown`'s Enter-to-send path calls the same `handleSend`, so Enter while busy-with-text also silently queues today, with no visual cue on the button | `Composer.tsx:98-109,116` |
+
+## Detail
+
+### 1. "Thinking..." header flickers / duplicates per block
+
+- Root cause A (flicker): `thinking` is a *momentary* signal, not a phase.
+  - `updateTurnState(ev.kind)` runs for every event: `thinking`→`thinking`, `text`→`responding`, `tool_use`→`tool` (`jsonAgent.ts:1000-1019`), each followed by `emitMeta()` (`jsonAgent.ts:966-969`).
+  - `ChatPane.tsx:88` maps that straight to `thinking`; `MessageList.tsx:336,468` mount/unmount `ThinkingHint` and swap in `WorkingIndicator` on each flip.
+- Root cause B (duplicate/stacked): two *different* components both say "Thinking…".
+  - `ThinkingHint` (`MessageList.tsx:175-182`) — global, anchored under last user message.
+  - `ThinkingBlock` (`ThinkingBlock.tsx:18-24,32`) — one per thinking item; `groupEvents` creates a new item whenever a non-thinking event intervenes (`MessageList.tsx:126-134`), so a tool-heavy turn yields N stacked "Thinking…" labels.
+- Proposed fix:
+  - Debounce/latch: derive a sticky `busy` phase in `ChatPane` (e.g. `thinking` sticky until `turnActive` goes false, or a ~300ms trailing debounce on `turnState`) instead of raw equality at `ChatPane.tsx:88`.
+  - Render exactly one live affordance: drop `ThinkingHint` entirely and let the single trailing `WorkingIndicator` carry the label (also satisfies issue 5), OR keep the hint but suppress `ThinkingBlock`'s label while its block is the live one.
+  - Collapse consecutive thinking groups in `groupEvents` across intervening empty items (extend the `MessageList.tsx:45-47` drop rule so empty thinking never opens a new block).
+
+### 2. Stale "Thinking..." never resolves to "Thought for Xs" + placement
+
+- Root cause: no duration data reaches the renderer.
+  - `RenderItem` (`MessageList.tsx:12-20`) has `id`/`text`/`turnId` only — no `ts`, no `startedAt`/`completedAt`.
+  - The source data has it: `NormalizedEvent.ts` (`web-ui/src/api/types.ts:191`), monotonic `logSeq` at `:214`.
+  - Completion is implicit: a thinking block is "done" once any later event with the same `turnId` arrives, or the turn goes idle — nothing computes or stores that boundary today.
+- Root cause (placement): the hint is emitted *after the last user item* (`MessageList.tsx:329-336`, insert at `:452-453`), so it always sits above the agent's streamed blocks, not attached to the block it describes.
+- Proposed fix:
+  - Extend the `thinking` `RenderItem` with `startedTs` (first thinking event's `ts`) and `endedTs` (`ts` of the first subsequent same-turn non-thinking event; unset while live).
+  - `ThinkingBlock`: label = `Thinking…` + dots while `endedTs == null`; `Thought for ${round((ended-started)/1000)}s` once set (still expandable to the reasoning text).
+  - Render the summary **below** the block's content (footer row of `.chat-thinking`), matching the "summarizes what's above" reading — requires reordering `ThinkingBlock.tsx:29-38` so the toggle row follows `__body`, or a second footer row.
+  - Live-clock option: tick from `startedTs` while live so the number is visible before completion (needs a 1s interval in `ThinkingBlock`, gated on live).
+
+### 3. Auto-scroll steals scroll position
+
+- Root cause: the primary scroll effect has **no** near-bottom guard.
+
+```
+MessageList.tsx:285-288
+useEffect(() => {
+  bottomRef.current?.scrollIntoView({ block: "end" });
+}, [items.length, pending.length, thinking, turnActive]);
+```
+
+- The guard the prior plan added lives only in the resize path (`MessageList.tsx:307-325`, `distance < 80`) — it does not protect the content-change path.
+- `thinking`/`turnActive` are in the dep array, and (per issue 1) they flip constantly → the yank-to-bottom fires repeatedly mid-turn, not just on new messages.
+- No jump-to-bottom control exists anywhere (`grep` above; only xterm's own `term.scrollToBottom()` in `TerminalPane.tsx:451`).
+- Proposed fix:
+  - Compute `distance = scrollHeight - scrollTop - clientHeight` fresh inside the effect (same technique/threshold as `:307-325`), scroll only when `distance < 80`; keep scrolling unconditionally on *own-user* sends (pending grows) so the composer still snaps down.
+  - Add a `stuck`/`atBottom` state, updated from a `scroll` listener on `listRef.current.parentElement`, driving a floating ↓ button.
+  - Placement: absolutely-positioned overlay bottom-right of the scroll viewport. `.chat-pane` is already `position: relative` (`chat.css:165`), but it also contains the footer — anchor to the pane and offset above the footer, or wrap `.chat-pane__body` in a relative wrapper so the button doesn't scroll away.
+  - Multiple panes can be mounted (canvas mode) — scope by ref traversal, not global selectors (same constraint noted at `MessageList.tsx:296-306`).
+
+### 4. Working 3-dot indicator too large
+
+- Current sizing: `width/height: 6px`, `gap: 4px`, container `padding: var(--space-1) 0` (`chat.css:730-750`).
+- Same 6px is used by `.chat-thinking-hint__dot` (`chat.css:713-719`) — shrinking one without the other will look inconsistent if both survive issue 1's cleanup.
+- Proposed fix: 4px dots, 3px gap, drop container padding to 0 (or `--space-0`); if the label moves in (issue 5), size dots relatively (e.g. `0.35em`) so they track chat font-zoom (`ChatPane` overrides `--font-size-*` inline, `chat.css:154-162`).
+- Tests assert `.chat-working-indicator__dot--on` counts (`MessageList.test.tsx:186,220`) — class names must survive or tests get updated.
+
+### 5. Remove circular spinner; status text left of dots, baseline-aligned
+
+- Current: `StatusBar.tsx:104` renders `<span className="chat-spinner" />` when `busy`, immediately left of the label (`:106`) and the Stop button (`:109-111`).
+- `chat-spinner` is shared — `ToolRunSummary.tsx:113,177` (per-tool running) and `ChatPane.tsx:189` (history loading) must keep it; only the StatusBar usage is removed. The CSS rule (`chat.css:1073-1082`) stays.
+- No test asserts it (`grep -n "spinner" web-ui/src/components/chat/*.test.tsx` → no output), so removal is test-safe.
+- The label text itself comes from `turnLabel()` (`StatusBar.tsx:24-38`, "Thinking…"/"Responding…"/"Running tool…"), which lives in `StatusBar` — `MessageList` currently receives only booleans (`MessageList.tsx:240-244`), so moving the text into `WorkingIndicator` requires plumbing `turnState` (or a precomputed label) from `ChatPane.tsx:84-88` into `MessageList` → `WorkingIndicator`.
+- Proposed fix:
+  - Delete line `StatusBar.tsx:104`; leave `.chat-statusbar__state` flex rules (`chat.css:912-918`) or simplify to inline.
+  - `WorkingIndicator({ label })` → `<span class="…__label">{label}</span><span class="…__dots">…</span>`.
+  - Baseline alignment to the *bottom* line of a wrapping label: `.chat-working-indicator { display: flex; align-items: last baseline; }` and remove `align-items: center` from `__dots` (`chat.css:735-739`); fall back to `align-items: baseline` where `last baseline` is unsupported.
+
+### 6. Composer: Send hidden behind Stop while agent is busy and text is typed
+
+- Current: `{busy ? <Stop> : <Send disabled={!canSend}>}` (`Composer.tsx:188-201`) — `busy` alone decides the branch; `canSend` (text/attachment present) is never checked in the busy case.
+- Effect: user types a follow-up while the agent works, sees only `Stop`, and Enter (`onKeyDown` → `handleSend`) *silently* enqueues the message with no button feedback that anything happened differently than "sending is blocked."
+- Proposed fix:
+  - Branch on `busy && !canSend` → `Stop`; `canSend` (any text/attachment ready, busy or not) → `Send`/queue icon.
+  - While busy *and* `canSend`, use a distinct icon/label from the idle Send state — e.g. a "queue" glyph (▤/⏎-into-tray) or `Send · will queue` tooltip — so it's clear the click enqueues rather than sends immediately; reuse `queueDepth`/`trayRows.length` (already computed in `ChatPane.tsx:217`) to optionally badge the count.
+  - Keep `Stop` reachable while busy with no text typed (today's only busy-with-empty-box case) — likely as a small icon-adjacent secondary control, or swap-on-hover, since one button can't be both `Stop` and `Send` at once; simplest: keep `Stop` as the button when the box is empty, swap to `Send`/queue the moment text/attachment appears, matching the `canSend` boundary exactly.
+
+## Not checked
+
+- No browser/device run — all findings are static; flicker cadence and dot sizes are inferred from code/CSS, not observed.
+- Cursor/opencode providers' event cadence (whether they emit `thinking` events at all, which changes how often `turnState` flips) — only `jsonAgent.ts`'s generic mapping was read.
+- Whether the daemon coalesces meta pushes over the WS before they reach `useChat` (throttle/dedupe on the client subscription path was not traced end-to-end).
+- Whether any *other* consumer of `SessionMeta.turnState` depends on its high-frequency per-event granularity (a debounce there could regress them).
+- Accessibility review of removing `ThinkingHint` (`role="status" aria-live="polite"` at `MessageList.tsx:177`) — the replacement must keep an aria-live announcement.
+
+## Follow-ups
+
+| # | Question | Why it matters |
+|---|----------|-----------------|
+| 1 | Debounce/latch `thinking` (and possibly `turnActive`) in `ChatPane.tsx:84-88` — client-side latch, or coalesce meta emission in `jsonAgent.ts:966-969`? | Fixes flicker at the source; client-side latch is lower-risk since other meta consumers are untraced |
+| 2 | Consolidate to ONE live "Thinking…" affordance: drop `ThinkingHint` (`MessageList.tsx:175-182,452-453,463`) and let `ThinkingBlock` + trailing `WorkingIndicator` carry it? | Eliminates the stacked-duplicate label; also unblocks issue 5's label placement |
+| 3 | Merge consecutive same-turn thinking groups across intervening empty/tool items in `groupEvents` (`MessageList.tsx:126-134`, `:45-47`) | Stops N "Thinking…" headers per tool-heavy turn |
+| 4 | Add `startedTs`/`endedTs` to the `thinking` `RenderItem` (`MessageList.tsx:12-20`) from `NormalizedEvent.ts` and render `Thought for Xs` on completion | Only way to replace the stale live label with a terminal summary |
+| 5 | Move the thinking summary line **below** the block body in `ThinkingBlock.tsx:29-38` — confirm this is wanted for the collapsed (no-content) case too | Placement change affects both live and completed states |
+| 6 | Gate `MessageList.tsx:285-288` on the same `distance < 80` check as `:307-325`, with an exception for user-initiated sends | Stops the scroll yank; the exception keeps send→snap-to-bottom feeling right |
+| 7 | Add a floating ↓ jump-to-bottom button — anchor above the footer inside `.chat-pane` (`chat.css:146-166`) or in a new relative wrapper around `.chat-pane__body` | Needs a layout decision before implementation; must work with multiple mounted panes |
+| 8 | Shrink dots to ~4px/3px gap (`chat.css:730-750`); do the same for `.chat-thinking-hint__dot` (`:713`) if that component survives | Keeps the two dot styles consistent |
+| 9 | Remove `StatusBar.tsx:104` only (keep `.chat-spinner` for `ToolRunSummary.tsx:113,177` and `ChatPane.tsx:189`) | Shared class — a blanket delete would break tool-running/loading indicators |
+| 10 | Plumb `turnState` (or a label string) `ChatPane` → `MessageList` → `WorkingIndicator`, with `align-items: last baseline` | Required prop-drilling for issue 5's "text left of dots, baseline-aligned" |
+| 11 | Rebranch `Composer.tsx:188-201` on `canSend` instead of raw `busy`, and design a distinct "will queue" affordance (icon/badge) for busy+canSend vs. idle Send | Restores the ability to send follow-ups while the agent works without hiding it behind a Stop-only button; needs a visual decision (icon vs. label vs. badge) before implementation |

--- a/.vibekit/reports/chat-thinking-scroll-send/report.md
+++ b/.vibekit/reports/chat-thinking-scroll-send/report.md
@@ -1,0 +1,110 @@
+<!--
+RULES — read before writing this report:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. ANSWER FIRST: the finding goes at the top, before any evidence
+3. EVERY CLAIM CITED: file:line, a command + its output, or a screenshot
+4. READING TIME: optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+# Report: chat-thinking-scroll-send — visual confirmation, final state
+
+**Date:** 2026-08-24 · **Commit:** `13daa0042309ecadbb7a914b81dc7d2a2bb6e974` base + uncommitted working-tree diff (plan `plan-chat-thinking-scroll-send.md`, all 49 checklist items `[x]`, plus 4 follow-up fixes made after this report's first draft — see Changelog) · **Scope:** visual verification only — component behavior itself is covered by the full `web-ui` vitest suite (547/547 passing at time of writing), not re-derived here · **Method:** Docker dev sandbox (`scripts/dev-sandbox.sh up vs-55 5180`), Playwright headless Chromium at desktop width. Two capture passes: (1) the **real running app** — a demo worktree session switched to Rich Chat, a real message sent through the real Composer; (2) a throwaway fixture-preview page for the 2 states a live turn can't reach without CLI credentials (a *completed* thinking block, and the scrolled-away jump button)
+
+## Changelog since the first draft of this report
+
+- Footer `StatusBar` no longer duplicates the turn-state text next to `Stop` — it now shows JUST `[Stop]` while busy (was: `Thinking… [Stop]`)
+- Busy-state labels dropped the trailing ellipsis: `"Thinking"` / `"Responding"` / `"Running tool"` (was: `"Thinking…"` etc.) — the animated `•••` dots next to the label already convey "in progress," the ellipsis was redundant with them
+- The per-block `ThinkingBlock` no longer renders AT ALL while its thinking group is still open/live (was: showed a redundant `"Thinking…"` header identical to the trailing working indicator) — it now only appears once the group closes, showing `"Thought for Xs"`
+- `QueuedTray` now renders above `StatusBar` in the footer (was: below it)
+- Scroll-to-top now auto-loads older history with scroll position preserved (was: manual "Load earlier messages" button only) — server-side bounded pagination (tail-20 window) already existed and was verified unaffected
+
+## Answer
+
+- **Confirmed live, in the real running app:** sending a real message shows the in-feed indicator reading exactly `Thinking •••` (no ellipsis in the text, small dots, one line) — the footer directly below shows **only `[Stop]`**, no duplicate text. Typing a follow-up while that turn is still busy swaps the Composer's button to a dashed-border "will queue" Send, not `Stop`.
+- **Confirmed via fixture** (states unreachable live without CLI credentials): a completed thinking block reads `▶ Thought for 6s` with no live "Thinking" duplicate ever having appeared for it; the jump-to-bottom button appears only when scrolled away from the live edge.
+- All 8 asks tracked in this session (see the audit table below) are PASS as of the latest fix pass.
+
+## Evidence
+
+| Claim | Source | Real app or fixture? |
+|-------|--------|:---:|
+| Live busy turn: `Thinking •••` (no ellipsis), footer shows ONLY `Stop` — no duplicate text | `screenshots/01-live-busy-thinking-dots-stop.png` | **Real** |
+| Composer shows dashed "will queue" Send — not `Stop` — while busy AND text is typed | `screenshots/02-live-composer-queue-send-busy.png` | **Real** |
+| Completed turn: `▶ Thought for 6s`, no live thinking duplicate ever shown for it | `screenshots/03-fixture-completed-thought-for.png` | Fixture |
+| Live turn, full pane view: single `Thinking •••` line, no per-block `ThinkingBlock` header duplicating it, footer has ONLY `Stop` | `screenshots/04-fixture-live-busy-full-pane.png` | Fixture |
+| Jump-to-bottom (↓) button appears only once scrolled away from the live edge | `screenshots/05-fixture-jump-to-bottom.png` | Fixture |
+| Composer: queue-styled (dashed border) Send while busy + text present | `screenshots/06-fixture-composer-queue.png` | Fixture |
+| Composer: `Stop` shown only while busy AND box is empty | `screenshots/07-fixture-composer-stop-empty.png` | Fixture |
+| No CLI credentials in the sandbox — every real turn errors before completing, hence sections 03/05 are fixture-driven | `$ docker exec vs-55-vst-dev-1 env \| grep -iE "anthropic\|claude\|openai"` → exit code 1, no output; live turn observed ending in `Not logged in · Please run /login` | — |
+| Latest fix source, spot-checked in the running container | `$ docker exec vs-55-vst-dev-1 grep -n "Running tool" /app/web-ui/src/components/chat/StatusBar.tsx` → `38: return "Running tool";` (no ellipsis) | — |
+
+## Live app screenshots
+
+**Busy — real turn sent, `Thinking •••` (no ellipsis), footer shows ONLY `Stop`:**
+
+![Real busy turn: no ellipsis, no duplicate footer text](./screenshots/01-live-busy-thinking-dots-stop.png)
+
+**Busy + typing a follow-up — Composer shows dashed "will queue" Send, not Stop:**
+
+![Real busy turn with text typed: queue-styled Send button](./screenshots/02-live-composer-queue-send-busy.png)
+
+## Fixture screenshots (states unreachable without live CLI credentials)
+
+**Completed turn — "Thought for 6s", never showed a live duplicate:**
+
+![Completed thinking block](./screenshots/03-fixture-completed-thought-for.png)
+
+**Live turn, full pane — single working line, no per-block duplicate, footer has only Stop:**
+
+![Live busy turn full pane](./screenshots/04-fixture-live-busy-full-pane.png)
+
+**Scrolled up — jump-to-bottom button:**
+
+![Jump to bottom button](./screenshots/05-fixture-jump-to-bottom.png)
+
+**Composer — queue-styled Send (busy + text):**
+
+![Composer queue send](./screenshots/06-fixture-composer-queue.png)
+
+**Composer — Stop (busy + empty):**
+
+![Composer stop](./screenshots/07-fixture-composer-stop-empty.png)
+
+## Full audit (all 8 asks tracked this session)
+
+| # | Ask | Result | Evidence |
+|---|---|---|---|
+| 1 | One working affordance, no stacked "Thinking…" headers | PASS | `MessageList.tsx` `thinkingOpenByTurnId`/`closeOpenThinking`; `ThinkingHint` fully removed |
+| 2 | "Thought for Xs" on completion, rendered below the block | PASS | `ThinkingBlock.tsx` `thinkingLabel()`, summary row after `__body` |
+| 3 | No scroll-steal; jump-to-bottom button | PASS | `MessageList.tsx` `atBottomRef`-guarded layout effect; `screenshots/05` |
+| 4 | Small dots | PASS | `chat.css` `.chat-working-indicator__dot` 4px / `__dots` gap 3px |
+| 5 | No spinner AND no duplicate text near Stop; bottom-aligned dots | PASS | `StatusBar.tsx` label hidden while `busy`; `chat.css` `align-items: baseline` → `last baseline` cascade order correct; `screenshots/01` |
+| 6 | Composer queue-Send vs. Stop | PASS | `Composer.tsx` `hasContent`/`canSend` split; `screenshots/02,06,07` |
+| 7 | Queued tray above status bar | PASS | `ChatPane.tsx` `.chat-pane__footer` renders `QueuedTray` before `StatusBar` |
+| 8 | Scroll-to-top auto-pagination, no jump | PASS | `MessageList.tsx` `NEAR_TOP_PX` trigger + height-delta `useLayoutEffect` restore |
+| 9 | No ellipsis in busy labels (dots already convey continuation) | PASS | `StatusBar.tsx`/`ThinkingBlock.tsx` — `"Thinking"`/`"Responding"`/`"Running tool"`, no `…` |
+| 10 | Live `ThinkingBlock` not shown until its group closes | PASS | `MessageList.tsx` `case "thinking"` renders `null` while `!item.endedTs && turnActive` |
+
+**Decided, not implemented:** a single `"Thought for Xs"` label is used always — no separate `"Worked for Xs"` variant for thinking groups that had a tool call interleaved. Tracking that would need new state (whether any tool event fell inside a group's open lifetime) for unclear readability gain. Ask explicitly if you still want it.
+
+## How the screenshots were produced
+- Started an isolated docker dev sandbox for this worktree: `scripts/dev-sandbox.sh up vs-55 5180`
+- **Live pass:** opened a real demo worktree session (`northstar-api` / `feat/auth-middleware`), already switched to Rich Chat from a prior capture pass (state persisted in the sandbox's data volume), typed a real message into the real `Composer`, pressed Enter — the client-side optimistic pending turn flips busy state immediately (before the daemon round-trip), so the busy UI is real even though the turn errors out ~1s later (no CLI credentials in this sandbox)
+- **Fixture pass:** a temporary Vite entry (`web-ui/dev-preview.html` + `web-ui/src/dev-preview-main.tsx`, never committed, deleted before sandbox teardown) mounting `MessageList`/`Composer`/`StatusBar` directly with hand-built `NormalizedEvent[]` fixtures
+- `web-ui/src` is bind-mounted with hot reload (`docker-compose.dev.yml`), so both passes ran the exact working-tree source, no rebuild needed
+- Cleanup: temporary preview files + driver scripts deleted, sandbox torn down with `dev-sandbox.sh down vs-55` (data volumes intentionally left intact, never `down -v`)
+
+## Not checked
+
+- No screenshot of the **anti-flicker debounce** itself (temporal behavior, not a static visual) — covered by `ChatPane.test.tsx`'s fake-timer test instead
+- No screenshot of a **full live-streamed LLM turn** reaching a *completed* state end-to-end — no CLI credentials in the sandbox; every real turn errors before finishing. Busy/mid-turn states ARE real; completed-thinking-block and jump-to-bottom states are fixture-driven
+- No mobile/narrow-viewport screenshots — mobile responsiveness is tracked separately in `.vibekit/reports/2026-08-24-mobile-agent-tools-split-not-responsive/`, explicitly out of scope for this fix
+- No cross-browser check — Chromium only; `align-items: last baseline` has a `baseline` fallback for browsers lacking support, not independently screenshotted in a non-supporting engine
+
+## Follow-ups
+
+| # | Question | Why it matters |
+|---|----------|-----------------|
+| 1 | Want a `"Worked for Xs"` label variant for thinking groups that had a tool call interleaved? | Explicitly deferred (see audit table) — needs new tracking state |
+| 2 | Should the temporary fixture-preview harness be turned into a permanent, checked-in dev route for future visual QA without live credentials? | Would make re-verifying chat UI changes visually reproducible without rebuilding this throwaway harness each time |
+| 3 | Worth a Playwright visual-regression snapshot test for `WorkingIndicator`/`ThinkingBlock`/jump-to-bottom? | Baseline-alignment and label-text regressions (like the ellipsis/duplicate-text ones just fixed) wouldn't be caught by DOM-assertion unit tests alone, only by a human or a visual diff |

--- a/web-ui/src/components/chat/Composer.test.tsx
+++ b/web-ui/src/components/chat/Composer.test.tsx
@@ -94,6 +94,60 @@ describe("Composer draft persistence (RA1)", () => {
   });
 });
 
+describe("Composer Send/Stop branching (Phase 4 — Decision 9, canSend not raw busy)", () => {
+  it("4.T1 — busy=true, empty box → Stop button renders (the one real busy-with-nothing-to-send case)", () => {
+    const api = createMockApi();
+    render(<Composer api={api} sessionId="s-busy-empty" onSend={vi.fn()} busy onStop={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Stop turn" })).toBeTruthy();
+    expect(screen.queryByLabelText("Send message")).toBeNull();
+    expect(screen.queryByLabelText(/queues after current turn/i)).toBeNull();
+  });
+
+  it("4.T2 — busy=true, text ready → Send (queue variant) renders instead of Stop, and clicking it calls onSend", async () => {
+    const api = createMockApi();
+    const onSend = vi.fn<(m: string, ids: string[]) => Promise<void>>(() => Promise.resolve());
+    render(<Composer api={api} sessionId="s-busy-text" onSend={onSend} busy onStop={vi.fn()} initialText="follow-up" />);
+    expect(screen.queryByRole("button", { name: "Stop turn" })).toBeNull();
+    const button = screen.getByLabelText("Send message (queues after current turn)");
+    expect(button.className).toContain("chat-composer__send--queue");
+    fireEvent.click(button);
+    await waitFor(() => expect(onSend).toHaveBeenCalledWith("follow-up", []));
+  });
+
+  it("4.T2b — a busy send that clears the box does NOT flip the button to Stop at the same position", async () => {
+    const api = createMockApi();
+    const onSend = vi.fn<(m: string, ids: string[]) => Promise<void>>(() => Promise.resolve());
+    render(<Composer api={api} sessionId="s-busy-swap" onSend={onSend} busy onStop={vi.fn()} initialText="follow-up" />);
+    fireEvent.click(screen.getByLabelText("Send message (queues after current turn)"));
+    await waitFor(() => expect(onSend).toHaveBeenCalled());
+    // Box is now empty and the turn is still busy — the hazard window. The
+    // button must stay Send (disabled), never Stop, so an impatient second
+    // click can't abort the running turn.
+    await waitFor(() =>
+      expect((screen.getByLabelText("Send message (queues after current turn)") as HTMLButtonElement).disabled).toBe(true),
+    );
+    expect(screen.queryByRole("button", { name: "Stop turn" })).toBeNull();
+    // Once the settle window elapses, Stop becomes reachable again.
+    await waitFor(() => expect(screen.getByRole("button", { name: "Stop turn" })).toBeTruthy(), { timeout: 2000 });
+  });
+
+  it("4.T3 — busy=false, text ready → plain Send renders (no queue class)", () => {
+    const api = createMockApi();
+    render(<Composer api={api} sessionId="s-idle-text" onSend={vi.fn()} initialText="hello" />);
+    const button = screen.getByLabelText("Send message");
+    expect(button.className).not.toContain("chat-composer__send--queue");
+    expect((button as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("4.T4 — regression: busy=false, empty box → Send renders disabled (unchanged existing behavior)", () => {
+    const api = createMockApi();
+    render(<Composer api={api} sessionId="s-idle-empty" onSend={vi.fn()} />);
+    const button = screen.getByLabelText("Send message") as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(button.className).not.toContain("chat-composer__send--queue");
+  });
+});
+
 describe("Composer textarea auto-grow", () => {
   // jsdom has no real layout, so `scrollHeight` is stubbed per-assertion.
   // `getComputedStyle`'s line-height/padding/border resolve to jsdom's UA

--- a/web-ui/src/components/chat/Composer.tsx
+++ b/web-ui/src/components/chat/Composer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { ApiInstance } from "@/api";
 import type { Attachment } from "@/api/types";
 import { useAttachmentDrafts } from "@/hooks/useAttachmentDrafts";
@@ -7,6 +7,10 @@ import { AttachmentChip } from "./AttachmentChip";
 
 /** Grow the textarea up to this many lines of content, then scroll internally. */
 const COMPOSER_MAX_GROW_LINES = 10;
+
+/** How long the Send button is held (disabled) at its position after OUR OWN
+ *  send emptied the box while a turn is still running — see `justSent`. */
+const SEND_SETTLE_MS = 700;
 
 /** Resize `el` to fit its content, capped at `COMPOSER_MAX_GROW_LINES` worth
  *  of height (derived from the element's own resolved line-height/padding/
@@ -93,7 +97,30 @@ export function Composer({
     if (internalTextareaRef.current) autosizeComposerTextarea(internalTextareaRef.current);
   }, [text]);
 
-  const canSend = !disabled && !sending && (text.trim().length > 0 || readyAttachments.length > 0);
+  // Split from `canSend`: whether the box HAS something to send (independent
+  // of `sending`) decides the Stop-vs-Send BRANCH; `canSend` (which also
+  // factors in `sending`/`disabled`) only decides whether the Send button is
+  // enabled. Collapsing these into one flag was a bug (see `busy` branch
+  // below): while a queued send is in flight, `sending` alone would make
+  // `canSend` false, which — if used for branching too — flips the button to
+  // Stop at the same screen position mid-send; a second/impatient click on
+  // what a moment ago was "Send" would then abort the ORIGINAL turn instead.
+  const hasContent = text.trim().length > 0 || readyAttachments.length > 0;
+  const canSend = !disabled && !sending && hasContent;
+
+  // The `hasContent` split above only deferred the swap hazard: a successful
+  // send CLEARS the box while the turn is still busy, so `hasContent` drops to
+  // false one tick later and the very same screen position turns into Stop —
+  // an impatient second click would then abort the running turn. Approach
+  // chosen (simplest that adds no persistent state): hold the Send branch,
+  // disabled, for a short settle window after our own send. A real Stop is
+  // still one moment (or one footer StatusBar click) away.
+  const [justSent, setJustSent] = useState(false);
+  useEffect(() => {
+    if (!justSent) return;
+    const id = window.setTimeout(() => setJustSent(false), SEND_SETTLE_MS);
+    return () => window.clearTimeout(id);
+  }, [justSent]);
 
   async function handleSend() {
     if (!canSend) return;
@@ -105,6 +132,7 @@ export function Composer({
       setText("");
       draft.clear();
       reset();
+      setJustSent(true);
     } finally {
       setSending(false);
     }
@@ -185,15 +213,24 @@ export function Composer({
           >
             📎
           </button>
-          {busy ? (
+          {/* Branch on `canSend`, not raw `busy` (Decision 9): a busy turn with
+           *  text/an attachment ready should still show Send — clicking it
+           *  enqueues a follow-up turn into the tray rather than sending
+           *  immediately, which is a real, working action, not a no-op. Stop
+           *  is reachable only in the one case where it's the sole useful
+           *  action: busy AND nothing ready to send — and not during the
+           *  `justSent` settle window, so our own clear-on-send can't swap
+           *  Send for Stop under the user's cursor. */}
+          {busy && !hasContent && !justSent ? (
             <button type="button" className="chat-composer__stop" onClick={onStop} aria-label="Stop turn">
               Stop
             </button>
           ) : (
             <button
               type="button"
-              className="chat-composer__send"
-              aria-label="Send message"
+              className={`chat-composer__send${busy ? " chat-composer__send--queue" : ""}`}
+              aria-label={busy ? "Send message (queues after current turn)" : "Send message"}
+              title={busy ? "Sends after the current turn finishes" : undefined}
               disabled={!canSend}
               onClick={() => void handleSend()}
             >

--- a/web-ui/src/components/chat/MessageList.test.tsx
+++ b/web-ui/src/components/chat/MessageList.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { NormalizedEvent } from "@/api/types";
 import { MessageList, groupEvents, mergeToolRuns } from "./MessageList";
@@ -48,6 +48,14 @@ function textEvent(id: string, turnId: string, text: string): NormalizedEvent {
   return { id, sessionId: "s1", ts: "", provider: "claude", kind: "text", role: "assistant", text, turnId };
 }
 
+function thinkingEvent(id: string, turnId: string, text: string, ts = ""): NormalizedEvent {
+  return { id, sessionId: "s1", ts, provider: "claude", kind: "thinking", text, turnId };
+}
+
+function toolUseEvent(id: string, turnId: string, ts = ""): NormalizedEvent {
+  return { id, sessionId: "s1", ts, provider: "claude", kind: "tool_use", toolName: "Bash", toolId: id, turnId };
+}
+
 describe("groupEvents assistant turn boundaries", () => {
   it("merges streaming deltas within a turn but splits consecutive turns", () => {
     const items = groupEvents([
@@ -71,6 +79,69 @@ describe("groupEvents status filtering (RA6 — benign rate-limit noise)", () =>
     ]);
     const texts = items.filter((i) => i.type === "status").map((i) => (i as { text: string }).text);
     expect(texts).toEqual(["rate limit: rejected", "Turn stopped"]);
+  });
+});
+
+describe("groupEvents thinking merge/close (1.T1 / 1.T2)", () => {
+  it("1.T1 — merges thinking across an intervening tool_use (same turnId, non-empty text) into one item", () => {
+    const items = groupEvents([
+      thinkingEvent("th1", "t1", "reasoning part one", "2024-01-01T00:00:00.000Z"),
+      toolUseEvent("tool1", "t1", "2024-01-01T00:00:01.000Z"),
+      thinkingEvent("th2", "t1", " and part two", "2024-01-01T00:00:02.000Z"),
+    ]);
+    const thinkingItems = items.filter((i) => i.type === "thinking");
+    expect(thinkingItems).toHaveLength(1);
+    expect(thinkingItems[0]).toMatchObject({ text: "reasoning part one and part two", startedTs: "2024-01-01T00:00:00.000Z" });
+    expect((thinkingItems[0] as { endedTs?: string }).endedTs).toBeUndefined();
+  });
+
+  it("1.T1 — a tool_use from a DIFFERENT turnId does not merge into the still-open group, and closes it", () => {
+    const items = groupEvents([
+      thinkingEvent("th1", "t1", "turn one reasoning", "2024-01-01T00:00:00.000Z"),
+      toolUseEvent("tool1", "t2", "2024-01-01T00:00:05.000Z"),
+      thinkingEvent("th2", "t2", "turn two reasoning", "2024-01-01T00:00:06.000Z"),
+    ]);
+    const thinkingItems = items.filter((i) => i.type === "thinking") as { text: string; turnId?: string; endedTs?: string }[];
+    expect(thinkingItems).toHaveLength(2);
+    expect(thinkingItems[0]).toMatchObject({ text: "turn one reasoning", turnId: "t1", endedTs: "2024-01-01T00:00:05.000Z" });
+    expect(thinkingItems[1]).toMatchObject({ text: "turn two reasoning", turnId: "t2" });
+    expect(thinkingItems[1]!.endedTs).toBeUndefined();
+  });
+
+  it("1.T2 — a text event after thinking sets endedTs from that event's ts (not a synthetic 'now')", () => {
+    // textEvent() stamps ts: "" — a raw event is used here to control the timestamp precisely.
+    const items = groupEvents([
+      thinkingEvent("th1", "t1", "reasoning", "2024-01-01T00:00:00.000Z"),
+      { id: "a1", sessionId: "s1", ts: "2024-01-01T00:00:06.400Z", provider: "claude", kind: "text", text: "answer", turnId: "t1" },
+    ]);
+    expect((items.find((i) => i.type === "thinking") as { endedTs?: string }).endedTs).toBe("2024-01-01T00:00:06.400Z");
+    expect(items.filter((i) => i.type === "assistant")).toHaveLength(1);
+  });
+
+  it("1.T2 — a second thinking burst after that text (same turnId) starts a NEW item", () => {
+    const items = groupEvents([
+      thinkingEvent("th1", "t1", "first burst", "2024-01-01T00:00:00.000Z"),
+      textEvent("a1", "t1", "partial answer"),
+      thinkingEvent("th2", "t1", "second burst", "2024-01-01T00:00:10.000Z"),
+    ]);
+    const thinkingItems = items.filter((i) => i.type === "thinking") as { text: string }[];
+    expect(thinkingItems).toHaveLength(2);
+    expect(thinkingItems.map((i) => i.text)).toEqual(["first burst", "second burst"]);
+  });
+
+  it("1.T3 — regression: empty/signature-only thinking events between tool calls still let mergeToolRuns collapse them into ONE toolRun", () => {
+    const items = mergeToolRuns(
+      groupEvents([
+        toolUseEvent("a", "t1"),
+        thinkingEvent("th1", "t1", ""),
+        toolUseEvent("b", "t1"),
+        thinkingEvent("th2", "t1", ""),
+        toolUseEvent("c", "t1"),
+      ]),
+    );
+    expect(items.map((i) => i.type)).toEqual(["toolRun"]);
+    expect((items[0] as { tools: unknown[] }).tools).toHaveLength(3);
+    expect(items.some((i) => i.type === "thinking")).toBe(false);
   });
 });
 
@@ -108,7 +179,7 @@ function toolItem(id: string, turnId: string) {
   return { type: "tool" as const, id, toolName: "Bash", turnId, toolInput: { command: "echo" } };
 }
 function thinkingItem(id: string, turnId: string, text: string) {
-  return { type: "thinking" as const, id, turnId, text };
+  return { type: "thinking" as const, id, turnId, text, startedTs: "" };
 }
 
 describe("mergeToolRuns", () => {
@@ -136,27 +207,100 @@ describe("mergeToolRuns", () => {
   });
 });
 
-describe("MessageList thinking hint (Change 3)", () => {
-  it("renders the hint after the last user message while thinking", () => {
-    render(<MessageList events={[userEvent("t1", "do the thing")]} pending={[]} thinking />);
-    expect(screen.getByText("Thinking…")).toBeTruthy();
+describe("MessageList consolidated working affordance (1.T5 — ThinkingHint removed)", () => {
+  it("never renders .chat-thinking-hint under any prop combination", () => {
+    const combos = [
+      { thinking: false, turnActive: false },
+      { thinking: true, turnActive: false },
+      { thinking: false, turnActive: true },
+      { thinking: true, turnActive: true },
+    ];
+    for (const props of combos) {
+      const { container, unmount } = render(
+        <MessageList events={[userEvent("t1", "do the thing")]} pending={[]} {...props} />,
+      );
+      expect(container.querySelector(".chat-thinking-hint")).toBeNull();
+      unmount();
+    }
   });
 
-  it("does not render the hint when not thinking", () => {
-    render(<MessageList events={[userEvent("t1", "do the thing")]} pending={[]} />);
-    expect(screen.queryByText("Thinking…")).toBeNull();
+  it("renders WorkingIndicator during the thinking sub-state (gate widened from turnActive && !thinking to plain turnActive)", () => {
+    render(<MessageList events={[userEvent("t1", "do the thing")]} pending={[]} turnActive thinking />);
+    expect(screen.getByRole("status", { name: "Agent is working" })).toBeTruthy();
+  });
+});
+
+describe("MessageList live thinking block suppression", () => {
+  // A thinking burst mid-turn: reasoning, then a tool call, group still open.
+  const liveEvents: NormalizedEvent[] = [
+    userEvent("t1", "do the thing"),
+    thinkingEvent("th1", "t1", "let me reason", "2024-01-01T00:00:00.000Z"),
+    toolUseEvent("tu1", "t1", "2024-01-01T00:00:01.000Z"),
+  ];
+
+  it("renders nothing for a still-open thinking group while the turn is active", () => {
+    const { container } = render(<MessageList events={liveEvents} pending={[]} turnActive />);
+    expect(container.querySelector(".chat-thinking")).toBeNull();
+    expect(screen.queryByText("let me reason")).toBeNull();
+    // The tool card around it is unaffected — no gap, no placeholder.
+    expect(screen.getByText("Bash")).toBeTruthy();
   });
 
-  it("renders the hint after an optimistic pending bubble", () => {
-    render(
+  it("renders the completed block in its original position once the group closes", () => {
+    const closed: NormalizedEvent[] = [
+      ...liveEvents,
+      { ...textEvent("a1", "t1", "done"), ts: "2024-01-01T00:00:03.000Z" },
+    ];
+    const { container } = render(<MessageList events={closed} pending={[]} turnActive />);
+    const block = container.querySelector(".chat-thinking");
+    expect(block).toBeTruthy();
+    expect(block!.textContent).toContain("Thought for 3s");
+    // Position preserved: thinking block precedes the tool card in DOM order.
+    const tool = screen.getByText("Bash");
+    expect(block!.compareDocumentPosition(tool) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("still renders an unclosable (turnId-less) thinking group once the turn is over", () => {
+    const noTurn: NormalizedEvent = {
+      id: "th0",
+      sessionId: "s1",
+      ts: "",
+      provider: "claude",
+      kind: "thinking",
+      text: "orphan reasoning",
+    };
+    const { container } = render(<MessageList events={[noTurn]} pending={[]} />);
+    expect(container.querySelector(".chat-thinking")).toBeTruthy();
+  });
+
+  it("keeps a turnId-less (historical) thinking group visible while a DIFFERENT turn is running", () => {
+    // Imported/resumed transcripts start with `currentTurnId: undefined`, so
+    // pre-watermark events carry no turnId and can never be closed — they must
+    // not vanish for the whole duration of every unrelated later turn.
+    const orphan: NormalizedEvent = {
+      id: "th0",
+      sessionId: "s1",
+      ts: "2024-01-01T00:00:00.000Z",
+      provider: "claude",
+      kind: "thinking",
+      text: "orphan reasoning",
+    };
+    const { container } = render(
       <MessageList
-        events={[]}
-        pending={[{ turnId: "p1", message: "just sent", attachments: [], queued: false }]}
-        thinking
+        events={[
+          orphan,
+          userEvent("t2", "a brand new question"),
+          thinkingEvent("th2", "t2", "live reasoning", "2024-01-01T00:01:00.000Z"),
+        ]}
+        pending={[]}
+        turnActive
       />,
     );
-    expect(screen.getByText("just sent")).toBeTruthy();
-    expect(screen.getByText("Thinking…")).toBeTruthy();
+    const blocks = container.querySelectorAll(".chat-thinking");
+    // Exactly one: the orphan stays, the LIVE (t2) group is the hidden one.
+    expect(blocks).toHaveLength(1);
+    const userBubble = screen.getByText("a brand new question");
+    expect(blocks[0]!.compareDocumentPosition(userBubble) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 });
 
@@ -179,6 +323,21 @@ describe("MessageList persistent working indicator", () => {
     expect(screen.queryByRole("status", { name: "Agent is working" })).toBeNull();
   });
 
+  it("3.T2 — renders the passed workingLabel text alongside the dots", () => {
+    const { container } = render(
+      <MessageList events={[userEvent("t1", "do the thing")]} pending={[]} turnActive workingLabel="Responding" />,
+    );
+    expect(screen.getByText("Responding")).toBeTruthy();
+    expect(container.querySelectorAll(".chat-working-indicator__dot")).toHaveLength(3);
+  });
+
+  it("3.T2 — omits the label span entirely when no workingLabel is passed", () => {
+    const { container } = render(
+      <MessageList events={[userEvent("t1", "do the thing")]} pending={[]} turnActive />,
+    );
+    expect(container.querySelector(".chat-working-indicator__label")).toBeNull();
+  });
+
   it("cycles dot count 1 -> 2 -> 3 -> 1 on an interval", () => {
     vi.useFakeTimers();
     try {
@@ -196,10 +355,9 @@ describe("MessageList persistent working indicator", () => {
     }
   });
 
-  it("does not render during the thinking sub-state (ThinkingHint already covers it)", () => {
+  it("1.T6 — DOES render during the thinking sub-state (inverted: ThinkingHint, which used to cover this, is gone)", () => {
     render(<MessageList events={[userEvent("t1", "do the thing")]} pending={[]} turnActive thinking />);
-    expect(screen.getByText("Thinking…")).toBeTruthy();
-    expect(screen.queryByRole("status", { name: "Agent is working" })).toBeNull();
+    expect(screen.getByRole("status", { name: "Agent is working" })).toBeTruthy();
   });
 
   it("does not start its dot interval when the user prefers reduced motion", () => {
@@ -285,5 +443,251 @@ describe("MessageList footer-resize-aware auto-scroll", () => {
     } finally {
       ro.restore();
     }
+  });
+});
+
+describe("MessageList primary scroll effect — atBottom guard + jump-to-bottom (Phase 2)", () => {
+  // Same rationale as the resize-effect tests above: stub scrollHeight/
+  // clientHeight on the render container (which IS `listRef.current.parentElement`),
+  // and assert on `container.scrollTop` directly.
+  function stubMetrics(container: HTMLElement, scrollHeight: number, clientHeight: number) {
+    Object.defineProperty(container, "scrollHeight", { value: scrollHeight, configurable: true });
+    Object.defineProperty(container, "clientHeight", { value: clientHeight, configurable: true });
+  }
+
+  it("2.T5 — fresh mount with no prior scroll event snaps to bottom (default atBottom = true)", () => {
+    // Stub BEFORE mounting (via RTL's `container` option) so the very first
+    // render's layout effect — not a later rerender — is what's observed.
+    const mountDiv = document.createElement("div");
+    document.body.appendChild(mountDiv);
+    stubMetrics(mountDiv, 777, 300);
+    mountDiv.scrollTop = 0;
+    try {
+      render(<MessageList events={[userEvent("t1", "hi")]} pending={[]} />, { container: mountDiv });
+      expect(mountDiv.scrollTop).toBe(777);
+    } finally {
+      document.body.removeChild(mountDiv);
+    }
+  });
+
+  it("2.T2 — content change while atBottom is true (never scrolled away) DOES set scrollTop = scrollHeight", () => {
+    const { container, rerender } = render(<MessageList events={[userEvent("t1", "hi")]} pending={[]} />);
+    stubMetrics(container, 900, 300);
+    container.scrollTop = 0;
+    // No `scroll` event fired — atBottomRef stays at its default `true`.
+    rerender(<MessageList events={[userEvent("t1", "hi"), userEvent("t2", "hi again")]} pending={[]} />);
+    expect(container.scrollTop).toBe(900);
+  });
+
+  it("2.T1 — content change while atBottom is false (user scrolled away) does NOT set scrollTop", () => {
+    const { container, rerender } = render(<MessageList events={[userEvent("t1", "hi")]} pending={[]} />);
+    stubMetrics(container, 1000, 300);
+    container.scrollTop = 0; // distance = 1000 - 0 - 300 = 700 → far from bottom
+    fireEvent.scroll(container); // atBottomRef -> false
+    container.scrollTop = 123; // distinct sentinel value the effect must NOT overwrite
+    rerender(<MessageList events={[userEvent("t1", "hi"), userEvent("t2", "hi again")]} pending={[]} />);
+    expect(container.scrollTop).toBe(123);
+  });
+
+  it("2.T3 — pending.length growing (own send) forces scroll even when atBottom is false", () => {
+    const { container, rerender } = render(<MessageList events={[userEvent("t1", "hi")]} pending={[]} />);
+    stubMetrics(container, 1000, 300);
+    container.scrollTop = 0;
+    fireEvent.scroll(container); // atBottomRef -> false
+    stubMetrics(container, 1200, 300); // content grew further (the new pending bubble)
+    rerender(
+      <MessageList
+        events={[userEvent("t1", "hi")]}
+        pending={[{ turnId: "p1", message: "just sent", attachments: [], queued: false }]}
+      />,
+    );
+    expect(container.scrollTop).toBe(1200);
+  });
+
+  it("2.T4 — jump-to-bottom button: absent when atBottom, appears + works when scrolled away, unmounts once back at bottom", () => {
+    const { container } = render(<MessageList events={[userEvent("t1", "hi")]} pending={[]} />);
+    expect(screen.queryByRole("button", { name: "Jump to latest message" })).toBeNull();
+
+    stubMetrics(container, 1000, 300);
+    container.scrollTop = 0; // distance = 700 → far from bottom
+    fireEvent.scroll(container);
+    const button = screen.getByRole("button", { name: "Jump to latest message" });
+    expect(button).toBeTruthy();
+
+    fireEvent.click(button);
+    expect(container.scrollTop).toBe(1000);
+    // The click handler sets `atBottom` directly (so the button hides
+    // immediately without waiting on a real scroll event) — but the same
+    // conclusion must also hold via the actual scroll-listener PATH the plan
+    // describes, not just the click shortcut. jsdom doesn't fire `scroll`
+    // automatically for a programmatic `scrollTop` assignment, so dispatch it
+    // explicitly: at scrollTop=1000 (what the click just set) against the
+    // same scrollHeight/clientHeight, distance is negative (< 80) — the
+    // listener's own "near bottom" computation must independently agree.
+    fireEvent.scroll(container);
+    expect(screen.queryByRole("button", { name: "Jump to latest message" })).toBeNull();
+  });
+});
+
+describe("MessageList auto load-earlier on scroll near top (infinite scroll upward)", () => {
+  // Same container idiom as the scroll tests above: RTL's mount div IS
+  // `listRef.current.parentElement`, so stubbing scrollHeight/clientHeight on
+  // it and driving `fireEvent.scroll` exercises the real listener path.
+  function stubMetrics(container: HTMLElement, scrollHeight: number, clientHeight: number) {
+    Object.defineProperty(container, "scrollHeight", { value: scrollHeight, configurable: true });
+    Object.defineProperty(container, "clientHeight", { value: clientHeight, configurable: true });
+  }
+
+  it("triggers onLoadEarlier when scrolled within the near-top threshold", () => {
+    const onLoadEarlier = vi.fn();
+    const { container } = render(
+      <MessageList events={[userEvent("t1", "hi")]} pending={[]} hasMore onLoadEarlier={onLoadEarlier} />,
+    );
+    stubMetrics(container, 1000, 300);
+    container.scrollTop = 10; // < 80px from the top
+    fireEvent.scroll(container);
+    expect(onLoadEarlier).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not trigger while scrolled away from the top", () => {
+    const onLoadEarlier = vi.fn();
+    const { container } = render(
+      <MessageList events={[userEvent("t1", "hi")]} pending={[]} hasMore onLoadEarlier={onLoadEarlier} />,
+    );
+    stubMetrics(container, 1000, 300);
+    container.scrollTop = 500;
+    fireEvent.scroll(container);
+    expect(onLoadEarlier).not.toHaveBeenCalled();
+  });
+
+  it("does not trigger once hasMore is false (top of history reached)", () => {
+    const onLoadEarlier = vi.fn();
+    const { container } = render(
+      <MessageList
+        events={[userEvent("t1", "hi")]}
+        pending={[]}
+        hasMore={false}
+        onLoadEarlier={onLoadEarlier}
+      />,
+    );
+    stubMetrics(container, 1000, 300);
+    container.scrollTop = 0;
+    fireEvent.scroll(container);
+    expect(onLoadEarlier).not.toHaveBeenCalled();
+  });
+
+  it("does not fire duplicate/overlapping calls: repeated scrolls before AND during the in-flight load", () => {
+    const onLoadEarlier = vi.fn();
+    const { container, rerender } = render(
+      <MessageList events={[userEvent("t1", "hi")]} pending={[]} hasMore onLoadEarlier={onLoadEarlier} />,
+    );
+    stubMetrics(container, 1000, 300);
+    container.scrollTop = 0;
+    // Several scroll events in the frames BEFORE `loadingEarlier` has come
+    // back down as a prop — the internal pending guard must absorb these.
+    fireEvent.scroll(container);
+    fireEvent.scroll(container);
+    fireEvent.scroll(container);
+    expect(onLoadEarlier).toHaveBeenCalledTimes(1);
+    // ...and once the prop does arrive, still no second call.
+    rerender(
+      <MessageList
+        events={[userEvent("t1", "hi")]}
+        pending={[]}
+        hasMore
+        loadingEarlier
+        onLoadEarlier={onLoadEarlier}
+      />,
+    );
+    fireEvent.scroll(container);
+    expect(onLoadEarlier).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves the read position when the older page is prepended (scrollTop += height delta)", () => {
+    const onLoadEarlier = vi.fn();
+    const props = { pending: [], hasMore: true, onLoadEarlier };
+    const { container, rerender } = render(
+      <MessageList events={[userEvent("t2", "recent")]} {...props} />,
+    );
+    stubMetrics(container, 1000, 300);
+    container.scrollTop = 0;
+    fireEvent.scroll(container); // triggers the load; records pre-prepend height
+    expect(onLoadEarlier).toHaveBeenCalledTimes(1);
+
+    rerender(<MessageList events={[userEvent("t2", "recent")]} {...props} loadingEarlier />);
+    // The user keeps reading while the fetch is in flight.
+    container.scrollTop = 10;
+
+    // Page lands: 600px of older history prepended, loadingEarlier back to false.
+    stubMetrics(container, 1600, 300);
+    rerender(
+      <MessageList events={[userEvent("t1", "older"), userEvent("t2", "recent")]} {...props} />,
+    );
+    expect(container.scrollTop).toBe(610);
+  });
+
+  it("leaves scrollTop alone when the load settles without prepending anything", () => {
+    const onLoadEarlier = vi.fn();
+    const props = { pending: [], hasMore: true, onLoadEarlier };
+    const { container, rerender } = render(
+      <MessageList events={[userEvent("t2", "recent")]} {...props} />,
+    );
+    stubMetrics(container, 1000, 300);
+    container.scrollTop = 0;
+    fireEvent.scroll(container);
+    rerender(<MessageList events={[userEvent("t2", "recent")]} {...props} loadingEarlier />);
+    container.scrollTop = 12;
+    rerender(<MessageList events={[userEvent("t2", "recent")]} {...props} />);
+    expect(container.scrollTop).toBe(12);
+  });
+
+  it("keeps a manual 'Load earlier messages' fallback that also routes through the guarded trigger", async () => {
+    const onLoadEarlier = vi.fn();
+    render(<MessageList events={[userEvent("t1", "hi")]} pending={[]} hasMore onLoadEarlier={onLoadEarlier} />);
+    const button = screen.getByRole("button", { name: "Load earlier messages" });
+    fireEvent.click(button);
+    fireEvent.click(button);
+    expect(onLoadEarlier).toHaveBeenCalledTimes(1);
+    // ...and the dedupe is genuinely IN-FLIGHT-scoped, not a permanent wedge:
+    // once the (here: instantly-settling, never-"loading") call settles, the
+    // trigger is armed again.
+    await act(async () => {});
+    fireEvent.click(button);
+    expect(onLoadEarlier).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not wedge when the load settles without ever rendering loadingEarlier=true", async () => {
+    // Reachable for real: `useChat.loadEarlier` early-returns before
+    // `setLoadingEarlier(true)` when there's no cursor, a transport can
+    // resolve fast enough that true→false coalesces into one `false` render,
+    // and a throw before the flag flips does the same. Any of those used to
+    // leave the prepend-pending flag set forever, killing pagination AND the
+    // primary auto-scroll effect for the rest of the session.
+    const onLoadEarlier = vi.fn(() => Promise.resolve());
+    const { container } = render(
+      <MessageList events={[userEvent("t1", "hi")]} pending={[]} hasMore onLoadEarlier={onLoadEarlier} />,
+    );
+    stubMetrics(container, 1000, 300);
+    container.scrollTop = 0;
+    fireEvent.scroll(container);
+    expect(onLoadEarlier).toHaveBeenCalledTimes(1);
+    await act(async () => {});
+    container.scrollTop = 0; // user is still up at the top of the loaded window
+    fireEvent.scroll(container);
+    expect(onLoadEarlier).toHaveBeenCalledTimes(2);
+  });
+
+  it("still releases the pending prepend when the triggered load REJECTS", async () => {
+    const onLoadEarlier = vi.fn(() => Promise.reject(new Error("boom")));
+    const { container } = render(
+      <MessageList events={[userEvent("t1", "hi")]} pending={[]} hasMore onLoadEarlier={onLoadEarlier} />,
+    );
+    stubMetrics(container, 1000, 300);
+    container.scrollTop = 0;
+    fireEvent.scroll(container);
+    await act(async () => {});
+    container.scrollTop = 0; // user is still up at the top of the loaded window
+    fireEvent.scroll(container);
+    expect(onLoadEarlier).toHaveBeenCalledTimes(2);
   });
 });

--- a/web-ui/src/components/chat/MessageList.tsx
+++ b/web-ui/src/components/chat/MessageList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { ApiInstance } from "@/api";
 import type { Attachment, NormalizedEvent } from "@/api/types";
 import type { PendingTurn } from "@/hooks/useChat";
@@ -12,7 +12,7 @@ import type { ToolCallEntry } from "./toolFormat";
 type RenderItem =
   | { type: "user"; id: string; text: string; attachments?: Attachment[]; turnId?: string; cancelled?: boolean }
   | { type: "assistant"; id: string; text: string; turnId?: string }
-  | { type: "thinking"; id: string; text: string; turnId?: string }
+  | { type: "thinking"; id: string; text: string; turnId?: string; startedTs: string; endedTs?: string }
   | ({ type: "tool" } & ToolCallEntry)
   | { type: "toolRun"; id: string; tools: ToolCallEntry[] }
   | { type: "error"; id: string; text: string }
@@ -80,11 +80,36 @@ export function groupEvents(events: NormalizedEvent[]): RenderItem[] {
   // A superseding (edited) `user` event carries the same turnId — keep the bubble
   // at its FIRST position but update to the LATEST text/attachments (A7).
   const userIndexByTurnId = new Map<string, number>();
+  // Same-turn thinking bursts merge into ONE RenderItem across intervening
+  // tool_use/tool_result (a turn can reason, call a tool, then keep
+  // reasoning about the result — that's still one logical "thinking" span
+  // from the user's perspective). The group is closed DETERMINISTICALLY
+  // inside this pure function — never by a later effect mutating the
+  // memoized result (see MessageList's primary render for why that would be
+  // unsound: it wouldn't survive the next `events` change, and it would
+  // never resolve for a cold-loaded/replayed transcript at all).
+  const thinkingOpenByTurnId = new Map<string, number>();
+  function closeOpenThinking(turnId: string | undefined, ts: string) {
+    if (!turnId) return;
+    const openIdx = thinkingOpenByTurnId.get(turnId);
+    const open = openIdx != null ? items[openIdx] : undefined;
+    if (open && open.type === "thinking" && !open.endedTs) open.endedTs = ts;
+    thinkingOpenByTurnId.delete(turnId);
+  }
 
   for (const ev of events) {
     // Guard: a superseded (forked-away) event never renders (R3.4). The daemon
     // already excludes these from replay; this is a belt-and-suspenders filter.
     if (ev.superseded) continue;
+    // Any event belonging to a DIFFERENT turn than a currently-open thinking
+    // group implies that prior turn's reasoning is over (turns are strictly
+    // sequential — one active turnId at a time per session) — close it before
+    // handling this event, regardless of this event's own kind.
+    if (ev.turnId) {
+      for (const openTurnId of thinkingOpenByTurnId.keys()) {
+        if (openTurnId !== ev.turnId) closeOpenThinking(openTurnId, ev.ts);
+      }
+    }
     switch (ev.kind) {
       case "user": {
         if (ev.turnId) {
@@ -112,6 +137,8 @@ export function groupEvents(events: NormalizedEvent[]): RenderItem[] {
         break;
       }
       case "text": {
+        // A real reply closes any open thinking group for this turn (Decision 3).
+        closeOpenThinking(ev.turnId, ev.ts);
         const last = items[items.length - 1];
         // Merge streaming deltas WITHIN a turn, but a new turn always starts a
         // fresh bubble — otherwise back-to-back replies (e.g. answers to several
@@ -124,11 +151,21 @@ export function groupEvents(events: NormalizedEvent[]): RenderItem[] {
         break;
       }
       case "thinking": {
-        const last = items[items.length - 1];
-        if (last && last.type === "thinking" && last.turnId === ev.turnId) {
-          last.text += ev.text ?? "";
+        // Empty/signature-only thinking events (no text) never open or append to
+        // a group — they carry no content or timing info, and letting them
+        // through would defeat the `mergeToolRuns` drop-rule below (an
+        // empty item that later gets text appended into it is no longer
+        // empty by the time that rule runs, breaking the tool-run merge).
+        if ((ev.text ?? "").trim().length === 0) break;
+        const openIdx = ev.turnId ? thinkingOpenByTurnId.get(ev.turnId) : undefined;
+        const open = openIdx != null ? items[openIdx] : undefined;
+        if (open && open.type === "thinking" && !open.endedTs) {
+          // Appends even across intervening tool_use/tool_result — those cases
+          // don't call closeOpenThinking, so the group stays open through them.
+          open.text += ev.text ?? "";
         } else {
-          items.push({ type: "thinking", id: ev.id, text: ev.text ?? "", turnId: ev.turnId });
+          items.push({ type: "thinking", id: ev.id, text: ev.text ?? "", turnId: ev.turnId, startedTs: ev.ts });
+          if (ev.turnId) thinkingOpenByTurnId.set(ev.turnId, items.length - 1);
         }
         break;
       }
@@ -149,6 +186,7 @@ export function groupEvents(events: NormalizedEvent[]): RenderItem[] {
         break;
       }
       case "error":
+        closeOpenThinking(ev.turnId, ev.ts);
         items.push({ type: "error", id: ev.id, text: ev.text ?? "" });
         break;
       case "status":
@@ -157,28 +195,25 @@ export function groupEvents(events: NormalizedEvent[]): RenderItem[] {
         // heartbeats (RA6 stops emitting these, but old transcripts persisted
         // "rate limit: unknown"/"allowed" noise) are filtered on render too so
         // history reads clean — real throttles (rejected/throttled/queued) show.
+        // The close call lives INSIDE this same condition, not unconditionally:
+        // a benign heartbeat carries no visible content, so closing the open
+        // thinking group on it would split one reasoning burst into
+        // "Thought for Xs" + a fresh "Thinking…" with nothing rendered in
+        // between to explain why — a real status (or any other event kind)
+        // still closes the group as before.
         if (ev.text && !isBenignRateLimit(ev.text)) {
+          closeOpenThinking(ev.turnId, ev.ts);
           items.push({ type: "status", id: ev.id, text: ev.text });
         }
         break;
       default:
-        // session_init / usage / result — not rendered as bubbles.
+        // session_init / usage / result — not rendered as bubbles, but a
+        // `result` event marks the turn as over, so close any open group.
+        closeOpenThinking(ev.turnId, ev.ts);
         break;
     }
   }
   return items;
-}
-
-/** A subtle "the agent is thinking on this point" affordance, anchored right
- *  below the most-recent user message (Change 3). Presence-only — the streaming
- *  ThinkingBlock renders the actual thinking content below it. */
-function ThinkingHint() {
-  return (
-    <div className="chat-thinking-hint" role="status" aria-live="polite">
-      <span className="chat-thinking-hint__dot" aria-hidden />
-      Thinking…
-    </div>
-  );
 }
 
 /** Milliseconds each dot-count step of `WorkingIndicator` is shown. */
@@ -191,13 +226,12 @@ const WORKING_INDICATOR_STEP_MS = 450;
  *  lands. Dot COUNT cycles 1 → 2 → 3 → 1 (not a spinner) — only mounted
  *  while busy (see call site), so the interval's lifetime is the busy
  *  window, no separate start/stop wiring needed. */
-function WorkingIndicator() {
+function WorkingIndicator({ label }: { label?: string }) {
   const [count, setCount] = useState(1);
   useEffect(() => {
-    // Respect the same reduced-motion convention as `.chat-thinking-hint__dot`
-    // (chat.css) — that one is stoppable via a CSS media query since its
-    // motion is CSS-driven; this one's motion is a JS interval, so it needs
-    // its own explicit check to honor the same opt-out.
+    // Explicit `prefers-reduced-motion` check: this dot-cycle's motion is a
+    // JS interval (not CSS-driven, so an `@media (prefers-reduced-motion)`
+    // rule alone can't stop it) — has to honor the opt-out itself.
     if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
     const id = window.setInterval(() => {
       setCount((c) => (c >= 3 ? 1 : c + 1));
@@ -205,7 +239,11 @@ function WorkingIndicator() {
     return () => window.clearInterval(id);
   }, []);
   return (
-    <div className="chat-working-indicator" role="status" aria-live="polite" aria-label="Agent is working">
+    // The accessible name tracks `label`: a STATIC name on a live-region root
+    // is what most assistive tech announces on change, which would suppress
+    // the actual (changing) "Thinking"/"Running tool" text entirely.
+    <div className="chat-working-indicator" role="status" aria-live="polite" aria-label={label ?? "Agent is working"}>
+      {label ? <span className="chat-working-indicator__label">{label}</span> : null}
       <span className="chat-working-indicator__dots" aria-hidden>
         {[1, 2, 3].map((n) => (
           <span
@@ -221,22 +259,40 @@ function WorkingIndicator() {
 /** Loaded-turn count above which the "load all" escape hatch warns (R2.5). */
 const LOAD_ALL_WARN_TURNS = 200;
 
+/** Distance (px) from the TOP of the scroll container within which scrolling
+ *  auto-triggers `onLoadEarlier` (infinite-scroll-upward). Deliberately the
+ *  same 80px scale as the near-BOTTOM guard used by the auto-scroll effects
+ *  below, so both edges feel symmetric. `onLoadAll` never auto-triggers — it
+ *  is a guarded escape hatch (R2.5) and stays manual-only. */
+const NEAR_TOP_PX = 80;
+
 interface MessageListProps {
   events: NormalizedEvent[];
   /** Optimistic user turns that are NOT queued (queued ones live in the tray). */
   pending: PendingTurn[];
   /** True while a turn is active — the trailing tool card shows a spinner. */
   turnActive?: boolean;
-  /** True while the active turn is in the pre-stream "thinking" state (Change 3). */
+  /** True while the active turn is in the pre-stream "thinking" state. No
+   *  longer drives any rendering choice directly (the old `ThinkingHint` that
+   *  consumed it as a boolean was removed) — kept only as a dependency of the
+   *  primary auto-scroll effect below, so a thinking↔responding/tool flip
+   *  still re-triggers that effect. */
   thinking?: boolean;
+  /** Turn-state label (e.g. "Thinking"/"Responding"/"Running tool" — no
+   *  trailing ellipsis; the animated dots carry the "in progress" sense) shown
+   *  next to the dots in the trailing `WorkingIndicator` (Decision 8) — computed
+   *  by `ChatPane` via the shared `turnLabel` export from `StatusBar.tsx`. */
+  workingLabel?: string;
   /** turnIds shown in the queued tray — filtered out of the inline chat log. */
   hiddenTurnIds?: ReadonlySet<string>;
   /** True when older history exists before the loaded window (R2.2). */
   hasMore?: boolean;
   /** True while a load-earlier / load-all fetch is in flight. */
   loadingEarlier?: boolean;
-  /** Fetch + prepend the previous keyset page. */
-  onLoadEarlier?: () => void;
+  /** Fetch + prepend the previous keyset page. May return a promise — when it
+   *  does, THAT promise (not the `loadingEarlier` prop's render transitions)
+   *  is what releases the internal prepend-pending state. */
+  onLoadEarlier?: () => void | Promise<void>;
   /** Guarded escape hatch: load the whole transcript. */
   onLoadAll?: () => void;
   onRetry?: () => void;
@@ -253,6 +309,7 @@ export function MessageList({
   pending,
   turnActive,
   thinking,
+  workingLabel,
   hiddenTurnIds,
   hasMore,
   loadingEarlier,
@@ -270,6 +327,17 @@ export function MessageList({
   // "answered" message (J6). Attachments/composer reuse the queued-turn editor.
   const canFork = !!onForkTurn && !!api && !!sessionId && !turnActive;
   const grouped = useMemo(() => groupEvents(events), [events]);
+  // The turnId of the turn that is actually running RIGHT NOW — the last
+  // event carrying one, since turns are strictly sequential (one active
+  // turnId at a time per session). Only meaningful while `turnActive`.
+  const activeTurnId = useMemo(() => {
+    if (!turnActive) return undefined;
+    for (let i = events.length - 1; i >= 0; i--) {
+      const id = events[i]?.turnId;
+      if (id) return id;
+    }
+    return undefined;
+  }, [events, turnActive]);
   // Queued / editing user turns render in the tray above the composer, not in
   // the log. Filter after grouping so the A7 edited-turn dedupe still applies.
   const items = useMemo(() => {
@@ -281,12 +349,185 @@ export function MessageList({
   }, [grouped, hiddenTurnIds]);
   const bottomRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
+  const prevPendingLenRef = useRef(pending.length);
+  // Whether the user is (or was, at last scroll) near the bottom of the
+  // scroll container — drives both the jump-to-bottom button's visibility
+  // AND the primary scroll effect's guard below. Initializes to `true`: no
+  // `scroll` event has fired at mount, and a fresh chat open should snap to
+  // the live edge like today's unconditional scroll did, not render at the
+  // top of history (that would be a mount-time regression).
+  const [atBottom, setAtBottom] = useState(true);
+  const atBottomRef = useRef(true);
 
+  // --- infinite-scroll-upward (auto "load earlier") state ---------------
+  // Set the moment a load-earlier is initiated (by the scroll trigger OR the
+  // manual button) and cleared once the prepended page has rendered. Doubles
+  // as the in-flight guard for the auto-trigger: a burst of scroll events
+  // near the top can't fan out into several overlapping fetches in the frames
+  // before the `loadingEarlier` prop has propagated back down from `useChat`.
+  const prependPendingRef = useRef(false);
+  // Whether we've observed `loadingEarlier` go true for the pending load —
+  // so a trigger the parent silently no-ops (no session / cursor) can't leave
+  // a scroll-restore armed against some unrelated later growth.
+  const sawLoadingRef = useRef(false);
+  // Identifies the CURRENT pending load, so a stale settle callback from an
+  // earlier (already-released) load can never release a later one.
+  const loadTokenRef = useRef(0);
+  // `scrollHeight` as of the END of the previous render, i.e. before the page
+  // about to be prepended exists. Re-captured on EVERY render (not once at
+  // trigger time) so height the feed gains at the BOTTOM while the fetch is in
+  // flight — streaming tokens, a growing tool card — is already folded in and
+  // never misattributed to the prepend. Same class of bug as the bottom-edge
+  // fix in this file: never restore from a stale measurement.
+  const prevScrollHeightRef = useRef(0);
+
+  /** Clear the pending-prepend state and re-anchor the read position: whatever
+   *  was on screen now sits `delta` px lower, so adding `delta` to `scrollTop`
+   *  leaves it pixel-identical. Applied in BOTH directions — a prepend can be
+   *  negative overall (a short page that also removes the `.chat-load-earlier`
+   *  row when `hasMore` flips false), and skipping those left the view shifted.
+   *
+   *  Known limit of measuring total `scrollHeight`: if a live bottom-edge
+   *  append (streaming tokens) commits in the SAME React batch as the prepend,
+   *  its height is folded into `delta` and the restore over-shifts by that
+   *  much. The per-render re-capture below keeps every OTHER frame of in-flight
+   *  bottom growth out of `delta`; isolating that single same-batch commit
+   *  would need per-item offset bookkeeping, which isn't worth it here. */
+  const releasePendingPrepend = useCallback(() => {
+    prependPendingRef.current = false;
+    sawLoadingRef.current = false;
+    const container = listRef.current?.parentElement;
+    if (!container) return;
+    const delta = container.scrollHeight - prevScrollHeightRef.current;
+    if (delta !== 0) container.scrollTop += delta;
+    prevScrollHeightRef.current = container.scrollHeight;
+  }, []);
+
+  const startLoadEarlier = useCallback(() => {
+    if (prependPendingRef.current || loadingEarlier || !hasMore || !onLoadEarlier) return;
+    prependPendingRef.current = true;
+    sawLoadingRef.current = false;
+    const token = ++loadTokenRef.current;
+    // Settlement is observed on the triggered call ITSELF, not inferred from
+    // the `loadingEarlier` prop's render transitions — a parent can
+    // legitimately never render `loadingEarlier === true` (it early-returns
+    // before flipping the flag when there's no session/cursor, throws first,
+    // or resolves fast enough that true→false coalesces into one `false`
+    // render). Any of those used to leave `prependPendingRef` set forever,
+    // which permanently disabled BOTH the primary auto-scroll effect and all
+    // further pagination for the rest of the session.
+    const settle = () => {
+      if (loadTokenRef.current !== token || !prependPendingRef.current) return;
+      // If the load DID render as in-flight, the guaranteed `loadingEarlier`
+      // false-edge commit owns the release (it lands with the prepended DOM);
+      // releasing here would race that commit.
+      if (sawLoadingRef.current) return;
+      releasePendingPrepend();
+    };
+    // `Promise.resolve` normalizes a `void`-returning parent too, so a silent
+    // no-op still settles (on the next microtask) instead of wedging.
+    Promise.resolve(onLoadEarlier()).then(settle, settle);
+  }, [hasMore, loadingEarlier, onLoadEarlier, releasePendingPrepend]);
+
+  // The scroll listener is registered ONCE (empty deps, passive) — read the
+  // current trigger through a ref instead of re-attaching on every prop change.
+  const startLoadEarlierRef = useRef(startLoadEarlier);
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ block: "end" });
-    // `turnActive` here so the new WorkingIndicator's own appear/disappear
-    // (it changes the feed's content height) re-triggers the scroll too.
+    startLoadEarlierRef.current = startLoadEarlier;
+  }, [startLoadEarlier]);
+
+  // Track near-bottom state from real user scrolling. Recomputes `distance`
+  // fresh on every `scroll` event rather than trusting a cached flag from
+  // elsewhere — same rationale as the ResizeObserver path below. The same
+  // listener also drives the near-TOP auto-load of the previous keyset page.
+  useEffect(() => {
+    const container = listRef.current?.parentElement;
+    if (!container) return;
+    const onScroll = () => {
+      const distance = container.scrollHeight - container.scrollTop - container.clientHeight;
+      const near = distance < 80;
+      atBottomRef.current = near;
+      setAtBottom(near);
+      if (container.scrollTop < NEAR_TOP_PX) startLoadEarlierRef.current();
+    };
+    container.addEventListener("scroll", onScroll, { passive: true });
+    return () => container.removeEventListener("scroll", onScroll);
+  }, []);
+
+  // MUST be useLayoutEffect, not useEffect: this needs to read/write layout
+  // (scrollTop) before the browser paints the just-added content, so the
+  // user never sees a frame at the old scroll position for content that's
+  // about to be snapped to bottom.
+  //
+  // Guards on `atBottomRef.current` (captured from the LAST scroll event,
+  // i.e. before this render's DOM mutation) rather than a fresh post-render
+  // `distance` measurement: a single render that appends a lot of height (a
+  // large tool card, a batched token flush) could otherwise read distance
+  // >= 80 even though the user was following along right up to that append,
+  // silently dropping them out of follow-mode mid-stream. `own send` (the
+  // user's own optimistic bubble appearing, i.e. `pending.length` growing)
+  // always snaps regardless, so sending still feels immediate.
+  useLayoutEffect(() => {
+    const container = listRef.current?.parentElement;
+    const ownSend = pending.length > prevPendingLenRef.current;
+    prevPendingLenRef.current = pending.length;
+    if (!container) {
+      bottomRef.current?.scrollIntoView({ block: "end" });
+      return;
+    }
+    // A render that lands a prepended "load earlier" page belongs to the
+    // scroll-restore effect below, which is the sole writer of `scrollTop`
+    // for it — snapping to the bottom here first would either fight that
+    // restore or overshoot past it. `ownSend` still wins: the user pressing
+    // send always jumps to their own message.
+    if (!ownSend && prependPendingRef.current) return;
+    if (ownSend || atBottomRef.current) {
+      container.scrollTop = container.scrollHeight;
+      // The scroll above doesn't fire a `scroll` event synchronously in every
+      // environment (and even where it does, staying pinned at the bottom
+      // should keep `atBottom` true regardless) — keep the tracked state in
+      // sync so the jump-to-bottom button doesn't flash on for a frame.
+      if (!atBottomRef.current) {
+        atBottomRef.current = true;
+        setAtBottom(true);
+      }
+    }
+    // `turnActive` here so the WorkingIndicator's own appear/disappear (it
+    // changes the feed's content height) re-triggers the scroll too.
   }, [items.length, pending.length, thinking, turnActive]);
+
+  // Scroll anchoring for prepended history. Declared AFTER the primary effect
+  // on purpose: layout effects run in declaration order, so this is the last
+  // writer of `scrollTop` for a prepend commit.
+  //
+  // MUST be useLayoutEffect: the shift has to be applied before the browser
+  // paints, otherwise the user sees one frame where the whole transcript has
+  // jumped down by the height of the newly prepended page — the classic
+  // infinite-scroll-upward jump.
+  //
+  // Runs on EVERY render (no dep array) because its other job is keeping
+  // `prevScrollHeightRef` current; the restore itself is gated on a pending
+  // load that has actually been observed in flight. The OTHER release path —
+  // for a load that never renders as in-flight — is the settle callback in
+  // `startLoadEarlier`, which calls the same `releasePendingPrepend`.
+  useLayoutEffect(() => {
+    const container = listRef.current?.parentElement;
+    if (!container) return;
+    if (loadingEarlier) {
+      sawLoadingRef.current = true;
+    } else if (prependPendingRef.current && sawLoadingRef.current) {
+      releasePendingPrepend(); // re-captures `prevScrollHeightRef` itself
+      return;
+    } else if (prependPendingRef.current) {
+      // A load is pending but this render is neither "in flight" nor its
+      // release — i.e. a page may already have landed while the parent never
+      // rendered `loadingEarlier === true`. Do NOT re-capture the height
+      // here: that would erase the pre-prepend measurement the settle
+      // callback is about to restore from.
+      return;
+    }
+    prevScrollHeightRef.current = container.scrollHeight;
+  });
 
   // Re-scroll to bottom when the SCROLL CONTAINER's own height changes (e.g.
   // the footer below it grows/shrinks — composer auto-grow, StatusBar
@@ -323,18 +564,6 @@ export function MessageList({
     return () => ro.disconnect();
   }, []);
 
-  // Anchor the thinking hint under the latest user message. When an optimistic
-  // (non-queued) pending bubble exists, the newest user message is that pending
-  // block, so the hint goes after it; otherwise after the last user item.
-  const lastUserIdx = useMemo(() => {
-    for (let i = items.length - 1; i >= 0; i--) {
-      if (items[i]!.type === "user") return i;
-    }
-    return -1;
-  }, [items]);
-  const hintAfterPending = !!thinking && pending.length > 0;
-  const hintAfterItem = !!thinking && !hintAfterPending && lastUserIdx >= 0;
-
   // Distinct loaded turns — the "load all" hatch warns once the window is large.
   const loadedTurns = useMemo(() => {
     const ids = new Set<string>();
@@ -344,12 +573,21 @@ export function MessageList({
 
   return (
     <div ref={listRef} className="chat-message-list" role="log" aria-label="Conversation">
+      {/* Older history is loaded AUTOMATICALLY on scrolling near the top (see
+       *  the scroll listener above); this button is kept deliberately as a
+       *  manual fallback, not as the primary path. The auto-trigger rides on
+       *  `scroll` events, so it cannot fire in the two cases where there is
+       *  nothing to scroll: a loaded window shorter than the viewport, and a
+       *  container already pinned at scrollTop 0. It also doubles as the
+       *  top-of-list loading affordance (reusing this file's existing
+       *  "Loading…" convention) so an in-flight auto-load is visible.
+       *  "Load entire history" stays manual-only — R2.5 escape hatch. */}
       {hasMore && onLoadEarlier ? (
-        <div className="chat-load-earlier">
+        <div className="chat-load-earlier" aria-live="polite">
           <button
             type="button"
             className="chat-load-earlier__btn"
-            onClick={onLoadEarlier}
+            onClick={startLoadEarlier}
             disabled={loadingEarlier}
           >
             {loadingEarlier ? "Loading…" : "Load earlier messages"}
@@ -427,7 +665,21 @@ export function MessageList({
             node = <TextMessage key={key} role="assistant" text={item.text} />;
             break;
           case "thinking":
-            node = <ThinkingBlock key={key} text={item.text} />;
+            // A still-open thinking group renders NOTHING while the turn is
+            // active: its live header is always just "Thinking", which the
+            // trailing `WorkingIndicator`'s "Thinking •••" line already says.
+            // Once `groupEvents` closes the group the block appears in place
+            // (items never reorder) as "Thought for Xs", expandable to the
+            // accumulated reasoning. The second half of the gate compares
+            // against the CURRENTLY RUNNING turn, not the global `turnActive`
+            // flag: a group whose events carry no `turnId` (imported/resumed
+            // transcripts start with `currentTurnId: undefined`) can never be
+            // closed by `closeOpenThinking`, so gating on "any turn is
+            // active" hid such historical reasoning for the whole duration of
+            // every unrelated later turn.
+            node = item.endedTs || !turnActive || item.turnId !== activeTurnId ? (
+              <ThinkingBlock key={key} text={item.text} startedTs={item.startedTs} endedTs={item.endedTs} />
+            ) : null;
             break;
           case "toolRun":
             // "Live" means this run is the trailing item of an active turn —
@@ -449,9 +701,7 @@ export function MessageList({
           default:
             node = null;
         }
-        return hintAfterItem && i === lastUserIdx
-          ? [node, <ThinkingHint key={`${key}-thinking`} />]
-          : node;
+        return node;
       })}
 
       {pending.map((p) => (
@@ -460,14 +710,32 @@ export function MessageList({
         </div>
       ))}
 
-      {hintAfterPending ? <ThinkingHint /> : null}
-
-      {/* Not during `thinking`: `ThinkingHint` already anchors a "Thinking…"
-          affordance above for that sub-state — showing both at once would be
-          two competing busy indicators on screen simultaneously. */}
-      {turnActive && !thinking ? <WorkingIndicator /> : null}
+      {turnActive ? <WorkingIndicator label={workingLabel} /> : null}
 
       <div ref={bottomRef} />
+
+      {/* Floating jump-to-bottom affordance — only needed once the scroll
+       *  guard above can leave the user stranded above the live edge (Decision
+       *  5). Its containing block resolves to `.chat-pane__viewport` (the
+       *  non-scrolling wrapper around `.chat-pane__body`, see chat.css), so it
+       *  neither scrolls away with the content it lives in nor overlaps the
+       *  footer below the viewport. */}
+      {!atBottom ? (
+        <button
+          type="button"
+          className="chat-jump-to-bottom"
+          aria-label="Jump to latest message"
+          onClick={() => {
+            const container = listRef.current?.parentElement;
+            if (!container) return;
+            container.scrollTop = container.scrollHeight;
+            atBottomRef.current = true;
+            setAtBottom(true);
+          }}
+        >
+          ↓
+        </button>
+      ) : null}
     </div>
   );
 }

--- a/web-ui/src/components/chat/StatusBar.test.tsx
+++ b/web-ui/src/components/chat/StatusBar.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import type { SessionMeta } from "@/api/types";
 import { createMockApi } from "@/api/mock";
-import { StatusBar } from "./StatusBar";
+import { StatusBar, turnLabel } from "./StatusBar";
 
 function meta(extra: Partial<SessionMeta> = {}): SessionMeta {
   return {
@@ -67,10 +67,37 @@ describe("StatusBar (5.T2)", () => {
     expect(screen.getByText("Queued (2)")).toBeTruthy();
   });
 
-  it("shows a Stop button while a turn is active", () => {
-    render(<StatusBar meta={meta({ turnState: "responding" })} onStop={() => {}} />);
-    expect(screen.getByText("Responding…")).toBeTruthy();
+  it("shows a Stop button — and NO duplicate turn label — while a turn is active", () => {
+    const { container } = render(<StatusBar meta={meta({ turnState: "responding" })} onStop={() => {}} />);
     expect(screen.getByRole("button", { name: "Stop" })).toBeTruthy();
+    // The label lives next to the in-feed WorkingIndicator's dots instead.
+    expect(screen.queryByText("Responding")).toBeNull();
+    expect(container.querySelector(".chat-statusbar__state")).toBeNull();
+  });
+
+  it("keeps the turn label for non-busy states (no in-feed indicator to duplicate)", () => {
+    const { container, rerender } = render(<StatusBar meta={meta({ turnState: "idle" })} onStop={() => {}} />);
+    expect(screen.getByText("Ready")).toBeTruthy();
+    rerender(<StatusBar meta={meta({ turnState: "error" })} onStop={() => {}} />);
+    expect(screen.getByText("Error")).toBeTruthy();
+    // error is never busy → the ⚠ icon is unaffected by the busy suppression.
+    expect(container.querySelector(".chat-statusbar__state--error")?.textContent).toContain("⚠");
+    expect(screen.queryByRole("button", { name: "Stop" })).toBeNull();
+  });
+
+  it("3.T1 — no longer renders a circular spinner while busy (Decision 7 — replaced by the in-feed WorkingIndicator)", () => {
+    const { container } = render(<StatusBar meta={meta({ turnState: "responding" })} onStop={() => {}} />);
+    expect(container.querySelector(".chat-spinner")).toBeNull();
+  });
+
+  it("3.T1 — exported turnLabel() busy strings carry no trailing ellipsis (the WorkingIndicator's dots convey continuation)", () => {
+    expect(turnLabel("thinking", 0)).toBe("Thinking");
+    expect(turnLabel("responding", 0)).toBe("Responding");
+    expect(turnLabel("tool", 0)).toBe("Running tool");
+    expect(turnLabel("queued", 3)).toBe("Queued (3)");
+    expect(turnLabel("error", 0)).toBe("Error");
+    expect(turnLabel("idle", 0)).toBe("Ready");
+    expect(turnLabel(undefined, 0)).toBe("Ready");
   });
 
   it("renders the model switcher when api + sessionId are provided", () => {

--- a/web-ui/src/components/chat/StatusBar.tsx
+++ b/web-ui/src/components/chat/StatusBar.tsx
@@ -21,14 +21,21 @@ function fmt(n: number): string {
 
 const BUSY_STATES: TurnState[] = ["thinking", "responding", "tool"];
 
-function turnLabel(state: TurnState | undefined, queue: number): string {
+/** Shared with `MessageList`'s `WorkingIndicator` (Decision 8) — one source of
+ *  truth for the turn-state label text instead of duplicating this switch.
+ *
+ *  The busy labels carry NO trailing "…": they render next to the
+ *  `WorkingIndicator`'s animated `•••`, so an ellipsis would read as "dots,
+ *  then more dots". The non-busy labels ("Ready" / "Queued (n)" / "Error")
+ *  never render beside the dots and are unaffected. */
+export function turnLabel(state: TurnState | undefined, queue: number): string {
   switch (state) {
     case "thinking":
-      return "Thinking…";
+      return "Thinking";
     case "responding":
-      return "Responding…";
+      return "Responding";
     case "tool":
-      return "Running tool…";
+      return "Running tool";
     case "queued":
       return `Queued (${queue})`;
     case "error":
@@ -100,11 +107,18 @@ export function StatusBar({ meta, queueDepth = 0, onStop, api, sessionId }: Stat
         {meta?.modeName ? <span className="chat-statusbar__mode">{meta.modeName}</span> : null}
       </div>
       <div className="chat-statusbar__turn">
-        <span className={`chat-statusbar__state chat-statusbar__state--${state ?? "idle"}`}>
-          {busy ? <span className="chat-spinner" aria-hidden /> : null}
-          {state === "error" ? <span aria-hidden>⚠ </span> : null}
-          {turnLabel(state, queue)}
-        </span>
+        {/* While busy, the SAME label already rides next to the in-feed
+         *  `WorkingIndicator`'s dots (Decision 8) — repeating it here, beside
+         *  the Stop button, is pure duplication, so the busy footer row is
+         *  just `[Stop]`. Non-busy states ("Ready" / "Queued (n)" / "Error")
+         *  have no in-feed counterpart and still render here. `error` is
+         *  never a busy state, so the ⚠ icon is unaffected. */}
+        {busy ? null : (
+          <span className={`chat-statusbar__state chat-statusbar__state--${state ?? "idle"}`}>
+            {state === "error" ? <span aria-hidden>⚠ </span> : null}
+            {turnLabel(state, queue)}
+          </span>
+        )}
         {busy && onStop ? (
           <button type="button" className="chat-statusbar__stop btn btn--secondary" onClick={onStop}>
             Stop

--- a/web-ui/src/components/chat/ThinkingBlock.test.tsx
+++ b/web-ui/src/components/chat/ThinkingBlock.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { ThinkingBlock } from "./ThinkingBlock";
+
+describe("ThinkingBlock label (1.T4 — Decision 4 'Thought for Xs')", () => {
+  it("renders 'Thinking' (no trailing ellipsis) while endedTs is unset", () => {
+    render(<ThinkingBlock text="" startedTs="2024-01-01T00:00:00.000Z" />);
+    expect(screen.getByText("Thinking")).toBeTruthy();
+  });
+
+  it("falls back to 'Thinking' rather than 'Thought for NaNs' on a malformed timestamp", () => {
+    render(<ThinkingBlock text="" startedTs="" endedTs="2024-01-01T00:00:06.400Z" />);
+    expect(screen.getByText("Thinking")).toBeTruthy();
+  });
+
+  it("renders 'Thought for 6s' when startedTs/endedTs are 6400ms apart (rounds to nearest second)", () => {
+    render(
+      <ThinkingBlock
+        text=""
+        startedTs="2024-01-01T00:00:00.000Z"
+        endedTs="2024-01-01T00:00:06.400Z"
+      />,
+    );
+    expect(screen.getByText("Thought for 6s")).toBeTruthy();
+  });
+
+  it("renders 'Thought for 0s' (not suppressed) when the span is under 500ms", () => {
+    render(
+      <ThinkingBlock
+        text=""
+        startedTs="2024-01-01T00:00:00.000Z"
+        endedTs="2024-01-01T00:00:00.300Z"
+      />,
+    );
+    expect(screen.getByText("Thought for 0s")).toBeTruthy();
+  });
+
+  it("expands to the reasoning body and shows the duration EXACTLY ONCE (no duplicate footer row)", async () => {
+    render(
+      <ThinkingBlock
+        text="some reasoning"
+        startedTs="2024-01-01T00:00:00.000Z"
+        endedTs="2024-01-01T00:00:03.000Z"
+      />,
+    );
+    await userEvent.setup().click(screen.getByRole("button", { name: /thought for 3s/i }));
+    expect(screen.getByText("some reasoning")).toBeTruthy();
+    // Once expanded the label must still appear a single time — the toggle
+    // row carries it; there is no second footer copy of the same string.
+    expect(screen.getAllByText("Thought for 3s")).toHaveLength(1);
+    expect(document.querySelector(".chat-thinking__summary")).toBeNull();
+  });
+});

--- a/web-ui/src/components/chat/ThinkingBlock.tsx
+++ b/web-ui/src/components/chat/ThinkingBlock.tsx
@@ -5,19 +5,49 @@ interface ThinkingBlockProps {
   text: string;
   /** Collapsed by default; expands on click. */
   defaultOpen?: boolean;
+  /** `ts` of the first event in this thinking group (always present —
+   *  `groupEvents` stamps it when the group opens). */
+  startedTs: string;
+  /** `ts` of the event that closed this group (a `text` reply, a turn-end
+   *  meta event, or the first event of the next turn); unset while the
+   *  block is still live. */
+  endedTs?: string;
 }
 
-/** Collapsible dim "Thinking…" reasoning block (Decision 9). Signature-only /
- *  redacted thinking events carry no text — those render as a plain label with
- *  no chevron, since there's nothing to expand. */
-export function ThinkingBlock({ text, defaultOpen = false }: ThinkingBlockProps) {
+/** "Thought for Xs" once `endedTs` is set, else the live "Thinking" label —
+ *  the only place elapsed time renders (Decision 4). Rounds to the nearest
+ *  second; a sub-second span still reads "Thought for 0s" rather than being
+ *  suppressed, so a very quick thinking burst doesn't look unresolved.
+ *
+ *  No trailing "…" on the live label, matching `turnLabel`'s busy strings —
+ *  the "in progress" continuation is carried by the trailing
+ *  `WorkingIndicator`'s animated dots. In practice `MessageList` no longer
+ *  renders a still-open thinking group at all, so the live label only
+ *  surfaces via the malformed-timestamp fallback below. */
+function thinkingLabel(startedTs: string, endedTs: string | undefined): string {
+  if (!endedTs) return "Thinking";
+  const seconds = Math.round((Date.parse(endedTs) - Date.parse(startedTs)) / 1000);
+  // Either timestamp can be empty/malformed (e.g. test fixtures, or a
+  // historical event predating this field) — `Date.parse` on an empty string
+  // is NaN, which would otherwise render "Thought for NaNs". Fall back to the
+  // live label rather than showing a broken duration.
+  if (!Number.isFinite(seconds)) return "Thinking";
+  return `Thought for ${seconds}s`;
+}
+
+/** Collapsible dim "Thinking" / "Thought for Xs" reasoning block (Decision 9,
+ *  extended by Decision 4). Signature-only / redacted thinking events carry no
+ *  text — those render as a plain label with no chevron, since there's
+ *  nothing to expand. */
+export function ThinkingBlock({ text, defaultOpen = false, startedTs, endedTs }: ThinkingBlockProps) {
   const [open, setOpen] = useState(defaultOpen);
   const hasContent = text.trim().length > 0;
+  const label = thinkingLabel(startedTs, endedTs);
   if (!hasContent) {
     return (
       <div className="chat-thinking">
         <span className="chat-thinking__toggle chat-thinking__toggle--static">
-          <span className="chat-thinking__label">Thinking…</span>
+          <span className="chat-thinking__label">{label}</span>
         </span>
       </div>
     );
@@ -31,8 +61,15 @@ export function ThinkingBlock({ text, defaultOpen = false }: ThinkingBlockProps)
         onClick={() => setOpen((v) => !v)}
       >
         <span className="chat-thinking__caret" aria-hidden>{open ? "▾" : "▸"}</span>
-        <span className="chat-thinking__label">Thinking…</span>
+        <span className="chat-thinking__label">{label}</span>
       </button>
+      {/* No second footer-row copy of `label` below the body: the toggle row
+       *  above already reads "Thought for Xs" once ended, and repeating the
+       *  identical string ~3 lines apart inside one card is exactly the
+       *  redundancy this pass removed elsewhere (the StatusBar busy label).
+       *  Plan Decision 4 offered the footer row OR the toggle-label swap as
+       *  alternatives — the toggle-label swap is implemented, so the footer
+       *  row is redundant, not additive. */}
       {open ? (
         <div className="chat-thinking__body">
           <StreamingMarkdown source={text} />

--- a/web-ui/src/components/layout/ChatPane.test.tsx
+++ b/web-ui/src/components/layout/ChatPane.test.tsx
@@ -2,11 +2,23 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { render, screen, within, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi, type Mock } from "vitest";
 import { createMockApi } from "@/api/mock";
 import type { NormalizedEvent, Session, SessionMeta } from "@/api/types";
 import { useWorkspaceStore } from "@/hooks/useStore";
+import { MessageList } from "@/components/chat/MessageList";
 import { ChatPane } from "./ChatPane";
+
+// Wraps the REAL MessageList (delegates every call to it, via importOriginal)
+// so the rest of this file's tests keep exercising real rendering — the mock
+// only adds the ability to inspect the exact props ChatPane passed on each
+// render, which is otherwise unobservable (1.T7 needs to assert the debounced
+// `thinking` prop's value across renders, not anything visibly different in
+// the DOM).
+vi.mock("@/components/chat/MessageList", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/chat/MessageList")>();
+  return { ...actual, MessageList: vi.fn(actual.MessageList) };
+});
 
 function meta(sessionId: string, extra: Partial<SessionMeta> = {}): SessionMeta {
   return {
@@ -145,5 +157,63 @@ describe("ChatPane (4.T2)", () => {
     expect(
       screen.queryByText("This session has been archived. Start a new agent to continue."),
     ).toBeNull();
+  });
+});
+
+describe("ChatPane thinking-state debounce (1.T7 — Decision 2 anti-flicker)", () => {
+  it("does not flip the debounced `thinking` prop false during rapid turnState oscillation, but commits once a value holds past 250ms", () => {
+    vi.useFakeTimers();
+    try {
+      const api = createMockApi();
+      // Needs at least one event so ChatPane's `isEmpty` branch doesn't render
+      // the empty-state placeholder INSTEAD of MessageList — otherwise MessageList
+      // never mounts for this session and there's nothing to inspect props on.
+      api.__test.pushChatEvent("js-debounce", ev("u1", { kind: "user", role: "user", text: "hi", turnId: "t1" }));
+      render(<ChatPane api={api} session={jsonSession("js-debounce")} visible />);
+      const mockedMessageList = MessageList as unknown as Mock;
+      mockedMessageList.mockClear();
+
+      // Settle into a steady "thinking" state first (past the debounce window).
+      act(() => {
+        api.__test.emit({
+          type: "session:meta",
+          sessionId: "js-debounce",
+          meta: meta("js-debounce", { turnState: "thinking" }),
+        });
+      });
+      act(() => {
+        vi.advanceTimersByTime(250);
+      });
+      expect(mockedMessageList.mock.calls.at(-1)![0].thinking).toBe(true);
+
+      // Rapidly oscillate thinking -> tool -> thinking -> tool, each change
+      // arriving well inside the 250ms debounce window (it resets on every
+      // `meta?.turnState` change) — the displayed `thinking` prop must stay
+      // true (its last COMMITTED value) throughout, never dropping to false.
+      mockedMessageList.mockClear();
+      const states: SessionMeta["turnState"][] = ["tool", "thinking", "tool"];
+      for (const turnState of states) {
+        act(() => {
+          api.__test.emit({ type: "session:meta", sessionId: "js-debounce", meta: meta("js-debounce", { turnState }) });
+        });
+        act(() => {
+          vi.advanceTimersByTime(80); // < 250ms — debounce timer keeps resetting
+        });
+      }
+      const thinkingPropsDuringOscillation = mockedMessageList.mock.calls.map((c) => c[0].thinking);
+      // Guard against a vacuous pass: this assertion is meaningless if the
+      // mock never actually re-rendered during the oscillation.
+      expect(thinkingPropsDuringOscillation.length).toBeGreaterThan(0);
+      expect(thinkingPropsDuringOscillation.every((t) => t === true)).toBe(true);
+
+      // Now let the final value ("tool") hold past the debounce window with no
+      // further change — it DOES commit, and `thinking` flips to false.
+      act(() => {
+        vi.advanceTimersByTime(250);
+      });
+      expect(mockedMessageList.mock.calls.at(-1)![0].thinking).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/web-ui/src/components/layout/ChatPane.tsx
+++ b/web-ui/src/components/layout/ChatPane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState, type CSSProperties } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 import type { ApiInstance } from "@/api";
 import type { Attachment, Session } from "@/api/types";
 import { useChat } from "@/hooks/useChat";
@@ -6,7 +6,7 @@ import { useWorkspaceStore } from "@/hooks/useStore";
 import { MessageList } from "@/components/chat/MessageList";
 import { QueuedTray, type QueuedTrayRow } from "@/components/chat/QueuedTray";
 import { Composer } from "@/components/chat/Composer";
-import { StatusBar } from "@/components/chat/StatusBar";
+import { StatusBar, turnLabel } from "@/components/chat/StatusBar";
 
 // Desktop bases for the --font-size-* tokens (tokens.css), scaled by the same
 // PaneTools "Aa −/+" control that zooms TerminalPane's xterm font (14 * scale
@@ -85,7 +85,36 @@ export function ChatPane({ api, session, visible }: ChatPaneProps) {
     const s = meta?.turnState;
     return s === "thinking" || s === "responding" || s === "tool";
   }, [meta]);
-  const thinking = meta?.turnState === "thinking";
+
+  // Display-facing turn state, debounced (trailing ~250ms): the daemon
+  // recomputes turnState per raw event, so it can oscillate thinking→tool→
+  // thinking many times within one turn — committing every flip straight to
+  // display state flickers the thinking-block/WorkingIndicator affordance.
+  // `turnActive` above stays RAW/instant — Composer's busy/Stop gating must
+  // never lag behind the real state.
+  const [displayTurnState, setDisplayTurnState] = useState(meta?.turnState);
+  useEffect(() => {
+    const id = setTimeout(() => setDisplayTurnState(meta?.turnState), 250);
+    return () => clearTimeout(id);
+  }, [meta?.turnState]);
+  const thinking = displayTurnState === "thinking";
+  // Label for the in-feed WorkingIndicator (Decision 8) — same `turnLabel`
+  // StatusBar uses, fed the DEBOUNCED state so it's consistent with
+  // `thinking`/the ThinkingBlock swap instead of flickering independently —
+  // BUT only once the debounced value has actually caught up to a busy
+  // state. On the very first idle→busy transition (or right after an
+  // oscillation resets the debounce timer), `displayTurnState` can still
+  // read "idle"/undefined for up to 250ms while `turnActive` (raw, driving
+  // WorkingIndicator's mount) is already true — falling back to `turnLabel`
+  // as-is would show "Ready •••" for that window. Falling back to the RAW
+  // `meta?.turnState` here is safe: `turnActive` is only true when the raw
+  // state is itself thinking/responding/tool, so the fallback is never
+  // "Ready" while the indicator is actually mounted. Once the debounce
+  // commits a busy value, this reads from `displayTurnState` again, so
+  // further label oscillation is still smoothed as intended.
+  const displayStateIsBusy =
+    displayTurnState === "thinking" || displayTurnState === "responding" || displayTurnState === "tool";
+  const workingLabel = turnLabel(displayStateIsBusy ? displayTurnState : meta?.turnState, meta?.queueDepth ?? 0);
 
   // Latest user text + attachments per turnId (last wins, mirroring the A7
   // edited-turn rule) + the set of turnIds that have a real `user` event.
@@ -182,43 +211,44 @@ export function ChatPane({ api, session, visible }: ChatPaneProps) {
 
   return (
     <div className="chat-pane" style={chatFontVars}>
-      <div className="chat-pane__body">
-        {loading ? (
-          <div className="chat-pane__state">
-            <span className="chat-spinner" aria-hidden /> Loading history…
-          </div>
-        ) : isEmpty ? (
-          <div className="chat-pane__state chat-pane__empty">
-            <div className="chat-pane__empty-icon" aria-hidden>💬</div>
-            <div className="chat-pane__empty-title">Start chatting</div>
-            <div className="chat-pane__empty-sub">with the agent</div>
-          </div>
-        ) : (
-          <MessageList
-            events={events}
-            pending={pendingActive}
-            turnActive={turnActive}
-            thinking={thinking}
-            hiddenTurnIds={hiddenTurnIds}
-            hasMore={hasMore}
-            loadingEarlier={loadingEarlier}
-            onLoadEarlier={() => void loadEarlier()}
-            onLoadAll={() => void loadAll()}
-            onRetry={handleRetry}
-            api={api}
-            {...(sessionId ? { sessionId } : {})}
-            onForkTurn={(turnId, message, attachmentIds) => forkTurn(turnId, message, attachmentIds)}
-          />
-        )}
+      {/* Non-scrolling wrapper whose box is exactly the scroll VIEWPORT — it,
+          not `.chat-pane`, is the containing block for the floating
+          jump-to-bottom button, so the button clears the footer (queued tray +
+          status bar + auto-growing composer) at any footer height instead of
+          relying on a fixed offset that a tall footer overlaps. */}
+      <div className="chat-pane__viewport">
+        <div className="chat-pane__body">
+          {loading ? (
+            <div className="chat-pane__state">
+              <span className="chat-spinner" aria-hidden /> Loading history…
+            </div>
+          ) : isEmpty ? (
+            <div className="chat-pane__state chat-pane__empty">
+              <div className="chat-pane__empty-icon" aria-hidden>💬</div>
+              <div className="chat-pane__empty-title">Start chatting</div>
+              <div className="chat-pane__empty-sub">with the agent</div>
+            </div>
+          ) : (
+            <MessageList
+              events={events}
+              pending={pendingActive}
+              turnActive={turnActive}
+              thinking={thinking}
+              workingLabel={workingLabel}
+              hiddenTurnIds={hiddenTurnIds}
+              hasMore={hasMore}
+              loadingEarlier={loadingEarlier}
+              onLoadEarlier={() => loadEarlier()}
+              onLoadAll={() => void loadAll()}
+              onRetry={handleRetry}
+              api={api}
+              {...(sessionId ? { sessionId } : {})}
+              onForkTurn={(turnId, message, attachmentIds) => forkTurn(turnId, message, attachmentIds)}
+            />
+          )}
+        </div>
       </div>
       <div className="chat-pane__footer">
-        <StatusBar
-          meta={meta}
-          queueDepth={trayRows.length}
-          onStop={() => void stop()}
-          api={api}
-          {...(sessionId ? { sessionId } : {})}
-        />
         {sessionId ? (
           <QueuedTray
             api={api}
@@ -233,6 +263,13 @@ export function ChatPane({ api, session, visible }: ChatPaneProps) {
             focusComposer={() => composerRef.current?.focus()}
           />
         ) : null}
+        <StatusBar
+          meta={meta}
+          queueDepth={trayRows.length}
+          onStop={() => void stop()}
+          api={api}
+          {...(sessionId ? { sessionId } : {})}
+        />
         {sessionId && archived ? (
           // Decision 4 / CUJ 3: an archived session is read-only in place — no
           // new turns can be sent. Exact copy from the original F5 mockup.

--- a/web-ui/src/styles/chat.css
+++ b/web-ui/src/styles/chat.css
@@ -168,6 +168,23 @@
   display: none;
 }
 
+/* Non-scrolling wrapper around the scroll viewport. Its box is exactly the
+   visible message area (footer excluded), and it is the positioned ancestor
+   for the floating jump-to-bottom button — see that rule below for why the
+   button can be anchored neither to `.chat-pane` (includes the footer) nor to
+   `.chat-pane__body` itself (an abspos child of a scroller scrolls with it).
+   Note the button is the ONLY thing this affects: the `.channel-toggle-button`
+   overlay is declared inside `.chat-pane__footer`, a SIBLING of this wrapper,
+   so it still resolves to `.chat-pane` and keeps its whole-pane top-right
+   corner. */
+.chat-pane__viewport {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
 .chat-pane__body {
   flex: 1;
   min-height: 0;
@@ -206,6 +223,40 @@
   flex-direction: column;
   gap: var(--space-3);
   padding: var(--space-4);
+}
+
+/* Floating jump-to-bottom button (Decision 5). `position: absolute` here
+   resolves its containing block to `.chat-pane__viewport` — the non-scrolling
+   wrapper whose box IS the scroll viewport — even though the button is
+   rendered as a child of `.chat-message-list` inside the scroll container.
+   That gives both properties at once, which neither alternative does:
+   `.chat-pane__body` (the scroller) can't be the containing block because an
+   abspos child of a scroll container scrolls away with its content, and
+   `.chat-pane` can't be it because that box INCLUDES the footer (queued tray +
+   status bar + auto-growing composer), so any fixed `bottom` offset is a guess
+   that a tall footer overlaps. Anchored to the viewport, a plain small offset
+   sits just above the footer at every footer height. */
+.chat-jump-to-bottom {
+  position: absolute;
+  right: var(--space-3);
+  bottom: var(--space-3);
+  z-index: 5;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-full);
+  border: var(--border-width) solid var(--border-default);
+  background: var(--bg-elevated);
+  color: var(--fg-primary);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--font-size-base);
+  line-height: 1;
+  box-shadow: var(--shadow-md);
+}
+.chat-jump-to-bottom:hover {
+  background: var(--bg-hover);
 }
 
 .chat-msg {
@@ -366,7 +417,6 @@
   margin-left: var(--space-1);
   opacity: 0.85;
 }
-
 /* ── Tool cards ───────────────────────────────────────────────────────────── */
 
 .chat-tool-card {
@@ -633,6 +683,11 @@
   padding: var(--space-2) var(--space-3);
   border-top: var(--border-width) solid var(--border-subtle);
 }
+/* The tray renders first in the footer, which already draws its own top border —
+   suppress the tray's so the two don't stack into a double rule. */
+.chat-pane__footer > .chat-queued-tray:first-child {
+  border-top: none;
+}
 .chat-queued-tray__row {
   display: flex;
   align-items: center;
@@ -698,48 +753,35 @@
   font-style: italic;
 }
 
-/* ── Thinking hint (anchored under the latest user message) ────────────────── */
-
-.chat-thinking-hint {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-  align-self: flex-start;
-  font-size: var(--font-size-sm);
-  color: var(--fg-muted);
-  font-style: italic;
-  line-height: 1;
-}
-.chat-thinking-hint__dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--chat-accent);
-  animation: chat-thinking-pulse 1.1s ease-in-out infinite;
-}
-@keyframes chat-thinking-pulse {
-  0%, 100% { opacity: 0.3; transform: scale(0.8); }
-  50% { opacity: 1; transform: scale(1.2); }
-}
-@media (prefers-reduced-motion: reduce) {
-  .chat-thinking-hint__dot { animation: none; }
-}
-
 /* ── Persistent working indicator (last item in the feed while busy) ───────── */
 
 .chat-working-indicator {
   display: flex;
   align-self: flex-start;
   padding: var(--space-1) 0;
+  gap: var(--space-1);
+  /* Bottom/baseline-align the label text with the dots, NOT center — fallback
+     FIRST, enhancement LAST: the cascade means the LAST valid declaration for
+     a property wins, so the fallback must precede the preferred value, not
+     follow it (reversing this order would make `last baseline` dead code
+     even on browsers that support it, since the later `baseline` line would
+     always win back over it). */
+  align-items: baseline;      /* fallback: applied first, then overridden below where supported */
+  align-items: last baseline; /* wins on browsers that support it — must be the LAST declaration */
+}
+.chat-working-indicator__label {
+  font-size: var(--font-size-sm);
+  color: var(--fg-muted);
+  font-style: italic;
 }
 .chat-working-indicator__dots {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 3px;
 }
 .chat-working-indicator__dot {
-  width: 6px;
-  height: 6px;
+  width: 4px;
+  height: 4px;
   border-radius: 50%;
   background: var(--chat-accent);
   opacity: 0.15;
@@ -910,8 +952,8 @@
   flex-shrink: 0;
 }
 .chat-statusbar__state {
-  /* Bare inline span otherwise — flexbox centers the spinner against the label
-     instead of dropping it to the text baseline. */
+  /* Text-only since the spinner moved out of this span; the flex box keeps it
+     vertically centered against its siblings (Stop button, queue depth). */
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);
@@ -1003,6 +1045,20 @@
   border-color: var(--chat-accent);
 }
 .chat-composer__send:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+/* "Will queue" variant (Decision 9): busy + canSend — clicking enqueues a
+   follow-up turn rather than sending immediately. Visually distinct from the
+   solid-accent idle Send (dashed border, muted fill) so it doesn't read as
+   "sends right now". */
+.chat-composer__send--queue {
+  background: var(--bg-elevated);
+  color: var(--chat-accent);
+  border-style: dashed;
+  border-color: var(--chat-accent);
+}
+.chat-composer__send--queue:disabled {
   opacity: 0.4;
   cursor: not-allowed;
 }

--- a/web-ui/src/styles/global.css
+++ b/web-ui/src/styles/global.css
@@ -9,8 +9,32 @@ body,
 #root {
   margin: 0;
   padding: 0;
+  /* `height: 100%` on the root resolves against the INITIAL CONTAINING BLOCK,
+     which mobile browsers size as the LARGE viewport (URL bar retracted).
+     With the URL bar showing, the shell is therefore ~50-100px TALLER than
+     the actually-visible area, and its bottom edge — including
+     AgentPaneSlot's 2px status border (chat.css), which sits flush against
+     the shell's outer edge with zero margin — falls below the fold and needs
+     a small scroll to reveal. `100dvh` tracks the DYNAMIC viewport, so the
+     shell always matches what's visible. `100%` stays first as the fallback
+     for engines without `dvh`. App.tsx's login shells already size
+     themselves with `100dvh`; the authed workspace path was the gap.
+     Note this does NOT regress the soft-keyboard reflow documented in
+     index.html: `interactive-widget=resizes-content` shrinks the ICB, and
+     `dvh` is defined in terms of that same viewport, so it follows suit. */
   height: 100%;
+  height: 100dvh;
   width: 100%;
+}
+
+/* The shell is definitionally viewport-sized — every route is a flex column
+   with `min-height: 0` and its own internal scrollers — so nothing should
+   ever scroll at the document level. Pinning that down makes the "bottom of
+   the pane is hidden until you scroll" symptom structurally impossible
+   rather than merely unlikely (e.g. iOS rubber-banding). */
+html,
+body {
+  overflow: hidden;
 }
 
 body {


### PR DESCRIPTION
## Summary

Rich Chat had several related UX issues, all bundled into one pass since they're small and touch the same components:

- The "Thinking…" indicator flickered and duplicated across components (a redundant `ThinkingHint`, per-block `ThinkingBlock` headers, and the trailing working indicator all showing at once), driven by raw `turnState` oscillating on every streamed event
- A live thinking block never resolved to an elapsed-time summary once done
- Auto-scroll stole the user's scroll position while reading history; no way back to the live edge except manually dragging
- The working-indicator dots were oversized, and the footer had both a redundant spinner and a duplicate turn-state text label next to Stop
- The Composer always swapped Send to Stop while busy, even with a message ready to send/queue
- On mobile, the colored status border around a single-pane agent chat had its bottom/right edges pushed slightly offscreen

## Changes

- Consolidate to **one** live working affordance; debounce turn-state client-side so rapid thinking/tool/responding flips don't flicker; merge thinking bursts across interleaved tool calls into a single block
- Completed thinking blocks show **"Thought for Xs"**; per-block headers no longer render while still live (redundant with the trailing indicator), except for historical blocks belonging to an already-finished turn (so paginated-in history doesn't flicker invisible during an unrelated active turn)
- Fix auto-scroll to respect the user's scroll position (only snap to bottom when already near it, or on the user's own send); add a floating jump-to-bottom button
- Shrink working-indicator dots (6px→4px), remove the footer spinner and the duplicate turn-state text next to Stop, drop the redundant ellipsis from busy labels ("Thinking" not "Thinking…" — the animated dots already convey continuation), bottom-align the label to the dots
- Composer shows a distinct dashed "will queue" Send while busy with content ready, instead of always swapping to Stop; Stop only shows while busy **and** the box is empty
- Move the queued-messages tray above the status bar
- Add scroll-to-top auto-pagination for older history (server-side bounded windowing already existed — this wires up the missing auto-trigger + scroll-position preservation across the prepend)
- Fix the mobile app shell to size against the dynamic viewport (`100dvh`, not `100%`/the initial containing block's large-viewport sizing) — mobile browsers' URL bar show/hide was leaving the shell taller than the actually-visible area, pushing zero-margin edge content (like the agent pane's colored status border) below the fold until scrolled; also pins `overflow: hidden` on `html`/`body` since no route should ever need document-level scroll

A pre-PR review pass caught and fixed a real correctness bug (pagination could permanently wedge auto-scroll under certain settle timing), a duplicate "Thought for Xs" render, historical thinking blocks vanishing during an unrelated active turn, a Composer Send→Stop swap hazard right after a queued send lands, a jump-to-bottom button that could overlap the footer, and an a11y issue where the working indicator's static `aria-label` suppressed the actual changing status text from being announced.

## Test plan

- [x] Full `web-ui` vitest suite: 64 files / 551 tests passing
- [x] Repo-wide typecheck clean (`cli` + `web-ui`)
- [x] Visually verified in a docker dev sandbox — both a real running session (busy-turn UI, composer states) and a fixture harness for states unreachable without live CLI credentials (completed "Thought for Xs", jump-to-bottom); see `.vibekit/reports/chat-thinking-scroll-send/report.md` for screenshots
- [x] Mobile viewport-height fix confirmed on a real phone against the dev sandbox (the `dvh` behavior isn't reproducible in headless Chromium, which has no dynamic URL bar)
- [ ] Manual smoke test against a real long-running Rich Chat session (recommended before merge, since the pagination/scroll changes are timing-sensitive)

## Related, not included here

Investigated a report of long-running Rich Chat sessions appearing to "stop" and needing a manual nudge — traced to the underlying CLI process cleanly completing a turn and an orchestrating agent not automatically checking back in on its own spawned sub-agents. That wake-up mechanism lives inside the CLI's own agent-orchestration runtime, not vibe-station's daemon, so there's no fix to make here; noting it in case a future "auto-continue after idle" feature is wanted.

Also found (separate report, not fixed here — flagged as out of scope): on mobile, the agent-pane/tools-panel split isn't responsive and can squeeze both panes into unusably narrow slivers when the Files panel is toggled on. This is distinct from the single-pane viewport-height fix above (confirmed unaffected by it). See `.vibekit/reports/2026-08-24-mobile-agent-tools-split-not-responsive/report.md`.
