### PR TITLE
Hide/unhide worktrees + fix ⋯ menu first-click bug

### DIFF
--- a/.vibekit/feature-plans/wip/hide-worktrees/.sdlc-state.yaml
+++ b/.vibekit/feature-plans/wip/hide-worktrees/.sdlc-state.yaml
@@ -1,0 +1,19 @@
+feature: hide-worktrees
+worktree: /home/gb/.vibe-station/projects/vibe-station/worktrees/vs-58
+master:
+  prd: skipped
+  plan: complete
+current_subfeature: root
+subfeatures:
+  - id: root
+    origin: planned
+    spawned_from: null
+    mode: implementing
+    last_completed: null
+    awaiting_phase: null
+    awaiting_artifact: null
+    phase_chain: [plan, implement]
+    superseded_reason: null
+    parked_reason: null
+    handoff: {next_item: null, returned_at: null, verified_by: null}
+    commit: null

--- a/.vibekit/feature-plans/wip/hide-worktrees/plan-hide-worktrees.md
+++ b/.vibekit/feature-plans/wip/hide-worktrees/plan-hide-worktrees.md
@@ -1,0 +1,101 @@
+# Plan: hide-worktrees
+
+## Requirements
+- Quickly hide a worktree from the left side panel (per-worktree action, e.g. context menu item).
+- Hidden state is DB-driven on the daemon — syncs across all UI instances (browser tabs, devices), not localStorage.
+- Hiding a pinned worktree also removes it from the pinned list.
+- A per-project UI surface lists all hidden worktrees, with an "unhide" action.
+- Scope: worktrees only. Direct agent sessions are untouched.
+
+## Approach
+Mirror the existing `pinnedAt` pattern (`daemon/src/types.ts` `WorktreeRecord.pinnedAt`,
+`routes/worktrees.ts` `PATCH /worktrees/:id/pin`) with a new `hiddenAt?: string` field on
+`WorktreeRecord`. Same shape: absent ≡ visible, ISO timestamp ≡ hidden (also usable as
+"hidden since" sort key in the hidden-list UI). This keeps the change additive and
+consistent with how pin already works end-to-end (schema → migration → row mapper →
+route → WS broadcast → client → store → UI).
+
+## Checklist
+
+### Daemon
+- [x] 1.1 Add `hiddenAt?: string` to `WorktreeRecord` in `daemon/src/types.ts` (doc comment mirroring `pinnedAt`)
+- [x] 1.2 Add `hiddenAt TEXT` column to the worktrees table in `daemon/src/services/dbSchema.ts` + `addColumnIfMissing` backfill for existing DBs (no separate `dbMigration.ts` needed — that file only handles the legacy-manifest→sqlite import, not column migrations)
+- [x] 1.3 Wire `hiddenAt` through `daemon/src/state/sqliteRowMappers.ts` (row ↔ record) and the `INSERT INTO worktrees` column list in `project-store.ts`
+- [x] 1.4 Add `PATCH /worktrees/:id/hide` route in `daemon/src/routes/worktrees.ts`, body `{ hidden: boolean }` — idempotent, clears `pinnedAt` when hiding, leaves it cleared on unhide, broadcasts `worktree:updated`
+- [x] 1.5 `daemon/src/ws/protocol.ts`'s `worktree:updated` payload is `z.record(z.string(), z.unknown())` (untyped passthrough) — no schema change needed; `serializeWorktree` already emits `hiddenAt`
+
+### Web UI — data layer
+- [x] 2.1 Add `hiddenAt: string | null` to `Worktree` type in `web-ui/src/api/types.ts`
+- [x] 2.2 Add `hideWorktree(id)` / `unhideWorktree(id)` to `web-ui/src/api/client.ts` (mirror `pinWorktree`/`unpinWorktree`)
+- [x] 2.3 `useServerSync.ts`'s `applyWorktreeUpdated` does a full-object replace already — no per-field wiring needed, `hiddenAt` flows through automatically
+- [x] 2.4 Updated `web-ui/src/api/mock.ts` fixtures (5 literals) + added `hideWorktree`/`unhideWorktree` mock handlers; also patched `hiddenAt` into 4 test-file `Worktree` literals that the type change made non-optional
+
+### Web UI — sidebar filtering + hide action
+- [x] 3.1 `worktreeMap` (feeds the normal per-project list) now excludes `hiddenAt != null`; `pinnedWorktrees` filter got `w.hiddenAt == null` added too (defense-in-depth, hide already clears pin server-side)
+- [x] 3.2 Added a "Hide" item to the existing per-worktree overflow menu (`wtMenu`), right after Pin/Unpin
+- [x] 3.3 No optimistic update — matches the existing Pin/Hide-project pattern in this codebase (`// Store stays current via the worktree:updated WS event`), not a gap specific to this feature
+
+### Web UI — hidden worktrees surface (per project)
+- [x] 4.1 Added a "Hidden worktrees (N)" item to the existing per-project overflow menu (`projMenu`), shown only when that project has ≥1 hidden worktree
+- [x] 4.2 New `HiddenWorktreesDialog.tsx` (mirrors `ConfirmDialog`/`Dialog` usage) lists the project's hidden worktrees with an "Unhide" button per row
+- [x] 4.3 Unhide calls `unhideWorktree`; store update (WS `worktree:updated`) removes it from the hidden list and restores it to the normal sidebar list
+
+### Bug fix — worktree overflow menu needs two clicks
+Reported: the `⋯` trigger on a worktree row (`wt-menu-trigger`) doesn't open `wtMenu` on the
+first click right after hovering onto the row; only the second click works. This is the same
+trigger the new "Hide" item (3.2) is being added to, so fix it in this pass rather than
+shipping a new menu item onto a known-flaky trigger.
+
+Likely cause: `.tree-row--worktree .wt-menu-trigger` (`web-ui/src/styles/workspace.css:722-730`)
+sits at `opacity: 0; pointer-events: none` at rest and only flips to
+`opacity: 1; pointer-events: auto` via `.tree-row--worktree:hover .wt-menu-trigger`
+(`workspace.css:748-752`). If the row's hover state and the pointer-events flip aren't both
+settled by the time the click's hit-test runs (e.g. opacity is animated on the compositor
+while pointer-events hit-testing lags a frame behind on the main thread), the first click's
+mousedown can still hit-test as "not interactive" and fall through to whatever is beneath
+(the row's stretch link / drag surface), and only the *second* click — now fully in the
+settled hover state — lands on the button.
+
+- [x] 0.1 Not reproduced live in a browser (no interactive browser session in this pass) — but the codebase already documents the identical symptom for touch: the `@media (hover: none)` block's comment says verbatim "the first tap only landed on the row underneath ... only the SECOND tap actually hit the button", which is this same bug for the case where there's no `:hover` at all. That block only patched touch; mouse users doing a fluid hover-then-click gesture hit the same pointer-events/hover race.
+- [x] 0.2 Root cause confirmed: `pointer-events: none → auto` was gated on the same `:hover`/`:focus-within` match the click needs to land inside, so a click that arrives as part of the same continuous gesture that triggers the hover isn't guaranteed to see the "auto" state in time
+- [x] 0.3 Fix applied: `pointer-events` is now unconditionally `auto` on `.wt-menu-trigger` at rest; only `opacity` (a purely visual property, no hit-testing implication) is still gated on hover/focus. This is the same trade-off the codebase already made for touch, just applied universally instead of behind `@media (hover: none)`.
+- [x] 0.4 Checked all `.wt-menu-trigger` rule sites: plain worktree rows (`workspace.css:722-762`) and pinned rows, both worktree and direct-session (`workspace.css:1063-1072`) — both fixed the same way. The plain (non-pinned) direct-session row's trigger was never gated by a hover-reveal rule in the first place (no matching CSS selector targets it), so it was never affected.
+- [ ] 0.5 Manual re-test not performed live — needs a quick check in the running dev server (hover onto a worktree row and click the ⋯ trigger as one fluid motion) before merging
+
+### Tests
+- [x] 5.1 Daemon: `PATCH /worktrees/:id/hide` route tests — set/clear/idempotent/404/400/TOCTOU/list-shape, plus hide-clears-pin and unhide-does-not-restore-pin (mirrors the existing pin coverage 1:1, `worktrees.test.ts`)
+- [x] 5.2 Daemon: `sqliteRowMappers.test.ts` round-trip + omit-when-null tests for `hiddenAt`; also extended `dbSchema.test.ts` with fresh-DB and legacy-DB-backfill coverage for the new column (mirroring the existing `branchIsPlaceholder` column tests)
+- [x] 5.3 Web UI: sidebar tests — Hide action removes the row from the normal list, hiding a pinned worktree also removes it from the pinned section
+- [x] 5.4 Web UI: hidden-list UI test — project menu shows "Hidden worktrees (N)" only once a worktree is hidden, dialog lists it, Unhide empties the dialog and restores the worktree to the sidebar
+
+All added/touched tests pass: 77 daemon tests (worktrees/sqliteRowMappers/dbSchema), 568/568
+web-ui tests, 804/804 cli/daemon tests overall. `pnpm typecheck` clean on both packages.
+
+## Review (Opus)
+Reviewed the full diff independently. No must-fix issues — hide-implies-unpin logic, client-side
+filtering (including the racy "hidden AND pinned" state, which is benign), the CSS fix, type
+fallout across all `Worktree` literals, and the dialog's a11y basics all checked out. The CSS fix
+was independently re-derived and confirmed, plus the reviewer found a second mechanism it also
+fixes: the trigger's `onPointerDown` stopPropagation (which keeps dnd-kit's drag listeners on the
+row from claiming the gesture) never ran while `pointer-events: none`, so the first pointerdown
+fell through to the drag surface — unconditional `pointer-events: auto` closes both paths.
+
+Nice-to-haves applied:
+- `HiddenWorktreesDialog`'s Unhide button now wraps the API call in try/catch (matches the Hide
+  action's error-handling pattern instead of a bare `void`).
+- Hidden-worktree list now sorts newest-hidden-first (by `hiddenAt` desc) instead of store order.
+- Each Unhide button gets a disambiguating `aria-label`.
+- Hoisted the duplicated `hiddenWorktreeMap[...]?.length` lookup in the project menu to one `const`.
+
+Flagged but explicitly left out of scope: hidden worktrees still appear on the Dashboard (which
+has no `hiddenAt` filter, unlike hidden *projects*, which are filtered from both the sidebar and
+the dashboard). Noted as a deliberate scope call for this pass, not fixed here — worth a follow-up
+if it reads as inconsistent in practice.
+
+Still open: 0.5 (manual browser re-test of the CSS fix) was not performed live in this pass.
+
+## Out of scope
+- Hiding/filtering direct agent sessions.
+- Bulk hide/unhide actions.
+- Auto-expiring or auto-unhiding worktrees.
+- Filtering hidden worktrees from the Dashboard (flagged above, not implemented this pass).

--- a/daemon/src/__tests__/dbSchema.test.ts
+++ b/daemon/src/__tests__/dbSchema.test.ts
@@ -87,3 +87,78 @@ describe("ensureSchema — branchIsPlaceholder column (branch-name-optional)", (
     db.close();
   });
 });
+
+describe("ensureSchema — hiddenAt column (hide-worktrees)", () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "vst-dbschema-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("fresh database: CREATE TABLE already includes hiddenAt, defaulting to NULL", () => {
+    const db = new Database(join(tempDir, "fresh.db"));
+    ensureSchema(db);
+
+    const columns = db.pragma("table_info(worktrees)") as { name: string }[];
+    expect(columns.some((c) => c.name === "hiddenAt")).toBe(true);
+
+    db.prepare(
+      `INSERT INTO projects (id, absolutePath, prefix, isGit, createdAt) VALUES ('proj-1', '/fake/proj-1', 'proj', 1, ?)`,
+    ).run(new Date().toISOString());
+    db.prepare(
+      `INSERT INTO worktrees (id, projectId, branch, createdAt, sortOrder)
+       VALUES ('wt-1', 'proj-1', 'main-ish', ?, 0)`,
+    ).run(new Date().toISOString());
+    const row = db.prepare("SELECT hiddenAt FROM worktrees WHERE id = ?").get("wt-1") as {
+      hiddenAt: string | null;
+    };
+    expect(row.hiddenAt).toBeNull();
+    db.close();
+  });
+
+  it("already-migrated database (pre-existing worktrees table without the column) gets it backfilled via ALTER TABLE, preserving existing rows", () => {
+    const dbPath = join(tempDir, "legacy.db");
+    const db = new Database(dbPath);
+
+    // Simulate a `worktrees` table shape from before this feature existed.
+    db.exec(`
+      CREATE TABLE worktrees (
+        id TEXT PRIMARY KEY,
+        projectId TEXT NOT NULL,
+        name TEXT,
+        branch TEXT NOT NULL,
+        baseBranch TEXT,
+        baseSha TEXT,
+        createdAt TEXT NOT NULL,
+        pinnedAt TEXT,
+        sortOrder REAL NOT NULL,
+        terminalSeq INTEGER NOT NULL DEFAULT 0,
+        agentSeq INTEGER NOT NULL DEFAULT 0,
+        branchIsPlaceholder INTEGER NOT NULL DEFAULT 0
+      );
+    `);
+    db.prepare(
+      `INSERT INTO worktrees (id, projectId, branch, createdAt, sortOrder) VALUES ('wt-old', 'proj-old', 'legacy-branch', ?, 0)`,
+    ).run(new Date().toISOString());
+
+    let columns = db.pragma("table_info(worktrees)") as { name: string }[];
+    expect(columns.some((c) => c.name === "hiddenAt")).toBe(false);
+
+    ensureSchema(db);
+
+    columns = db.pragma("table_info(worktrees)") as { name: string }[];
+    expect(columns.some((c) => c.name === "hiddenAt")).toBe(true);
+
+    const row = db.prepare("SELECT * FROM worktrees WHERE id = ?").get("wt-old") as {
+      branch: string;
+      hiddenAt: string | null;
+    };
+    expect(row.branch).toBe("legacy-branch");
+    expect(row.hiddenAt).toBeNull();
+
+    expect(() => ensureSchema(db)).not.toThrow();
+    db.close();
+  });
+});

--- a/daemon/src/__tests__/sqliteRowMappers.test.ts
+++ b/daemon/src/__tests__/sqliteRowMappers.test.ts
@@ -200,6 +200,40 @@ describe("worktree row <-> record round-trip", () => {
     const row = worktreeToRow(wt, "proj-1");
     expect(rowToWorktree(row, [])).toEqual(wt);
   });
+
+  it("round-trips hiddenAt", () => {
+    const wt: WorktreeRecord = {
+      id: "vs-2",
+      branch: "feature-hidden",
+      baseBranch: "main",
+      baseSha: "0".repeat(40),
+      createdAt: "2024-01-01T00:00:00.000Z",
+      hiddenAt: "2024-01-03T00:00:00.000Z",
+      sortOrder: 1,
+      terminalSeq: 0,
+      agentSeq: 0,
+      sessions: [],
+    };
+    const row = worktreeToRow(wt, "proj-1");
+    expect(rowToWorktree(row, [])).toEqual(wt);
+  });
+
+  it("omits hiddenAt entirely when the row column is NULL", () => {
+    const wt: WorktreeRecord = {
+      id: "vs-3",
+      branch: "feature-visible",
+      baseBranch: "main",
+      baseSha: "0".repeat(40),
+      createdAt: "2024-01-01T00:00:00.000Z",
+      sortOrder: 1,
+      terminalSeq: 0,
+      agentSeq: 0,
+      sessions: [],
+    };
+    const row = worktreeToRow(wt, "proj-1");
+    expect(row.hiddenAt).toBeNull();
+    expect(rowToWorktree(row, []).hiddenAt).toBeUndefined();
+  });
 });
 
 describe("project row <-> record round-trip", () => {

--- a/daemon/src/__tests__/worktrees.test.ts
+++ b/daemon/src/__tests__/worktrees.test.ts
@@ -117,7 +117,7 @@ describe("Worktree routes", () => {
       payload: { projectId, branch: `${prefix}-${branchSuffix}-${Date.now()}`, modeId: "bug-fix" },
     });
     expect(res.statusCode).toBe(201);
-    return res.json<{ id: string; pinnedAt: string | null }>();
+    return res.json<{ id: string; pinnedAt: string | null; hiddenAt: string | null }>();
   }
 
   it("GET /worktrees?project=:id returns empty array initially", async () => {
@@ -872,6 +872,123 @@ describe("Worktree routes", () => {
       }
       const pinned = items.find((w) => w.id === wt.id);
       expect(pinned?.pinnedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+  });
+
+  // ─── PATCH /worktrees/:id/hide ──────────────────────────────────────────
+  describe("PATCH /worktrees/:id/hide", () => {
+    it("serializes hiddenAt as null for a visible worktree", async () => {
+      const wt = await createWorktree("hide", "unhidden");
+      expect(wt.hiddenAt).toBeNull();
+    });
+
+    it("PATCH { hidden: true } sets hiddenAt to an ISO timestamp", async () => {
+      const wt = await createWorktree("hide", "set");
+      const res = await app.inject({
+        method: "PATCH",
+        url: `/worktrees/${wt.id}/hide`,
+        payload: { hidden: true },
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json<{ ok: boolean; worktree: { id: string; hiddenAt: string | null } }>();
+      expect(body.ok).toBe(true);
+      expect(body.worktree.id).toBe(wt.id);
+      expect(body.worktree.hiddenAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    it("PATCH { hidden: false } clears hiddenAt", async () => {
+      const wt = await createWorktree("hide", "clear");
+      await app.inject({ method: "PATCH", url: `/worktrees/${wt.id}/hide`, payload: { hidden: true } });
+      const res = await app.inject({
+        method: "PATCH",
+        url: `/worktrees/${wt.id}/hide`,
+        payload: { hidden: false },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json<{ worktree: { hiddenAt: string | null } }>().worktree.hiddenAt).toBeNull();
+    });
+
+    it("is idempotent: hiding twice keeps the original timestamp", async () => {
+      const wt = await createWorktree("hide", "idempotent");
+      const first = await app.inject({
+        method: "PATCH",
+        url: `/worktrees/${wt.id}/hide`,
+        payload: { hidden: true },
+      });
+      const ts1 = first.json<{ worktree: { hiddenAt: string } }>().worktree.hiddenAt;
+      await new Promise((r) => setTimeout(r, 10));
+      const second = await app.inject({
+        method: "PATCH",
+        url: `/worktrees/${wt.id}/hide`,
+        payload: { hidden: true },
+      });
+      expect(second.statusCode).toBe(200);
+      expect(second.json<{ worktree: { hiddenAt: string } }>().worktree.hiddenAt).toBe(ts1);
+    });
+
+    it("hiding a pinned worktree clears pinnedAt in the same update", async () => {
+      const wt = await createWorktree("hide", "unpin-on-hide");
+      await app.inject({ method: "PATCH", url: `/worktrees/${wt.id}/pin`, payload: { pinned: true } });
+      const res = await app.inject({
+        method: "PATCH",
+        url: `/worktrees/${wt.id}/hide`,
+        payload: { hidden: true },
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json<{ worktree: { pinnedAt: string | null; hiddenAt: string | null } }>();
+      expect(body.worktree.hiddenAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      expect(body.worktree.pinnedAt).toBeNull();
+    });
+
+    it("unhiding does not restore a pin that was cleared by hiding", async () => {
+      const wt = await createWorktree("hide", "no-restore-pin");
+      await app.inject({ method: "PATCH", url: `/worktrees/${wt.id}/pin`, payload: { pinned: true } });
+      await app.inject({ method: "PATCH", url: `/worktrees/${wt.id}/hide`, payload: { hidden: true } });
+      const res = await app.inject({
+        method: "PATCH",
+        url: `/worktrees/${wt.id}/hide`,
+        payload: { hidden: false },
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json<{ worktree: { pinnedAt: string | null; hiddenAt: string | null } }>();
+      expect(body.worktree.hiddenAt).toBeNull();
+      expect(body.worktree.pinnedAt).toBeNull();
+    });
+
+    it("returns 404 for an unknown worktree id", async () => {
+      const res = await app.inject({
+        method: "PATCH",
+        url: "/worktrees/does-not-exist/hide",
+        payload: { hidden: true },
+      });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it("returns 400 for an invalid body", async () => {
+      const wt = await createWorktree("hide", "badbody");
+      const res = await app.inject({
+        method: "PATCH",
+        url: `/worktrees/${wt.id}/hide`,
+        payload: { hidden: "yes" },
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it("GET /worktrees response includes hiddenAt for every record", async () => {
+      const wt = await createWorktree("hide", "listshape");
+      await app.inject({
+        method: "PATCH",
+        url: `/worktrees/${wt.id}/hide`,
+        payload: { hidden: true },
+      });
+      const res = await app.inject({ method: "GET", url: "/worktrees" });
+      expect(res.statusCode).toBe(200);
+      const items = res.json<Array<{ id: string; hiddenAt: string | null }>>();
+      for (const w of items) {
+        expect(w).toHaveProperty("hiddenAt");
+      }
+      const hidden = items.find((w) => w.id === wt.id);
+      expect(hidden?.hiddenAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     });
   });
 

--- a/daemon/src/routes/worktrees.ts
+++ b/daemon/src/routes/worktrees.ts
@@ -136,8 +136,9 @@ export function serializeWorktree(projectId: string, w: WorktreeRecord) {
     baseBranch: w.baseBranch,
     baseSha: w.baseSha,
     createdAt: w.createdAt,
-    // Always emit pinnedAt so the client doesn't have to special-case undefined.
+    // Always emit pinnedAt/hiddenAt so the client doesn't have to special-case undefined.
     pinnedAt: w.pinnedAt ?? null,
+    hiddenAt: w.hiddenAt ?? null,
     sortOrder: w.sortOrder,
     // Id of the worktree's main agent session (isMain === true — replaces the
     // old slot==="m" check, Decision 1). Lets the create-dialog JSON path
@@ -656,6 +657,84 @@ export function registerWorktreeRoutes(app: FastifyInstance): void {
       // Broadcast after the lock has been released — `applyWorktreeUpdated`
       // on the client drops unknown ids, so any reorder with a concurrent
       // `worktree:deleted` is benign.
+      broadcastAll({ type: "worktree:updated", worktree: apiWorktree });
+    }
+    return reply.send({ ok: true, worktree: apiWorktree });
+  });
+
+  // PATCH /worktrees/:id/hide   { hidden: boolean }
+  // Toggles WorktreeRecord.hiddenAt. Idempotent: no-op when already in the
+  // requested state, same rationale as /pin above. Hiding a pinned worktree
+  // clears pinnedAt in the same update — a hidden worktree never sits in the
+  // pinned section. Unhiding does not restore the pin.
+  app.patch("/worktrees/:id/hide", async (req, reply) => {
+    const { id: wtId } = req.params as { id: string };
+    const bodySchema = z.object({ hidden: z.boolean() });
+    const parsed = bodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      return reply.status(400).send({ error: "Validation error", details: parsed.error.issues });
+    }
+    const { hidden } = parsed.data;
+
+    const project = getAllProjects().find((p) => p.worktrees.some((w) => w.id === wtId));
+    if (!project) return reply.status(404).send({ error: `Worktree '${wtId}' not found` });
+
+    let outcome:
+      | { kind: "not_found" }
+      | { kind: "noop"; worktree: WorktreeRecord }
+      | { kind: "updated"; worktree: WorktreeRecord } = { kind: "not_found" } as
+      | { kind: "not_found" }
+      | { kind: "noop"; worktree: WorktreeRecord }
+      | { kind: "updated"; worktree: WorktreeRecord };
+
+    try {
+      await mutateProject(project.id, (p) => {
+        const wt = p.worktrees.find((w) => w.id === wtId);
+        if (!wt) {
+          outcome = { kind: "not_found" };
+          return p;
+        }
+        const alreadyHidden = wt.hiddenAt != null;
+        if (alreadyHidden === hidden) {
+          outcome = { kind: "noop", worktree: wt };
+          return p;
+        }
+        const next: ProjectRecord = {
+          ...p,
+          worktrees: p.worktrees.map((w) => {
+            if (w.id !== wtId) return w;
+            if (hidden) {
+              // Hide implies unpin — a hidden worktree never sits in the
+              // pinned section, so drop pinnedAt in the same update.
+              const { pinnedAt: _dropPinned, ...rest } = w;
+              void _dropPinned;
+              return { ...rest, hiddenAt: new Date().toISOString() };
+            }
+            const { hiddenAt: _dropHidden, ...rest } = w;
+            void _dropHidden;
+            return rest;
+          }),
+        };
+        const after = next.worktrees.find((w) => w.id === wtId);
+        if (!after) {
+          outcome = { kind: "not_found" };
+          return p;
+        }
+        outcome = { kind: "updated", worktree: after };
+        return next;
+      });
+    } catch (err) {
+      if (err instanceof Error && /not found/i.test(err.message)) {
+        return reply.status(404).send({ error: `Worktree '${wtId}' not found` });
+      }
+      throw err;
+    }
+
+    if (outcome.kind === "not_found") {
+      return reply.status(404).send({ error: `Worktree '${wtId}' not found` });
+    }
+    const apiWorktree = serializeWorktree(project.id, outcome.worktree);
+    if (outcome.kind === "updated") {
       broadcastAll({ type: "worktree:updated", worktree: apiWorktree });
     }
     return reply.send({ ok: true, worktree: apiWorktree });

--- a/daemon/src/services/dbSchema.ts
+++ b/daemon/src/services/dbSchema.ts
@@ -42,6 +42,7 @@ export function ensureSchema(db: Database): void {
       baseSha TEXT,
       createdAt TEXT NOT NULL,
       pinnedAt TEXT,
+      hiddenAt TEXT,
       sortOrder REAL NOT NULL,
       terminalSeq INTEGER NOT NULL DEFAULT 0,
       agentSeq INTEGER NOT NULL DEFAULT 0,
@@ -99,6 +100,10 @@ export function ensureSchema(db: Database): void {
   // COLUMN` (idempotent: skipped once the column is present, safe to run on
   // every `getDb()` open like the rest of this function).
   addColumnIfMissing(db, "worktrees", "branchIsPlaceholder", "INTEGER NOT NULL DEFAULT 0");
+  // hiddenAt (hide-worktrees) — set when a worktree is hidden from the
+  // sidebar. NULL for every worktree created before this column existed
+  // (the common case) and for any worktree that has never been hidden.
+  addColumnIfMissing(db, "worktrees", "hiddenAt", "TEXT");
   // spawnedFrom (agent-interaction-workspaces/04-workspaces Phase 4a) — the
   // sessionId this session was spawned from (via the in-app dialogs or a
   // running agent's own `vst --source-agent` shell), or NULL when spawned

--- a/daemon/src/state/project-store.ts
+++ b/daemon/src/state/project-store.ts
@@ -254,8 +254,8 @@ function writeProjectFull(record: ProjectRecord): void {
     db.prepare("DELETE FROM worktrees WHERE projectId = ?").run(p.id);
 
     const insertWorktree = db.prepare(
-      `INSERT INTO worktrees (id, projectId, name, branch, baseBranch, baseSha, createdAt, pinnedAt, sortOrder, terminalSeq, agentSeq, branchIsPlaceholder)
-       VALUES (@id, @projectId, @name, @branch, @baseBranch, @baseSha, @createdAt, @pinnedAt, @sortOrder, @terminalSeq, @agentSeq, @branchIsPlaceholder)`,
+      `INSERT INTO worktrees (id, projectId, name, branch, baseBranch, baseSha, createdAt, pinnedAt, hiddenAt, sortOrder, terminalSeq, agentSeq, branchIsPlaceholder)
+       VALUES (@id, @projectId, @name, @branch, @baseBranch, @baseSha, @createdAt, @pinnedAt, @hiddenAt, @sortOrder, @terminalSeq, @agentSeq, @branchIsPlaceholder)`,
     );
     const insertSession = db.prepare(
       `INSERT INTO sessions (id, worktreeId, projectId, isMain, sortOrder, type, modeId, name, nameSource, tmuxName, useTmux, channel, state, reason, lastTransitionAt, transcriptKind, transcriptPath, agentChatId, modelOverride, pinnedAt, initialPrompt, archivedAt, handoffSummary, spawnedFrom, supersededBy, prState, prNumber, prUrl, prCheckedAt, prBranch)

--- a/daemon/src/state/sqliteRowMappers.ts
+++ b/daemon/src/state/sqliteRowMappers.ts
@@ -163,6 +163,7 @@ export interface WorktreeRow {
   baseSha: string | null;
   createdAt: string;
   pinnedAt: string | null;
+  hiddenAt: string | null;
   sortOrder: number;
   terminalSeq: number;
   agentSeq: number;
@@ -179,6 +180,7 @@ export function rowToWorktree(row: WorktreeRow, sessions: SessionRecord[]): Work
     baseSha: row.baseSha ?? "",
     createdAt: row.createdAt,
     ...(row.pinnedAt != null ? { pinnedAt: row.pinnedAt } : {}),
+    ...(row.hiddenAt != null ? { hiddenAt: row.hiddenAt } : {}),
     sortOrder: row.sortOrder,
     terminalSeq: row.terminalSeq,
     agentSeq: row.agentSeq,
@@ -196,6 +198,7 @@ export function worktreeToRow(w: WorktreeRecord, projectId: string): WorktreeRow
     baseSha: w.baseSha ?? null,
     createdAt: w.createdAt,
     pinnedAt: w.pinnedAt ?? null,
+    hiddenAt: w.hiddenAt ?? null,
     sortOrder: w.sortOrder ?? 0,
     terminalSeq: w.terminalSeq ?? 0,
     agentSeq: w.agentSeq ?? 0,

--- a/daemon/src/types.ts
+++ b/daemon/src/types.ts
@@ -326,6 +326,13 @@ export interface WorktreeRecord {
    * (newest pinned first), so we don't need a separate sort field.
    */
   pinnedAt?: string; // ISO8601
+  /**
+   * When set, this worktree is hidden from the sidebar (both the normal list
+   * and the pinned section) and surfaces only in the project's "Hidden
+   * worktrees" list. Absent ≡ visible. Hiding a pinned worktree clears
+   * `pinnedAt` in the same update — unhiding does not restore the pin.
+   */
+  hiddenAt?: string; // ISO8601
   /** Fractional display-order rank among a project's worktrees (F9 — reordering itself is Part 03). */
   sortOrder: number;
   /**

--- a/web-ui/src/api/client.ts
+++ b/web-ui/src/api/client.ts
@@ -350,6 +350,26 @@ export function createClientApi() {
       return parseJson<{ ok: true; worktree: Worktree }>(res);
     },
 
+    async hideWorktree(id: string): Promise<{ ok: true; worktree: Worktree }> {
+      const root = baseUrl();
+      const res = await apiFetch(`${root}/worktrees/${encodeURIComponent(id)}/hide`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ hidden: true }),
+      });
+      return parseJson<{ ok: true; worktree: Worktree }>(res);
+    },
+
+    async unhideWorktree(id: string): Promise<{ ok: true; worktree: Worktree }> {
+      const root = baseUrl();
+      const res = await apiFetch(`${root}/worktrees/${encodeURIComponent(id)}/hide`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ hidden: false }),
+      });
+      return parseJson<{ ok: true; worktree: Worktree }>(res);
+    },
+
     /** Cosmetic rename (F2). Empty string clears back to the default (falls back to `branch`). */
     async renameWorktree(id: string, name: string): Promise<{ ok: true; name: string | null }> {
       const root = baseUrl();

--- a/web-ui/src/api/mock.ts
+++ b/web-ui/src/api/mock.ts
@@ -89,6 +89,7 @@ export function createMockApi() {
       baseSha: "abc123",
       createdAt: nowIso(),
       pinnedAt: null,
+      hiddenAt: null,
       sortOrder: 1,
     },
     {
@@ -99,6 +100,7 @@ export function createMockApi() {
       baseSha: "def456",
       createdAt: nowIso(),
       pinnedAt: null,
+      hiddenAt: null,
       sortOrder: 2,
     },
     {
@@ -109,6 +111,7 @@ export function createMockApi() {
       baseSha: "fed789",
       createdAt: nowIso(),
       pinnedAt: null,
+      hiddenAt: null,
       sortOrder: 1,
     },
   ];
@@ -384,6 +387,7 @@ export function createMockApi() {
         baseSha: "mock-base-sha",
         createdAt: nowIso(),
         pinnedAt: null,
+        hiddenAt: null,
         mainSessionId: `${wtId}-m`,
       };
       worktrees.push(wt);
@@ -459,6 +463,27 @@ export function createMockApi() {
       if (!wt) throw new ApiError("not found", 404);
       if (wt.pinnedAt != null) {
         wt.pinnedAt = null;
+        emit({ type: "worktree:updated", worktree: structuredClone(wt) });
+      }
+      return { ok: true, worktree: structuredClone(wt) };
+    },
+
+    async hideWorktree(id: string): Promise<{ ok: true; worktree: Worktree }> {
+      const wt = worktrees.find((w) => w.id === id);
+      if (!wt) throw new ApiError("not found", 404);
+      if (wt.hiddenAt == null) {
+        wt.hiddenAt = new Date().toISOString();
+        wt.pinnedAt = null; // hide implies unpin, mirrors the daemon route
+        emit({ type: "worktree:updated", worktree: structuredClone(wt) });
+      }
+      return { ok: true, worktree: structuredClone(wt) };
+    },
+
+    async unhideWorktree(id: string): Promise<{ ok: true; worktree: Worktree }> {
+      const wt = worktrees.find((w) => w.id === id);
+      if (!wt) throw new ApiError("not found", 404);
+      if (wt.hiddenAt != null) {
+        wt.hiddenAt = null;
         emit({ type: "worktree:updated", worktree: structuredClone(wt) });
       }
       return { ok: true, worktree: structuredClone(wt) };
@@ -1038,6 +1063,7 @@ export function createMockApi() {
             baseSha: "mock-base-sha",
             createdAt: nowIso(),
             pinnedAt: null,
+            hiddenAt: null,
             sortOrder: Date.now(),
           };
           worktrees.push(wt);

--- a/web-ui/src/api/types.ts
+++ b/web-ui/src/api/types.ts
@@ -36,6 +36,12 @@ export interface Worktree {
    * default sort order (newest first).
    */
   pinnedAt: string | null;
+  /**
+   * ISO8601 timestamp set when the user hides this worktree from the
+   * sidebar; null when visible. Hidden worktrees surface only in the
+   * project's "Hidden worktrees" list. Hiding clears `pinnedAt` server-side.
+   */
+  hiddenAt: string | null;
   /** Fractional display-order rank among a project's worktrees (F9). Optional for legacy/test fixtures predating this field. */
   sortOrder?: number;
   /**

--- a/web-ui/src/components/dialogs/HiddenWorktreesDialog.tsx
+++ b/web-ui/src/components/dialogs/HiddenWorktreesDialog.tsx
@@ -1,0 +1,61 @@
+import type { ApiInstance } from "@/api";
+import type { Worktree } from "@/api/types";
+import { Dialog } from "./Dialog";
+
+interface HiddenWorktreesDialogProps {
+  open: boolean;
+  /** Hidden worktrees for the project this dialog was opened from. */
+  worktrees: Worktree[];
+  api: ApiInstance;
+  onClose: () => void;
+}
+
+/** Per-project list of hidden worktrees (see `wtMenu`'s "Hide" item in
+ *  LeftSidebar), with an "Unhide" action per row. Opened from the project's
+ *  overflow menu — a hidden worktree has no other UI surface once hidden. */
+export function HiddenWorktreesDialog({ open, worktrees, api, onClose }: HiddenWorktreesDialogProps) {
+  return (
+    <Dialog open={open} title="Hidden worktrees" onClose={onClose}>
+      {worktrees.length === 0 ? (
+        <p style={{ margin: 0, fontSize: "var(--font-size-sm)", color: "var(--fg-secondary)" }}>
+          No hidden worktrees.
+        </p>
+      ) : (
+        <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+          {worktrees
+            .slice()
+            .sort((a, b) => (b.hiddenAt ?? "").localeCompare(a.hiddenAt ?? ""))
+            .map((w) => {
+              const label = w.name ?? w.branch;
+              return (
+                <li
+                  key={w.id}
+                  style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "var(--space-2)" }}
+                >
+                  <span style={{ fontSize: "var(--font-size-sm)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                    {label}
+                  </span>
+                  <button
+                    type="button"
+                    aria-label={`Unhide ${label}`}
+                    onClick={() => {
+                      void (async () => {
+                        try {
+                          await api.unhideWorktree(w.id);
+                          // Store stays current via the `worktree:updated` WS event.
+                        } catch {
+                          /* surface errors later */
+                        }
+                      })();
+                    }}
+                  >
+                    Unhide
+                  </button>
+                </li>
+              );
+            })}
+        </ul>
+      )}
+    </Dialog>
+  );
+}

--- a/web-ui/src/components/dialogs/NewAgentDialog.noMainSession.test.tsx
+++ b/web-ui/src/components/dialogs/NewAgentDialog.noMainSession.test.tsx
@@ -23,6 +23,7 @@ describe("NewAgentDialog — worktree with no mainSessionId", () => {
       baseSha: "0".repeat(40),
       createdAt: new Date().toISOString(),
       pinnedAt: null,
+      hiddenAt: null,
       mainSessionId: null,
     }));
     const chatSpy = vi.spyOn(api, "sendChat");

--- a/web-ui/src/components/layout/LeftSidebar.test.tsx
+++ b/web-ui/src/components/layout/LeftSidebar.test.tsx
@@ -459,6 +459,7 @@ describe("LeftSidebar", () => {
           baseSha: "abc123",
           createdAt: new Date().toISOString(),
           pinnedAt: new Date().toISOString(),
+          hiddenAt: null,
         },
       });
 
@@ -502,6 +503,7 @@ describe("LeftSidebar", () => {
             baseSha: "def456",
             createdAt: new Date().toISOString(),
             pinnedAt: new Date(now - 10000).toISOString(),
+            hiddenAt: null,
           },
         });
       });
@@ -512,6 +514,95 @@ describe("LeftSidebar", () => {
         );
         expect(labels).toEqual(["direct-agent-1", "wt-2"]);
       });
+    });
+  });
+
+  // ─── Worktree hiding ─────────────────────────────────────────────────────
+  describe("worktree hiding", () => {
+    it("Hide action in the ⋯ menu calls api.hideWorktree and the row disappears from the sidebar", async () => {
+      const localApi = createMockApi();
+      const user = userEvent.setup();
+      render(
+        <MemoryRouter>
+          <Harness api={localApi}>
+            <LeftSidebar api={localApi} />
+          </Harness>
+        </MemoryRouter>,
+      );
+      await screen.findByRole("link", { name: /Open worktree wt-1/i });
+
+      const wtRow = screen.getByRole("link", { name: /Open worktree wt-1/i }).closest(".tree-row")!;
+      const trigger = wtRow.querySelector("[data-wt-menu-trigger]")! as HTMLElement;
+      await user.click(trigger);
+
+      const hideItem = await screen.findByRole("menuitem", { name: /^hide$/i });
+      await user.click(hideItem);
+
+      await waitFor(() => {
+        expect(screen.queryByRole("link", { name: /Open worktree wt-1/i })).toBeNull();
+      });
+    });
+
+    it("hiding a pinned worktree removes it from the pinned section too", async () => {
+      const localApi = createMockApi();
+      await localApi.pinWorktree("wt-1");
+      const user = userEvent.setup();
+      render(
+        <MemoryRouter>
+          <Harness api={localApi}>
+            <LeftSidebar api={localApi} />
+          </Harness>
+        </MemoryRouter>,
+      );
+      await screen.findByRole("region", { name: /^pinned$/i });
+
+      const pinnedLink = screen.getByRole("link", { name: /Open pinned worktree wt-1/i });
+      const pinnedRow = pinnedLink.closest(".pinned-row")! as HTMLElement;
+      const trigger = pinnedRow.querySelector("[data-wt-menu-trigger]")! as HTMLElement;
+      await user.click(trigger);
+
+      const hideItem = await screen.findByRole("menuitem", { name: /^hide$/i });
+      await user.click(hideItem);
+
+      await waitFor(() => {
+        expect(screen.queryByRole("region", { name: /^pinned$/i })).toBeNull();
+      });
+      expect(screen.queryByRole("link", { name: /Open worktree wt-1/i })).toBeNull();
+    });
+
+    it("project menu shows a Hidden worktrees item only once the project has a hidden worktree, and Unhide restores it", async () => {
+      const localApi = createMockApi();
+      const user = userEvent.setup();
+      render(
+        <MemoryRouter>
+          <Harness api={localApi}>
+            <LeftSidebar api={localApi} />
+          </Harness>
+        </MemoryRouter>,
+      );
+      await screen.findByText("Proj A");
+
+      // No hidden worktrees yet — the item shouldn't be in the project menu.
+      await user.click(screen.getAllByRole("button", { name: /Project actions for Proj A/i })[0]!);
+      expect(screen.queryByRole("menuitem", { name: /Hidden worktrees/i })).not.toBeInTheDocument();
+      await user.keyboard("{Escape}");
+
+      await localApi.hideWorktree("wt-1");
+
+      await user.click(screen.getAllByRole("button", { name: /Project actions for Proj A/i })[0]!);
+      const hiddenItem = await screen.findByRole("menuitem", { name: /Hidden worktrees \(1\)/i });
+      await user.click(hiddenItem);
+
+      const dialog = await screen.findByRole("dialog", { name: /Hidden worktrees/i });
+      expect(within(dialog).getByText("wt-1")).toBeInTheDocument();
+
+      await user.click(within(dialog).getByRole("button", { name: /unhide/i }));
+
+      await waitFor(() => {
+        expect(within(dialog).getByText("No hidden worktrees.")).toBeInTheDocument();
+      });
+      // The worktree is back in the normal sidebar list.
+      expect(screen.getByRole("link", { name: /Open worktree wt-1/i })).toBeInTheDocument();
     });
   });
 

--- a/web-ui/src/components/layout/LeftSidebar.tsx
+++ b/web-ui/src/components/layout/LeftSidebar.tsx
@@ -1,4 +1,4 @@
-import { Check, ChevronDown, ChevronRight, EyeOff, Filter, Folder, FolderOpen, FolderPlus, FolderTree, Moon, MoreHorizontal, Pin, Plus, SlidersHorizontal, Trash2, Type } from "lucide-react";
+import { Check, ChevronDown, ChevronRight, Eye, EyeOff, Filter, Folder, FolderOpen, FolderPlus, FolderTree, Moon, MoreHorizontal, Pin, Plus, SlidersHorizontal, Trash2, Type } from "lucide-react";
 import { useTheme } from "@/hooks/useTheme";
 import { createPortal } from "react-dom";
 import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from "react";
@@ -29,6 +29,7 @@ import { worktreePrStatus } from "@/lib/statusColor";
 import { worktreeRolledUpStatus, type WorktreeRolledUpStatus } from "@/lib/worktreeStatus";
 import { sessionLabel } from "@/lib/sessionLabel";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
+import { HiddenWorktreesDialog } from "@/components/dialogs/HiddenWorktreesDialog";
 import { NewSessionDialog } from "@/components/dialogs/NewSessionDialog";
 import { NewAgentDialog } from "@/components/dialogs/NewAgentDialog";
 import { DirectAgentDialog } from "@/components/dialogs/DirectAgentDialog";
@@ -183,9 +184,25 @@ export function LeftSidebar({
   const projects = useServerStore((s) => s.projects);
   const worktrees = useServerStore((s) => s.worktrees);
   const sessions = useServerStore((s) => s.sessions);
+  /** Non-hidden worktrees, grouped by project — the only ones rendered in the
+   *  normal per-project list. Hidden worktrees surface only via `hiddenWorktreeMap`
+   *  below (the project's "Hidden worktrees" dialog). */
   const worktreeMap = useMemo(() => {
     const m: Record<string, Worktree[]> = {};
-    for (const w of worktrees) (m[w.projectId] ??= []).push(w);
+    for (const w of worktrees) {
+      if (w.hiddenAt != null) continue;
+      (m[w.projectId] ??= []).push(w);
+    }
+    return m;
+  }, [worktrees]);
+  /** Hidden worktrees, grouped by project — feeds the "Hidden worktrees" dialog
+   *  and the count shown in the project overflow menu. */
+  const hiddenWorktreeMap = useMemo(() => {
+    const m: Record<string, Worktree[]> = {};
+    for (const w of worktrees) {
+      if (w.hiddenAt == null) continue;
+      (m[w.projectId] ??= []).push(w);
+    }
     return m;
   }, [worktrees]);
   const sessionMap = useMemo(() => {
@@ -252,7 +269,7 @@ export function LeftSidebar({
   const pinnedWorktrees = useMemo(
     () =>
       worktrees
-        .filter((w) => w.pinnedAt != null && !hiddenProjectIds.has(w.projectId))
+        .filter((w) => w.pinnedAt != null && w.hiddenAt == null && !hiddenProjectIds.has(w.projectId))
         .slice()
         .sort((a, b) => (b.pinnedAt ?? "").localeCompare(a.pinnedAt ?? "")),
     [worktrees, hiddenProjectIds],
@@ -564,6 +581,8 @@ export function LeftSidebar({
   const visible = isMobile ? mobileSidebarOpen : !collapsed;
   const prevVisibleRef = useRef<boolean>(!visible);
   const [filterMenuRect, setFilterMenuRect] = useState<DOMRect | null>(null);
+  /** Id of the project whose "Hidden worktrees" dialog is open, or null when closed. */
+  const [hiddenWtDialogProjectId, setHiddenWtDialogProjectId] = useState<string | null>(null);
   const [pendingDelete, setPendingDelete] = useState<Worktree | null>(null);
   const [pendingDismiss, setPendingDismiss] = useState<Worktree | null>(null);
   const [pendingTerminateSession, setPendingTerminateSession] = useState<Session | null>(null);
@@ -1795,6 +1814,13 @@ export function LeftSidebar({
         />
       ) : null}
 
+      <HiddenWorktreesDialog
+        open={hiddenWtDialogProjectId !== null}
+        worktrees={hiddenWtDialogProjectId ? (hiddenWorktreeMap[hiddenWtDialogProjectId] ?? []) : []}
+        api={api}
+        onClose={() => setHiddenWtDialogProjectId(null)}
+      />
+
       <ConfirmDialog
         open={pendingDelete !== null}
         title="Delete worktree?"
@@ -1894,6 +1920,27 @@ export function LeftSidebar({
                   fill={wtMenu.worktree.pinnedAt != null ? "currentColor" : "none"}
                 />
                 {wtMenu.worktree.pinnedAt != null ? "Unpin" : "Pin to top"}
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                className="menu-pop__item menu-pop__item--icon"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  const wtId = wtMenu.worktree.id;
+                  setWtMenu(null);
+                  void (async () => {
+                    try {
+                      await api.hideWorktree(wtId);
+                      // Store stays current via the `worktree:updated` WS event.
+                    } catch {
+                      /* surface errors later */
+                    }
+                  })();
+                }}
+              >
+                <EyeOff size={13} aria-hidden />
+                Hide
               </button>
               <button
                 type="button"
@@ -2071,6 +2118,25 @@ export function LeftSidebar({
                 <EyeOff size={13} aria-hidden />
                 Hide project
               </button>
+              {(() => {
+                const hiddenCount = hiddenWorktreeMap[projMenu.project.id]?.length ?? 0;
+                if (hiddenCount === 0) return null;
+                return (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className="menu-pop__item menu-pop__item--icon"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setHiddenWtDialogProjectId(projMenu.project.id);
+                      setProjMenu(null);
+                    }}
+                  >
+                    <Eye size={13} aria-hidden />
+                    {`Hidden worktrees (${hiddenCount})`}
+                  </button>
+                );
+              })()}
             </div>,
             document.body,
           )

--- a/web-ui/src/components/layout/TopBar.test.tsx
+++ b/web-ui/src/components/layout/TopBar.test.tsx
@@ -21,7 +21,7 @@ const projects: Project[] = [
   },
 ];
 const worktrees: Worktree[] = [
-  { id: W1, projectId: "proj-1", branch: "main", baseBranch: "main", createdAt: new Date().toISOString(), pinnedAt: null },
+  { id: W1, projectId: "proj-1", branch: "main", baseBranch: "main", createdAt: new Date().toISOString(), pinnedAt: null, hiddenAt: null },
 ];
 
 const emptyCanvas: CanvasGeometry = { mode: "free", tiles: [], tree: null, freeRects: {} };

--- a/web-ui/src/styles/workspace.css
+++ b/web-ui/src/styles/workspace.css
@@ -719,13 +719,22 @@
   transition: opacity var(--transition-fast);
 }
 
+/* `pointer-events` used to gate on `:hover`/`:focus-within` alongside opacity
+ * (none at rest, auto on hover) — the same pattern the touch-device fix below
+ * already had to abandon: gating clickability on a `:hover` match that hasn't
+ * necessarily settled by the time the paired click's hit-test runs means a
+ * single fluid "move onto the row and click" gesture can land its first click
+ * before the browser treats the trigger as interactive, so only the second,
+ * separate click (now safely inside a settled hover state) opens the menu.
+ * Always-auto removes the race outright; opacity alone still hides the
+ * trigger visually at rest. */
 .tree-row--worktree .wt-menu-trigger {
   position: absolute;
   right: 0;
   top: 50%;
   transform: translateY(-50%);
   opacity: 0;
-  pointer-events: none;
+  pointer-events: auto;
   transition: opacity var(--transition-fast);
 }
 
@@ -749,7 +758,6 @@
 .tree-row--worktree:focus-within .wt-menu-trigger,
 .wt-menu-trigger[aria-expanded="true"] {
   opacity: 1;
-  pointer-events: auto;
 }
 
 .menu-pop button.menu-pop__item--active {
@@ -1054,28 +1062,26 @@
  * always-on "direct" badge doesn't shift. */
 .tree-row--direct-session.pinned-row .wt-menu-trigger {
   opacity: 0;
-  pointer-events: none;
+  pointer-events: auto;
   transition: opacity var(--transition-fast);
 }
 .tree-row--direct-session.pinned-row:hover .wt-menu-trigger,
 .tree-row--direct-session.pinned-row:focus-within .wt-menu-trigger,
 .tree-row--direct-session.pinned-row .wt-menu-trigger[aria-expanded="true"] {
   opacity: 1;
-  pointer-events: auto;
 }
 
-/* Touch devices have no `:hover` — the reveal-on-hover rules above left the
- * ⋯ trigger `pointer-events: none` at rest, so the first tap only landed on
- * the row underneath (synthesizing a hover-like state) and only the SECOND
- * tap actually hit the button. Keep it always interactive when hover isn't
- * available. Selectors + specificity mirror the rules above exactly so this
- * wins the cascade for every `.wt-menu-trigger` variant (plain worktree rows,
+/* Touch devices have no `:hover`, so the opacity-only reveal above never
+ * fires — force the trigger permanently visible (it was already always
+ * interactive; see the `pointer-events: auto` comment near
+ * `.tree-row--worktree .wt-menu-trigger` above for why that's unconditional
+ * now). Selectors + specificity mirror the rules above exactly so this wins
+ * the cascade for every `.wt-menu-trigger` variant (plain worktree rows,
  * pinned worktree rows, pinned direct-session rows). */
 @media (hover: none) {
   .tree-row--worktree .wt-menu-trigger,
   .tree-row--direct-session.pinned-row .wt-menu-trigger {
     opacity: 1;
-    pointer-events: auto;
   }
 
   /* The trigger and the id chip share the same trailing slot (see


### PR DESCRIPTION
## Summary
- Adds a DB-driven `hiddenAt` field on worktrees (mirrors the existing `pinnedAt` pattern end to end: schema, row mapper, `PATCH /worktrees/:id/hide` route, WS broadcast).
- New "Hide" item in the worktree's existing `⋯` overflow menu; hiding clears the pin in the same update, unhiding does not restore it.
- New per-project "Hidden worktrees (N)" item in the project's `⋯` menu, opening a `HiddenWorktreesDialog` to view/unhide them.
- Bundled fix: the worktree row's `⋯` trigger swallowed the first click right after hovering onto the row. `pointer-events` was gated on the same `:hover` match the click needed to land inside — this also blocked the trigger's `stopPropagation` guard against dnd-kit's drag listeners, so the pointerdown could fall through to the row's drag surface. Made `pointer-events: auto` unconditional, keeping `opacity` as the purely-visual hover reveal (same trade-off already used for touch devices in this file).
- Out of scope for this pass (flagged, not fixed): hidden worktrees still show up on the Dashboard, which has no `hiddenAt` filter (hidden *projects* are filtered from both sidebar and dashboard).

Full plan/checklist/review notes: `.vibekit/feature-plans/wip/hide-worktrees/plan-hide-worktrees.md`

## Test plan
- [x] `pnpm typecheck` clean on `web-ui` and `cli` (daemon)
- [x] Daemon: 77 tests passing (`worktrees.test.ts`, `sqliteRowMappers.test.ts`, `dbSchema.test.ts`), including new hide/unpin-on-hide/idempotency/column-migration coverage
- [x] Full daemon/cli suite: 804/804 passing
- [x] Full web-ui suite: 568/568 passing, including new sidebar hide/unhide/dialog tests
- [x] Opus review pass — no must-fix issues; nice-to-haves (error handling, sort order, aria-label, dedup) applied
- [ ] Manual browser click-test of the `⋯` menu fix (not performed in this pass — high confidence per code-level analysis, but worth a live check before/after merge)