### PR TITLE
Sync pinned-item order across clients via the daemon

### DIFF
--- a/.vibekit/feature-plans/wip/pinned-order-sync/.sdlc-state.yaml
+++ b/.vibekit/feature-plans/wip/pinned-order-sync/.sdlc-state.yaml
@@ -1,0 +1,17 @@
+feature: pinned-order-sync
+worktree: /home/gb/.vibe-station/projects/vibe-station/worktrees/vs-59
+master: {prd: skipped, plan: complete}
+current_subfeature: root
+subfeatures:
+  - id: root
+    origin: planned
+    spawned_from: null
+    mode: implementing
+    last_completed: "3.3"
+    awaiting_phase: implement
+    awaiting_artifact: ".vibekit/feature-plans/wip/pinned-order-sync/plan-pinned-order-sync.md"
+    phase_chain: [plan, implement]
+    superseded_reason: null
+    parked_reason: null
+    handoff: {next_item: null, returned_at: null, verified_by: null}
+    commit: null

--- a/.vibekit/feature-plans/wip/pinned-order-sync/plan-pinned-order-sync.md
+++ b/.vibekit/feature-plans/wip/pinned-order-sync/plan-pinned-order-sync.md
@@ -1,0 +1,374 @@
+<!--
+RULES — read before writing or implementing:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. REQUIREMENTS: One crisp line each — no verbose descriptions
+3. CHECKLIST: Mark items [x] as you complete them — this is your persistent todo list
+4. READING TIME: Optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+# Plan: pinned-order-sync
+
+> Move the pinned-items drag order (currently `localStorage`-only, per-browser) to the daemon DB so pin order stays consistent across every client (phone, laptop1, laptop2, …), designed as the first instance of a generic per-user "ordered list" primitive other client-only orderings (projects, saved workspaces) can adopt later without a schema change.
+
+**Issue:** pinned-order-sync
+**Branch:** `pinned-order-clients` (current worktree branch)
+**Status:** WIP — implementation complete except 3.T4 (manual two-client verification)
+**PRD:** none — small enough to skip (single table, 2 endpoints, 1 sidebar wiring point)
+
+**Reference files:**
+- Data / schema: `daemon/src/services/dbSchema.ts`
+- Core logic: `daemon/src/state/orderedListsStore.ts` (new), `daemon/src/routes/orderedLists.ts` (new)
+- UI / entrypoint: `web-ui/src/components/layout/LeftSidebar.tsx`
+- Wiring: `daemon/src/server.ts`, `web-ui/src/hooks/useServerSync.ts`, `web-ui/src/hooks/useStore.ts`, `web-ui/src/api/client.ts`, `web-ui/src/api/mock.ts`
+
+---
+
+## Problem
+
+- `sortOrders["pinned-all"]` — the user's dragged order for the combined pinned-worktrees + pinned-direct-sessions list — lives only in `zustand/persist` → `localStorage` (`web-ui/src/hooks/useStore.ts:252,829-832,1345`), keyed `"vibestation:workspace"`.
+- Each browser/device has its own `localStorage`, so the same account sees a different pin order on phone vs. laptop1 vs. laptop2 — no daemon round-trip happens on drag.
+- Regular (unpinned) worktree/session order is **already** server-backed via a real `sortOrder` column + `PATCH /worktrees/:id/reorder` / `PATCH /sessions/:id/reorder` (`daemon/src/routes/worktrees.ts:790`, `daemon/src/routes/sessions.ts:1019`) — that mechanism is *not* broken, it's per-project/per-worktree by design and can't express a list that mixes items across projects, which is what "pinned" requires (documented at `LeftSidebar.tsx:299-303`).
+
+## Out of Scope
+
+- The two other local-only orderings that share the identical mechanism — `sortOrders["projects"]` and `workspaceOrder["workspaces:global"]` (`useStore.ts:252-258`, `LeftSidebar.tsx:553`) — are NOT migrated this round.
+  - The new table/route generalize by `scopeKey` so either can adopt it later with zero schema change (Decision 1) — that generalization is in scope, migrating their call sites is not.
+- No real multi-user auth/identity — matches `PRD-scenes.md:29-35,102-103`'s explicit phasing (single implicit `local` user now, real user model deferred).
+- No UI to view/manage order history or per-item pin metadata beyond the existing `pinnedAt` column — unchanged.
+- No change to `Worktree.pinnedAt` / `Session.pinnedAt` (which items are pinned, and the default-if-never-dragged order) — those already round-trip through the daemon (`dbSchema.ts:44,73`) and are untouched.
+
+## Concept
+
+- New daemon-owned table stores a **named, user-scoped ordered list of ids** — generic enough that "pinned-all" is just the first `scopeKey` to use it.
+- Sidebar's pinned-list drag handler writes to the daemon (not just local state) on every reorder; every connected client receives the new order over the existing WebSocket broadcast channel and re-renders, the same way `worktree:updated`/`session:updated` already propagate.
+- On load, a client with a still-local-only order (pre-migration `localStorage` state) pushes it to the daemon exactly once if the daemon has no row yet, so nobody's current arrangement is silently discarded.
+
+## Requirements
+
+| # | Requirement |
+|---|-------------|
+| 1 | Dragging to reorder the pinned list persists the new order to the daemon DB, not just `localStorage`. |
+| 2 | A second open client (same daemon, different browser/device) sees the new pinned order live, without a manual refresh, via the existing WS channel. |
+| 3 | A fresh client with no daemon-side order yet (first upgrade) does not lose a user's existing local drag order — it is pushed up once. |
+| 4 | Storage is shaped so it can be namespaced per real user later (`users/<id>/...`) with no migration, per the Scenes-PRD direction (`PRD-scenes.md:29-35`) — implemented today as a single implicit `userId = 'local'`. |
+| 5 | The new table/endpoint generalize by `scopeKey`, not a `pinned`-specific name, so `sortOrders["projects"]` / `workspaceOrder["workspaces:global"]` can move to the same mechanism later without a new table. |
+
+---
+
+## Research
+
+### Current pinned-order storage (client-only)
+
+- **File:** `web-ui/src/hooks/useStore.ts:252` — `sortOrders: Record<string, string[]>` field declaration.
+- **File:** `web-ui/src/hooks/useStore.ts:829-832` — `setSortOrder(scopeKey, orderedIds)` setter, plain local `set()`, no API call.
+- **File:** `web-ui/src/hooks/useStore.ts:1345` — `sortOrders: s.sortOrders` inside `partialize`, persisted to `localStorage` under key `"vibestation:workspace"` (`useStore.ts:1088-1089`, schema `version: 16`).
+- **Risk:** MEDIUM — three scopes (`pinned-all`, `projects`, `workspaces:global`) share this exact mechanism; touching `setSortOrder`'s signature affects all three, so this plan adds new plumbing alongside it rather than changing the shared setter's contract.
+
+### Pinned-list render + reorder site
+
+- **File:** `web-ui/src/components/layout/LeftSidebar.tsx:412-427` — `orderedPinnedItems`: builds `[...pinnedWorktrees, ...pinnedDirectSessions]`, default-sorts by `pinnedAt` DESC, then overrides via `applyLocalSortOrder(sortOrders["pinned-all"], ids)` (`LeftSidebar.tsx:109-116`).
+- **File:** `web-ui/src/components/layout/LeftSidebar.tsx:439-452` — `handleReorder(scopeKey, currentIds, e)`: generic dnd-kit drag-end handler; for the pinned section called with `scopeKey = "pinned-all"`, ends in `setSortOrder(scopeKey, next)` — this is the **only** call site needing a daemon write added.
+- **File:** `web-ui/src/components/layout/LeftSidebar.tsx:472-511` — `handleServerReorder(...)`: the *existing* pattern for a server-backed reorder (optimistic local patch via `useServerStore`, `api.reorderWorktree`/`api.reorderSession`, rollback on failure) — model the new pinned write path on this, not on `handleReorder`'s local-only shape.
+- **Risk:** LOW — single call site, well-isolated function.
+
+### Server-side reorder precedent (regular worktree/session order)
+
+- **File:** `daemon/src/routes/worktrees.ts:786-815` — `PATCH /worktrees/:id/reorder`, `zod` body validation, `mutateProject` write, **full-object** WS broadcast (`broadcastAll({ type: "worktree:updated", worktree: ... })`) — comment at `worktrees.ts:770-776` explains a partial `{id, sortOrder}` broadcast previously corrupted client state ("reorder-drag-makes-the-row-vanish bug"). New broadcast must carry the full new list, not a delta.
+- **File:** `daemon/src/routes/sessions.ts:1019` — identical pattern for sessions.
+- **Risk:** LOW — pattern to imitate is clear and proven.
+
+### Closest whole-resource GET/PATCH precedent
+
+- **File:** `daemon/src/routes/settings.ts:14-46` — `GET /settings` / `PATCH /settings`, backed by `readSettings()`/`writeSettings()` (`daemon/src/services/config.ts`, JSON file at `~/.vibe-station/config.json`, **not** SQLite).
+- **Decision:** the pinned order needs live WS fan-out to other clients and is naturally keyed (`scopeKey`), which the settings file (single global blob) doesn't model well — use SQLite + a dedicated route file instead of extending `settings.ts` (see Decision 2).
+
+### Daemon schema / migration mechanism
+
+- **File:** `daemon/src/services/dbSchema.ts:19-93` — `ensureSchema(db)`, `better-sqlite3`, raw SQL, `CREATE TABLE IF NOT EXISTS` for new tables (idempotent, runs on every `getDb()` open).
+- **File:** `daemon/src/services/dbSchema.ts:138-142` — `addColumnIfMissing(db, table, column, ddl)` — only needed for *adding a column to an existing table*; a brand-new table just needs `CREATE TABLE IF NOT EXISTS`, no migration helper required.
+- **No existing `settings`/`user_prefs`/order-list table in SQLite** — this is a new table, not a retrofit.
+
+### Route registration + WS broadcast plumbing
+
+- **File:** `daemon/src/server.ts:134-140` — every route module is registered here (`registerProjectRoutes(app)` … `registerSettingsRoutes(app)`); a new `registerOrderedListsRoutes(app)` call is added alongside them.
+- **File:** `daemon/src/broadcaster.ts:32` — `export function broadcastAll(msg: ServerMessage): void` — the single fan-out point every route already uses. **`ServerMessage` is a zod-validated discriminated union**, not a bare TS type — `daemon/src/ws/protocol.ts:469-502` (`export const ServerMessage = z.discriminatedUnion("type", [...])`, e.g. `WorktreeUpdatedEvent` at `protocol.ts:409-412`). A new event needs its own `z.object({...})` schema added to that array **in addition to** the client-side `WSEvent` union below — `broadcastAll` will throw/reject at runtime if the event shape isn't in this array, regardless of what `web-ui/src/api/types.ts` declares.
+- **File:** `web-ui/src/api/types.ts:313-492` — `WSEvent` discriminated union (`session:created` | `session:updated` | … | `worktree:updated` | …) — a new member is added here (client-side type only; does not satisfy `protocol.ts`'s server-side runtime schema above).
+- **File:** `web-ui/src/hooks/useServerSync.ts:97-121` — `api.on("worktree:updated", ...)` etc.: the pattern every incremental WS reducer follows; a new `api.on("orderedList:updated", ...)` handler is added the same way.
+- **File:** `daemon/src/server.ts:95-119` — a global Fastify `onRequest` hook enforces auth (Bearer token or `vst-session` cookie) on every route except the explicitly-stubbed `/auth/*` routes in no-auth dev mode; **no per-route opt-out exists**, so the new routes inherit this automatically — no extra wiring needed, but the API Contract below must document the `401` this implies (see Decision 3 update).
+
+### Client API pattern
+
+- **File:** `web-ui/src/api/client.ts:385-393` — `reorderWorktree(id, sortOrder)`: `apiFetch` + `PATCH` + `parseJson` — template for the new methods.
+- **File:** `web-ui/src/api/mock.ts:501` — mirrored mock implementation; every real `client.ts` method needs a mock counterpart (mock/preview mode has no daemon). Mock methods that mutate state also **emit** the matching WS-shaped event (e.g. `mock.ts:501`'s `reorderWorktree` emits `worktree:updated`) so mock-mode tests can exercise the same `useServerSync` reducer path as the real client — the new mock `setOrderedList` must do the same for `orderedList:updated`.
+- **File:** `web-ui/src/api/index.ts:8` — `ApiInstance = ReturnType<typeof createMockApi> | ReturnType<typeof createClientApi>` — no separate interface to edit; adding a method to both factories is sufficient, TypeScript infers the union.
+- **Risk:** LOW — established, repeated pattern (this is the 3rd/4th "add a reorder-shaped endpoint" in this codebase).
+
+## Root Cause
+
+- The pinned list is the one ordering surface whose items legitimately span projects (mixed worktree + direct-session ids from anywhere), so it was deliberately kept off the existing per-project `sortOrder` column (`LeftSidebar.tsx:299-303`) — and nothing was ever built to replace that gap with a cross-project, server-side equivalent.
+- Everything else needed (auth, DB, WS broadcast, route conventions) already exists in the codebase; this is additive plumbing, not a new subsystem.
+
+---
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    subgraph A["Client A (laptop1)"]
+      UI_A[LeftSidebar drag] -->|"PUT /user/ordered-lists/pinned-all"| API
+      UI_A -.->|"ws: orderedList:updated"| WS_A[useServerSync]
+    end
+    subgraph B["Client B (phone)"]
+      WS_B[useServerSync] -.->|"ws: orderedList:updated"| UI_B[LeftSidebar re-render]
+    end
+    API[daemon routes/orderedLists.ts] --> Store[state/orderedListsStore.ts]
+    Store --> DB[(SQLite: user_ordered_lists)]
+    API --> Broadcast[broadcaster.ts: broadcastAll]
+    Broadcast --> WS_A
+    Broadcast --> WS_B
+```
+
+---
+
+## Design Details
+
+### System Boundaries
+
+| Boundary | Fields + types | Errors | Source of truth |
+|----------|----------------|--------|-----------------|
+| Frontend ↔ Backend | `scopeKey: string` (path param, allowlisted — Decision 7), `itemIds: string[]` (body/response), `updatedAt: string \| null` (ISO8601) | `400 VALIDATION_ERROR` (bad body shape or non-allowlisted `scopeKey`) · `401` (missing/invalid auth — global `onRequest` hook, `server.ts:95-119`, applies to every route including these, same as `/worktrees/*`) | Daemon SQLite is authoritative; client `sortOrders[scopeKey]` is a cache overlaid by WS/refetch |
+| Client ↔ DB | table `user_ordered_lists(userId, scopeKey, itemIds, updatedAt)`, PK `(userId, scopeKey)` | n/a (no FK — `userId` is a bare string, no `users` table exists yet) | daemon owns writes; `mutateProject`-style single-writer discipline not needed since this table isn't nested under `projects.json`-equivalent state |
+
+### Critical User Journeys (CUJs)
+
+#### CUJ 1 — Drag-reorder propagates to a second open client
+
+```
+User on laptop1 drags a pinned item to a new position
+  → LeftSidebar.handleReorder computes `next: string[]`
+  → Optimistic local setSortOrder("pinned-all", next) — list re-renders instantly on laptop1
+  → api.setOrderedList("pinned-all", next) → PUT /user/ordered-lists/pinned-all
+  → daemon upserts row, broadcasts { type: "orderedList:updated", scopeKey: "pinned-all", itemIds: next, updatedAt }
+  → phone (open, WS connected) receives the event, useServerSync applies it into sortOrders["pinned-all"]
+  → phone's pinned list re-renders in the new order, no manual refresh
+```
+
+- **Error path:** `PUT` fails (network drop) → laptop1's optimistic local order stays, no rollback attempted (there is nothing to roll back *to* — local state already reflects the user's intent, unlike `handleServerReorder`'s rollback which restores a known-good prior value). No user-visible error toast. It is stale vs. daemon until the next successful write or the next mount-time `GET`.
+- **Edge case:** two clients drag concurrently within the same second → last `PUT` wins (whole-array overwrite, no merge) — acceptable, same last-write-wins semantics as every other WS-synced entity in this codebase (e.g. `worktree:updated`).
+- **Self-echo:** `broadcastAll` fans out to every connected client **including the one that issued the `PUT`** — laptop1 also receives its own `orderedList:updated` event. The reducer (Phase 2.4) applies it unconditionally (`setSortOrder("pinned-all", ev.itemIds)`), which is a harmless no-op re-set to the same value it optimistically wrote already — same posture as `worktree:updated`'s existing self-echo (no dedup/origin-check exists for that event either), so no new mechanism is needed here.
+- **Reconnect race:** `refresh()` (Decision 5's hydrate/migrate block) re-runs on **every `ws:open`**, not just initial mount (`useServerSync.ts:87-90`) — a reconnect that lands between an optimistic local drag and its in-flight `PUT`'s response could `GET` a stale server array and clobber the just-made local order via the `else` (hydrate) branch. Mitigation: skip the hydrate branch's `setSortOrder` call if a `setOrderedList` call is currently in flight (module-level `let orderedListWriteInFlight: Promise<unknown> | null` in `useServerSync.ts`, set/cleared around the Phase 3.1 `PUT` the same way `inFlightRefresh` guards `refresh()`) — the pending write's own response (or its WS echo) will land right after and settle to the correct value regardless.
+
+#### CUJ 2 — First load after upgrade: local-only order migrates up once
+
+```
+User opens vibe-station on a client that already has sortOrders["pinned-all"] in localStorage
+  → useServerSync mount effect: GET /user/ordered-lists/pinned-all
+  → Response has itemIds: [] (no daemon row yet — never synced before)
+  → Local sortOrders["pinned-all"] is non-empty
+  → Client pushes it once: PUT /user/ordered-lists/pinned-all { itemIds: <local order> }
+  → Daemon row now exists; every other client's next GET/broadcast sees this order
+```
+
+- **Edge case:** daemon already has a row (another client synced first) → server response `itemIds` is authoritative, local `sortOrders["pinned-all"]` is overwritten with it (no merge, no "whose order wins" prompt) — first client to sync after this ships wins, deterministic and simple.
+- **Edge case:** neither client has ever set an order → both get `itemIds: []`, `applyLocalSortOrder` already handles an empty/undefined order by falling back to `pinnedAt` DESC (`LeftSidebar.tsx:109-116`) — no special-case code needed.
+
+### Data Model
+
+| Entity | Field | Type | Constraints | Notes |
+|--------|-------|------|-------------|-------|
+| `user_ordered_lists` | `userId` | `TEXT` | PK (composite), `NOT NULL DEFAULT 'local'` | No `users` table yet — bare string, matches `PRD-scenes.md:33-35`'s `users/<id>/...`-shaped-but-single-user-today direction |
+| `user_ordered_lists` | `scopeKey` | `TEXT` | PK (composite), `NOT NULL` | e.g. `"pinned-all"` today; `"projects"` / `"workspaces:global"` could reuse this table later, out of scope this round |
+| `user_ordered_lists` | `itemIds` | `TEXT` | `NOT NULL` | JSON-encoded `string[]` — mirrors the client's `sortOrders[scopeKey]: string[]` shape exactly, no translation needed at either boundary |
+| `user_ordered_lists` | `updatedAt` | `TEXT` | `NOT NULL` | ISO8601, set server-side on every upsert |
+
+- **Relationships:** none (no FK — `userId` is not yet backed by a real `users` table, by design, same posture as Scenes).
+- **Indexes:** none beyond the composite PK — lookups are always by exact `(userId, scopeKey)`, no range/scan query exists.
+- **Migration:** Y — brand-new table via `CREATE TABLE IF NOT EXISTS` in `ensureSchema` (`dbSchema.ts`); no `addColumnIfMissing` needed since nothing is added to an existing table. No backfill — table starts empty, CUJ 2 backfills client-side on first sync per user/browser.
+
+### API Contracts
+
+```
+GET /user/ordered-lists/:scopeKey
+  Request:  — (scopeKey e.g. "pinned-all", validated against an allowlist — Decision 7)
+  Response: { scopeKey: string, itemIds: string[], updatedAt: string | null }
+            (itemIds: [], updatedAt: null when no row exists yet — never a 404 for an unknown-but-valid scopeKey)
+  Errors:   400 VALIDATION_ERROR (scopeKey not in the allowlist) · 401 (auth — global hook, every route)
+
+PUT /user/ordered-lists/:scopeKey
+  Request:  { itemIds: string[] }
+  Response: { ok: true, scopeKey: string, itemIds: string[], updatedAt: string }
+  Errors:   400 VALIDATION_ERROR (itemIds missing / not string[], or scopeKey not in the allowlist) · 401 (auth)
+```
+
+- Both routes implicitly operate on `userId = 'local'` server-side — no `userId` in the URL or body (Decision 3).
+- WS broadcast on every successful `PUT`: `{ type: "orderedList:updated", scopeKey: string, itemIds: string[], updatedAt: string }` — new member on **both** the server-side `ServerMessage` zod union (`daemon/src/ws/protocol.ts:469-502`) and the client-side `WSEvent` TS union (`web-ui/src/api/types.ts`) — see Phase 1.5/1.6.
+
+### Key Decisions
+
+#### Decision 1: Generic `scopeKey`-dimensioned table, not a `pinned_order`-specific one
+
+- **Decision:** table and route are named/shaped around an arbitrary `scopeKey: string`, not hardcoded to pinned items.
+- **Rationale:** `sortOrders["projects"]` and `workspaceOrder["workspaces:global"]` (`useStore.ts:252-258`) are the exact same "client-only ordered id list" shape — building `scopeKey`-generic plumbing now means moving them later is a client-side wiring change only, zero new table/migration. Matches the plan's explicit future-scalability ask.
+- **Where:** `daemon/src/services/dbSchema.ts` (table def), `daemon/src/routes/orderedLists.ts` (route param).
+
+#### Decision 2: New SQLite table + route, not an extension of `settings.ts`
+
+- **Decision:** dedicated `user_ordered_lists` table and `orderedLists.ts` route, instead of adding a `pinnedOrder` field to the JSON-file-backed `Settings` (`daemon/src/services/config.ts`).
+- **Rationale:** Settings is a single global blob with no live WS fan-out to other clients (`settings.ts:14-46` — no `broadcastAll` call anywhere in that file); this feature's core requirement (#2: live cross-client sync) needs the WS broadcast + keyed-row pattern that `worktrees.ts`/`sessions.ts` already use. SQLite is also queryable per-key, which a single JSON blob is not.
+- **Where:** `daemon/src/services/dbSchema.ts`, `daemon/src/routes/orderedLists.ts` (new), `daemon/src/server.ts:139` (registration).
+
+#### Decision 3: Implicit `userId = 'local'`, no user in the URL
+
+- **Decision:** every route call operates on a single hardcoded `userId = 'local'` string; the API surface never accepts a `userId` param today.
+- **Rationale:** no real user/auth-identity model exists yet (confirmed: `daemon/src/routes/auth.ts` is a single shared-token login, no per-user identity) — matches `PRD-scenes.md:29-35` exactly ("store scenes on the daemon under a single implicit user... defaulting to a `local` user"). The `userId` **column** exists today so a future real user model is an `authenticated-user-id-instead-of-'local'` swap at the route layer, not a schema migration.
+- **Where:** `daemon/src/routes/orderedLists.ts` — every query hardcodes `'local'`.
+
+#### Decision 4: Whole-array upsert (last-write-wins), no operational-transform / merge
+
+- **Decision:** `PUT` always replaces the entire `itemIds` array; no per-item move/insert endpoint, no conflict resolution beyond "last write wins."
+- **Rationale:** matches this codebase's existing WS-sync semantics — full-object broadcast, not a patch (`worktrees.ts:770-776`'s "reorder-drag-makes-the-row-vanish" comment).
+  - Concurrent drags from two devices in the same second are rare and low-stakes (worst case: re-drag to fix) — not worth building real conflict resolution for a pin-order list.
+- **Where:** `daemon/src/routes/orderedLists.ts`.
+
+#### Decision 5: One-time client-side migration push, no server-side backfill
+
+- **Decision:** the "don't lose an existing local order on upgrade" requirement (#3) is handled entirely client-side in `useServerSync`'s mount effect (CUJ 2) — the daemon has no awareness of `localStorage` and does nothing special on first boot.
+- **Rationale:** the daemon cannot see `localStorage` (it's per-browser); the client already knows its own local `sortOrders["pinned-all"]` and can trivially detect "server has nothing yet" via `updatedAt === null` on the `GET` response — no daemon-side migration script is needed or possible.
+- **Where:** `web-ui/src/hooks/useServerSync.ts` (new block in the mount effect, alongside the existing initial-bundle fetch).
+
+```ts
+// useServerSync.ts — inside the existing mount-effect refresh(), after the
+// initial projects/worktrees/sessions fetch. NOTE: refresh() re-runs on
+// EVERY ws:open, not just initial mount (useServerSync.ts:87-90) — so this
+// block runs on every reconnect too, not once. The `orderedListWriteInFlight`
+// check (CUJ 1 "Reconnect race") guards the hydrate branch from clobbering
+// a drag that's still in flight when a reconnect happens to land.
+const pinnedOrder = await api.getOrderedList("pinned-all");
+if (pinnedOrder.updatedAt === null) {
+  // No daemon row yet — this client is the first to sync since upgrade.
+  // Push local state up if there is any; an empty local order pushes an
+  // empty array, which is harmless (GET already treats [] as "no order").
+  const local = useWorkspaceStore.getState().sortOrders["pinned-all"];
+  if (local && local.length > 0) {
+    await api.setOrderedList("pinned-all", local);
+  }
+} else if (!orderedListWriteInFlight) {
+  useWorkspaceStore.getState().setSortOrder("pinned-all", pinnedOrder.itemIds);
+}
+```
+
+#### Decision 6: Reuse `setSortOrder` for the server-hydrated value, no new store field
+
+- **Decision:** the daemon's `itemIds` for `"pinned-all"` is written into the exact same `sortOrders["pinned-all"]` field the local-only mechanism already uses — no parallel `serverSortOrders` field.
+- **Rationale:** `orderedPinnedItems` (`LeftSidebar.tsx:412-427`) already reads `sortOrders["pinned-all"]` via `applyLocalSortOrder` — keeping one field means zero changes to the render/merge logic; only the *write path* gains a daemon round-trip (Decision 5's snippet, plus the drag handler in Phase 3).
+- **`localStorage` persistence stays unchanged:** `sortOrders` remains in `useStore.ts:1345`'s `partialize` (still written to `localStorage`). Post this change it doubles as an offline/first-paint cache — a client renders its last-known order immediately on load, then the mount-effect hydrate (Decision 5) overwrites it with the daemon's value once the `GET` resolves. This can produce a brief stale-order flash on a client that's behind (acceptable — same "flash then reconcile" pattern the app already has for `sessionStates`, see `useServerSync.ts:70-74`'s comment on why REST truth overlays the persisted cache rather than replacing it outright).
+- **Where:** `web-ui/src/hooks/useStore.ts:829-832` (`setSortOrder`, unchanged signature/body), `web-ui/src/components/layout/LeftSidebar.tsx:439-452` (`handleReorder`, gains a conditional API call for `scopeKey === "pinned-all"`).
+
+#### Decision 7: `scopeKey` allowlisted server-side, not free-form
+
+- **Decision:** the route validates `scopeKey` against a small hardcoded allowlist (`["pinned-all"]` today) via zod, rejecting anything else with `400`, rather than accepting any string.
+- **Rationale:** Decision 1 deliberately makes the table/route generic over `scopeKey` for future reuse (`projects`, `workspaces:global`) — but an unvalidated free-form key lets any authenticated client grow the table with arbitrary rows (no cap on distinct keys or on `itemIds` length). An allowlist keeps the generalization (schema/route shape) while closing that off; extending to a new scope later is a one-line allowlist addition, not a schema change.
+- **Where:** `daemon/src/routes/orderedLists.ts` — `z.enum(["pinned-all"])` (or equivalent) on the `scopeKey` path param; `itemIds` also capped (e.g. `z.array(z.string()).max(500)`) since a pinned list has no natural bound enforced elsewhere.
+
+---
+
+## Risks / Open Questions
+
+| # | Question | Notes |
+|---|----------|-------|
+| 1 | **Should `handleReorder`'s daemon write be awaited/rolled back on failure, like `handleServerReorder`?** | No — Decision 4/CUJ 1: local state already reflects user intent optimistically; a failed `PUT` just means this client is stale vs. daemon until the next successful write or mount-time `GET`. Silent retry-on-next-drag is acceptable for a cosmetic ordering feature. |
+| 2 | **What if `itemIds` references a worktree/session id that's since been deleted?** | Handled identically to today: `applyLocalSortOrder` (`LeftSidebar.tsx:109-116`) already filters `order` down to `liveIds` and appends any new/unknown live ids — no daemon-side validation needed, stale ids are silently dropped client-side same as now. |
+| 3 | **Multiple browser tabs on the same device — does each push its own migration (Decision 5) redundantly?** | Yes, possible but harmless: second tab's `GET` will see `updatedAt` already set (first tab's push landed) and skip the migration push — a race where both fire simultaneously just means two back-to-back identical `PUT`s, no corruption (Decision 4, last-write-wins on an identical array is a no-op). |
+| 4 | **Does a reconnect mid-drag clobber the local order before the in-flight `PUT` resolves?** | Mitigated by the `orderedListWriteInFlight` guard (CUJ 1 "Reconnect race", Decision 5 snippet) — the hydrate branch skips `setSortOrder` while a write is pending; the pending write's own response/echo settles the value right after. `clearOrderedListWrite` (Phase 2.3/3.1) is compare-and-clear, so a second drag's still-pending write can't be cleared early by the first drag's `finally` settling after it started. |
+| 5 | **Does the originating client double-apply its own reorder via the WS self-echo?** | No functional issue — `broadcastAll` fans out to the originator too (no origin-check exists for any event in this codebase), so the reducer re-`setSortOrder`s to the same value it already optimistically set. Harmless no-op, same posture as every other WS-synced entity. |
+
+---
+
+## Implementation Phases
+
+- Each phase ends with a **verification block** — the phase is not complete until those tests pass
+- Test items use `N.Tn` numbering to distinguish them from implementation items
+
+---
+
+### Phase 1 — Daemon: schema, store, route, broadcast
+
+- [x] **1.1** `daemon/src/services/dbSchema.ts`: add `CREATE TABLE IF NOT EXISTS user_ordered_lists (userId TEXT NOT NULL, scopeKey TEXT NOT NULL, itemIds TEXT NOT NULL, updatedAt TEXT NOT NULL, PRIMARY KEY (userId, scopeKey))` inside the existing `db.exec(...)` block (alongside `projects`/`worktrees`/`sessions`/`manifest_migrations`) — no `DEFAULT 'local'` needed since the route always supplies it explicitly (Decision 3).
+- [x] **1.2** New `daemon/src/state/orderedListsStore.ts`: `getOrderedList(scopeKey: string): { itemIds: string[]; updatedAt: string | null }` (SELECT by `userId='local' AND scopeKey=?`, `JSON.parse(itemIds)`, `{itemIds: [], updatedAt: null}` if no row) and `setOrderedList(scopeKey: string, itemIds: string[]): { itemIds: string[]; updatedAt: string }` (upsert via `INSERT ... ON CONFLICT(userId, scopeKey) DO UPDATE SET itemIds=excluded.itemIds, updatedAt=excluded.updatedAt`, `JSON.stringify(itemIds)`, `updatedAt = new Date().toISOString()`) using `getDb()` from `daemon/src/state/db.ts`.
+- [x] **1.3** New `daemon/src/routes/orderedLists.ts`: `registerOrderedListsRoutes(app: FastifyInstance)` with `GET /user/ordered-lists/:scopeKey` and `PUT /user/ordered-lists/:scopeKey`. `scopeKey` param validated via `z.enum(["pinned-all"])` (Decision 7); `PUT` body via `z.object({ itemIds: z.array(z.string()).max(500) })`; 400 on either `safeParse` failure, mirroring `worktrees.ts:790-795`'s validation shape. `PUT` calls `setOrderedList`, then `broadcastAll({ type: "orderedList:updated", scopeKey, itemIds, updatedAt })`.
+- [x] **1.4** `daemon/src/ws/protocol.ts:469-502`: add `const OrderedListUpdatedEvent = z.object({ type: z.literal("orderedList:updated"), scopeKey: z.string(), itemIds: z.array(z.string()), updatedAt: z.string() })` and insert it into the `ServerMessage` discriminated-union array — **required** for `broadcastAll` in 1.3 to accept the event at runtime; the client-side `WSEvent` union (1.6) alone does not satisfy this.
+- [x] **1.5** `daemon/src/server.ts:139` (next to `registerSettingsRoutes(app)`): add `registerOrderedListsRoutes(app)` + its import.
+- [x] **1.6** `web-ui/src/api/types.ts:313-492` (`WSEvent` union): add `| { type: "orderedList:updated"; scopeKey: string; itemIds: string[]; updatedAt: string }` member.
+
+**Verify phase 1:**
+- [x] **1.T1** Integration — `orderedLists route`: `GET /user/ordered-lists/pinned-all` with no prior `PUT` returns `{ scopeKey: "pinned-all", itemIds: [], updatedAt: null }`.
+- [x] **1.T2** Integration — `orderedLists route`: `PUT /user/ordered-lists/pinned-all` with `{ itemIds: ["a","b"] }` returns `{ ok: true, scopeKey: "pinned-all", itemIds: ["a","b"], updatedAt: <iso> }`, and a subsequent `GET` returns the same `itemIds`.
+- [x] **1.T3** Integration — `orderedLists route`: `PUT` with `{ itemIds: "not-an-array" }` returns `400` with `error: "Validation error"`; `PUT /user/ordered-lists/not-a-real-scope` also returns `400` (Decision 7 allowlist).
+- [x] **1.T4** Integration — `orderedLists route`: `PUT /user/ordered-lists/pinned-all` broadcasts `{ type: "orderedList:updated", scopeKey: "pinned-all", itemIds, updatedAt }` via `broadcastAll` — assert on a spied `broadcaster.ts` export, mirroring `daemon/src/__tests__/sessions.rename.broadcast.test.ts`'s pattern.
+- [x] **1.T5** Unit — `orderedListsStore`: `setOrderedList` called twice with different arrays for the same `scopeKey` overwrites (not appends) — second `getOrderedList` reflects only the latest call.
+- [x] **1.T6** Unit — `orderedListsStore`: `setOrderedList("pinned-all", ["a"])` then `setOrderedList("workspaces:global", ["b"])` — `getOrderedList("pinned-all")` still returns `["a"]` (store itself is not allowlist-restricted, only the route is — composite-PK isolation is the property under test, Decision 1's premise).
+
+---
+
+### Phase 2 — Web-UI: API client + store wiring
+
+- [x] **2.1** `web-ui/src/api/client.ts` (near `reorderWorktree`, `client.ts:385-393`): add `getOrderedList(scopeKey: string): Promise<{ scopeKey: string; itemIds: string[]; updatedAt: string | null }>` (`GET`) and `setOrderedList(scopeKey: string, itemIds: string[]): Promise<{ ok: true; scopeKey: string; itemIds: string[]; updatedAt: string }>` (`PUT`, JSON body `{ itemIds }`).
+- [x] **2.2** `web-ui/src/api/mock.ts` (near `reorderWorktree`, `mock.ts:501-507`): mirrored in-memory mock — module-level `Map<string, {itemIds: string[], updatedAt: string | null}>`, same request/response shapes as 2.1. `setOrderedList` must call `emit({ type: "orderedList:updated", scopeKey, itemIds, updatedAt })` after writing, same as `mock.ts:505`'s `reorderWorktree` — required for 2.T4/3.T2 to exercise the WS reducer path in mock mode.
+- [x] **2.3** `web-ui/src/hooks/useServerSync.ts`: add a module-level `let orderedListWriteInFlight: Promise<unknown> | null = null;` (mirrors `inFlightRefresh` at `useServerSync.ts:24`) plus two exported functions: `export function markOrderedListWrite(p: Promise<unknown>): void { orderedListWriteInFlight = p; }` and `export function clearOrderedListWrite(p: Promise<unknown>): void { if (orderedListWriteInFlight === p) orderedListWriteInFlight = null; }` — the compare-and-clear on `clearOrderedListWrite` is required so a second drag's still-pending write (a newer promise) can't be wiped by the first drag's `finally` settling after it. `LeftSidebar.tsx` (Phase 3.1) is a different module and cannot reach a bare module-level `let` directly, so it drives the flag through these two functions.
+- [x] **2.4** `web-ui/src/hooks/useServerSync.ts`: inside the existing mount `refresh()` effect (`useServerSync.ts:59-92`), after the initial bundle fetch, add the Decision 5 migration/hydrate block (GET → push-if-empty-on-server else hydrate local `sortOrders["pinned-all"]` via `useWorkspaceStore.getState().setSortOrder`, guarded by `orderedListWriteInFlight`) — note this effect re-runs on every `ws:open`, not just initial mount.
+- [x] **2.5** `web-ui/src/hooks/useServerSync.ts`: in the incremental WS-reducer effect (`useServerSync.ts:97-121`), add `api.on("orderedList:updated", (ev) => { if (ev.type === "orderedList:updated" && ev.scopeKey === "pinned-all") useWorkspaceStore.getState().setSortOrder("pinned-all", ev.itemIds); })`.
+
+**Verify phase 2:**
+- [x] **2.T1** Unit — `mock.ts`: `getOrderedList("pinned-all")` before any `setOrderedList` call returns `{ itemIds: [], updatedAt: null }`; after `setOrderedList("pinned-all", ["x"])`, `getOrderedList` returns `{ itemIds: ["x"], updatedAt: <non-null> }`.
+- [x] **2.T2** Integration — `useServerSync` mount effect: given a mocked `api.getOrderedList` returning `updatedAt: null` and a pre-populated local `sortOrders["pinned-all"] = ["a","b"]`, asserts `api.setOrderedList` is called once with `("pinned-all", ["a","b"])`.
+- [x] **2.T3** Integration — `useServerSync` mount effect: given `api.getOrderedList` returning `{ itemIds: ["c","d"], updatedAt: "..." }`, asserts local store's `sortOrders["pinned-all"]` becomes `["c","d"]` (server wins over any stale local value).
+- [x] **2.T4** Integration — `useServerSync` WS reducer: firing a mocked `orderedList:updated` event with `scopeKey: "pinned-all"` updates `sortOrders["pinned-all"]` in the store; an event with a different `scopeKey` (e.g. `"projects"`) is a no-op (Decision 1 forward-compat — no consumer for other scopes yet).
+- [x] **2.T5** Integration — `useServerSync` mount effect: while `orderedListWriteInFlight` is set (simulated pending `setOrderedList` promise), a `refresh()` triggered by a mocked `ws:open` does NOT call `setSortOrder` from the hydrate branch, even if `api.getOrderedList` resolves with a different `itemIds` than local state (CUJ 1 "Reconnect race", Risk 4).
+
+---
+
+### Phase 3 — Sidebar drag handler + end-to-end
+
+- [x] **3.1** `web-ui/src/components/layout/LeftSidebar.tsx:439-452` (`handleReorder`): after the existing `setSortOrder(scopeKey, next)` call, add a daemon write for the pinned scope that also drives the Phase 2.3 in-flight guard via its exported functions:
+  ```ts
+  import { markOrderedListWrite, clearOrderedListWrite } from "@/hooks/useServerSync";
+  // ...
+  if (scopeKey === "pinned-all") {
+    const p = api.setOrderedList("pinned-all", next).catch(() => {
+      // stale until next successful write or reload — Decision/Risk 1
+    });
+    markOrderedListWrite(p);
+    // Compare-and-clear: if a second drag started a newer write before this
+    // one settles, `clearOrderedListWrite` no-ops instead of wiping the
+    // newer promise out from under it (Risk 4).
+    void p.finally(() => clearOrderedListWrite(p));
+  }
+  ```
+- [x] **3.2** Update the doc comment at `LeftSidebar.tsx:299-303` and `:408-411,438` to reflect that `pinned-all` is no longer purely local — it's now daemon-synced (still distinct from the `sortOrder`-column mechanism used for regular worktrees/sessions).
+- [x] **3.3** `LeftSidebar.test.tsx`: extend/add coverage for the pinned-list drag handler calling `api.setOrderedList` with the new order (mock `api`, assert call args), plus a case that a WS `orderedList:updated` event re-renders the list in the new order.
+
+**Verify phase 3:**
+- [x] **3.T1** Unit — `LeftSidebar.test.tsx`: dragging a pinned item calls `api.setOrderedList("pinned-all", <expected new order>)` exactly once.
+- [x] **3.T2** Integration — `LeftSidebar.test.tsx`: simulating an incoming `orderedList:updated` WS event with `scopeKey: "pinned-all"` re-renders `orderedPinnedItems` in the new order without a page reload.
+- [x] **3.T3** Regression — `LeftSidebar.test.tsx`: `sortOrders["projects"]` reorder (unrelated scope) still works unchanged — no `api.setOrderedList` call for that scope (confirms Decision 1's scoping didn't leak).
+- [ ] **3.T4** Manual/device — two browser sessions against the same daemon (e.g. two tabs, or laptop + phone over Tailscale): drag a pinned item in one, confirm the other reflects the new order within a few seconds without manual refresh.
+
+---
+
+## Files & Phase Impact
+
+| File | Status | Phase | Description / Contract Change |
+|------|--------|-------|-------------------------------|
+| `daemon/src/services/dbSchema.ts` | **Modified** | 1.1 | New table: `user_ordered_lists(userId, scopeKey, itemIds, updatedAt)`, composite PK |
+| `daemon/src/state/orderedListsStore.ts` | **New** | 1.2 | Contract: `getOrderedList(scopeKey): {itemIds, updatedAt}`, `setOrderedList(scopeKey, itemIds): {itemIds, updatedAt}` · Owns: `user_ordered_lists` rows |
+| `daemon/src/routes/orderedLists.ts` | **New** | 1.3 | Contract: `GET/PUT /user/ordered-lists/:scopeKey`, `scopeKey` allowlisted (Decision 7) |
+| `daemon/src/ws/protocol.ts` | **Modified** | 1.4 | New `ServerMessage` union member: `OrderedListUpdatedEvent` (zod schema — required for `broadcastAll` to accept the event) |
+| `daemon/src/server.ts` | **Modified** | 1.5 | Register `registerOrderedListsRoutes(app)` |
+| `web-ui/src/api/types.ts` | **Modified** | 1.6 | New `WSEvent` member: `orderedList:updated` |
+| `web-ui/src/api/client.ts` | **Modified** | 2.1 | New methods: `getOrderedList`, `setOrderedList` |
+| `web-ui/src/api/mock.ts` | **Modified** | 2.2 | Mirrored mock implementations; `setOrderedList` emits `orderedList:updated` |
+| `web-ui/src/hooks/useServerSync.ts` | **Modified** | 2.3, 2.4, 2.5 | `orderedListWriteInFlight` guard + exported `markOrderedListWrite`, mount-time migration/hydration, WS reducer for `orderedList:updated` |
+| `web-ui/src/components/layout/LeftSidebar.tsx` | **Modified** | 3.1, 3.2 | `handleReorder` gains a daemon write + in-flight guard for `scopeKey === "pinned-all"` |
+| `web-ui/src/components/layout/LeftSidebar.test.tsx` | **Modified** | 3.3 | New/extended drag + WS-sync test cases |
+| `daemon/src/__tests__/orderedListsStore.test.ts` | **New** | 1.T5, 1.T6 | Unit tests for the store module, incl. scope isolation |
+| `daemon/src/__tests__/orderedLists.routes.test.ts` | **New** | 1.T1-1.T4 | Route integration tests incl. broadcast (mirrors `worktrees.reorder.test.ts` / `sessions.rename.broadcast.test.ts` conventions) |

--- a/daemon/src/__tests__/orderedLists.routes.test.ts
+++ b/daemon/src/__tests__/orderedLists.routes.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildServer } from "../server.js";
+import type { FastifyInstance } from "fastify";
+import * as broadcasterNs from "../broadcaster.js";
+
+let tempDir: string;
+
+vi.mock("../services/paths.js", async () => {
+  const { join: pathJoin } = await import("node:path");
+  return {
+    vstHome: () => tempDir,
+    projectDir: (id: string) => pathJoin(tempDir, "projects", id),
+    manifestPath: (id: string) => pathJoin(tempDir, "projects", id, "manifest.json"),
+    manifestTmpPath: (id: string) => pathJoin(tempDir, "projects", id, "manifest.json.tmp"),
+    worktreePath: (id: string, wtId: string) =>
+      pathJoin(tempDir, "projects", id, "worktrees", wtId),
+    configPath: () => pathJoin(tempDir, "config.json"),
+    modesPath: () => pathJoin(tempDir, "modes.json"),
+    daemonLogPath: () => pathJoin(tempDir, "logs", "daemon.log"),
+    dbPath: () => pathJoin(tempDir, "vibe-station.db"),
+    cleanupSessionDataDir: () => {},
+    sessionDataDir: (p: string, w: string, s: string) =>
+      pathJoin(tempDir, "projects", p, "session-data", w, s),
+  };
+});
+
+vi.mock("../broadcaster.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../broadcaster.js")>();
+  return {
+    ...original,
+    broadcastAll: vi.fn(),
+  };
+});
+
+describe("GET/PUT /user/ordered-lists/:scopeKey", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "vst-ordered-lists-test-"));
+    app = await buildServer();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("1.T1 GET with no prior PUT returns an empty list and null updatedAt", async () => {
+    const res = await app.inject({ method: "GET", url: "/user/ordered-lists/pinned-all" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ scopeKey: "pinned-all", itemIds: [], updatedAt: null });
+  });
+
+  it("1.T2 PUT persists the order and a subsequent GET returns it", async () => {
+    const putRes = await app.inject({
+      method: "PUT",
+      url: "/user/ordered-lists/pinned-all",
+      payload: { itemIds: ["a", "b"] },
+    });
+    expect(putRes.statusCode).toBe(200);
+    const putBody = putRes.json<{ ok: boolean; scopeKey: string; itemIds: string[]; updatedAt: string }>();
+    expect(putBody).toMatchObject({ ok: true, scopeKey: "pinned-all", itemIds: ["a", "b"] });
+    expect(typeof putBody.updatedAt).toBe("string");
+
+    const getRes = await app.inject({ method: "GET", url: "/user/ordered-lists/pinned-all" });
+    expect(getRes.json<{ itemIds: string[] }>().itemIds).toEqual(["a", "b"]);
+  });
+
+  it("1.T3 rejects a non-array itemIds and an unknown scopeKey with 400", async () => {
+    const badBody = await app.inject({
+      method: "PUT",
+      url: "/user/ordered-lists/pinned-all",
+      payload: { itemIds: "not-an-array" },
+    });
+    expect(badBody.statusCode).toBe(400);
+    expect(badBody.json().error).toBe("Validation error");
+
+    const badScope = await app.inject({
+      method: "PUT",
+      url: "/user/ordered-lists/not-a-real-scope",
+      payload: { itemIds: [] },
+    });
+    expect(badScope.statusCode).toBe(400);
+
+    const badScopeGet = await app.inject({ method: "GET", url: "/user/ordered-lists/not-a-real-scope" });
+    expect(badScopeGet.statusCode).toBe(400);
+  });
+
+  it("1.T4 broadcasts orderedList:updated on a successful PUT", async () => {
+    const broadcastAll = vi.mocked(broadcasterNs.broadcastAll);
+    broadcastAll.mockClear();
+
+    const res = await app.inject({
+      method: "PUT",
+      url: "/user/ordered-lists/pinned-all",
+      payload: { itemIds: ["x", "y"] },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const call = broadcastAll.mock.calls.find(
+      ([msg]) => (msg as { type?: string }).type === "orderedList:updated",
+    );
+    expect(call).toBeDefined();
+    const event = call![0] as { scopeKey: string; itemIds: string[]; updatedAt: string };
+    expect(event.scopeKey).toBe("pinned-all");
+    expect(event.itemIds).toEqual(["x", "y"]);
+    expect(typeof event.updatedAt).toBe("string");
+  });
+});

--- a/daemon/src/__tests__/orderedListsStore.test.ts
+++ b/daemon/src/__tests__/orderedListsStore.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { vi } from "vitest";
+
+let tempDir: string;
+
+vi.mock("../services/paths.js", async () => {
+  const { join: pathJoin } = await import("node:path");
+  return {
+    dbPath: () => pathJoin(tempDir, "vibe-station.db"),
+  };
+});
+
+describe("orderedListsStore", () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "vst-ordered-lists-store-test-"));
+    const { _resetDbForTest } = await import("../state/db.js");
+    _resetDbForTest();
+  });
+
+  afterEach(async () => {
+    const { _resetDbForTest } = await import("../state/db.js");
+    _resetDbForTest();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("1.T5 setOrderedList overwrites rather than appending on repeated calls", async () => {
+    const { getOrderedList, setOrderedList } = await import("../state/orderedListsStore.js");
+    setOrderedList("pinned-all", ["a", "b"]);
+    setOrderedList("pinned-all", ["c"]);
+    expect(getOrderedList("pinned-all").itemIds).toEqual(["c"]);
+  });
+
+  it("1.T6 rows for different scopeKeys are isolated (composite PK)", async () => {
+    const { getOrderedList, setOrderedList } = await import("../state/orderedListsStore.js");
+    setOrderedList("pinned-all", ["a"]);
+    setOrderedList("workspaces:global", ["b"]);
+    expect(getOrderedList("pinned-all").itemIds).toEqual(["a"]);
+    expect(getOrderedList("workspaces:global").itemIds).toEqual(["b"]);
+  });
+
+  it("getOrderedList returns an empty list and null updatedAt when no row exists", async () => {
+    const { getOrderedList } = await import("../state/orderedListsStore.js");
+    expect(getOrderedList("pinned-all")).toEqual({ itemIds: [], updatedAt: null });
+  });
+});

--- a/daemon/src/routes/orderedLists.ts
+++ b/daemon/src/routes/orderedLists.ts
@@ -1,0 +1,48 @@
+/**
+ * GET/PUT /user/ordered-lists/:scopeKey — daemon-persisted, cross-client
+ * ordered id lists (pinned-order-sync). `scopeKey` is a generic dimension
+ * (Decision 1, `.vibekit/feature-plans/wip/pinned-order-sync/plan-pinned-order-sync.md`)
+ * but allowlisted here (Decision 7) so an authenticated client can't grow
+ * the table with arbitrary keys. Every query implicitly targets the single
+ * implicit 'local' user — see `state/orderedListsStore.ts` and the Scenes
+ * PRD's identical "single implicit user, shaped for later" direction.
+ */
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { getOrderedList, setOrderedList } from "../state/orderedListsStore.js";
+import { broadcastAll } from "../broadcaster.js";
+
+const ScopeKeyParam = z.object({
+  scopeKey: z.enum(["pinned-all"]),
+});
+
+const PutOrderedListBody = z.object({
+  itemIds: z.array(z.string()).max(500),
+});
+
+export function registerOrderedListsRoutes(app: FastifyInstance): void {
+  app.get("/user/ordered-lists/:scopeKey", async (req, reply) => {
+    const parsedParams = ScopeKeyParam.safeParse(req.params);
+    if (!parsedParams.success) {
+      return reply.status(400).send({ error: "Validation error", details: parsedParams.error.issues });
+    }
+    const { scopeKey } = parsedParams.data;
+    const { itemIds, updatedAt } = getOrderedList(scopeKey);
+    return reply.send({ scopeKey, itemIds, updatedAt });
+  });
+
+  app.put("/user/ordered-lists/:scopeKey", async (req, reply) => {
+    const parsedParams = ScopeKeyParam.safeParse(req.params);
+    if (!parsedParams.success) {
+      return reply.status(400).send({ error: "Validation error", details: parsedParams.error.issues });
+    }
+    const parsedBody = PutOrderedListBody.safeParse(req.body);
+    if (!parsedBody.success) {
+      return reply.status(400).send({ error: "Validation error", details: parsedBody.error.issues });
+    }
+    const { scopeKey } = parsedParams.data;
+    const { itemIds, updatedAt } = setOrderedList(scopeKey, parsedBody.data.itemIds);
+    broadcastAll({ type: "orderedList:updated", scopeKey, itemIds, updatedAt });
+    return reply.send({ ok: true, scopeKey, itemIds, updatedAt });
+  });
+}

--- a/daemon/src/server.ts
+++ b/daemon/src/server.ts
@@ -12,6 +12,7 @@ import { registerSessionRoutes } from "./routes/sessions.js";
 import { registerAttachmentRoutes } from "./routes/attachments.js";
 import { registerModeRoutes } from "./routes/modes.js";
 import { registerSettingsRoutes } from "./routes/settings.js";
+import { registerOrderedListsRoutes } from "./routes/orderedLists.js";
 import { registerFsRoutes } from "./routes/fs.js";
 import { registerAuthRoutes } from "./routes/auth.js";
 import { registerWSEndpoint } from "./ws/server.js";
@@ -137,6 +138,7 @@ export async function buildServer(opts: BuildServerOptions = {}) {
   registerAttachmentRoutes(app);
   registerModeRoutes(app);
   registerSettingsRoutes(app);
+  registerOrderedListsRoutes(app);
   registerFsRoutes(app);
   await registerWSEndpoint(app, noAuth ? undefined : token);
 

--- a/daemon/src/services/dbSchema.ts
+++ b/daemon/src/services/dbSchema.ts
@@ -90,6 +90,22 @@ export function ensureSchema(db: Database): void {
       status TEXT NOT NULL CHECK (status IN ('ok', 'failed')),
       error TEXT
     );
+
+    -- Per-user, per-scope ordered id list (pinned-order-sync) — generic over
+    -- scopeKey so future client-only orderings (e.g. the sidebar's project
+    -- tree order, saved-workspace order) can reuse this table without a new
+    -- migration. No users table exists yet, so userId is a bare string,
+    -- always 'local' today (routes/orderedLists.ts) — see PRD-scenes.md's
+    -- identical "single implicit user, shaped for a real user model later"
+    -- direction. itemIds is a JSON-encoded string array, mirroring the
+    -- client's sortOrders[scopeKey] shape exactly.
+    CREATE TABLE IF NOT EXISTS user_ordered_lists (
+      userId TEXT NOT NULL,
+      scopeKey TEXT NOT NULL,
+      itemIds TEXT NOT NULL,
+      updatedAt TEXT NOT NULL,
+      PRIMARY KEY (userId, scopeKey)
+    );
   `);
 
   // `CREATE TABLE IF NOT EXISTS` above is a no-op against a `worktrees` table

--- a/daemon/src/state/orderedListsStore.ts
+++ b/daemon/src/state/orderedListsStore.ts
@@ -1,0 +1,34 @@
+/**
+ * Read/write access to the `user_ordered_lists` table (pinned-order-sync).
+ * Every query is scoped to the single implicit `'local'` user — see
+ * `routes/orderedLists.ts` for the allowlist of valid `scopeKey`s and the
+ * future-user-model rationale.
+ */
+import { getDb } from "./db.js";
+
+const LOCAL_USER_ID = "local";
+
+export interface OrderedList {
+  itemIds: string[];
+  updatedAt: string | null;
+}
+
+export function getOrderedList(scopeKey: string): OrderedList {
+  const row = getDb()
+    .prepare("SELECT itemIds, updatedAt FROM user_ordered_lists WHERE userId = ? AND scopeKey = ?")
+    .get(LOCAL_USER_ID, scopeKey) as { itemIds: string; updatedAt: string } | undefined;
+  if (!row) return { itemIds: [], updatedAt: null };
+  return { itemIds: JSON.parse(row.itemIds) as string[], updatedAt: row.updatedAt };
+}
+
+export function setOrderedList(scopeKey: string, itemIds: string[]): OrderedList {
+  const updatedAt = new Date().toISOString();
+  getDb()
+    .prepare(
+      `INSERT INTO user_ordered_lists (userId, scopeKey, itemIds, updatedAt)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(userId, scopeKey) DO UPDATE SET itemIds = excluded.itemIds, updatedAt = excluded.updatedAt`,
+    )
+    .run(LOCAL_USER_ID, scopeKey, JSON.stringify(itemIds), updatedAt);
+  return { itemIds, updatedAt };
+}

--- a/daemon/src/ws/protocol.ts
+++ b/daemon/src/ws/protocol.ts
@@ -411,6 +411,17 @@ const WorktreeUpdatedEvent = z.object({
   worktree: z.record(z.string(), z.unknown()),
 });
 
+// Pinned-order-sync — broadcast whenever PUT /user/ordered-lists/:scopeKey
+// upserts a row (routes/orderedLists.ts). `scopeKey` is generic (Decision 1,
+// plan-pinned-order-sync.md) even though only "pinned-all" is allowlisted
+// server-side today.
+const OrderedListUpdatedEvent = z.object({
+  type: z.literal("orderedList:updated"),
+  scopeKey: z.string(),
+  itemIds: z.array(z.string()),
+  updatedAt: z.string(),
+});
+
 const ModeCreatedEvent = z.object({
   type: z.literal("mode:created"),
   mode: z.record(z.string(), z.unknown()),
@@ -488,6 +499,7 @@ export const ServerMessage = z.discriminatedUnion("type", [
   WorktreeCreatedEvent,
   WorktreeDeletedEvent,
   WorktreeUpdatedEvent,
+  OrderedListUpdatedEvent,
   ModeCreatedEvent,
   ModeUpdatedEvent,
   ModeDeletedEvent,

--- a/web-ui/src/api/client.ts
+++ b/web-ui/src/api/client.ts
@@ -392,6 +392,27 @@ export function createClientApi() {
       return parseJson<{ ok: true; sortOrder: number }>(res);
     },
 
+    /** Daemon-persisted ordered id list for a given scope (pinned-order-sync). */
+    async getOrderedList(scopeKey: string): Promise<{ scopeKey: string; itemIds: string[]; updatedAt: string | null }> {
+      const root = baseUrl();
+      const res = await apiFetch(`${root}/user/ordered-lists/${encodeURIComponent(scopeKey)}`);
+      return parseJson<{ scopeKey: string; itemIds: string[]; updatedAt: string | null }>(res);
+    },
+
+    /** Persist the full ordered id list for a given scope (pinned-order-sync). */
+    async setOrderedList(
+      scopeKey: string,
+      itemIds: string[],
+    ): Promise<{ ok: true; scopeKey: string; itemIds: string[]; updatedAt: string }> {
+      const root = baseUrl();
+      const res = await apiFetch(`${root}/user/ordered-lists/${encodeURIComponent(scopeKey)}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ itemIds }),
+      });
+      return parseJson<{ ok: true; scopeKey: string; itemIds: string[]; updatedAt: string }>(res);
+    },
+
     async listSessions(worktreeId?: string): Promise<Session[]> {
       const root = baseUrl();
       const url = worktreeId

--- a/web-ui/src/api/mock.test.ts
+++ b/web-ui/src/api/mock.test.ts
@@ -130,6 +130,31 @@ describe("mock api contract", () => {
     off();
   });
 
+  it("2.T1 getOrderedList/setOrderedList round-trip and emit orderedList:updated", async () => {
+    const api = createMockApi();
+    const handler = vi.fn();
+    const off = api.on("orderedList:updated", handler);
+
+    expect(await api.getOrderedList("pinned-all")).toEqual({
+      scopeKey: "pinned-all",
+      itemIds: [],
+      updatedAt: null,
+    });
+
+    const res = await api.setOrderedList("pinned-all", ["x"]);
+    expect(res.ok).toBe(true);
+    expect(res.itemIds).toEqual(["x"]);
+    expect(typeof res.updatedAt).toBe("string");
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "orderedList:updated", scopeKey: "pinned-all", itemIds: ["x"] }),
+    );
+
+    const after = await api.getOrderedList("pinned-all");
+    expect(after.itemIds).toEqual(["x"]);
+    expect(after.updatedAt).toBe(res.updatedAt);
+    off();
+  });
+
   it("renameSession updates name/nameSource, clears on empty string, and emits session:updated", async () => {
     const api = createMockApi();
     const handler = vi.fn();

--- a/web-ui/src/api/mock.ts
+++ b/web-ui/src/api/mock.ts
@@ -57,6 +57,9 @@ const MOCK_FS_TREE: Record<string, string[]> = {
 };
 
 export function createMockApi() {
+  /** Daemon-persisted ordered id lists, keyed by scopeKey (pinned-order-sync). */
+  const orderedLists = new Map<string, { itemIds: string[]; updatedAt: string }>();
+
   const projects: Project[] = [
     {
       id: "proj-a",
@@ -504,6 +507,23 @@ export function createMockApi() {
       wt.sortOrder = sortOrder;
       emit({ type: "worktree:updated", worktree: structuredClone(wt) });
       return { ok: true, sortOrder };
+    },
+
+    async getOrderedList(scopeKey: string): Promise<{ scopeKey: string; itemIds: string[]; updatedAt: string | null }> {
+      const row = orderedLists.get(scopeKey);
+      return row
+        ? { scopeKey, itemIds: [...row.itemIds], updatedAt: row.updatedAt }
+        : { scopeKey, itemIds: [], updatedAt: null };
+    },
+
+    async setOrderedList(
+      scopeKey: string,
+      itemIds: string[],
+    ): Promise<{ ok: true; scopeKey: string; itemIds: string[]; updatedAt: string }> {
+      const updatedAt = nowIso();
+      orderedLists.set(scopeKey, { itemIds: [...itemIds], updatedAt });
+      emit({ type: "orderedList:updated", scopeKey, itemIds: [...itemIds], updatedAt });
+      return { ok: true, scopeKey, itemIds: [...itemIds], updatedAt };
     },
 
     async listSessions(worktreeId?: string): Promise<Session[]> {

--- a/web-ui/src/api/types.ts
+++ b/web-ui/src/api/types.ts
@@ -465,6 +465,14 @@ export type WSEvent =
       worktree: Worktree;
     }
   | {
+      /** Broadcast after PUT /user/ordered-lists/:scopeKey (pinned-order-sync).
+       *  `scopeKey` is generic even though only "pinned-all" is wired up today. */
+      type: "orderedList:updated";
+      scopeKey: string;
+      itemIds: string[];
+      updatedAt: string;
+    }
+  | {
       type: "mode:created";
       mode: Mode;
     }

--- a/web-ui/src/components/layout/LeftSidebar.test.tsx
+++ b/web-ui/src/components/layout/LeftSidebar.test.tsx
@@ -21,6 +21,16 @@ import { useServerSync } from "@/hooks/useServerSync";
  */
 let capturedOnDragStart: (() => void) | null = null;
 let capturedOnDragEnd: ((e: DragEndEvent) => void) | null = null;
+/**
+ * Pinned-order-sync: with a pinned item AND a regular (unpinned) worktree
+ * both present, more than one `DndContext` renders, so the single
+ * "last one wins" capture above can't isolate the pinned list's handler
+ * (it renders first in JSX, not last). Pair each `DndContext`'s `onDragEnd`
+ * with its immediate child `SortableContext`'s `items` (the id list) so
+ * tests can pick the pair whose `items` match the pinned list.
+ */
+let capturedDndPairs: Array<{ onDragEnd: (e: DragEndEvent) => void; items: string[] }> = [];
+let pendingOnDragEnd: ((e: DragEndEvent) => void) | null = null;
 vi.mock("@dnd-kit/core", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@dnd-kit/core")>();
   return {
@@ -28,7 +38,24 @@ vi.mock("@dnd-kit/core", async (importOriginal) => {
     DndContext: (props: Parameters<typeof actual.DndContext>[0]) => {
       capturedOnDragStart = (props.onDragStart as (() => void) | undefined) ?? null;
       capturedOnDragEnd = props.onDragEnd ?? null;
+      pendingOnDragEnd = props.onDragEnd ?? null;
       return createElement(actual.DndContext, props);
+    },
+  };
+});
+vi.mock("@dnd-kit/sortable", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@dnd-kit/sortable")>();
+  return {
+    ...actual,
+    SortableContext: (props: Parameters<typeof actual.SortableContext>[0]) => {
+      if (pendingOnDragEnd) {
+        capturedDndPairs.push({
+          onDragEnd: pendingOnDragEnd,
+          items: (props.items as Array<string | number>).map(String),
+        });
+        pendingOnDragEnd = null;
+      }
+      return createElement(actual.SortableContext, props);
     },
   };
 });
@@ -47,6 +74,8 @@ describe("LeftSidebar", () => {
   beforeEach(() => {
     capturedOnDragStart = null;
     capturedOnDragEnd = null;
+    capturedDndPairs = [];
+    pendingOnDragEnd = null;
     localStorage.clear();
     useWorkspaceStore.persist.clearStorage?.();
     useWorkspaceStore.setState({
@@ -514,6 +543,123 @@ describe("LeftSidebar", () => {
         );
         expect(labels).toEqual(["direct-agent-1", "wt-2"]);
       });
+    });
+  });
+
+  // ─── Pinned-order-sync: daemon-persisted pinned-list drag order ────────────
+  describe("pinned order sync", () => {
+    beforeEach(() => {
+      // Prevent a prior test's pinned-all order from leaking into this one's
+      // CUJ-2 migration check (a non-empty local order + a fresh mock api's
+      // empty server-side row would otherwise auto-push on mount).
+      useWorkspaceStore.setState({ sortOrders: {} });
+    });
+
+    /**
+     * wt-1 (proj-a) + wt-3 (proj-b) — a CROSS-project pair. Every other
+     * DndContext in this fixture is scoped to a single project, so no other
+     * SortableContext's `items` can ever equal this exact pair; that's
+     * precisely the reason the pinned list needs its own daemon-synced
+     * mechanism (Problem, plan-pinned-order-sync.md). Using a same-project
+     * pair here (e.g. wt-1 + wt-2) would collide with proj-a's own regular
+     * worktree-order DndContext, which happens to list exactly those two.
+     */
+    async function pinCrossProjectPair(localApi: ReturnType<typeof createMockApi>) {
+      await localApi.pinWorktree("wt-1");
+      await localApi.pinWorktree("wt-3");
+    }
+
+    function findPinnedPair() {
+      return capturedDndPairs.find(
+        (p) => p.items.length === 2 && p.items.includes("wt-1") && p.items.includes("wt-3"),
+      );
+    }
+
+    it("3.T1 dragging a pinned item calls api.setOrderedList with the new order", async () => {
+      const localApi = createMockApi();
+      await pinCrossProjectPair(localApi);
+      const setOrderedListSpy = vi.spyOn(localApi, "setOrderedList");
+      render(
+        <MemoryRouter>
+          <Harness api={localApi}>
+            <LeftSidebar api={localApi} />
+          </Harness>
+        </MemoryRouter>,
+      );
+      await screen.findByRole("region", { name: /^pinned$/i });
+
+      await waitFor(() => {
+        expect(findPinnedPair()).toBeDefined();
+      });
+      const pinnedPair = findPinnedPair()!;
+      const [firstId, secondId] = pinnedPair.items;
+
+      act(() => {
+        pinnedPair.onDragEnd({
+          active: { id: firstId },
+          over: { id: secondId },
+        } as DragEndEvent);
+      });
+
+      await waitFor(() => {
+        expect(setOrderedListSpy).toHaveBeenCalledWith(
+          "pinned-all",
+          expect.arrayContaining([firstId, secondId]),
+        );
+      });
+      // The dragged item must actually have moved — not a same-position no-op.
+      const [, calledOrder] = setOrderedListSpy.mock.calls[setOrderedListSpy.mock.calls.length - 1]!;
+      expect(calledOrder).not.toEqual(pinnedPair.items);
+    });
+
+    it("3.T2 an incoming orderedList:updated WS event re-renders the pinned list in the new order, no reload", async () => {
+      const localApi = createMockApi();
+      await pinCrossProjectPair(localApi);
+      render(
+        <MemoryRouter>
+          <Harness api={localApi}>
+            <LeftSidebar api={localApi} />
+          </Harness>
+        </MemoryRouter>,
+      );
+      await screen.findByRole("region", { name: /^pinned$/i });
+
+      act(() => {
+        localApi.__test.emit({
+          type: "orderedList:updated",
+          scopeKey: "pinned-all",
+          itemIds: ["wt-3", "wt-1"],
+          updatedAt: new Date().toISOString(),
+        });
+      });
+
+      await waitFor(() => {
+        const region = screen.getByRole("region", { name: /^pinned$/i });
+        const labels = Array.from(region.querySelectorAll(".pinned-row__primary")).map(
+          (n) => n.textContent,
+        );
+        expect(labels).toEqual(["wt-main", "wt-1"]);
+      });
+    });
+
+    it("3.T3 reordering the (unrelated) projects scope does not call api.setOrderedList", async () => {
+      const localApi = createMockApi();
+      const setOrderedListSpy = vi.spyOn(localApi, "setOrderedList");
+      render(
+        <MemoryRouter>
+          <Harness api={localApi}>
+            <LeftSidebar api={localApi} />
+          </Harness>
+        </MemoryRouter>,
+      );
+      await screen.findByRole("link", { name: /Open worktree wt-1/i });
+
+      act(() => {
+        useWorkspaceStore.getState().setSortOrder("projects", ["proj-b", "proj-a"]);
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(setOrderedListSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/web-ui/src/components/layout/LeftSidebar.tsx
+++ b/web-ui/src/components/layout/LeftSidebar.tsx
@@ -21,6 +21,7 @@ import type { ApiInstance } from "@/api";
 import type { Project, Session, SessionState, Worktree } from "@/api/types";
 import { computeNewSortOrder, useWorkspaceStore, type WorkspaceDoc } from "@/hooks/useStore";
 import { useServerStore } from "@/hooks/useServerStore";
+import { markOrderedListWrite, clearOrderedListWrite } from "@/hooks/useServerSync";
 import { useLayout } from "@/hooks/useLayout";
 import { useDragClickGuard } from "@/hooks/useDragClickGuard";
 import { useSubscription } from "@/hooks/useSubscription";
@@ -297,10 +298,15 @@ export function LeftSidebar({
   const hasPinned = pinnedWorktrees.length > 0 || pinnedDirectSessions.length > 0;
 
   // --- Rename + drag-reorder (Part 03 Phase 2): real daemon endpoints for
-  // regular (unpinned) worktree/direct-session scopes. Pinned sub-lists keep
-  // the old local-only `sortOrders` mechanism (see `applyLocalSortOrder`
-  // above) — the server's per-worktree/per-project `sortOrder` column can't
-  // express a cross-project pinned order (Decision 1 exception). ---
+  // regular (unpinned) worktree/direct-session scopes, via the per-worktree/
+  // per-project `sortOrder` column, which can't express a cross-project
+  // pinned order (Decision 1 exception). The `pinned-all` sub-list is ALSO
+  // daemon-synced now (pinned-order-sync), but through a separate mechanism:
+  // a generic `user_ordered_lists` table keyed by scopeKey, not the
+  // `sortOrder` column — see `handleReorder`'s `scopeKey === "pinned-all"`
+  // branch below. Every other scope (`projects`, `workspaces:global`) still
+  // uses the old local-only `sortOrders` mechanism (`applyLocalSortOrder`
+  // above). ---
   const sortOrders = useWorkspaceStore((s) => s.sortOrders);
   const setSortOrder = useWorkspaceStore((s) => s.setSortOrder);
   // --- Saved workspace layouts (per-worktree, purely client-side — no daemon
@@ -408,7 +414,9 @@ export function LeftSidebar({
   /** Reorder scope: pinned worktrees and direct sessions float in a single drag-order list,
    *  independent of pin recency once the user has dragged them (documented
    *  choice — see task write-up: pin recency is only the *default* order).
-   *  Pinned lists keep the OLD local-only mechanism (Decision 1 exception). */
+   *  `sortOrders["pinned-all"]` is now daemon-synced (pinned-order-sync) —
+   *  hydrated on mount/reconnect and kept live via `orderedList:updated`
+   *  (see `useServerSync.ts`), so this read site needs no changes. */
   const orderedPinnedItems = useMemo(() => {
     const items = [
       ...pinnedWorktrees.map((w) => ({ id: w.id, kind: "worktree" as const, data: w })),
@@ -435,7 +443,9 @@ export function LeftSidebar({
     return order.map((id) => byId.get(id)!).filter(Boolean);
   }, [visibleProjects, sortOrders]);
 
-  /** Pinned-scope reorder handler — unchanged local-only mechanism. */
+  /** Pinned-scope reorder handler. `pinned-all` is now daemon-synced
+   *  (pinned-order-sync) — every other scope stays on the old local-only
+   *  `sortOrders` mechanism (see the comment above `sortOrders`). */
   function handleReorder(scopeKey: string, currentIds: string[], e: DragEndEvent) {
     // Mark BEFORE the early return: a drag that ends where it started still
     // produces the trailing click that would navigate the row's <a href>.
@@ -449,6 +459,18 @@ export function LeftSidebar({
     next.splice(from, 1);
     next.splice(to, 0, String(active.id));
     setSortOrder(scopeKey, next);
+
+    if (scopeKey === "pinned-all") {
+      const p = api.setOrderedList("pinned-all", next).catch(() => {
+        // Stale until the next successful write or reload — there is
+        // nothing to roll back to, local state already reflects intent.
+      });
+      markOrderedListWrite(p);
+      // Compare-and-clear: if a second drag started a newer write before
+      // this one settles, clearOrderedListWrite no-ops instead of wiping
+      // the newer promise out from under it.
+      void p.finally(() => clearOrderedListWrite(p));
+    }
   }
 
   /** Workspaces-section reorder — client-only, mirrors `handleReorder` above

--- a/web-ui/src/hooks/useServerSync.test.ts
+++ b/web-ui/src/hooks/useServerSync.test.ts
@@ -334,6 +334,90 @@ describe("useServerSync — session:created auto-insert (Phase 4c)", () => {
   });
 });
 
+// --- pinned-order-sync: mount-time migration/hydration + WS reducer ---
+describe("useServerSync — pinned order sync", () => {
+  beforeEach(() => {
+    useServerStore.setState({ projects: [], worktrees: [], sessions: [], loaded: false });
+    useWorkspaceStore.setState({ sortOrders: {} });
+  });
+
+  it("2.T2 pushes an existing local order to the daemon when the server has none yet", async () => {
+    useWorkspaceStore.setState({ sortOrders: { "pinned-all": ["a", "b"] } });
+    const api = createMockApi();
+    const setOrderedListSpy = vi.spyOn(api, "setOrderedList");
+    renderHook(() => useServerSync(api));
+    await waitFor(() => expect(useServerStore.getState().loaded).toBe(true));
+
+    await waitFor(() => {
+      expect(setOrderedListSpy).toHaveBeenCalledWith("pinned-all", ["a", "b"]);
+    });
+  });
+
+  it("2.T3 hydrates local sortOrders from an existing daemon-side order, overriding stale local state", async () => {
+    useWorkspaceStore.setState({ sortOrders: { "pinned-all": ["stale"] } });
+    const api = createMockApi();
+    await api.setOrderedList("pinned-all", ["c", "d"]);
+    renderHook(() => useServerSync(api));
+    await waitFor(() => expect(useServerStore.getState().loaded).toBe(true));
+
+    await waitFor(() => {
+      expect(useWorkspaceStore.getState().sortOrders["pinned-all"]).toEqual(["c", "d"]);
+    });
+  });
+
+  it("2.T4 applies an orderedList:updated WS event for pinned-all, ignores other scopeKeys", async () => {
+    const api = createMockApi();
+    renderHook(() => useServerSync(api));
+    await waitFor(() => expect(useServerStore.getState().loaded).toBe(true));
+
+    act(() => {
+      api.__test.emit({
+        type: "orderedList:updated",
+        scopeKey: "pinned-all",
+        itemIds: ["x", "y"],
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      });
+    });
+    await waitFor(() => {
+      expect(useWorkspaceStore.getState().sortOrders["pinned-all"]).toEqual(["x", "y"]);
+    });
+
+    act(() => {
+      api.__test.emit({
+        type: "orderedList:updated",
+        scopeKey: "projects",
+        itemIds: ["should-not-apply"],
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      });
+    });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(useWorkspaceStore.getState().sortOrders["projects"]).toBeUndefined();
+  });
+
+  it("2.T5 skips the hydrate branch while a pinned-order write is in flight", async () => {
+    useWorkspaceStore.setState({ sortOrders: { "pinned-all": ["local"] } });
+    const api = createMockApi();
+    await api.setOrderedList("pinned-all", ["server"]);
+
+    const { markOrderedListWrite } = await import("./useServerSync");
+    let resolveWrite!: () => void;
+    const pendingWrite = new Promise<void>((resolve) => {
+      resolveWrite = resolve;
+    });
+    markOrderedListWrite(pendingWrite);
+
+    renderHook(() => useServerSync(api));
+    await waitFor(() => expect(useServerStore.getState().loaded).toBe(true));
+
+    // The hydrate branch would normally overwrite local with the server's
+    // ["server"] value — it must NOT while the write guard is set.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(useWorkspaceStore.getState().sortOrders["pinned-all"]).toEqual(["local"]);
+
+    resolveWrite();
+  });
+});
+
 // --- worktree:deleted sweeps `tools:<worktreeId>` tiles, which carry no
 // sessionId and so are unreachable by the session-keyed cleanup ---
 describe("useServerSync — worktree:deleted tools-tile cleanup", () => {

--- a/web-ui/src/hooks/useServerSync.ts
+++ b/web-ui/src/hooks/useServerSync.ts
@@ -23,6 +23,28 @@ import {
  */
 let inFlightRefresh: Promise<void> | null = null;
 
+/** Dedup guard for `syncPinnedOrder`, mirroring `inFlightRefresh` above. */
+let inFlightPinnedOrderSync: Promise<void> | null = null;
+
+/**
+ * Set while a `pinned-all` `PUT /user/ordered-lists/pinned-all` (LeftSidebar's
+ * drag handler) is in flight. Guards `syncPinnedOrder`'s hydrate branch below
+ * from clobbering a just-made local drag with a stale server value fetched by
+ * a reconnect-triggered refresh landing mid-write (pinned-order-sync CUJ 1
+ * "Reconnect race"). `clearOrderedListWrite` is compare-and-clear so a second
+ * drag's still-pending write can't be cleared early by the first drag's
+ * `finally` settling after a newer write started (Risk 4).
+ */
+let orderedListWriteInFlight: Promise<unknown> | null = null;
+
+export function markOrderedListWrite(p: Promise<unknown>): void {
+  orderedListWriteInFlight = p;
+}
+
+export function clearOrderedListWrite(p: Promise<unknown>): void {
+  if (orderedListWriteInFlight === p) orderedListWriteInFlight = null;
+}
+
 /**
  * Mount once at the top of the authenticated app (in `Workspace`). Owns:
  *
@@ -85,9 +107,38 @@ export function useServerSync(api: ApiInstance): void {
       return inFlightRefresh;
     }
 
+    // Pinned-order-sync (Decision 5): mirrors `refresh()`'s trigger points
+    // (mount + every `ws:open`, including reconnects) but is a separate,
+    // independently-dedup'd resource — a stale bundle refetch racing this
+    // is unrelated. The hydrate branch is skipped while a local drag's
+    // write is in flight (`orderedListWriteInFlight`) so a reconnect landing
+    // mid-drag can't clobber the just-made local order with a stale server
+    // value; the pending write's own response/WS-echo settles it right after.
+    function syncPinnedOrder(): Promise<void> {
+      if (inFlightPinnedOrderSync) return inFlightPinnedOrderSync;
+      inFlightPinnedOrderSync = (async () => {
+        try {
+          const pinnedOrder = await api.getOrderedList("pinned-all");
+          if (pinnedOrder.updatedAt === null) {
+            const local = useWorkspaceStore.getState().sortOrders["pinned-all"];
+            if (local && local.length > 0) {
+              await api.setOrderedList("pinned-all", local);
+            }
+          } else if (!orderedListWriteInFlight) {
+            useWorkspaceStore.getState().setSortOrder("pinned-all", pinnedOrder.itemIds);
+          }
+        } finally {
+          inFlightPinnedOrderSync = null;
+        }
+      })();
+      return inFlightPinnedOrderSync;
+    }
+
     void refresh();
+    void syncPinnedOrder();
     const off = api.on("ws:open", () => {
       void refresh();
+      void syncPinnedOrder();
     });
     return off;
   }, [api, replaceAll, syncSessionsFromApi]);
@@ -227,6 +278,11 @@ export function useServerSync(api: ApiInstance): void {
         }
       }
     });
+    const offOrderedListUpdated = api.on("orderedList:updated", (ev) => {
+      if (ev.type === "orderedList:updated" && ev.scopeKey === "pinned-all") {
+        useWorkspaceStore.getState().setSortOrder("pinned-all", ev.itemIds);
+      }
+    });
     return () => {
       offProjCreated();
       offProjDeleted();
@@ -240,6 +296,7 @@ export function useServerSync(api: ApiInstance): void {
       offSessResumed();
       offSessDeleted();
       offSessUpdated();
+      offOrderedListUpdated();
     };
   }, [
     api,


### PR DESCRIPTION
## Summary
- The pinned worktrees/direct-sessions drag order lived only in browser `localStorage`, so it differed per device (phone, laptop1, laptop2, ...).
- Adds a daemon-persisted, per-user ordered-list primitive: a generic `user_ordered_lists` SQLite table keyed by `(userId, scopeKey)` (single implicit `'local'` user for now, shaped for a real user model later — matches the existing Scenes-PRD direction), with `GET/PUT /user/ordered-lists/:scopeKey` and a live `orderedList:updated` WS broadcast.
- Wires the pinned list's drag handler in `LeftSidebar` + `useServerSync`'s mount/reconnect hydration through it, so pin order now follows the user across every open client instead of being per-browser.
- One-time client-side migration: an existing local-only order is pushed to the daemon on first sync if the daemon has no row yet, so no one's current arrangement is lost.
- Design/plan (reviewed by Opus, 2 rounds): `.vibekit/feature-plans/wip/pinned-order-sync/plan-pinned-order-sync.md`

## Test plan
- [x] `cli` package (daemon) test suite: 811 tests pass, incl. new route/store tests for the ordered-lists endpoint (validation, persistence, WS broadcast, scope isolation)
- [x] `web-ui` test suite: 576 tests pass, incl. new tests for the mock API, `useServerSync` migration/hydration/reconnect-race guard, and the sidebar drag → daemon write → live WS re-render flow
- [x] Both packages typecheck and lint clean
- [ ] Manual: confirm two real open clients (e.g. two browser tabs, or laptop + phone) see a pinned-list drag propagate live without a manual refresh — not run in this session (no device seized); every link in that chain is unit/integration-tested individually (broadcast payload, WS reducer, sidebar re-render) via existing shared WS infrastructure already proven for every other synced entity