### PR TITLE
fix(daemon,web-ui): support json↔terminal channel toggle for direct sessions

### DIFF
--- a/daemon/src/__tests__/jsonChannelToggle.test.ts
+++ b/daemon/src/__tests__/jsonChannelToggle.test.ts
@@ -247,25 +247,26 @@ async function getAgentChatId(sid: string): Promise<string | undefined> {
 
 async function getLifecycleState(sid: string): Promise<string | undefined> {
   const { getProject } = await import("../state/project-store.js");
-  return getProject(PROJECT_ID)
-    ?.worktrees.flatMap((w) => w.sessions)
+  const project = getProject(PROJECT_ID);
+  return project?.worktrees
+    .flatMap((w) => w.sessions)
+    .concat(project.directSessions)
     .find((s) => s.id === sid)?.lifecycle.state;
 }
 
 /** Force a session's persisted lifecycle to "exited" (simulates a real prior
- *  tmux death) — the exact precondition the stale-banner bug needs. */
+ *  tmux death) — the exact precondition the stale-banner bug needs. Patches
+ *  BOTH worktree and direct sessions so it works for either kind. */
 async function forceExited(sid: string): Promise<void> {
   const { mutateProject } = await import("../state/project-store.js");
+  const patchExited = (s: SessionRecord): SessionRecord =>
+    s.id === sid
+      ? { ...s, lifecycle: { state: "exited" as const, lastTransitionAt: new Date().toISOString() } }
+      : s;
   await mutateProject(PROJECT_ID, (p) => ({
     ...p,
-    worktrees: p.worktrees.map((w) => ({
-      ...w,
-      sessions: w.sessions.map((s) =>
-        s.id === sid
-          ? { ...s, lifecycle: { state: "exited" as const, lastTransitionAt: new Date().toISOString() } }
-          : s,
-      ),
-    })),
+    worktrees: p.worktrees.map((w) => ({ ...w, sessions: w.sessions.map(patchExited) })),
+    directSessions: p.directSessions.map(patchExited),
   }));
 }
 
@@ -385,6 +386,17 @@ describe("P3 — JSON↔terminal channel toggle", () => {
     // the EMPTY_SID worktree case (P3.T4) but through the direct-session path.
     expect(await getAgentChatId(DIRECT_SID)).toBeUndefined();
 
+    // Force a stale "exited" lifecycle first (as if a prior real tmux death
+    // was never cleared) — this is the ONE field the toggle route only ever
+    // writes via `mutateProject`'s `directSessions.map(patchToggledSession)`
+    // branch (channel/useTmux/tmuxName/agentChatId are ALSO mutated in place
+    // on the live in-memory record before mutateProject runs, so they'd look
+    // persisted even if that branch silently no-op'd — lifecycle is not
+    // touched anywhere else, so this is what actually proves the direct-
+    // session persist path runs, not just the in-memory object).
+    await forceExited(DIRECT_SID);
+    expect(await getLifecycleState(DIRECT_SID)).toBe("exited");
+
     const spawn = await import("../services/spawn.js");
     const toTty = await app.inject({ method: "PATCH", url: `/sessions/${DIRECT_SID}/channel`, payload: { channel: "tmux" } });
     expect(toTty.statusCode).toBe(200);
@@ -393,6 +405,10 @@ describe("P3 — JSON↔terminal channel toggle", () => {
     // No restore argv (no agentChatId) → fresh launch via spawnDirectSession,
     // NOT the worktree-only spawnSession.
     expect((spawn.spawnDirectSession as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0);
+    // Proves the mutateProject persist branch actually wrote into
+    // `directSessions` (not a silent no-op onto `worktrees`) — same
+    // stale-banner fix as P3.T3b, exercised through the direct-session path.
+    expect(await getLifecycleState(DIRECT_SID)).toBe("working");
 
     const toJson = await app.inject({ method: "PATCH", url: `/sessions/${DIRECT_SID}/channel`, payload: { channel: "json" } });
     expect(toJson.statusCode).toBe(200);

--- a/daemon/src/__tests__/jsonChannelToggle.test.ts
+++ b/daemon/src/__tests__/jsonChannelToggle.test.ts
@@ -148,7 +148,7 @@ const JSON_SID = `${WT_ID}-a1`; // claude json worktree agent
 const CURSOR_SID = `${WT_ID}-a2`; // cursor json worktree agent (blocked)
 const AGY_SID = `${WT_ID}-a3`; // agy json worktree agent (blocked)
 const EMPTY_SID = `${WT_ID}-a4`; // claude json worktree agent, never run
-const DIRECT_SID = `${PROJECT_ID}-d1`; // claude json DIRECT agent (blocked, R1.5)
+const DIRECT_SID = `${PROJECT_ID}-d1`; // claude json DIRECT (non-worktree) agent
 
 function ev(kind: NormalizedEvent["kind"], extra: Partial<NormalizedEvent> = {}): NormalizedEvent {
   return {
@@ -238,8 +238,10 @@ async function getChannel(sid: string): Promise<string | undefined> {
 
 async function getAgentChatId(sid: string): Promise<string | undefined> {
   const { getProject } = await import("../state/project-store.js");
-  return getProject(PROJECT_ID)
-    ?.worktrees.flatMap((w) => w.sessions)
+  const project = getProject(PROJECT_ID);
+  return project?.worktrees
+    .flatMap((w) => w.sessions)
+    .concat(project.directSessions)
     .find((s) => s.id === sid)?.agentChatId;
 }
 
@@ -378,10 +380,24 @@ describe("P3 — JSON↔terminal channel toggle", () => {
     expect(res.statusCode).toBe(409);
   });
 
-  it("P3.T1 — 400 for a direct (non-worktree) session (R1.5)", async () => {
-    const res = await app.inject({ method: "PATCH", url: `/sessions/${DIRECT_SID}/channel`, payload: { channel: "tmux" } });
-    expect(res.statusCode).toBe(400);
-    expect(res.json<{ error: string }>().error).toContain("worktree");
+  it("P3.T1 — a direct (non-worktree) session toggles json→tty→json via spawnDirectSession (R1.5)", async () => {
+    // DIRECT_SID never ran a turn → no agentChatId → fresh launch, mirroring
+    // the EMPTY_SID worktree case (P3.T4) but through the direct-session path.
+    expect(await getAgentChatId(DIRECT_SID)).toBeUndefined();
+
+    const spawn = await import("../services/spawn.js");
+    const toTty = await app.inject({ method: "PATCH", url: `/sessions/${DIRECT_SID}/channel`, payload: { channel: "tmux" } });
+    expect(toTty.statusCode).toBe(200);
+    expect(toTty.json<{ channel: string }>().channel).toBe("tmux");
+    expect(await getChannel(DIRECT_SID)).toBe("tmux");
+    // No restore argv (no agentChatId) → fresh launch via spawnDirectSession,
+    // NOT the worktree-only spawnSession.
+    expect((spawn.spawnDirectSession as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0);
+
+    const toJson = await app.inject({ method: "PATCH", url: `/sessions/${DIRECT_SID}/channel`, payload: { channel: "json" } });
+    expect(toJson.statusCode).toBe(200);
+    expect(toJson.json<{ channel: string }>().channel).toBe("json");
+    expect(await getChannel(DIRECT_SID)).toBe("json");
   });
 
   it("P3.T1 — cursor + agy (no native-history importer) toggle in BOTH directions, lossily", async () => {

--- a/daemon/src/routes/sessions.ts
+++ b/daemon/src/routes/sessions.ts
@@ -1835,21 +1835,25 @@ export function registerSessionRoutes(app: FastifyInstance): void {
     return reply.send({ ok: true, model: parsed.data.model ?? mode.model ?? null });
   });
 
-  // Spawn the tmux/pty process for an EXISTING worktree agent session, resuming
-  // its `agentChatId` when one exists (P3 json→tty, R1.2/R1.3). Reuses the same
-  // restore primitives as POST /resume — `getRestoreCommand` → `spawnSessionFromArgv`
-  // — with a fresh-launch fallback for an empty session (no `agentChatId`, J12).
-  // It does NOT reserve a slot or create a record (no create-time side effects).
-  async function spawnTtyForWorktreeAgent(opts: {
+  // Spawn the tmux/pty process for an EXISTING agent session (worktree OR
+  // direct), resuming its `agentChatId` when one exists (P3 json→tty,
+  // R1.2/R1.3). Reuses the same restore primitives as POST /resume —
+  // `getRestoreCommand` → `spawnSessionFromArgv` — with a fresh-launch
+  // fallback for an empty session (no `agentChatId`, J12). `worktree` is
+  // `undefined` for a direct (non-worktree) session — mirrors POST /resume's
+  // `isWorktreeSession` branching so direct sessions restore too (R1.5 no
+  // longer disables the toggle for them). It does NOT reserve a slot or
+  // create a record (no create-time side effects).
+  async function spawnTtyForAgent(opts: {
     project: ProjectRecord;
-    worktree: WorktreeRecord;
+    worktree?: WorktreeRecord;
     session: SessionRecord;
     plugin: AgentPlugin;
     model?: string;
     context?: string;
   }): Promise<void> {
     const { project, worktree, session, plugin, model, context } = opts;
-    const cwd = worktreePath(project.id, worktree.id);
+    const cwd = worktree ? worktreePath(project.id, worktree.id) : project.absolutePath;
     const daemonPort = (app.server.address() as { port?: number })?.port ?? 7421;
 
     const restoreArgv = await plugin.getRestoreCommand?.({
@@ -1864,7 +1868,7 @@ export function registerSessionRoutes(app: FastifyInstance): void {
       if (plugin.setupWorkspaceHooks) await plugin.setupWorkspaceHooks(cwd);
       const launchCfg = {
         project,
-        ctx: resolvedContextOf(project, worktree),
+        ctx: resolvedContextOf(project, worktree ?? null),
         session,
         daemonPort: 0,
         ...(model ? { model } : {}),
@@ -1872,7 +1876,8 @@ export function registerSessionRoutes(app: FastifyInstance): void {
       const env: Record<string, string> = {
         VST_SESSION: session.id,
         VST_SPAWN_TOKEN: session.id,
-        VST_WORKTREE: worktree.id,
+        // Direct sessions have no worktree — omit rather than fake it.
+        ...(worktree ? { VST_WORKTREE: worktree.id } : {}),
         VST_PROJECT: project.id,
         VST_DATA_DIR: `${process.env.HOME ?? "~"}/.vibe-station/projects/${project.id}`,
         VST_DAEMON_URL: `http://127.0.0.1:${daemonPort}`,
@@ -1881,7 +1886,7 @@ export function registerSessionRoutes(app: FastifyInstance): void {
       await spawnSessionFromArgv({
         project,
         cwd,
-        worktreeId: worktree.id,
+        worktreeId: worktree?.id,
         session,
         argv: restoreArgv,
         env,
@@ -1894,7 +1899,7 @@ export function registerSessionRoutes(app: FastifyInstance): void {
         const capturedId = (await plugin.captureChatId?.({ session, project, cwd })) ?? null;
         if (capturedId) session.agentChatId = capturedId;
       }
-    } else {
+    } else if (worktree) {
       // Fresh launch — an empty session with nothing to resume (J12).
       const { buildPrompt } = await import("../services/promptBuilder.js");
       const built = await buildPrompt({
@@ -1912,13 +1917,32 @@ export function registerSessionRoutes(app: FastifyInstance): void {
         taskPrompt: built.taskPrompt,
         ...(model ? { model } : {}),
       });
+    } else {
+      // Fresh launch — direct-session counterpart of the branch above.
+      const { buildDirectPrompt } = await import("../services/promptBuilder.js");
+      const built = await buildDirectPrompt({
+        project,
+        ...(context ? { modeContext: context } : {}),
+      });
+      const { spawnDirectSession } = await import("../services/spawn.js");
+      await spawnDirectSession({
+        project,
+        session,
+        plugin,
+        daemonPort,
+        systemPrompt: built.systemPrompt,
+        taskPrompt: built.taskPrompt,
+        ...(model ? { model } : {}),
+      });
     }
   }
 
   // PATCH …/sessions/:id/channel — live JSON↔terminal toggle (P3, R1.1–R1.7).
-  // Idle-gated (409 when a turn is active/queued/held for edit); worktree-only
-  // (400 for direct sessions — no restore path, R1.5). Works for EVERY agent CLI
-  // in both directions: json→tty spawns the TTY resuming the same agentChatId;
+  // Idle-gated (409 when a turn is active/queued/held for edit). Supports BOTH
+  // worktree-backed and direct/project-scoped sessions (R1.5 — direct sessions
+  // restore the same way POST /resume already does, via project.absolutePath
+  // as cwd). Works for EVERY agent CLI in both directions: json→tty spawns the
+  // TTY resuming the same agentChatId;
   // tty→json tears the TTY down and re-establishes the JSON session. The
   // terminal-phase turns are backfilled via the P2 importer ONLY for CLIs that
   // ship a native-history importer (claude/opencode); CLIs without one
@@ -1942,11 +1966,9 @@ export function registerSessionRoutes(app: FastifyInstance): void {
     const current = sessionChannel(session);
     if (current === target) return reply.send({ ok: true, channel: current }); // idempotent no-op
 
-    // R1.5 — direct (non-worktree) sessions have no restore path; disable toggle.
-    if (ctx.kind !== "worktree") {
-      return reply.status(400).send({ error: "Channel toggle is only supported for worktree sessions" });
-    }
-    const { worktree } = ctx;
+    // R1.5 — direct (non-worktree) sessions restore via project.absolutePath,
+    // same as POST /resume; `worktree` is undefined for them.
+    const worktree = ctx.kind === "worktree" ? ctx.worktree : undefined;
 
     // Resolve mode → plugin. Deleting an in-use mode is allowed, so a missing
     // mode falls back instead of hard-failing the toggle: prefer the cli a
@@ -2006,9 +2028,9 @@ export function registerSessionRoutes(app: FastifyInstance): void {
         session.tmuxName = ttyTmuxName;
         session.channel = newChannel;
         session.useTmux = newUseTmux;
-        await spawnTtyForWorktreeAgent({
+        await spawnTtyForAgent({
           project,
-          worktree,
+          ...(worktree ? { worktree } : {}),
           session,
           plugin,
           ...(mode.model ? { model: mode.model } : {}),
@@ -2065,30 +2087,29 @@ export function registerSessionRoutes(app: FastifyInstance): void {
     // genuinely live tmux window does not by itself clear a stale "exited"
     // record, so the terminal pane keeps showing the "Session exited /
     // Resume" banner over a terminal that is actually live and working.
-    await mutateProject(project.id, (p) => ({
-      ...p,
-      worktrees: p.worktrees.map((w) =>
-        w.id === worktree.id
-          ? {
-              ...w,
-              sessions: w.sessions.map((s) =>
-                s.id === id
-                  ? {
-                      ...s,
-                      channel: newChannel,
-                      useTmux: newUseTmux,
-                      tmuxName: session.tmuxName,
-                      ...(session.agentChatId ? { agentChatId: session.agentChatId } : {}),
-                      ...(fromJson
-                        ? { lifecycle: { state: "working" as const, lastTransitionAt: new Date().toISOString() } }
-                        : {}),
-                    }
-                  : s,
-              ),
-            }
-          : w,
-      ),
-    }));
+    const patchToggledSession = (s: SessionRecord): SessionRecord =>
+      s.id === id
+        ? {
+            ...s,
+            channel: newChannel,
+            useTmux: newUseTmux,
+            tmuxName: session.tmuxName,
+            ...(session.agentChatId ? { agentChatId: session.agentChatId } : {}),
+            ...(fromJson
+              ? { lifecycle: { state: "working" as const, lastTransitionAt: new Date().toISOString() } }
+              : {}),
+          }
+        : s;
+    await mutateProject(project.id, (p) =>
+      worktree
+        ? {
+            ...p,
+            worktrees: p.worktrees.map((w) =>
+              w.id === worktree.id ? { ...w, sessions: w.sessions.map(patchToggledSession) } : w,
+            ),
+          }
+        : { ...p, directSessions: p.directSessions.map(patchToggledSession) },
+    );
 
     // Compute the fresh meta to mirror to other tabs.
     let meta: SessionMeta;

--- a/daemon/src/services/spawn.ts
+++ b/daemon/src/services/spawn.ts
@@ -167,7 +167,8 @@ export interface AgentPlugin {
   refreshChatIdOnToggle?(args: {
     session: SessionRecord;
     project: ProjectRecord;
-    worktree: WorktreeRecord;
+    /** Undefined for a direct (non-worktree) session. */
+    worktree?: WorktreeRecord;
   }): Promise<string | null>;
   /**
    * Return the list of models available for this CLI.

--- a/daemon/src/services/spawn.ts
+++ b/daemon/src/services/spawn.ts
@@ -542,9 +542,17 @@ export async function spawnDirectSession(opts: DirectSpawnOptions): Promise<void
     ...(model ? { model } : {}),
   };
 
-  // Setup workspace hooks in project directory
-  if (plugin.setupWorkspaceHooks) {
-    await plugin.setupWorkspaceHooks(cwd);
+  // provideChatId + setupWorkspaceHooks in parallel (both pre-spawn, independent)
+  // — same as spawnSession's steps 2.5+3. Without this, a CLI that pre-mints
+  // its own chat id (cursor) never gets one for a direct session, so a later
+  // json→tty→json channel toggle (or any /resume) has nothing to --resume and
+  // silently starts a fresh conversation instead of continuing this one.
+  const [preSpawnChatId] = await Promise.all([
+    plugin.provideChatId?.({ session, project, cwd }) ?? Promise.resolve(null),
+    plugin.setupWorkspaceHooks ? plugin.setupWorkspaceHooks(cwd) : Promise.resolve(),
+  ]);
+  if (preSpawnChatId) {
+    session.agentChatId = preSpawnChatId;
   }
 
   // Write system-prompt file to this context's session data dir

--- a/web-ui/src/components/layout/TerminalChannelToggle.test.tsx
+++ b/web-ui/src/components/layout/TerminalChannelToggle.test.tsx
@@ -61,11 +61,17 @@ describe("TerminalChannelToggle (terminal→JSON)", () => {
     expect(screen.queryByRole("button", { name: /Rich Chat/i })).toBeNull();
   });
 
-  it("hides for a direct (non-worktree) session", () => {
+  it("shows for a direct (non-worktree) session — the daemon supports the toggle for direct sessions too", async () => {
+    const api = createMockApi();
+    const spy = vi.spyOn(api, "setSessionChannel");
     render(
-      <TerminalChannelToggle api={createMockApi()} session={session({ worktreeId: null })} />,
+      <TerminalChannelToggle api={api} session={session({ worktreeId: null })} />,
     );
-    expect(screen.queryByRole("button", { name: /Rich Chat/i })).toBeNull();
+
+    const toggle = await screen.findByRole("button", { name: /Rich Chat/i });
+    await userEvent.click(toggle);
+    await userEvent.click(screen.getByRole("button", { name: /Switch to Rich Chat/i }));
+    await waitFor(() => expect(spy).toHaveBeenCalledWith("sess-main", "json"));
   });
 
   it("hides when the session is already on the JSON channel", () => {

--- a/web-ui/src/components/layout/TerminalChannelToggle.tsx
+++ b/web-ui/src/components/layout/TerminalChannelToggle.tsx
@@ -11,9 +11,9 @@ interface TerminalChannelToggleProps {
 
 /**
  * Terminal→JSON channel control — mirror of the StatusBar JSON→terminal
- * affordance (`chat/StatusBar.tsx`). Rendered for EVERY worktree-backed
- * **agent** session on a tmux/pty channel (the daemon supports the toggle for
- * all agent CLIs now); direct/non-worktree sessions are still ineligible.
+ * affordance (`chat/StatusBar.tsx`). Rendered for EVERY **agent** session
+ * (worktree-backed or direct/project-scoped) on a tmux/pty channel — the
+ * daemon supports the toggle for all agent CLIs in both contexts.
  *
  * Switching tears down the live terminal and reopens the same conversation as
  * JSON chat (resumed via --resume). The terminal-phase turns are backfilled by
@@ -31,7 +31,6 @@ export function TerminalChannelToggle({ api, session }: TerminalChannelTogglePro
   const channel = session.channel ?? "tmux";
   const eligible =
     session.type === "agent" &&
-    session.worktreeId != null &&
     channel !== "json" &&
     session.modeId != null;
 


### PR DESCRIPTION
## Summary
- Direct (non-worktree) sessions couldn't toggle between Rich Chat (JSON) and terminal — `PATCH /sessions/:id/channel` unconditionally 400'd them with "Channel toggle is only supported for worktree sessions". The comment claimed direct sessions have "no restore path", but that's stale: `POST /resume` already restores direct sessions fine via `project.absolutePath` as cwd.
- Generalized the toggle's internal `spawnTtyForWorktreeAgent` helper (renamed `spawnTtyForAgent`) to accept an optional `worktree`, mirroring `/resume`'s existing `isWorktreeSession` branching: cwd resolution, env (`VST_WORKTREE` omitted for direct), fresh-launch via `buildDirectPrompt`/`spawnDirectSession`, and the `mutateProject` persist path (`worktrees` vs `directSessions`).
- Removed `TerminalChannelToggle`'s stale `session.worktreeId != null` eligibility check on the terminal→Rich-Chat direction, which hid the button for direct sessions even though nothing else gated them (the json→terminal direction, in `StatusBar`, never had this check — so the bug was actually asymmetric: json→terminal showed the button and failed on click with a 400, terminal→json just hid the button).
- Updated `daemon/src/services/spawn.ts`'s `refreshChatIdOnToggle` plugin-interface signature to make `worktree` optional (only `agy.ts` implements it, and it doesn't use `worktree`).

## Test plan
- [x] `pnpm typecheck` (cli/daemon + web-ui) — clean
- [x] `pnpm lint` — clean (pre-existing unrelated warnings only)
- [x] Daemon test suite (791 tests) — all pass, including a new/rewritten `jsonChannelToggle.test.ts` case exercising the direct-session json→tty→json round trip (verifies `spawnDirectSession` is used, not the worktree-only `spawnSession`)
- [x] Web-ui test suite (551 tests) — all pass, including `TerminalChannelToggle.test.tsx`'s direct-session case flipped from "hides" to "shows and works"
- [x] `pnpm build` — clean
- [x] End-to-end in a `scripts/dev-sandbox.sh` Docker sandbox against a real Claude Code process: created a direct JSON session via the API, toggled it to terminal (fresh launch, verified real `claude` process running in the project's base dir via `tmux capture-pane`), toggled back to Rich Chat (`historyImported: true`), then repeated the full round trip through the actual browser UI (confirm dialogs, live terminal, toggle back) via Claude-in-Chrome