### PR TITLE
fix(web-ui): render Thought/Worked-for-Xs for real thinking bursts, footer busy dots when scrolled away

### DIFF
--- a/web-ui/src/components/chat/MessageList.test.tsx
+++ b/web-ui/src/components/chat/MessageList.test.tsx
@@ -143,6 +143,58 @@ describe("groupEvents thinking merge/close (1.T1 / 1.T2)", () => {
     expect((items[0] as { tools: unknown[] }).tools).toHaveLength(3);
     expect(items.some((i) => i.type === "thinking")).toBe(false);
   });
+
+  it("a group that opened EMPTY but later gained text is not swept under its stale position — the tool run stays whole", () => {
+    // The late text arrives AFTER tool b, so it must not render between a and
+    // b. The drop-rule keys on emptiness at creation, so the (still logically
+    // empty at that point) group stays transparent to the run, and the merged
+    // group renders after it.
+    const items = mergeToolRuns(
+      groupEvents([
+        toolUseEvent("a", "t1"),
+        thinkingEvent("th1", "t1", ""),
+        toolUseEvent("b", "t1"),
+        thinkingEvent("th2", "t1", "late reasoning"),
+      ]),
+    );
+    expect(items.map((i) => i.type)).toEqual(["toolRun", "thinking"]);
+    expect((items[0] as { tools: unknown[] }).tools).toHaveLength(2);
+    expect((items[1] as { text: string }).text).toBe("late reasoning");
+  });
+
+  it("an empty/signature-only thinking event NOT sandwiched between tool calls survives and renders 'Thought for Xs'", () => {
+    // The common real-world shape: Claude emits signature-only reasoning (text
+    // "") and then answers. This used to be dropped in `groupEvents`, so no
+    // ThinkingBlock ever rendered for it.
+    const closed: NormalizedEvent[] = [
+      thinkingEvent("th1", "t1", "", "2024-01-01T00:00:00.000Z"),
+      { ...textEvent("a1", "t1", "answer"), ts: "2024-01-01T00:00:04.000Z" },
+    ];
+    const items = mergeToolRuns(groupEvents(closed));
+    expect(items.filter((i) => i.type === "thinking")).toHaveLength(1);
+
+    const { container } = render(<MessageList events={closed} pending={[]} />);
+    const block = container.querySelector(".chat-thinking");
+    expect(block).toBeTruthy();
+    expect(block!.textContent).toContain("Thought for 4s");
+  });
+
+  it("hadToolCall: true when a tool call ran while the group was open, false for a thinking-only group", () => {
+    const withTool = groupEvents([
+      thinkingEvent("th1", "t1", "reasoning", "2024-01-01T00:00:00.000Z"),
+      toolUseEvent("tool1", "t1", "2024-01-01T00:00:01.000Z"),
+      { ...textEvent("a1", "t1", "answer"), ts: "2024-01-01T00:00:03.000Z" },
+    ]).find((i) => i.type === "thinking") as { hadToolCall?: boolean; endedTs?: string };
+    expect(withTool.endedTs).toBe("2024-01-01T00:00:03.000Z");
+    expect(withTool.hadToolCall).toBe(true);
+
+    const withoutTool = groupEvents([
+      thinkingEvent("th1", "t1", "reasoning", "2024-01-01T00:00:00.000Z"),
+      { ...textEvent("a1", "t1", "answer"), ts: "2024-01-01T00:00:03.000Z" },
+    ]).find((i) => i.type === "thinking") as { hadToolCall?: boolean; endedTs?: string };
+    expect(withoutTool.endedTs).toBe("2024-01-01T00:00:03.000Z");
+    expect(withoutTool.hadToolCall).toBeFalsy();
+  });
 });
 
 describe("MessageList queued-turn filtering (tray relocation)", () => {
@@ -179,7 +231,9 @@ function toolItem(id: string, turnId: string) {
   return { type: "tool" as const, id, toolName: "Bash", turnId, toolInput: { command: "echo" } };
 }
 function thinkingItem(id: string, turnId: string, text: string) {
-  return { type: "thinking" as const, id, turnId, text, startedTs: "" };
+  // `openedEmpty` mirrors what `groupEvents` records at push time for a group
+  // whose first (and here only) event carries this text.
+  return { type: "thinking" as const, id, turnId, text, startedTs: "", openedEmpty: text.trim().length === 0 };
 }
 
 describe("mergeToolRuns", () => {
@@ -254,7 +308,9 @@ describe("MessageList live thinking block suppression", () => {
     const { container } = render(<MessageList events={closed} pending={[]} turnActive />);
     const block = container.querySelector(".chat-thinking");
     expect(block).toBeTruthy();
-    expect(block!.textContent).toContain("Thought for 3s");
+    // "Worked for", not "Thought for": a tool call ran while this group was
+    // open (see `liveEvents`), so the completed label takes the tool variant.
+    expect(block!.textContent).toContain("Worked for 3s");
     // Position preserved: thinking block precedes the tool card in DOM order.
     const tool = screen.getByText("Bash");
     expect(block!.compareDocumentPosition(tool) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
@@ -271,6 +327,22 @@ describe("MessageList live thinking block suppression", () => {
     };
     const { container } = render(<MessageList events={[noTurn]} pending={[]} />);
     expect(container.querySelector(".chat-thinking")).toBeTruthy();
+  });
+
+  it("renders NOTHING for an unclosable (turnId-less) thinking group with no text", () => {
+    // Empty + never-closeable: `closeOpenThinking` early-returns without a
+    // turnId, so this group can never gain an `endedTs` — rendering it would
+    // leave a permanent, live-looking "Thinking" label over dead content.
+    const noTurnEmpty: NormalizedEvent = {
+      id: "th0",
+      sessionId: "s1",
+      ts: "",
+      provider: "claude",
+      kind: "thinking",
+      text: "",
+    };
+    const { container } = render(<MessageList events={[noTurnEmpty]} pending={[]} />);
+    expect(container.querySelector(".chat-thinking")).toBeNull();
   });
 
   it("keeps a turnId-less (historical) thinking group visible while a DIFFERENT turn is running", () => {
@@ -526,6 +598,30 @@ describe("MessageList primary scroll effect — atBottom guard + jump-to-bottom 
     // listener's own "near bottom" computation must independently agree.
     fireEvent.scroll(container);
     expect(screen.queryByRole("button", { name: "Jump to latest message" })).toBeNull();
+  });
+
+  it("notifies onAtBottomChange on the scroll path and on the jump-to-bottom click", () => {
+    const onAtBottomChange = vi.fn();
+    const { container } = render(
+      <MessageList events={[userEvent("t1", "hi")]} pending={[]} onAtBottomChange={onAtBottomChange} />,
+    );
+    // No scroll yet → no notification; the parent's own default (true) holds.
+    expect(onAtBottomChange).not.toHaveBeenCalled();
+
+    stubMetrics(container, 1000, 300);
+    container.scrollTop = 0; // distance = 700 → scrolled away
+    fireEvent.scroll(container);
+    expect(onAtBottomChange).toHaveBeenLastCalledWith(false);
+
+    fireEvent.click(screen.getByRole("button", { name: "Jump to latest message" }));
+    expect(onAtBottomChange).toHaveBeenLastCalledWith(true);
+
+    // Already at the bottom: the listener's own near-bottom computation
+    // (scrollTop = 1000) agrees, so this scroll is NOT a transition and must
+    // not re-notify — the callback fires on change only.
+    onAtBottomChange.mockClear();
+    fireEvent.scroll(container);
+    expect(onAtBottomChange).not.toHaveBeenCalled();
   });
 });
 

--- a/web-ui/src/components/chat/MessageList.tsx
+++ b/web-ui/src/components/chat/MessageList.tsx
@@ -7,12 +7,32 @@ import { QueuedTurnEditor } from "./QueuedTurnEditor";
 import { ThinkingBlock } from "./ThinkingBlock";
 import { ToolRunSummary } from "./ToolRunSummary";
 import { ErrorCard } from "./ErrorCard";
+import { WorkingDots } from "./WorkingDots";
 import type { ToolCallEntry } from "./toolFormat";
 
 type RenderItem =
   | { type: "user"; id: string; text: string; attachments?: Attachment[]; turnId?: string; cancelled?: boolean }
   | { type: "assistant"; id: string; text: string; turnId?: string }
-  | { type: "thinking"; id: string; text: string; turnId?: string; startedTs: string; endedTs?: string }
+  | {
+      type: "thinking";
+      id: string;
+      text: string;
+      turnId?: string;
+      startedTs: string;
+      endedTs?: string;
+      /** True when at least one tool call happened while this group was open —
+       *  the completed label then reads "Worked for Xs" instead of "Thought
+       *  for Xs", since the span covered real work, not just reasoning. */
+      hadToolCall?: boolean;
+      /** Whether this group is still empty AT THE POSITION IT OCCUPIES —
+       *  set at push time, and cleared only by an append that lands while the
+       *  group is still the trailing item (so its position is honest).
+       *  `mergeToolRuns` drops such groups between tool calls, so an empty blip
+       *  never fragments one logical tool run. Testing the item's current text
+       *  at merge time instead would let text appended after an intervening
+       *  tool call resurrect the group at its stale, too-early position. */
+      openedEmpty: boolean;
+    }
   | ({ type: "tool" } & ToolCallEntry)
   | { type: "toolRun"; id: string; tools: ToolCallEntry[] }
   | { type: "error"; id: string; text: string }
@@ -31,7 +51,11 @@ type RenderItem =
  * signature-only reasoning block, common between near-every tool call in
  * some sessions) carries no information, so it's transparent to an
  * in-progress run: it's dropped rather than splitting one logical burst of
- * tool calls into several single-tool runs.
+ * tool calls into several single-tool runs. The drop tests `openedEmpty`
+ * (emptiness AT CREATION, see the RenderItem field) rather than the item's
+ * current text: `groupEvents` can append later text into a group that was
+ * empty when it took its position, and dropping THAT would render real,
+ * late-arriving reasoning at a stale, too-early spot in the transcript.
  */
 export function mergeToolRuns(items: RenderItem[]): RenderItem[] {
   const out: RenderItem[] = [];
@@ -42,7 +66,7 @@ export function mergeToolRuns(items: RenderItem[]): RenderItem[] {
     run = [];
   };
   for (const item of items) {
-    if (item.type === "thinking" && item.text.trim().length === 0 && run.length > 0) {
+    if (item.type === "thinking" && item.openedEmpty && run.length > 0) {
       continue;
     }
     // A run never spans a turn boundary — two tool calls from different
@@ -95,6 +119,15 @@ export function groupEvents(events: NormalizedEvent[]): RenderItem[] {
     const open = openIdx != null ? items[openIdx] : undefined;
     if (open && open.type === "thinking" && !open.endedTs) open.endedTs = ts;
     thinkingOpenByTurnId.delete(turnId);
+  }
+  /** Pure bookkeeping: mark the still-open thinking group of `turnId` (if any)
+   *  as having spanned a tool call. Never touches control flow — tool events
+   *  deliberately do NOT close the group (see the thinking case). */
+  function markToolCallDuringThinking(turnId: string | undefined) {
+    if (!turnId) return;
+    const openIdx = thinkingOpenByTurnId.get(turnId);
+    const open = openIdx != null ? items[openIdx] : undefined;
+    if (open && open.type === "thinking" && !open.endedTs) open.hadToolCall = true;
   }
 
   for (const ev of events) {
@@ -151,30 +184,56 @@ export function groupEvents(events: NormalizedEvent[]): RenderItem[] {
         break;
       }
       case "thinking": {
-        // Empty/signature-only thinking events (no text) never open or append to
-        // a group — they carry no content or timing info, and letting them
-        // through would defeat the `mergeToolRuns` drop-rule below (an
-        // empty item that later gets text appended into it is no longer
-        // empty by the time that rule runs, breaking the tool-run merge).
-        if ((ev.text ?? "").trim().length === 0) break;
+        // Empty/signature-only thinking events (no text) DO open a group: they
+        // are the common case for real Claude reasoning, and dropping them here
+        // meant "Thought for Xs" never rendered for such a turn at all
+        // (`ThinkingBlock`'s static, non-expandable branch was unreachable).
+        // The noisy case — an empty blip sitting between two tool calls, which
+        // would otherwise fragment one logical tool run — is already handled
+        // downstream by `mergeToolRuns`' drop-rule above.
         const openIdx = ev.turnId ? thinkingOpenByTurnId.get(ev.turnId) : undefined;
         const open = openIdx != null ? items[openIdx] : undefined;
-        if (open && open.type === "thinking" && !open.endedTs) {
+        const incoming = ev.text ?? "";
+        // Real text arriving into a group that opened EMPTY and no longer sits
+        // at the end of the feed (a tool call has rendered since) must NOT be
+        // appended: that group's position is stale, so the reasoning would show
+        // up EARLIER than it was actually emitted — and, being empty at
+        // creation, it may also be dropped outright by `mergeToolRuns`. Start a
+        // fresh group at the current position instead. The abandoned empty
+        // placeholder is either merged away between tool calls or hidden by the
+        // render gate (empty + never closed → nothing to show).
+        const staleEmptyGroup =
+          open != null &&
+          open.type === "thinking" &&
+          open.openedEmpty &&
+          incoming.trim().length > 0 &&
+          openIdx !== items.length - 1;
+        if (open && open.type === "thinking" && !open.endedTs && !staleEmptyGroup) {
           // Appends even across intervening tool_use/tool_result — those cases
           // don't call closeOpenThinking, so the group stays open through them.
-          open.text += ev.text ?? "";
+          open.text += incoming;
+          if (open.openedEmpty && open.text.trim().length > 0) open.openedEmpty = false;
         } else {
-          items.push({ type: "thinking", id: ev.id, text: ev.text ?? "", turnId: ev.turnId, startedTs: ev.ts });
+          items.push({
+            type: "thinking",
+            id: ev.id,
+            text: incoming,
+            turnId: ev.turnId,
+            startedTs: ev.ts,
+            openedEmpty: incoming.trim().length === 0,
+          });
           if (ev.turnId) thinkingOpenByTurnId.set(ev.turnId, items.length - 1);
         }
         break;
       }
       case "tool_use": {
+        markToolCallDuringThinking(ev.turnId);
         items.push({ type: "tool", id: ev.id, toolName: ev.toolName ?? "tool", toolInput: ev.toolInput, turnId: ev.turnId });
         if (ev.toolId) toolIndexById.set(ev.toolId, items.length - 1);
         break;
       }
       case "tool_result": {
+        markToolCallDuringThinking(ev.turnId);
         const result = { content: ev.toolResult?.content, isError: ev.toolResult?.isError };
         const idx = ev.toolId ? toolIndexById.get(ev.toolId) : undefined;
         const target = idx != null ? items[idx] : undefined;
@@ -216,42 +275,21 @@ export function groupEvents(events: NormalizedEvent[]): RenderItem[] {
   return items;
 }
 
-/** Milliseconds each dot-count step of `WorkingIndicator` is shown. */
-const WORKING_INDICATOR_STEP_MS = 450;
-
 /** Persistent "agent is working" affordance pinned as the LAST item in the
  *  feed while a turn is active — the footer `StatusBar` spinner (near Stop)
  *  is easy to miss when scrolled up or glancing away from the composer; this
  *  is the same `turnActive` signal, just anchored where the eye actually
- *  lands. Dot COUNT cycles 1 → 2 → 3 → 1 (not a spinner) — only mounted
- *  while busy (see call site), so the interval's lifetime is the busy
- *  window, no separate start/stop wiring needed. */
+ *  lands. The dot-cycle itself lives in the shared `WorkingDots` (also used
+ *  by the footer `StatusBar` when the user has scrolled away from this
+ *  indicator); this component only adds the live region and the label. */
 function WorkingIndicator({ label }: { label?: string }) {
-  const [count, setCount] = useState(1);
-  useEffect(() => {
-    // Explicit `prefers-reduced-motion` check: this dot-cycle's motion is a
-    // JS interval (not CSS-driven, so an `@media (prefers-reduced-motion)`
-    // rule alone can't stop it) — has to honor the opt-out itself.
-    if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
-    const id = window.setInterval(() => {
-      setCount((c) => (c >= 3 ? 1 : c + 1));
-    }, WORKING_INDICATOR_STEP_MS);
-    return () => window.clearInterval(id);
-  }, []);
   return (
     // The accessible name tracks `label`: a STATIC name on a live-region root
     // is what most assistive tech announces on change, which would suppress
     // the actual (changing) "Thinking"/"Running tool" text entirely.
     <div className="chat-working-indicator" role="status" aria-live="polite" aria-label={label ?? "Agent is working"}>
       {label ? <span className="chat-working-indicator__label">{label}</span> : null}
-      <span className="chat-working-indicator__dots" aria-hidden>
-        {[1, 2, 3].map((n) => (
-          <span
-            key={n}
-            className={`chat-working-indicator__dot${n <= count ? " chat-working-indicator__dot--on" : ""}`}
-          />
-        ))}
-      </span>
+      <WorkingDots />
     </div>
   );
 }
@@ -302,6 +340,11 @@ interface MessageListProps {
   /** Edit an already-answered user turn → fork (R3.1). When provided, answered
    *  user bubbles show an Edit affordance; only enabled while the session is idle. */
   onForkTurn?: (turnId: string, message: string, attachmentIds: string[]) => Promise<void> | void;
+  /** Notified whenever the tracked near-bottom state changes (the same signal
+   *  that drives the jump-to-bottom button). `ChatPane` mirrors it so the
+   *  footer `StatusBar` can show busy dots exactly when the in-feed
+   *  `WorkingIndicator` is scrolled out of view. */
+  onAtBottomChange?: (atBottom: boolean) => void;
 }
 
 export function MessageList({
@@ -319,6 +362,7 @@ export function MessageList({
   api,
   sessionId,
   onForkTurn,
+  onAtBottomChange,
 }: MessageListProps) {
   // Which answered user turn (if any) this tab is editing → fork. Local to the
   // list; a fork closes the editor and the daemon truncates + re-runs (R3.1).
@@ -358,6 +402,26 @@ export function MessageList({
   // top of history (that would be a mount-time regression).
   const [atBottom, setAtBottom] = useState(true);
   const atBottomRef = useRef(true);
+  // Read through a ref so the once-registered scroll listener below (empty
+  // deps, passive) never has to re-attach when the parent passes a new
+  // callback identity.
+  const onAtBottomChangeRef = useRef(onAtBottomChange);
+  useEffect(() => {
+    onAtBottomChangeRef.current = onAtBottomChange;
+  }, [onAtBottomChange]);
+  /** Single writer for the near-bottom state: keeps the ref (read by the
+   *  layout effects), the local state (jump-to-bottom button) and the parent
+   *  notification in lockstep. */
+  const applyAtBottom = useCallback((next: boolean) => {
+    // Only genuine transitions propagate — a `scroll` burst that never leaves
+    // the near-bottom band would otherwise re-notify the parent on every
+    // event, contradicting this callback's own contract ("notified whenever
+    // the tracked state CHANGES").
+    if (next === atBottomRef.current) return;
+    atBottomRef.current = next;
+    setAtBottom(next);
+    onAtBottomChangeRef.current?.(next);
+  }, []);
 
   // --- infinite-scroll-upward (auto "load earlier") state ---------------
   // Set the moment a load-earlier is initiated (by the scroll trigger OR the
@@ -446,13 +510,12 @@ export function MessageList({
     const onScroll = () => {
       const distance = container.scrollHeight - container.scrollTop - container.clientHeight;
       const near = distance < 80;
-      atBottomRef.current = near;
-      setAtBottom(near);
+      applyAtBottom(near);
       if (container.scrollTop < NEAR_TOP_PX) startLoadEarlierRef.current();
     };
     container.addEventListener("scroll", onScroll, { passive: true });
     return () => container.removeEventListener("scroll", onScroll);
-  }, []);
+  }, [applyAtBottom]);
 
   // MUST be useLayoutEffect, not useEffect: this needs to read/write layout
   // (scrollTop) before the browser paints the just-added content, so the
@@ -487,14 +550,11 @@ export function MessageList({
       // environment (and even where it does, staying pinned at the bottom
       // should keep `atBottom` true regardless) — keep the tracked state in
       // sync so the jump-to-bottom button doesn't flash on for a frame.
-      if (!atBottomRef.current) {
-        atBottomRef.current = true;
-        setAtBottom(true);
-      }
+      if (!atBottomRef.current) applyAtBottom(true);
     }
     // `turnActive` here so the WorkingIndicator's own appear/disappear (it
     // changes the feed's content height) re-triggers the scroll too.
-  }, [items.length, pending.length, thinking, turnActive]);
+  }, [items.length, pending.length, thinking, turnActive, applyAtBottom]);
 
   // Scroll anchoring for prepended history. Declared AFTER the primary effect
   // on purpose: layout effects run in declaration order, so this is the last
@@ -677,8 +737,25 @@ export function MessageList({
             // closed by `closeOpenThinking`, so gating on "any turn is
             // active" hid such historical reasoning for the whole duration of
             // every unrelated later turn.
-            node = item.endedTs || !turnActive || item.turnId !== activeTurnId ? (
-              <ThinkingBlock key={key} text={item.text} startedTs={item.startedTs} endedTs={item.endedTs} />
+            //
+            // A group that is BOTH empty and unclosable (no `endedTs` and no
+            // text — e.g. a turnId-less imported event, or a turn whose last
+            // persisted event is a thinking event because the session died
+            // mid-turn) never gets an `endedTs` from `closeOpenThinking`, so
+            // it would otherwise render forever as a bare, non-expandable,
+            // live-looking "Thinking" label over permanently dead content.
+            // There is nothing meaningful to show, so it renders nothing. A
+            // NON-empty unclosable group still renders once the turn ends.
+            node =
+              (item.endedTs || !turnActive || item.turnId !== activeTurnId) &&
+              (item.endedTs || item.text.trim().length > 0) ? (
+              <ThinkingBlock
+                key={key}
+                text={item.text}
+                startedTs={item.startedTs}
+                endedTs={item.endedTs}
+                hadToolCall={item.hadToolCall}
+              />
             ) : null;
             break;
           case "toolRun":
@@ -729,8 +806,7 @@ export function MessageList({
             const container = listRef.current?.parentElement;
             if (!container) return;
             container.scrollTop = container.scrollHeight;
-            atBottomRef.current = true;
-            setAtBottom(true);
+            applyAtBottom(true);
           }}
         >
           ↓

--- a/web-ui/src/components/chat/StatusBar.test.tsx
+++ b/web-ui/src/components/chat/StatusBar.test.tsx
@@ -188,3 +188,42 @@ describe("StatusBar (5.T2)", () => {
     });
   });
 });
+
+describe("StatusBar busy dots when scrolled away", () => {
+  const busyMeta = meta({ turnState: "thinking" });
+
+  it("renders the dots (and NO busy text label) left of Stop when busy and scrolled away", () => {
+    const { container } = render(<StatusBar meta={busyMeta} atBottom={false} onStop={() => {}} />);
+    expect(container.querySelectorAll(".chat-working-indicator__dot")).toHaveLength(3);
+    // The removed duplicate label must NOT come back with the dots.
+    expect(screen.queryByText("Thinking")).toBeNull();
+    // Order: dots precede the Stop button in DOM order.
+    const dots = container.querySelector(".chat-statusbar__busy")!;
+    expect(dots.className).not.toContain("chat-statusbar__busy--hidden");
+    const stop = container.querySelector(".chat-statusbar__stop")!;
+    expect(dots.compareDocumentPosition(stop) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("keeps the dots mounted but HIDDEN while busy at the bottom, so the Stop button never shifts", () => {
+    // Present-but-hidden (not unmounted): the reserved box keeps the row's
+    // layout identical across the near-bottom threshold the user is crossing
+    // while they scroll.
+    const { container } = render(<StatusBar meta={busyMeta} atBottom onStop={() => {}} />);
+    const dots = container.querySelector(".chat-statusbar__busy")!;
+    expect(dots).toBeTruthy();
+    expect(dots.className).toContain("chat-statusbar__busy--hidden");
+    expect(dots.getAttribute("aria-hidden")).toBe("true");
+    expect(container.querySelector(".chat-statusbar__stop")).toBeTruthy();
+  });
+
+  it("defaults to hidden dots when `atBottom` is not supplied at all", () => {
+    const { container } = render(<StatusBar meta={busyMeta} onStop={() => {}} />);
+    expect(container.querySelector(".chat-statusbar__busy--hidden")).toBeTruthy();
+  });
+
+  it("renders no dots when idle, even if scrolled away", () => {
+    const { container } = render(<StatusBar meta={meta({ turnState: "idle" })} atBottom={false} onStop={() => {}} />);
+    expect(container.querySelector(".chat-statusbar__busy")).toBeNull();
+    expect(screen.getByText("Ready")).toBeTruthy();
+  });
+});

--- a/web-ui/src/components/chat/StatusBar.tsx
+++ b/web-ui/src/components/chat/StatusBar.tsx
@@ -3,6 +3,7 @@ import type { ApiInstance } from "@/api";
 import type { SessionMeta, TurnState } from "@/api/types";
 import { ModelSwitch } from "./ModelSwitch";
 import { ChannelToggleButton } from "./ChannelToggleButton";
+import { WorkingDots } from "./WorkingDots";
 
 interface StatusBarProps {
   meta: SessionMeta | null;
@@ -13,6 +14,13 @@ interface StatusBarProps {
   /** When provided (with sessionId), the model becomes a live switcher. */
   api?: ApiInstance;
   sessionId?: string;
+  /** Whether the message list is scrolled to (or near) the live edge, mirrored
+   *  up from `MessageList` by `ChatPane`. While busy AND scrolled away, the
+   *  in-feed `WorkingIndicator` is off-screen, so the footer shows the same
+   *  animated dots next to Stop; at the bottom it stays dots-free (the in-feed
+   *  indicator already covers it). Defaults to `true` — no busy dots — so
+   *  callers that don't track scrolling are unaffected. */
+  atBottom?: boolean;
 }
 
 function fmt(n: number): string {
@@ -51,7 +59,7 @@ export function turnLabel(state: TurnState | undefined, queue: number): string {
  * branching). Fields absent from `meta` (e.g. costUsd, contextWindow) hide
  * gracefully.
  */
-export function StatusBar({ meta, queueDepth = 0, onStop, api, sessionId }: StatusBarProps) {
+export function StatusBar({ meta, queueDepth = 0, onStop, api, sessionId, atBottom = true }: StatusBarProps) {
   const usage = meta?.usage;
   const state = meta?.turnState;
   const queue = Math.max(queueDepth, meta?.queueDepth ?? 0);
@@ -119,6 +127,28 @@ export function StatusBar({ meta, queueDepth = 0, onStop, api, sessionId }: Stat
             {turnLabel(state, queue)}
           </span>
         )}
+        {/* Dots ONLY (never the busy label — that would re-create the exact
+         *  duplication removed above), and visible only while the in-feed
+         *  indicator is actually out of view. This is the sole "still working"
+         *  affordance left for a user who has scrolled up.
+         *
+         *  The element stays MOUNTED for the whole busy period and only toggles
+         *  visibility: mounting/unmounting it would resize the row and shove
+         *  the Stop button sideways every time the user crosses the 80px
+         *  near-bottom threshold — i.e. exactly while they are scrolling.
+         *  `visibility: hidden` (not `display: none`) keeps the box, so the
+         *  reserved space is identical either way. `aria-hidden` while
+         *  invisible keeps it out of the a11y tree, matching the visual. */}
+        {busy ? (
+          <span
+            className={`chat-statusbar__busy${atBottom ? " chat-statusbar__busy--hidden" : ""}`}
+            role="status"
+            aria-label="Agent is working"
+            {...(atBottom ? { "aria-hidden": true } : {})}
+          >
+            <WorkingDots />
+          </span>
+        ) : null}
         {busy && onStop ? (
           <button type="button" className="chat-statusbar__stop btn btn--secondary" onClick={onStop}>
             Stop

--- a/web-ui/src/components/chat/ThinkingBlock.test.tsx
+++ b/web-ui/src/components/chat/ThinkingBlock.test.tsx
@@ -51,4 +51,22 @@ describe("ThinkingBlock label (1.T4 — Decision 4 'Thought for Xs')", () => {
     expect(screen.getAllByText("Thought for 3s")).toHaveLength(1);
     expect(document.querySelector(".chat-thinking__summary")).toBeNull();
   });
+
+  it("renders 'Worked for Xs' instead of 'Thought for Xs' when hadToolCall is set", () => {
+    render(
+      <ThinkingBlock
+        text=""
+        startedTs="2024-01-01T00:00:00.000Z"
+        endedTs="2024-01-01T00:00:06.400Z"
+        hadToolCall
+      />,
+    );
+    expect(screen.getByText("Worked for 6s")).toBeTruthy();
+    expect(screen.queryByText("Thought for 6s")).toBeNull();
+  });
+
+  it("keeps the LIVE label as 'Thinking' even when hadToolCall is set (no 'Working' variant)", () => {
+    render(<ThinkingBlock text="" startedTs="2024-01-01T00:00:00.000Z" hadToolCall />);
+    expect(screen.getByText("Thinking")).toBeTruthy();
+  });
 });

--- a/web-ui/src/components/chat/ThinkingBlock.tsx
+++ b/web-ui/src/components/chat/ThinkingBlock.tsx
@@ -12,6 +12,9 @@ interface ThinkingBlockProps {
    *  meta event, or the first event of the next turn); unset while the
    *  block is still live. */
   endedTs?: string;
+  /** True when a tool call ran while this thinking group was open — the
+   *  completed label reads "Worked for Xs" instead of "Thought for Xs". */
+  hadToolCall?: boolean;
 }
 
 /** "Thought for Xs" once `endedTs` is set, else the live "Thinking" label —
@@ -24,7 +27,9 @@ interface ThinkingBlockProps {
  *  `WorkingIndicator`'s animated dots. In practice `MessageList` no longer
  *  renders a still-open thinking group at all, so the live label only
  *  surfaces via the malformed-timestamp fallback below. */
-function thinkingLabel(startedTs: string, endedTs: string | undefined): string {
+function thinkingLabel(startedTs: string, endedTs: string | undefined, hadToolCall = false): string {
+  // The LIVE label stays "Thinking" either way — only the completed label
+  // distinguishes a reasoning-only span from one that spanned real work.
   if (!endedTs) return "Thinking";
   const seconds = Math.round((Date.parse(endedTs) - Date.parse(startedTs)) / 1000);
   // Either timestamp can be empty/malformed (e.g. test fixtures, or a
@@ -32,17 +37,17 @@ function thinkingLabel(startedTs: string, endedTs: string | undefined): string {
   // is NaN, which would otherwise render "Thought for NaNs". Fall back to the
   // live label rather than showing a broken duration.
   if (!Number.isFinite(seconds)) return "Thinking";
-  return `Thought for ${seconds}s`;
+  return hadToolCall ? `Worked for ${seconds}s` : `Thought for ${seconds}s`;
 }
 
 /** Collapsible dim "Thinking" / "Thought for Xs" reasoning block (Decision 9,
  *  extended by Decision 4). Signature-only / redacted thinking events carry no
  *  text — those render as a plain label with no chevron, since there's
  *  nothing to expand. */
-export function ThinkingBlock({ text, defaultOpen = false, startedTs, endedTs }: ThinkingBlockProps) {
+export function ThinkingBlock({ text, defaultOpen = false, startedTs, endedTs, hadToolCall }: ThinkingBlockProps) {
   const [open, setOpen] = useState(defaultOpen);
   const hasContent = text.trim().length > 0;
-  const label = thinkingLabel(startedTs, endedTs);
+  const label = thinkingLabel(startedTs, endedTs, hadToolCall);
   if (!hasContent) {
     return (
       <div className="chat-thinking">

--- a/web-ui/src/components/chat/WorkingDots.tsx
+++ b/web-ui/src/components/chat/WorkingDots.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+
+/** Milliseconds each dot-count step of `WorkingDots` is shown. */
+const WORKING_INDICATOR_STEP_MS = 450;
+
+/** The animated `•••` dot-cycle shared by the in-feed `WorkingIndicator`
+ *  (MessageList) and the footer `StatusBar`'s scrolled-away busy hint. Dot
+ *  COUNT cycles 1 → 2 → 3 → 1 (not a spinner). Only the dots — every caller
+ *  supplies its own wrapper (live region, label, positioning), so the interval
+ *  and the reduced-motion opt-out live in exactly one place.
+ *
+ *  Mount it only while busy: the interval's lifetime IS the component's, so
+ *  there is no separate start/stop wiring. */
+export function WorkingDots() {
+  const [count, setCount] = useState(1);
+  useEffect(() => {
+    // Explicit `prefers-reduced-motion` check: this dot-cycle's motion is a
+    // JS interval (not CSS-driven, so an `@media (prefers-reduced-motion)`
+    // rule alone can't stop it) — has to honor the opt-out itself.
+    if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
+    const id = window.setInterval(() => {
+      setCount((c) => (c >= 3 ? 1 : c + 1));
+    }, WORKING_INDICATOR_STEP_MS);
+    return () => window.clearInterval(id);
+  }, []);
+  return (
+    <span className="chat-working-indicator__dots" aria-hidden>
+      {[1, 2, 3].map((n) => (
+        <span
+          key={n}
+          className={`chat-working-indicator__dot${n <= count ? " chat-working-indicator__dot--on" : ""}`}
+        />
+      ))}
+    </span>
+  );
+}

--- a/web-ui/src/components/layout/ChatPane.test.tsx
+++ b/web-ui/src/components/layout/ChatPane.test.tsx
@@ -217,3 +217,58 @@ describe("ChatPane thinking-state debounce (1.T7 — Decision 2 anti-flicker)", 
     }
   });
 });
+
+describe("ChatPane atBottom threading (MessageList → ChatPane → StatusBar)", () => {
+  it("passes MessageList's onAtBottomChange through, so the footer busy dots follow the scroll position", async () => {
+    const api = createMockApi();
+    api.__test.pushChatEvent("js-atbottom", ev("u1", { kind: "user", role: "user", text: "hi", turnId: "t1" }));
+    const { container } = render(<ChatPane api={api} session={jsonSession("js-atbottom")} visible />);
+    const mockedMessageList = MessageList as unknown as Mock;
+
+    // Busy, but still at the live edge → in-feed indicator covers it, footer
+    // stays dots-free.
+    act(() => {
+      api.__test.emit({
+        type: "session:meta",
+        sessionId: "js-atbottom",
+        meta: meta("js-atbottom", { turnState: "thinking" }),
+      });
+    });
+    expect(container.querySelector(".chat-statusbar__busy--hidden")).toBeTruthy();
+
+    const onAtBottomChange = mockedMessageList.mock.calls.at(-1)![0].onAtBottomChange;
+    expect(typeof onAtBottomChange).toBe("function");
+
+    // Scrolled away while busy → the footer shows the dots.
+    act(() => onAtBottomChange(false));
+    expect(container.querySelector(".chat-statusbar__busy--hidden")).toBeNull();
+    expect(container.querySelector(".chat-statusbar__busy")).toBeTruthy();
+
+    // Back at the bottom → the dots hide again (the box stays reserved).
+    act(() => onAtBottomChange(true));
+    expect(container.querySelector(".chat-statusbar__busy--hidden")).toBeTruthy();
+  });
+
+  it("resets to at-bottom when the pane switches session, so stale dots don't survive the MessageList remount", async () => {
+    const api = createMockApi();
+    api.__test.pushChatEvent("js-a", ev("u1", { kind: "user", role: "user", text: "hi", turnId: "t1" }));
+    api.__test.pushChatEvent("js-b", ev("u2", { kind: "user", role: "user", text: "hello", turnId: "t2" }));
+    const { container, rerender } = render(<ChatPane api={api} session={jsonSession("js-a")} visible />);
+    const mockedMessageList = MessageList as unknown as Mock;
+
+    act(() => {
+      api.__test.emit({ type: "session:meta", sessionId: "js-a", meta: meta("js-a", { turnState: "thinking" }) });
+    });
+    act(() => mockedMessageList.mock.calls.at(-1)![0].onAtBottomChange(false));
+    expect(container.querySelector(".chat-statusbar__busy--hidden")).toBeNull();
+
+    // Switch to a different conversation: MessageList remounts pinned to the
+    // bottom, so the footer must not keep the previous session's dots — and no
+    // scroll event will ever fire to correct it.
+    rerender(<ChatPane api={api} session={jsonSession("js-b")} visible />);
+    act(() => {
+      api.__test.emit({ type: "session:meta", sessionId: "js-b", meta: meta("js-b", { turnState: "thinking" }) });
+    });
+    expect(container.querySelector(".chat-statusbar__busy--hidden")).toBeTruthy();
+  });
+});

--- a/web-ui/src/components/layout/ChatPane.tsx
+++ b/web-ui/src/components/layout/ChatPane.tsx
@@ -92,6 +92,24 @@ export function ChatPane({ api, session, visible }: ChatPaneProps) {
   // display state flickers the thinking-block/WorkingIndicator affordance.
   // `turnActive` above stays RAW/instant — Composer's busy/Stop gating must
   // never lag behind the real state.
+  // Mirrored up from `MessageList` (which stays the owner of the scroll
+  // measurement) purely so the footer `StatusBar` knows whether the in-feed
+  // working indicator is visible. Defaults to `true`, matching MessageList's
+  // own initial value, so no dots flash before the first scroll event.
+  const [atBottom, setAtBottom] = useState(true);
+  // `ChatPane` is NOT re-keyed per session — this one instance survives a pane
+  // hide (`enabled` flips), a channel toggle and a session switch, while the
+  // `MessageList` below fully unmounts/remounts across all three (the
+  // loading/isEmpty/!enabled branches). Its own `atBottom` resets to `true` on
+  // that remount, but this mirrored copy is only ever written by
+  // `onAtBottomChange`, which by design doesn't fire until a real scroll
+  // happens — so without this reset the footer could keep showing (or keep
+  // hiding) the busy dots based on the PREVIOUS conversation's scroll
+  // position, with no way to self-correct if the new transcript is shorter
+  // than the viewport.
+  useEffect(() => {
+    setAtBottom(true);
+  }, [sessionId, enabled]);
   const [displayTurnState, setDisplayTurnState] = useState(meta?.turnState);
   useEffect(() => {
     const id = setTimeout(() => setDisplayTurnState(meta?.turnState), 250);
@@ -244,6 +262,7 @@ export function ChatPane({ api, session, visible }: ChatPaneProps) {
               api={api}
               {...(sessionId ? { sessionId } : {})}
               onForkTurn={(turnId, message, attachmentIds) => forkTurn(turnId, message, attachmentIds)}
+              onAtBottomChange={setAtBottom}
             />
           )}
         </div>
@@ -266,6 +285,7 @@ export function ChatPane({ api, session, visible }: ChatPaneProps) {
         <StatusBar
           meta={meta}
           queueDepth={trayRows.length}
+          atBottom={atBottom}
           onStop={() => void stop()}
           api={api}
           {...(sessionId ? { sessionId } : {})}

--- a/web-ui/src/styles/chat.css
+++ b/web-ui/src/styles/chat.css
@@ -951,6 +951,19 @@
   gap: var(--space-2);
   flex-shrink: 0;
 }
+/* Busy dots shown left of Stop only while the user is scrolled away from the
+   live edge. Reuses the in-feed `.chat-working-indicator__dot(s)` rules
+   verbatim — this wrapper only centers them in the footer row. */
+.chat-statusbar__busy {
+  display: inline-flex;
+  align-items: center;
+}
+/* Kept in flow (NOT `display: none`) so crossing the near-bottom threshold
+   mid-scroll only fades the dots out — it never re-lays-out the row and
+   shifts the Stop button sideways. */
+.chat-statusbar__busy--hidden {
+  visibility: hidden;
+}
 .chat-statusbar__state {
   /* Text-only since the spinner moved out of this span; the flex box keeps it
      vertically centered against its siblings (Stop button, queue depth). */


### PR DESCRIPTION
## Summary

Two follow-ups to #69 (Rich Chat thinking indicator work), found while dogfooding the merged fix:

1. **"Thought for Xs" never actually rendered in practice.** Verified against live production sessions: real Claude thinking events are almost always empty/signature-only text, not the visible-reasoning case the original fix was tested against. `groupEvents` dropped every empty-text thinking event before a `RenderItem` was ever created, so `ThinkingBlock`'s completed label had nothing to attach to — the feature was effectively dead code for real usage.

2. **No busy affordance once you scroll away from the bottom.** The in-feed working indicator is the only "agent is working" signal, and it scrolls out of view the moment you read back through history.

## Changes

- Stop dropping empty-text thinking events at the source; track whether a group **opened** empty and let the existing `mergeToolRuns` drop-rule keep hiding the ones that genuinely sit between two tool calls (the actual noisy case it was meant for) — a standalone or trailing empty burst now correctly resolves to "Thought for Xs" once its turn ends
- Add a **"Worked for Xs"** label variant for a thinking burst that had a tool call interleaved during it, instead of always "Thought for Xs" — real work happened, not just reasoning. (If late text would otherwise land at a stale, already-passed position in the feed because a tool call ran since the group opened, a fresh `RenderItem` is opened instead of misplacing it.)
- A group that's both empty AND permanently unclosable (imported/`turnId`-less transcripts, or a session that died mid-turn) renders nothing, instead of a stuck-live "Thinking" label forever
- Show the working-indicator dots (no text — the footer text label was deliberately removed in #69, staying removed) to the left of the footer Stop button when the agent is busy **and** the user has scrolled away from the bottom; space is reserved (not mounted/unmounted) so the Stop button doesn't shift as you cross the near-bottom threshold; resets on session/pane switch so it can't go stale

## Test plan

- [x] Full `web-ui` vitest suite: 64 files / 564 tests passing
- [x] Repo-wide typecheck clean (`cli` + `web-ui`)
- [x] Pre-PR opus review pass caught and fixed 3 real issues before this was pushed: a never-closing empty thinking group that would've rendered a permanently stuck "Thinking" label, a late-arriving thinking append that could re-split an already-merged tool run and render at the wrong position, and stale footer-dot state surviving across a session/pane switch (plus 2 minor polish fixes — notify-on-change only, reserved dot spacing)
- [ ] Manual smoke test against a real long-running session with interleaved tool calls, to confirm "Worked for Xs" reads correctly in practice (recommended before merge)