### PR TITLE
ACP: migrate Rich Chat to Agent Client Protocol + lossless normalize + permission fix

### DIFF
--- a/.vibekit/feature-plans/wip/acp-migration/.sdlc-state.yaml
+++ b/.vibekit/feature-plans/wip/acp-migration/.sdlc-state.yaml
@@ -1,0 +1,48 @@
+feature: acp-migration
+worktree: /home/gb/.vibe-station/projects/vibe-station/worktrees/vs-60
+master:
+  prd: skipped
+  plan: skipped
+current_subfeature: 02-new-plugins
+subfeatures:
+  - id: 01-core-plugins
+    origin: planned
+    spawned_from: null
+    mode: planning
+    last_completed: null
+    awaiting_phase: review
+    awaiting_artifact: .vibekit/feature-plans/wip/acp-migration/01-core-plugins/plan-01-acp-migration-core-plugins.md
+    phase_chain: [plan, review]
+    superseded_reason: null
+    parked_reason: null
+    handoff: {next_item: null, returned_at: null, verified_by: null}
+    commit: null
+    reviewer_model: opus
+    reviewer_verdict: "had issues — fixed in place, now clean"
+  - id: 02-new-plugins
+    origin: planned
+    spawned_from: null
+    mode: planning
+    last_completed: null
+    awaiting_phase: review
+    awaiting_artifact: .vibekit/feature-plans/wip/acp-migration/02-new-plugins/plan-02-acp-migration-new-plugins.md
+    phase_chain: [plan, review]
+    superseded_reason: null
+    parked_reason: null
+    handoff: {next_item: null, returned_at: null, verified_by: null}
+    commit: null
+    reviewer_model: opus
+    reviewer_verdict: "had issues — fixed in place, now clean"
+
+notes:
+  - "Unattended decomposition decision: no master PRD/arch was written. This feature was split directly
+     into two sibling sub-plans (01-core-plugins, 02-new-plugins) at feature creation, bypassing the
+     normal root->arch->parts flow, because the task explicitly asked for two related-but-separable
+     plans and both are independently executable without a system-level arch document. Flagged here
+     as a human-confirmable process choice, not a technical one."
+  - "Chain requested was plan+review only, per invocation scope. Both sub-features are correctly
+     stopped at awaiting_phase: review (chain end is a hard stop regardless of gate). implement/verify
+     were never started."
+  - "reviewer.model: opus was used for both review passes (config had no .vibekit/config.yaml override;
+     opus is also the ${CLI_DEFAULT} resolution for Claude Code, so this matches both the explicit ask
+     and the tool default)."

--- a/.vibekit/feature-plans/wip/acp-migration/01-core-plugins/plan-01-acp-migration-core-plugins.md
+++ b/.vibekit/feature-plans/wip/acp-migration/01-core-plugins/plan-01-acp-migration-core-plugins.md
@@ -1,0 +1,820 @@
+<!--
+RULES — read before writing or implementing:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. REQUIREMENTS: One crisp line each — no verbose descriptions
+3. CHECKLIST: Mark items [x] as you complete them — this is your persistent todo list
+4. READING TIME: Optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+# Plan: ACP Migration — Core Plugins (claude, cursor, opencode, agy)
+
+> Swap the Rich Chat (`json` channel) turn transport from per-turn one-shot CLI subprocess to a persistent Agent Client Protocol (ACP) connection, for all 4 plugins. Terminal channel (tmux/PTY) untouched.
+
+**Issue:** acp-migration
+**Branch:** `feat/acp-migration-core-plugins`
+**Status:** Implemented (all 5 phases, all checkboxes complete) — pending human review before ship, particularly agy's third-party/Bun-adapter trade-off (see Phase 4 notes and `docs/JSON-CHAT-ARCHITECTURE.md`'s caveat). Not committed — left as uncommitted working-tree changes for review.
+**PRD:** none — scoped directly from engineering investigation
+**Parent:** none (first sub-plan of the `acp-migration` feature)
+
+**Reference files (verified paths):**
+
+| Role | Path |
+|---|---|
+| Turn engine | `daemon/src/services/jsonAgent.ts` (1221 lines) |
+| Plugin contract (`AgentJsonTransport`, `TurnContext`) | `daemon/src/services/spawn.ts:30-92` |
+| Plugins | `daemon/src/agent-plugins/{claude,cursor,opencode,agy}.ts` |
+| Plugin registry | `daemon/src/agent-plugins/registry.ts` (32 lines, flat map) |
+| Live-session map | `daemon/src/state/jsonAgentRegistry.ts` (15 lines) — **NOT** under `services/` |
+| Boot recovery | `daemon/src/services/recover.ts` |
+| Schema | `daemon/src/services/dbSchema.ts` |
+| Manifest→sqlite boot migration | `daemon/src/services/dbMigration.ts` |
+| HTTP routes (stop / toggle / delete) | `daemon/src/routes/sessions.ts` |
+| Tests (all daemon tests live here) | `daemon/src/__tests__/*.test.ts` |
+| Daemon dependency manifest | `cli/package.json` — `cli/src/daemon` is a **symlink** to `daemon/src`; there is **no** `daemon/package.json` |
+| UI (unaffected — see UI Changes) | `web-ui/src/components/chat/*` |
+
+---
+
+## Problem
+
+- Rich Chat spawns a fresh one-shot CLI subprocess per turn.
+  - `claude.ts:502` `spawn("claude", args, { detached: true, … })`; mirrored at `cursor.ts:344`, `opencode.ts:308`, `agy.ts:525`.
+  - Process exits when the CLI's own `result` line lands.
+- Background work started mid-turn (`run_in_background` Bash, dev server) dies with that process.
+- Terminal channel does not have this bug — one persistent tmux session per CLI lifetime (`spawn.ts:338-714`, `spawnSession`/`spawnDirectSession`).
+- Rich Chat needs the same persistence without losing its structured event stream.
+
+## Out of Scope
+
+- Terminal channel mechanics — `spawn.ts` `spawnSession` (338) / `spawnDirectSession` (529), `web-ui/src/components/layout/TerminalPane.tsx`. Zero behavioral change.
+- The `json↔tty` channel-toggle **feature** itself (idle gate, `getRestoreCommand`, `captureChatId`, native-history import) — its mechanics are unchanged. **In scope, and newly so:** keeping the *value* those mechanics read (`agentChatId`) correct under ACP (Decision 6), plus the ACP-teardown side effect (Decision 9).
+- User/session data migration, dual-write, feature flags, gradual rollout.
+  - Justification: no production users of json-chat exist today.
+- Fork-a-sent-message — stays on the legacy one-shot spawn path (Decision 8).
+- A "N background processes running" UI badge — follow-up, not this plan.
+- New user-facing settings for idle-TTL or reconnect — fixed constants only (Decisions 4, 5).
+
+## Concept
+
+- One ACP agent process per session, spawned once, alive across turns.
+- Each turn = one `session/prompt` over that same connection.
+- Background work becomes a **host-managed ACP terminal** (`terminal/*`) owned by the daemon, not by any single turn.
+- Only user-visible change: background work started in one turn is still running in later turns.
+
+---
+
+## Requirements
+
+| # | Requirement |
+|---|---|
+| 1 | Background work survives past its turn's `result` event, for every plugin whose ACP adapter supports host-managed terminals |
+| 2 | Explicit teardown (`DELETE /sessions/:id`, `POST /sessions/:id/done`, worktree delete) hard-kills the agent process and all its background terminals |
+| 3 | Boot after an unclean restart sweeps orphaned ACP processes via the existing pidfile mechanism (`recover.ts:61-95`) — no reconnect, no silent respawn |
+| 4 | `/chat/stop` cancels only the in-flight turn (ACP `session/cancel`) and must not kill the connection or any live terminal |
+| 4b | **Force-send** (`POST …/chat/queue/:turnId/promote`, "Send now") preempts through the SAME `session/cancel` path as Stop — never `killProcessTree` — so live background terminals and the connection survive it too |
+| 5 | `NormalizedEvent` kinds/shapes emitted to the UI are unchanged — web-ui requires zero changes |
+| 6 | `sessions.agentChatId` keeps meaning "the id the RAW CLI's own resume flag understands"; whether the ACP session id can share that slot is a **per-plugin, spike-gated** decision (Decision 6, Option A/B) |
+| 7 | cursor + opencode use native ACP modes; claude uses the Zed-maintained adapter over the user's own binary; agy is gated behind an auth spike (Phase 4.1) |
+| 8 | No feature flags, no gradual rollout, no backward-compat shim |
+
+---
+
+## Research
+
+### Per-turn spawn today (the code being replaced)
+
+| Plugin | `runTurn` lines | Command today |
+|---|---|---|
+| claude | `claude.ts:475-561` | `claude -p --output-format stream-json --verbose --dangerously-skip-permissions [--model][--resume <chatId>]` |
+| cursor | `cursor.ts:327-392` | `cursor-agent -p <msg> --output-format stream-json -f [--resume <id>]` |
+| opencode | `opencode.ts:283-358` | `opencode run <msg> --format json [-m model][--session <id>]`; system prompt via `OPENCODE_CONFIG` env (`opencode.ts:239,312`) |
+| agy | `agy.ts:503-578` | `agy --print=<msg> --output-format stream-json --dangerously-skip-permissions [--model][--conversation <id>]` |
+
+- Each plugin independently re-spawns, re-parses NDJSON, and re-implements `onAbort`/exit-code/stderr plumbing.
+
+### Turn engine — what stays, what changes
+
+- `spawn.ts:30-48` — `AgentJsonTransport` doc comment states the current contract: "the async-iterator completing == the turn is done."
+  - This plan keeps the iterator shape and swaps only the completion signal (Decision 2).
+- `spawn.ts:67-92` — `TurnContext` (`cwd`, `project`, `worktree`, `session`, `chatId?`, `forkFromChatId?`, `model?`, `systemPromptFile`, `daemonPort`, `onSpawn?`).
+  - Gains one field for ACP (Decision 2).
+- `jsonAgent.ts:753-786` (`drain`) — FIFO queue, sequential runner; unchanged.
+- `jsonAgent.ts:802-899` (`runOneTurn`) — builds ctx → iterates `plugin.runTurn` → persists via `handleEvent` (945-970); shape reused.
+- `jsonAgent.ts:127` `collectDescendants`, `jsonAgent.ts:175` `killProcessTree` — today's hard-kill machinery.
+- `jsonAgent.ts:921` `killLivePids()` is called from exactly two places:
+  - `abortAndDrain()` (410-420) — teardown; only caller is `release()` (456).
+  - `stopActiveTurn()` (470-478) — the Stop button.
+- `jsonAgent.ts:911` `recordTurnPid` — mirrors each spawned PID into `<dataDir>/turn.pids`, fed by `ctx.onSpawn`.
+- `daemon/src/state/jsonAgentRegistry.ts` — `Map<sessionId, JsonAgentSession>`, lazily populated by `getOrCreateJsonAgentSession` (`jsonAgent.ts:1092-1098`).
+  - Natural home for a 1:1 `sessionId → AcpConnection` mapping (Decision 1) — no new registry needed.
+
+### Boot recovery / orphan safety
+
+- `recover.ts:61-95` `sweepOrphanTurnPids` — reads each json session's `<dataDir>/turn.pids`, `process.kill(-pid, "SIGKILL")`, unlinks the file.
+- `recover.ts:38-52` `verifyPidIsTurnProcess` — reads `/proc/<pid>/stat` comm name; guards against PID reuse after a machine reboot; returns `true` (proceed) when inconclusive.
+- `recover.ts:22` `KNOWN_TURN_BINARIES = new Set(["claude","cursor-agent","opencode","agy"])`.
+  - Must gain the ACP adapter process comm names, or a genuinely orphaned connection is never killed.
+- `recover.ts:~104-114` `recoverJsonSession` — a `working` session reconciles to `idle` on boot; outcome unchanged by this plan.
+
+### DB / schema
+
+- `dbSchema.ts:53-77` — `sessions` table; `agentChatId TEXT` at line 71 (nullable).
+- `dbSchema.ts:154-158` `addColumnIfMissing(db, table, column, ddl)` — **this** is the established additive-migration pattern: `PRAGMA table_info` check, then `ALTER TABLE … ADD COLUMN`, called unconditionally from `ensureSchema`.
+  - Existing users of it: `prState`, `prNumber`, `prUrl`, `prCheckedAt`, `prBranch` (`dbSchema.ts:142-151`).
+- `dbMigration.ts` is a different thing — the one-shot per-project `manifest.json → sqlite` boot migration, gated by the `manifest_migrations` table.
+  - Not the additive-column pattern; not touched by this plan.
+- **Schema impact is conditional, not zero** (Decision 6): Option A adds no column; Option B adds one nullable `sessions.acpSessionId TEXT` via `addColumnIfMissing`. Decided per plugin after the Phase 1.8 spike. `dbMigration.ts` is untouched either way.
+- `agentChatId` has THREE consumers, all of which need the CLI's OWN native id — this is why the id-space question is a correctness gap, not cosmetics:
+  1. `getRestoreCommand` resume argv — `claude.ts:575`, `cursor.ts:493`, `opencode.ts:501`, `agy.ts:587`.
+  2. Terminal **launch** argv (not only restore) — `cursor.ts:254,292` (`--resume`), `agy.ts:394,442` (`--conversation`).
+  3. **Native-history import** on tty→json backfill — `claudeImport.ts:209` builds `~/.claude/projects/<slug>/<agentChatId>.jsonl`; `opencodeImport.ts:68` runs `WHERE session_id = <agentChatId>` on `~/.local/share/opencode/opencode.db`. A non-native id here imports zero turns, silently.
+- Existing per-plugin native-id side channels (reused verbatim by Decision 6 Option B — no new discovery code):
+
+| Plugin | Side channel | Source |
+|---|---|---|
+| claude | `findLatestChatUuid(cwd)` — newest `~/.claude/projects/<slug>/*.jsonl` by mtime | `agent-plugins/claudeRestore.ts:24` |
+| cursor | `findLatestCursorChatId(cwd)` — newest dir under `~/.cursor/projects/<slug>/agent-transcripts/` | `agent-plugins/cursorRestore.ts:33` |
+| opencode | `.opencode/plugins/vst-recorder.ts` `session.created` → writes native `sessionID` to `<cwd>/.vibe-station/agent-chat-ids/$VST_SPAWN_TOKEN` | `opencode.ts:355-380`, read by `captureChatId` |
+| agy | `readLatestAgyConversationId(cwd)` → `last_conversations.json[cwd]` — self-documented as UNRELIABLE (cwd-keyed, no session identity); **superseded 2026-08-30** as the primary channel by `readAgyAcpSessionConversationId(acpSessionId)` (see Decision 6 Spike Results table) — kept only as the last-resort fallback | `agy.ts` |
+
+- **agy-specific regression risk (resolved 2026-08-30):** agy's only *trustworthy* capture channel WAS the per-session `--log-file` it injects into its OWN argv (`agy.ts:394-401`) — under ACP the adapter builds agy's argv, so that flag genuinely cannot be injected (confirmed by reading the `antigravity-acp` adapter's own `buildAgyArgs`). However the adapter itself turned out to expose an equally session-scoped replacement: its own `~/.agy-acp/sessions.json`, keyed by ACP session id. agy is Option B (ids diverge) but does NOT take the documented degrade.
+
+### Web UI — evidence for "no changes needed"
+
+- `MessageList.tsx:229-246` builds a `toolIndexById` map over the **entire** event list (not per turn).
+  - `tool_use` (229-233) pushes a card and records `toolId → item index`.
+  - `tool_result` (235-246) looks the id up and attaches; on a miss it pushes a standalone tool item.
+  - Consequence: a `tool_result` arriving in a **later turn** still attaches to its original card — no crash, no dropped event, no new event kind.
+- `ToolUseCard.tsx:6-12` — `running?: boolean` prop is documented as "true while the matching tool_result hasn't arrived yet (shows a spinner)"; the card renders fully without a result.
+- `daemon/src/types.ts:74-84` — `NormalizedEventKind` is exactly `session_init | user | thinking | text | tool_use | tool_result | usage | result | error | status`; this plan introduces no new kind.
+- Known cosmetic nit (accepted, not a blocker): a late `tool_result` renders at the **original** card's feed position, not chronologically at arrival time.
+
+### Sibling-project precedents (facts restated inline — no external reading required)
+
+| Source | Fact this plan uses |
+|---|---|
+| emdash `packages/core/src/runtimes/acp/node/connection/source.ts:56-73` | Pools ACP connections by `(providerId, cwd)` with an `idleTtlMs` — rejected here, see Decision 1 |
+| emdash `acp-agent-connection.ts:40-133` | Spawn → `initialize` → race against "process closed before ready" → return `{ agent, normalize, supportsLoadSession, mcpCapabilities }` |
+| emdash `acp-agent-connection.ts:118-119` | `failClosedBeforeReady` race pattern — mirrored by test 1.T1 |
+| emdash `acp-agent-connection.ts:94-97` | Per-provider `behavior.enrich` hook over a shared normalizer — mirrored by `normalize.ts` |
+| agent-orchestrator `chatdriver/claudeacp/driver.go:33-98` | Resolve the user's own `claude` binary, set `CLAUDE_CODE_EXECUTABLE=<path>` on the adapter process; `session/new` once, `session/prompt` for every later turn on the same connection |
+| agent-orchestrator `acp/process.go`, `acp/conversation.go` | "`session/load` if supported, otherwise a fresh session — never a silent respawn" |
+| agent-orchestrator `chatdriver/registry/registry.go` | Flat harness→driver map — matches `registry.ts`, which stays a flat map |
+
+### External ACP facts (as researched Aug 2026)
+
+| CLI | ACP support | Detail |
+|---|---|---|
+| Claude Code | Adapter-mediated | `@agentclientprotocol/claude-agent-acp` (previously `@zed-industries/claude-code-acp`); wraps `@anthropic-ai/claude-agent-sdk`; `CLAUDE_CODE_EXECUTABLE` selects the binary |
+| Cursor | Native, first-party | `cursor-agent acp` (`cursor.com/docs/cli/acp`), JSON-RPC 2.0 over stdio |
+| OpenCode | Native | `opencode acp` (`opencode.ai/docs/acp/`); all features except `/undo`, `/redo` |
+| Antigravity (agy) | Adapter via Zed registry | `zed.dev/acp/agent/antigravity-acp`; auth via Google Account / Antigravity plan / Gemini Enterprise |
+| Antigravity SSH auth bug | Open | ACP auth hangs over SSH even when the CLI is already authenticated on the same remote host; vibe-station's daemon is headless by design |
+
+- > **Decision made unattended — needs human confirmation:** npm package names above are from a research pass, not from an install. Phase 1.7 must run `npm view <name> version` for both packages before pinning, and substitute the current published names if they have moved again.
+
+## Root Cause
+
+- Structural: a process that exits at `result` cannot own live children past that point.
+- Compounding 1: the CLI itself may reap its own background shells at final response (CLI-internal).
+- Compounding 2: `killProcessTree` (`jsonAgent.ts:175`) SIGKILLs the whole descendant tree on Stop and on teardown.
+  - Harmless today (the process was dying anyway); becomes an active cause once a connection persists — hence Decisions 3 and 4.
+
+---
+
+## Architecture Diagram
+
+```mermaid
+flowchart TB
+  subgraph Daemon["vibe-station daemon"]
+    JAS["JsonAgentSession (jsonAgent.ts)\nFIFO turn queue + owns 1 AcpConnection"]
+    ACM["AcpConnection (new: services/acp/acpTransport.ts)\nJSON-RPC client over stdio + idle TTL"]
+    ATM["AcpTerminalManager (new: services/acp/acpTerminalManager.ts)\nserves terminal/* as ACP Client"]
+    STORE[("SqliteTranscriptStore\n(unchanged)")]
+    JAS -->|"session/prompt per turn"| ACM
+    ACM -->|"session/update stream"| JAS
+    JAS --> STORE
+    ACM -.->|"terminal/create, output, kill"| ATM
+  end
+
+  subgraph AgentProc["Agent process — spawned once, lives across turns"]
+    ADAPTER["claude-agent-acp / cursor-agent acp /\nopencode acp / antigravity-acp"]
+    CLI["wrapped CLI\n(claude / cursor-agent / opencode / agy)"]
+    ADAPTER --> CLI
+  end
+
+  BG["background terminal\n(dev server, backgrounded Bash)\nOS child owned by AcpTerminalManager"]
+
+  ACM <-->|"stdio JSON-RPC"| ADAPTER
+  CLI -.->|"tool call: run in background"| ATM
+  ATM --> BG
+
+  WEBUI["web-ui chat/* (unchanged)"]
+  STORE -.->|"WS broadcast"| WEBUI
+```
+
+- `JsonAgentSession ↔ AcpConnection` — in-process Module ↔ Module boundary.
+- `AcpConnection ↔ Agent process` — JSON-RPC-over-stdio, Module ↔ Platform/SDK boundary.
+
+## Process Lifecycle — Today vs After
+
+```mermaid
+stateDiagram-v2
+    state "TODAY — one process per turn" as today {
+        [*] --> NoProcess: session idle
+        NoProcess --> Spawning: user sends message
+        Spawning --> Streaming: process launched, stdout NDJSON parsed
+        Streaming --> Exited: CLI emits `result`, process exits
+        Streaming --> ForceKilled: Stop clicked → killProcessTree
+        Exited --> NoProcess: background work spawned mid-turn DIES HERE
+        ForceKilled --> NoProcess: background work DIES HERE
+    }
+```
+
+```mermaid
+stateDiagram-v2
+    state "AFTER — one persistent ACP connection per session" as after {
+        [*] --> NoConnection: session created, no turn yet
+        NoConnection --> Connecting: first turn — spawn adapter, initialize
+        Connecting --> SessionEstablishing: session/new or session/load
+        SessionEstablishing --> Idle: connection ready, no active turn
+        Idle --> Prompting: user sends message (session/prompt)
+        Prompting --> Idle: stopReason end_turn — CONNECTION SURVIVES
+        Prompting --> Idle: Stop → session/cancel — connection + terminals SURVIVE
+        Idle --> Idle: background terminal keeps running across turns
+        Idle --> Disposed: TEARDOWN — idle TTL expired AND zero live terminals
+        Idle --> Disposed: TEARDOWN — DELETE /sessions/:id, /done, worktree delete
+        Idle --> Disposed: TEARDOWN — json→tty channel toggle
+        Idle --> Disposed: TEARDOWN — daemon graceful shutdown
+        Prompting --> Disposed: TEARDOWN — delete during an active turn (hard kill)
+        NoConnection --> Disposed: daemon crash — boot sweep kills the orphan
+        Disposed --> [*]
+    }
+```
+
+| | Today | After |
+|---|---|---|
+| Processes per session | 1 per turn | 1 total |
+| Turn-done signal | CLI process exit | `session/prompt` response resolves |
+| Stop button | `killProcessTree` (SIGKILL group) | `session/cancel` notification |
+| Background work at turn end | dies | survives |
+| Background work at Stop | dies | survives |
+| Teardown triggers | none needed | delete · done · worktree delete · json→tty toggle · idle TTL (only with zero live terminals) · daemon shutdown · boot sweep |
+
+---
+
+## Design Details
+
+### System Boundaries
+
+| Boundary | Fields + types | Errors | Source of truth |
+|---|---|---|---|
+| `JsonAgentSession` ↔ `AcpConnection` (in-process) | `sendPrompt(prompt: PromptBlock[], signal: AbortSignal): { updates: AsyncIterable<SessionUpdate>, result: Promise<{ stopReason: StopReason }> }` · `cancelActivePrompt(): void` · `hasLiveTerminals(): boolean` · `dispose(): Promise<void>` | `ConnectionSpawnFailed`, `InitializeFailed`, `SessionLoadFailed` — each maps to a synthetic `error` NormalizedEvent, exactly as today's non-zero-exit handling does | `AcpConnection` owns process liveness; `JsonAgentSession` owns turn-queue state |
+| `AcpConnection` ↔ Agent process (ACP JSON-RPC over stdio) | See API Contracts below | Process exit or stderr before ready → `ConnectionSpawnFailed`; capability mismatch → `InitializeFailed` | The wrapped CLI's own auth + session store; ACP carries no auth of its own |
+| `AcpTerminalManager` ↔ OS processes | `terminal/create{ command, args, cwd, env, outputByteLimit? } → { terminalId }`; daemon holds `terminalId → ChildProcess` | Spawn failure → JSON-RPC error response, surfaced as a failed tool call | The daemon owns the OS child handles |
+| `JsonAgentSession` ↔ `SqliteTranscriptStore` | Existing, unchanged — no restatement |
+
+### API Contracts
+
+```
+ACP JSON-RPC 2.0 over stdio — one long-lived pipe pair per session.
+
+initialize                              (client → agent, request)
+  params:  { protocolVersion: number,
+             clientCapabilities: { fs: { readTextFile: bool, writeTextFile: bool },
+                                   terminal: bool } }
+  result:  { protocolVersion, agentCapabilities: { loadSession?: bool,
+                                                   promptCapabilities?: {...},
+                                                   mcpCapabilities?: {...} },
+             authMethods?: [...] }
+
+session/new                             (client → agent, request)
+  params:  { cwd: string (absolute), mcpServers: [] }   ← array required, may be empty
+  result:  { sessionId: string }
+
+session/load                            (client → agent, request)
+  precondition: agentCapabilities.loadSession === true
+  params:  { sessionId: string, cwd: string, mcpServers: [] }
+  result:  {}  |  JSON-RPC error → SessionLoadFailed → fall back to session/new (Decision 5)
+
+session/prompt                          (client → agent, request)
+  params:  { sessionId: string,
+             prompt: [ { type: "text", text: string }
+                     | { type: "resource_link", uri: "file:///abs/path", name: string } ] }
+  result:  { stopReason: "end_turn" | "cancelled" | "refusal"
+                       | "max_tokens" | "max_turn_requests" }
+  ── this result resolving IS the turn-done signal (replaces process exit, Decision 2)
+
+session/update                          (agent → client, NOTIFICATION, streamed)
+  params:  { sessionId, update: { sessionUpdate: "agent_message_chunk"
+                                                | "agent_thought_chunk"
+                                                | "user_message_chunk"
+                                                | "tool_call" | "tool_call_update" | "plan", … } }
+  ── mapped 1:1 into the EXISTING NormalizedEventKind set (Decision 2)
+
+session/cancel                          (client → agent, NOTIFICATION — no response)
+  params:  { sessionId: string }
+  ── the in-flight session/prompt then resolves with stopReason: "cancelled"
+
+fs/read_text_file, fs/write_text_file   (agent → client, request)
+  ── daemon serves from the session's own cwd; same filesystem reach the CLI already had
+
+terminal/create        params { sessionId, command, args, cwd, env, outputByteLimit? } → { terminalId }
+terminal/output        params { sessionId, terminalId } → { output: string, truncated: bool, exitStatus?: {...} }
+terminal/wait_for_exit params { sessionId, terminalId } → { exitStatus: { exitCode?, signal? } }
+terminal/kill          params { sessionId, terminalId } → {}
+terminal/release       params { sessionId, terminalId } → {}
+  Errors on all fs/* and terminal/*: standard JSON-RPC error object; the daemon
+  surfaces it as a failed tool_result — no new error primitive.
+```
+
+- Daemon-facing contracts are unchanged: `POST /chat`, `POST /sessions/:id/chat/stop`, WS `chat:message`/`chat:meta`, `NormalizedEvent` shape (Requirement 5).
+
+### Critical User Journeys
+
+#### CUJ 1 — background dev server survives past the turn (happy path)
+
+```
+User sends "start the dev server in the background"
+  → jsonAgent.ts:802 runOneTurn calls plugin.runTurn on the SAME connection as prior turns
+  → agent's Bash tool issues a backgrounded command
+  → adapter routes it through terminal/create
+  → AcpTerminalManager spawns + tracks the OS process, returns terminalId
+  → turn's `result` event lands; drain() moves the session to idle
+  → AcpConnection stays alive — idle TTL is pinned open by the live terminal (Decision 4)
+  → later turn: "is the server still running?"
+  → agent calls terminal/output on the same terminalId → still running → reports back
+```
+
+- Edge case — adapter does not support the `terminal` capability:
+  - The CLI spawns the background command as its own child instead.
+  - That child is owned by the CLI process, which now survives turn end.
+  - Net: background work still survives; it is just not independently inspectable.
+  - `terminal` capability buys inspectability, not survival.
+
+#### CUJ 2 — daemon crashes mid-turn, restarts uncleanly (error path)
+
+```
+Daemon crashes while a turn is streaming
+  → on restart, sweepOrphanTurnPids (recover.ts:61) reads the session's turn.pids
+  → verifyPidIsTurnProcess (recover.ts:38) confirms a known ACP adapter comm name
+  → process.kill(-pid, "SIGKILL") on the group; pidfile unlinked
+  → recoverJsonSession reconciles `working` → `idle` (unchanged outcome)
+  → next user message lazily creates a FRESH AcpConnection
+  → if initialize advertised loadSession → session/load(agentChatId)
+  → else, or on failure → session/new + a `status` event flagging the fallback
+```
+
+- Error path — `session/load` unsupported or failing:
+  - No silent respawn; the plugin throws typed `SessionLoadFailed`.
+  - `JsonAgentSession` starts a fresh ACP session.
+  - Emits `status`: "resumed with a fresh agent session — prior context may not be visible to the CLI".
+  - The user's transcript is unaffected — SQLite persistence is untouched by any of this.
+
+### Data Model
+
+| Entity | Field | Type | Constraints | Option | Notes |
+|---|---|---|---|---|---|
+| `sessions` | `agentChatId` | `TEXT` | nullable, **existing** | A + B | Always means "the id the RAW CLI's own resume flag / native store understands". Option A: the ACP `sessionId` IS that value. Option B: written by `captureNativeChatId()`, may stay NULL |
+| `sessions` | `acpSessionId` | `TEXT` | nullable, **NEW — Option B only** | B | The ACP `session/new` id, used solely for `session/load` (Decision 5). Added via `addColumnIfMissing(db, "sessions", "acpSessionId", "TEXT")`, same pattern as `prState`/`prNumber`/`prBranch` (`dbSchema.ts:142-151`) |
+
+- Relationships: none new. Indexes: none new.
+- **Migration: conditional (Decision 6)** — N under Option A; additive-only, backward-compatible `ALTER TABLE … ADD COLUMN` under Option B. The column is added **once**, for all plugins, as soon as *any* plugin lands on Option B; plugins on Option A simply leave it NULL.
+- Option B touch points (exhaustive — all additive):
+  - `daemon/src/services/dbSchema.ts` — one `addColumnIfMissing` line + comment.
+  - `daemon/src/types.ts:170,238` — `acpSessionId?: string` on the session types.
+  - `daemon/src/state/sqliteRowMappers.ts:36,95,141` — `SessionRow` field + `rowToSession` + `sessionToRow`.
+  - `daemon/src/state/project-store.ts:261-262` — the explicit INSERT column/values lists.
+  - `daemon/src/services/jsonAgent.ts:1031` — a `persistAcpSessionId()` twin of `persistChatId()`.
+  - **Not** `web-ui/*` — the UI never reads it, so "UI Changes: none" still holds.
+
+### Key Decisions
+
+#### Decision 1: One `AcpConnection` per `sessionId`, no `(providerId, cwd)` pool
+- **Decision:** each `JsonAgentSession` owns exactly one `AcpConnection`, created lazily on first turn, disposed on teardown.
+- **Rationale:** a vibe-station `sessionId` is already 1:1 with a stable `cwd`, so a `cwd`-keyed pool would collapse to the same mapping while adding a second place lifecycle can go wrong.
+- **Where:** `daemon/src/services/jsonAgent.ts` — `JsonAgentSession` gains a private `connection?: AcpConnection` and a `getOrCreateConnection()` called from `runOneTurn` (802-899); registration itself stays in `daemon/src/state/jsonAgentRegistry.ts`, unchanged.
+
+#### Decision 2: `session/prompt` resolving replaces "process exit" as the turn-done signal
+- **Decision:** `runTurn` keeps its exact signature `(input, ctx, signal) => AsyncIterable<NormalizedEvent>`; internally it yields off `session/update` notifications and returns when the matching `session/prompt` resolves.
+- **Rationale:** preserves the iterator contract that `runOneTurn`, the queue, abort handling, and `firstTurnDone` bookkeeping all depend on — a small diff instead of a rewrite.
+- **Where:** `daemon/src/agent-plugins/{claude,cursor,opencode,agy}.ts` (`runTurn` bodies); `daemon/src/services/spawn.ts:67-92` (`TurnContext` gains `getAcpConnection?(): Promise<AcpConnection>`).
+
+```typescript
+// daemon/src/agent-plugins/claude.ts — replaces lines 475-561.
+// Demonstrates the completion-signal swap: yield from a live stream, but end
+// the generator on the session/prompt RESULT, not on a process exit.
+async *runTurn(input: TurnInput, ctx: TurnContext, signal: AbortSignal): AsyncIterable<NormalizedEvent> {
+  const conn = await ctx.getAcpConnection!();          // Decision 1's per-session connection
+  const prompt = conn.sendPrompt(toAcpPrompt(input), signal);
+  for await (const raw of prompt.updates) {
+    const ev = normalizeSessionUpdate(raw, ctx.session.id, claudeEnrich);
+    if (ev) yield ev;
+  }
+  const { stopReason } = await prompt.result;          // throws → mapped to an `error` event
+  yield resultEventFor(stopReason, ctx.session.id);
+}
+```
+
+#### Decision 3: EVERY turn-preemption (Stop **and** force-send) sends `session/cancel`, never `killProcessTree`
+- **Decision:** `stopActiveTurn()` stops calling `this.killLivePids()` when an ACP connection exists; it calls `this.connection.cancelActivePrompt()` and then `this.activeAbort.abort()` to unwind the iterator.
+- **Rationale:** killing the process tree on a preemption is the compounding cause named in Root Cause; the connection and its terminals must outlive it.
+- **Where:** `daemon/src/services/jsonAgent.ts:494-507`; route caller `daemon/src/routes/sessions.ts:1657-1665` is unchanged.
+- **Force-send is covered by construction, not by a second fix** — `promoteQueuedTurn()` (`jsonAgent.ts:654-669`, route `POST /sessions/:id/chat/queue/:turnId/promote`, UI `useChat.ts` `sendNow` → `QueuedTray`'s "Send now") reorders the queue and then calls **`stopActiveTurn()`**. It is the only preemption path besides `/chat/stop`, so it inherits the cancel-not-kill semantics automatically. This is load-bearing: `stopActiveTurn` is the *single* chokepoint for "interrupt the running turn but keep the session", and any future preemption feature must route through it rather than `abortAndDrain()`.
+- **Kill semantics, exhaustive (Requirement 2 vs 4/4b):**
+
+| Path | Method | Kills the process tree? | Background terminals |
+|---|---|---|---|
+| `/chat/stop` (Stop button) | `stopActiveTurn()` | No — `session/cancel` | survive |
+| `…/queue/:turnId/promote` (force-send / "Send now") | `promoteQueuedTurn()` → `stopActiveTurn()` | No — `session/cancel` | survive |
+| `DELETE /sessions/:id` · `/done` · worktree delete · json→tty toggle | `release()` → `abortAndDrain()` → `killLivePids()` + `connection.dispose()` | **Yes, deliberately** (Requirement 2) | killed via `AcpTerminalManager.killAll()` |
+
+- **Honest limit (not a vibe-station bug, cannot be routed around):** `session/cancel` preserves the **connection** and every **host-managed terminal** (`AcpTerminalManager`-tracked OS children — `run_in_background` Bash, dev servers). It does **not** preserve an in-flight **Task-tool subagent**. Claude Code's subagents are not separate OS processes: they are in-process sub-conversations inside the single wrapped `claude` process, driven by the same agent loop the cancelled turn owns. Cancelling that turn is exactly what ends them, at the CLI's own layer — no process-management change on the daemon side can keep them running, because there is no separate process to keep. What the daemon *can* guarantee, and now does for force-send as well as Stop, is that (a) nothing is SIGKILLed, (b) the adapter process and the ACP session survive, and (c) any background terminal a subagent already started keeps running and is still inspectable on the next turn.
+
+#### Decision 4: Idle-TTL disposal is pinned open by any live background terminal
+- **Decision:** a connection with zero active turns AND zero live terminals is disposed after **30 minutes** idle; a connection with ≥1 live terminal is never disposed by the timer.
+- **Rationale:** an idle timer that ignored live terminals would reintroduce the exact bug with a longer fuse.
+- **Where:** `daemon/src/services/acp/acpTransport.ts` — the timer lives on `AcpConnection` itself, gated on `AcpTerminalManager.hasLiveTerminals()`; **no separate `acpConnectionManager.ts` file** (Decision 1 already makes the mapping 1:1, so a manager layer has nothing to manage).
+- > **Decision made unattended — needs human confirmation:** the 30-minute value is a reasonable default (survives a coffee break, reclaims abandoned sessions) but was not specified by any stakeholder. Confirm or override before shipping.
+
+#### Decision 5: Reconnect is `session/load`-or-fresh, never a silent respawn
+- **Decision:** on the first turn over a newly created connection for a session that already has an `agentChatId`, attempt `session/load(agentChatId)` iff `initialize` advertised `agentCapabilities.loadSession === true`; on unsupported or failure, fall through to `session/new` and emit a `status` event naming the fallback.
+- **Rationale:** a daemon that pretends to resume when it cannot produces "the agent forgot everything but acted like it remembered" behavior.
+- **Where:** `daemon/src/services/jsonAgent.ts:802-899` — extend the existing `isFirstTurnPending`/`firstTurnDone` bookkeeping to also mean "first turn on THIS connection instance."
+
+#### Decision 6: `agentChatId` stays the NATIVE id — ACP id storage is a per-plugin, spike-gated choice (Option A / Option B)
+
+- **Invariant (both options, non-negotiable):** `sessions.agentChatId` means *only* "the id the raw CLI's own resume flag and native store understand". It is read by `getRestoreCommand`, by cursor/agy's terminal **launch** argv, and by the native-history importers (see Research). It must never be overwritten with an id only the ACP layer understands.
+- **The open question:** is the `session/new` `sessionId` the same value? Native-ACP CLIs (cursor, opencode) plausibly share one id space; claude goes through `claude-agent-acp` → `@anthropic-ai/claude-agent-sdk` (external reports say the SDK id IS the `~/.claude/projects/**/<uuid>.jsonl` uuid — unverified here); agy has no evidence either way.
+- **Decision:** do NOT settle this globally. Phase 1.8 defines the spike; each plugin's phase runs it (2.0 / 3.0a / 3.0b / 4.1b) and records a verdict in the Spike Results table below **before** that plugin's toggle regression test is written. A per-plugin split is expected and fine.
+
+##### Spike Results (fill in during implementation — this table is the record of decision)
+
+| Plugin | ACP `sessionId` == native id? | Native resume smoke (`<flag> <acp id>`) | Option chosen | Native side channel used (Option B) |
+|---|---|---|---|---|
+| claude | YES — byte-identical (`f45aefd8-…`) | PASS — `claude --resume <S> -p "…"` recalled PINGSPIKE | **Option A** | n/a |
+| cursor | NO — root-caused, not a timing issue (re-investigated 2026-08-30, see below) | **FAIL** — `cursor-agent --resume <S> --workspace <cwd> --force -p "…"` did NOT recall PINGSPIKE | **Option B** (degrade — confirmed no fix exists) | `findLatestCursorChatId(cwd)` — see re-investigation note: for a genuinely fresh ACP-only cwd this now returns `null` (no `agent-transcripts/` entry is ever written), not merely a wrong id. Documented, non-crashing degrade (see Option B fallback) |
+| opencode | YES — byte-identical (`ses_fab8a4bd…`), confirmed via `SELECT id FROM session` in `~/.local/share/opencode/opencode.db` | PASS — `opencode run --session <S> "…"` recalled PINGSPIKE | **Option A** | n/a |
+| agy | NO — `S` (ACP `session/new` id) is a DIFFERENT uuid than agy's own native conversation id | FAIL for `S` (`agy --conversation <S>` → `warning: conversation "<S>" not found`, fresh conversation). **PASS, live-reverified 2026-08-30**, for the `antigravity-acp` adapter's own recorded native id (see below) | **Option B** | **REVISED 2026-08-30**: `readAgyAcpSessionConversationId(acpSessionId)` (`agy.ts`) — reads the `antigravity-acp` npm adapter's own `~/.agy-acp/sessions.json` (keyed by the exact ACP `sessionId`, not cwd), which the adapter itself populates with agy's native `conversationId` after every turn. `readLatestAgyConversationId(cwd)` kept as a same-behavior-as-before fallback for older adapter versions/cleared state |
+
+**Cursor re-investigation (2026-08-30, live spikes against real `cursor-agent 2026.08.25-3e8eec8`, task: find a real fix or document why none exists):**
+- Live-reproduced the Phase 1.8 procedure end-to-end in a fresh scratch cwd: `initialize` → `session/new` → `session/prompt "say PINGSPIKE"` → `stopReason: end_turn`, PINGSPIKE observed in the stream.
+- **Root cause found**: `initialize`'s result includes `sessionCapabilities: { list: {} }` and `agentCapabilities.loadSession: true`; the ACP session is persisted at `~/.cursor/acp-sessions/<sessionId>/{meta.json,store.db}` — a **dedicated SQLite store keyed by the ACP session id itself**, structurally separate from BOTH `~/.cursor/chats/` (interactive-mode sessions) and `~/.cursor/projects/<slug>/agent-transcripts/` (print/`-p`-mode sessions, the store `findLatestCursorChatId` reads and the one the raw CLI's `--resume` flag understands).
+- **Timing hypothesis explicitly tested and refuted**: polled `~/.cursor/projects/<slug>/agent-transcripts/` for >90s after the ACP turn completed in a fresh scratch cwd — no entry EVER appeared (not merely delayed). The earlier "appears after a short async delay" note could not be reproduced under the exact Phase 1.8 procedure; ACP-mode conversations do not sync to `agent-transcripts/` at all in this repro.
+- `cursor-agent acp` (the ACP-server subcommand) takes **zero flags** (`cursor-agent acp --help`) — there is no `--resume`/`--workspace`-style bridge into an existing ACP session from the CLI's own argv; the only way to resume an ACP session's actual content is the ACP `session/load` RPC (`loadSession: true`), which only a client speaking ACP (not a plain terminal invocation) can call.
+- **Sibling-project confirmation that no fix exists elsewhere**: `agent-orchestrator` (`chatdriver/cursoracp`, `chatdriver/acp/driver.go`) resumes cursor ACP sessions exclusively via ACP `session/load`/`session/resume` (`driver.go:205-300`) — it NEVER falls back to a raw terminal `cursor-agent --resume <id>` command, so it never needs to cross this boundary. `emdash` (`packages/plugins/src/agents/impl/cursor/index.ts`) keeps ACP (`createNativeAcpBehavior`) and the terminal/prompt path (`buildStandardCommand` with `resumeFlag: '--resume'`) as two entirely separate, non-bridged behaviors — it never attempts to resume a terminal session from an ACP id either. Both projects sidestep exactly the cross-protocol problem this plan's json→tty toggle requires; neither is evidence a fix exists, and their design choice (never cross the boundary) is itself evidence this is a genuine, unaddressed gap in `cursor-agent`'s CLI surface, not a vibe-station bug.
+- **Conclusion: no fix exists in the current `cursor-agent` CLI.** The Option B degrade (documented above and in Option B fallback) is correct and final for cursor; re-investigate only if a future `cursor-agent` release adds a CLI-level bridge from an ACP session id to its `--resume`-compatible store.
+- **Made explicit, not implicit:** this fact is now a named, queryable capability rather than an inferred side effect of `getRestoreCommand` returning null — `AgentPlugin.supportsChannelResume?(): boolean` (`spawn.ts`), implemented as `false` in `cursor.ts` (all other plugins default to `true`). Surfaced through `GET /supported-clis` as `supportsChannelResume`, consumed by `web-ui`'s `StatusBar.tsx` to show an honest pre-toggle warning ("this switch starts a FRESH terminal conversation") instead of a silent degrade the user only discovers after switching. The toggle itself is never disabled — only labeled honestly.
+
+##### Option A — ids coincide (zero schema change)
+
+- **When:** spike shows `sessionId` byte-identical to the plugin's native id AND the raw CLI resumes from it.
+- **Design:** unchanged from the pre-spike plan — `session/new`'s `sessionId` flows through the existing `persistChatId` path (`jsonAgent.ts:1031-1056`); `session/load` reads the same `agentChatId`. No column, no new plugin method, no change to `getRestoreCommand` / importers / launch argv.
+- **Cost:** zero. `dbSchema.ts`, `sqliteRowMappers.ts`, `project-store.ts`, `types.ts` all untouched.
+
+##### Option B — ids diverge (one nullable column + one optional plugin method)
+
+- **When:** spike shows the two ids differ, or the raw CLI rejects the ACP id.
+- **Storage split:**
+  - `sessions.acpSessionId TEXT` (new, nullable) — the ACP resume token; read ONLY by Decision 5's `session/load`.
+  - `sessions.agentChatId` — unchanged meaning; populated out-of-band by the plugin (below); may legitimately stay NULL.
+- **New plugin-contract method** (`daemon/src/services/spawn.ts`, in the `AgentPlugin` JSON-transport block next to `captureChatId`) — keeps ALL CLI-specific recovery inside the plugin, per AGENTS.md:
+
+```ts
+  /**
+   * Option B only (Decision 6). Read the NATIVE chat id — the one this CLI's own
+   * `--resume`/`--session`/`--conversation` flag and native transcript store
+   * understand — out of band, after an ACP session has been established and the
+   * first turn has produced output. Return null when this plugin cannot recover it.
+   *
+   * Optional, and deliberately NOT implemented by plugins whose spike proved the ACP
+   * id IS the native id (Option A) — for those, `agentChatId` is already correct and a
+   * second write would be a chance to make it wrong.
+   */
+  captureNativeChatId?(args: {
+    session: SessionRecord;
+    project: ProjectRecord;
+    /** Session working directory — same semantics as provideChatId/captureChatId. */
+    cwd: string;
+    /** The ACP session/new id, for plugins that can derive or verify from it. */
+    acpSessionId: string;
+  }): Promise<string | null>;
+```
+
+- **Required-vs-optional:** optional, exactly like `captureChatId` / `refreshChatIdOnToggle`. Per-plugin obligation:
+
+| Plugin | Implements? | Body |
+|---|---|---|
+| claude | iff spike 2.0 says diverge | `return session.agentChatId ?? (await findLatestChatUuid(cwd))` — reuses `claudeRestore.ts` verbatim |
+| cursor | iff spike 3.0a says diverge | `return session.agentChatId ?? (await findLatestCursorChatId(cwd))` — reuses `cursorRestore.ts` verbatim |
+| opencode | iff spike 3.0b says diverge | Re-read `<cwd>/.vibe-station/agent-chat-ids/<VST_SPAWN_TOKEN>` written by the existing `session.created` hook — the ACP connection spawn must therefore carry `VST_SPAWN_TOKEN=<session.id>` in its env (Phase 3.2), and `setupWorkspaceHooks` must have run for the worktree |
+| agy | iff spike 4.1b says diverge | **REVISED 2026-08-30**: `readAgyAcpSessionConversationId(acpSessionId)` — the `antigravity-acp` adapter's own `~/.agy-acp/sessions.json`, keyed by the exact ACP session id (found by reading the published adapter's source and live-verifying the bind + a real `agy --conversation <id>` resume). Falls back to `readLatestAgyConversationId(cwd)` only if that file/entry is absent. agy's reliable per-session `--log-file` signal (`agy.ts:394-401`) is still unavailable under ACP because the adapter owns agy's argv — this is a *different*, adapter-provided channel, not a recovery of the log-file one |
+
+- **Call site — exactly one, CLI-agnostic** (`daemon/src/services/jsonAgent.ts`, inside `getOrCreateConnection`'s post-establishment step):
+  - After `session/new` → `persistAcpSessionId(sessionId)` immediately.
+  - `captureNativeChatId?()` is called **once per connection, at the `result` event of that connection's FIRST turn** — not right after `session/new`. Rationale: every side channel above is a filesystem artifact the CLI writes only once it has actually produced a conversation; probing earlier returns null or, worse, a previous conversation's id.
+  - Write-once semantics, mirroring `sessions.ts:1223` and `spawn.ts:626-629`: `if (!session.agentChatId && captured) persistChatId(captured)` — never overwrite an id captured by the terminal path.
+  - `null` is a normal outcome, not an error: no `status` event, no retry loop, no turn failure.
+- **What does NOT change under Option B:** `getRestoreCommand`, `captureChatId`, `refreshChatIdOnToggle`, `getForkCommand`, launch argv, both native-history importers, and every route in `sessions.ts` — they keep reading `agentChatId` and are correct by construction, because `agentChatId` never stops meaning "native id".
+- **Side-channel check to run during the spike (cheap, do it while you're there):** does `initialize` or the `session/new` result expose the native id (an extra field, a `_meta`, an adapter-specific extension)? If yes, prefer it over a filesystem probe — same method, different body, no other design change.
+
+##### Option B fallback — the native id genuinely cannot be recovered (state it, don't imply it)
+
+- `agentChatId` stays NULL for that session.
+- `getRestoreCommand` returns null (all four plugins already `return null` on a missing id).
+- `spawnTtyForAgent` (`routes/sessions.ts:1848-1936`) takes its existing **J12 fresh-launch** branch — worktree sessions via `spawnSession` with the mode's system/task prompt, direct sessions via `spawnDirectSession`. No crash, no bogus `--resume`, no 500.
+- **Accepted, explicitly documented behaviour:** for that plugin, *Rich Chat → Terminal starts a FRESH terminal conversation; the terminal side loses the resume. The Rich Chat transcript itself is untouched — it lives in SQLite and still renders in full in the UI.* The loss is the CLI's in-terminal memory, not the user's history.
+- Also lost for that plugin in that direction: nothing else — the tty→json native-history backfill already returns `historyImported:false` for CLIs with no importer (cursor/agy), so this degrades along an existing, already-handled axis.
+- If a plugin lands here, say so in the Spike Results table AND in `docs/JSON-CHAT-ARCHITECTURE.md` (Phase 5.2) — an undocumented silent degrade is the failure mode this whole decision exists to prevent.
+
+#### Decision 7: Extend the existing boot sweep — reuse the pidfile pattern
+- **Decision:** the ACP connection process is spawned `detached` and its PID mirrored into the session's existing `<dataDir>/turn.pids` file via the existing `ctx.onSpawn` → `recordTurnPid` path; `KNOWN_TURN_BINARIES` gains the adapter comm names; no new pidfile format and no new sweep mechanism.
+- **Rationale:** reuses a mechanism already proven correct (PID-reuse guard via `/proc/<pid>/stat`) and requires no change to `sweepOrphanTurnPids`' control flow — only its allowlist.
+- **Where:** `daemon/src/services/recover.ts:14-22` (allowlist + doc comment); `daemon/src/services/jsonAgent.ts:911` (`recordTurnPid`, now called once per connection instead of once per turn); `daemon/src/services/acp/acpTransport.ts` (spawn site calls `onSpawn`).
+- **Note:** `recoverJsonSession` (`recover.ts:~104-114`) keeps its current `working → idle` behavior — after the sweep the connection is definitively dead, so the outcome is identical.
+
+#### Decision 8: Fork-a-sent-message keeps the legacy one-shot spawn (claude only)
+- **Decision:** `forkTurn` and claude's `--fork-session` path continue to spawn a one-shot `claude --resume <id> --fork-session` process, bypassing the persistent connection.
+- **Rationale:** ACP has no standardized "fork a session" primitive; fork inherently starts a new branch, so there is no prior background work to lose.
+- **Where:** `daemon/src/services/jsonAgent.ts:594-614` (`forkTurn`), `daemon/src/agent-plugins/claude.ts:491-493` (fork args) and `claude.ts:563-566` (`getForkCommand`) — all unchanged.
+
+#### Decision 9: `json → tty` toggle disposes the connection — via the `release()` call that already exists
+- **Decision:** no new call site — `JsonAgentSession.release()` awaits `AcpConnection.dispose()`, and the toggle route already calls `release()`.
+- **Rationale:** without disposal, a toggle away from json leaks the adapter process — the tty side has no knowledge a json-side connection existed.
+- **Where:** `daemon/src/routes/sessions.ts:2023-2025` (`jsonAgentRegistry.delete(id); await jsonAgentToClose?.release();`) — verified present today, unchanged. The only edit is inside `jsonAgent.ts:453-462` `release()` (Phase 1.5).
+- **Note:** `dispose()` (434-440) is synchronous and store-only today; it stays that way, so no caller's signature changes.
+
+---
+
+## Risks / Open Questions
+
+| # | Question | Notes |
+|---|---|---|
+| 1 | Does Antigravity's ACP SSH auth hang block agy entirely? | **Resolved (this pass): did NOT reproduce.** Phase 4.1's live spike (`initialize` + `session/new` + `session/prompt` against a real, already-authenticated `agy`) completed cleanly with no hang, on this implementation machine (not tested specifically over SSH, so the documented SSH-specific bug remains theoretically possible in a different deployment topology — flag for the human to re-verify on an actual SSH-accessed daemon host before shipping). **New finding, not in the original plan:** the only available ACP adapter, `antigravity-acp`, is a THIRD-PARTY, single-maintainer npm package (not Google/Zed/agentclientprotocol) built on Bun — it requires installing `bun`/`bunx` as a brand-new system dependency this plan did not anticipate. This is a real go/no-go question for a human, not something resolved by a passing spike alone. |
+| 2 | Is Cursor's ACP first-party or a third-party adapter? | Resolved: `cursor-agent acp` is Cursor's own official mode (`cursor.com/docs/cli/acp`), same trust level as opencode's native ACP. No third-party adapter is used |
+| 3 | Do claude's `/vst` slash commands still work under the ACP adapter? | `setupWorkspaceHooks` (`claude.ts:291`) writes `.claude/commands/vst.md` + `.claude/settings.json` — filesystem-level project config the wrapped binary should read identically. Not empirically verified → Phase 2 verification item 2.T3, not a redesign |
+| 4 | Is the `terminal` capability always-on once the client declares it? | Assumed yes per ACP's general capability-negotiation pattern; verify against each adapter's real `initialize` response in Phase 1 |
+| 5 | Is opencode's ACP `sessionId` the same id space as `--session <id>`? | Subsumed by Decision 6 — answered empirically by spike 3.0b, which also re-verifies the `.opencode/plugins/vst-recorder.ts` `session.created` hook (`opencode.ts:355-380`) still fires under `opencode acp` |
+| 6 | Are the npm package names current? | Verify with `npm view` in Phase 1.7 before pinning — see the unattended-decision callout in Research |
+| 7 | Does the ACP session id double as the native terminal-resume id? | **The correctness gap this plan was re-reviewed for.** If it diverges and we reuse `agentChatId`, json→tty silently builds a resume command the raw CLI rejects, breaking a shipped feature. Mitigation: Decision 6's Option A/B + the per-plugin spikes (1.8, 2.0, 3.0a, 3.0b, 4.1b), each gating that plugin's toggle regression test |
+| 8 | agy loses its only reliable chat-id capture channel under ACP | `--log-file` is injected into agy's OWN argv (`agy.ts:394-401`); the ACP adapter owns that argv, so that specific channel is gone. **Resolved 2026-08-30**: the `antigravity-acp` adapter itself provides an equally reliable, session-scoped replacement — `~/.agy-acp/sessions.json`, keyed by ACP session id, live-verified to carry agy's real native `conversationId` and to round-trip through `agy --conversation <id>`. agy is Option B (ids diverge) but is NOT a degrade — see `readAgyAcpSessionConversationId` in `agy.ts` and the Decision 6 Spike Results table |
+
+---
+
+## Daemon Changes (explicit)
+
+| Change | Detail |
+|---|---|
+| **New** `daemon/src/services/acp/` | ACP JSON-RPC transport, connection lifecycle + idle TTL, terminal manager, shared normalizer. Nothing CLI-specific — plugins supply only launch argv + an enrich hook |
+| **Modified** `jsonAgent.ts` | `getOrCreateConnection()`; `runOneTurn` branches on `plugin.supportsAcp?.()`; `stopActiveTurn` cancels instead of killing (Decision 3); `release()` awaits `connection.dispose()` (Decision 9) |
+| **Modified** `agent-plugins/{claude,cursor,opencode,agy}.ts` | `runTurn` bodies replaced (Decision 2) + `supportsAcp()` added. **Conditionally** `captureNativeChatId()` added, per that plugin's Decision 6 spike verdict. `setupWorkspaceHooks`, `provideChatId`, `captureChatId`, `refreshChatIdOnToggle`, `getRestoreCommand`, `getForkCommand`, `composeLaunchPrompt` all UNCHANGED — they belong to the terminal path and the toggle glue |
+| **Modified** `recover.ts` | `KNOWN_TURN_BINARIES` + doc comment (Decision 7) |
+| **Modified** `spawn.ts` | **Doc comment + `TurnContext` field (+ conditionally one optional `AgentPlugin` method)** — `AgentJsonTransport` comment (30-48) updated; `TurnContext` (67-92) gains `getAcpConnection?`; `AgentPlugin` gains `captureNativeChatId?` iff any plugin lands on Decision 6 Option B. `spawnSession`/`spawnDirectSession` untouched |
+| **Conditional (Decision 6 Option B only)** `dbSchema.ts` · `types.ts` · `sqliteRowMappers.ts` · `project-store.ts` · `jsonAgent.ts` | One nullable `sessions.acpSessionId TEXT` column plumbed through the record type, row mappers, INSERT list, and a `persistAcpSessionId()` twin of `persistChatId()`. Additive only; no data migration; NULL for every existing row |
+| **Modified** `cli/package.json` | New dependencies land here — there is no `daemon/package.json`; `cli/src/daemon` symlinks to `daemon/src` |
+| **Unchanged** | `promptBuilder.ts`, `dbMigration.ts`, `agent-plugins/registry.ts`, `routes/sessions.ts`, `claudeImport.ts`/`opencodeImport.ts`, all terminal-channel code |
+
+## UI Changes (explicit)
+
+- **None required.** Evidence, from reading `web-ui/src/components/chat/`:
+  - `MessageList.tsx:229-246` — `toolIndexById` spans the whole event list, so a `tool_result` from a later turn still attaches to its `tool_use` card; a miss falls back to a standalone card rather than dropping the event.
+  - `ToolUseCard.tsx:6-12` — `running?: boolean` is explicitly documented as "the matching tool_result hasn't arrived yet"; the card renders without a result.
+  - `StatusBar.tsx`, `QueuedTray.tsx`, `ToolResultCard.tsx` — all render purely off `NormalizedEvent`s from the existing WS `JsonAgentStream` (`jsonAgent.ts:32`); none reference process spawning, PIDs, or turn transport.
+  - `daemon/src/types.ts:74-84` — no new `NormalizedEventKind` is introduced, so no component needs a new case.
+- The transport swap is entirely daemon-internal; the WS payload contract does not change.
+- Deferred follow-up (Out of Scope): a "background processes running" indicator in `StatusBar.tsx`, once `AcpTerminalManager` has metadata to source it from.
+
+## What Gets Reused (explicit)
+
+| Reused largely intact | Net-new |
+|---|---|
+| `daemon/src/services/jsonAgent.ts` — turn queue, `drain()`, transcript persistence, meta tracking, fork (Decision 8), queue controls (edit/withdraw/promote/cancel) | `daemon/src/services/acp/acpTransport.ts` — `AcpConnection`: spawn, `initialize`, `session/new`/`load`/`prompt`/`cancel`, idle TTL |
+| `daemon/src/state/jsonAgentRegistry.ts` — `sessionId → JsonAgentSession` map, unchanged | `daemon/src/services/acp/acpTerminalManager.ts` — serves `terminal/*`, owns OS child handles |
+| `daemon/src/services/recover.ts` — `verifyPidIsTurnProcess`, PID-reuse guard, sweep control flow, `turn.pids` format | `daemon/src/services/acp/normalize.ts` — shared `SessionUpdate → NormalizedEvent` mapping + per-plugin `enrich` hook |
+| `daemon/src/services/dbMigration.ts` — zero changes | Per-plugin `runTurn` bodies (signatures unchanged) |
+| `daemon/src/services/spawn.ts` — `spawnSession`/`spawnDirectSession`, terminal channel, untouched | Two npm dependencies in `cli/package.json` |
+| `daemon/src/services/promptBuilder.ts` — 3-layer prompt builder, zero changes | |
+| `daemon/src/agent-plugins/registry.ts` — flat map, unchanged | |
+| `web-ui/src/components/chat/*` — zero changes | |
+| `daemon/src/routes/sessions.ts` — stop / toggle / delete routes, unchanged | |
+| `daemon/src/services/dbSchema.ts` — `addColumnIfMissing` pattern reused as-is under Decision 6 Option B; file untouched under Option A | |
+| `daemon/src/agent-plugins/claudeRestore.ts` / `cursorRestore.ts` — native-id probes reused **verbatim** by Option B's `captureNativeChatId` | |
+| `daemon/src/agent-plugins/{claudeImport,opencodeImport}.ts` — native-history importers, unchanged (correct by construction once `agentChatId` keeps meaning "native id") | |
+
+---
+
+## Implementation Phases
+
+- Each phase ends with a **verification block** — the phase is not complete until those tests pass.
+- Test items use `N.Tn` numbering.
+- Run tests with `pnpm -r test` from the repo root, or `pnpm --filter @vibestation/cli test` for daemon-only.
+
+---
+
+### Phase 1 — ACP transport core (no plugin migrated yet)
+
+- [x] **1.1** New `daemon/src/services/acp/acpTransport.ts` — `AcpConnection`: spawn `detached` in its own process group (matching `spawn.ts:86-91`'s `onSpawn` contract), `initialize()`, `sendPrompt() → { updates, result }`, `cancelActivePrompt()`, `dispose()`, 30-minute idle timer gated on `hasLiveTerminals()` (Decision 4)
+- [x] **1.2** New `daemon/src/services/acp/acpTerminalManager.ts` — serves `terminal/create|output|wait_for_exit|kill|release`; tracks `terminalId → ChildProcess`; exposes `hasLiveTerminals(): boolean`
+- [x] **1.3** New `daemon/src/services/acp/normalize.ts` — `normalizeSessionUpdate(raw, sessionId, enrich?): NormalizedEvent | null`, pure, maps `agent_message_chunk`/`agent_thought_chunk`/`tool_call`/`tool_call_update`/`plan` onto the existing kinds in `daemon/src/types.ts:74-84`
+- [x] **1.4** `daemon/src/services/jsonAgent.ts` — add `getOrCreateConnection()` to `JsonAgentSession`; add `getAcpConnection?` to `TurnContext` (`spawn.ts:67-92`); branch `runOneTurn` (802-899) on `plugin.supportsAcp?.()` so unmigrated plugins keep working through Phases 2-4
+- [x] **1.5** `daemon/src/services/jsonAgent.ts` — split kill semantics:
+  - `stopActiveTurn()` (470-478) calls `connection.cancelActivePrompt()` instead of `killLivePids()` when a connection exists (Decision 3).
+  - `release()` (453-462) awaits `connection.dispose()` before calling `dispose()` (434-440, which stays sync and store-only).
+  - `abortAndDrain()` (410-420) keeps `killLivePids()` — that now group-kills the connection process, which is the correct teardown behavior (Requirement 2).
+- [x] **1.6** `daemon/src/services/recover.ts:14-22` — add the ACP adapter comm names to `KNOWN_TURN_BINARIES` and update its doc comment (Decision 7)
+- [x] **1.7** `cli/package.json` — run `npm view @agentclientprotocol/sdk version` and `npm view @agentclientprotocol/claude-agent-acp version` first; if either name has moved, use the current published name; then add both pinned to exact versions (npm-installed, not vendored)
+- [x] **1.8 (spike harness — the shared mechanism for Decision 6; per-plugin runs happen in 2.0 / 3.0a / 3.0b / 4.1b)** Establish the ACP-id-vs-native-id comparison procedure. Throwaway script, **not** checked in; results recorded in Decision 6's Spike Results table.
+  - Procedure (identical for all four; only the two bracketed parts differ):
+    1. `mkdir` a fresh scratch git checkout, `git init`, e.g. `/tmp/acp-id-spike-<cli>` — a *fresh* cwd is essential: cwd-keyed native stores (cursor, agy) are ambiguous in a reused directory.
+    2. Spawn `[the plugin's ACP launch argv]` with piped stdio; `initialize` → `session/new { cwd }` → `session/prompt` with the literal text `say the word PINGSPIKE and nothing else` → wait for `stopReason`.
+    3. Record `S = session/new.result.sessionId`. Also dump the raw `initialize` result and the raw `session/new` result — check for any field carrying a native id (a side channel beats a filesystem probe; see Decision 6).
+    4. Record `N = [the plugin's native side channel]` for that same cwd.
+    5. Smoke: in a plain terminal in that cwd, run `[the plugin's native resume argv, using S]` and check the conversation contains `PINGSPIKE`.
+  - Verdicts:
+    - **PASS → Option A:** `S === N` (byte-identical) AND the native resume with `S` reopens the conversation.
+    - **PARTIAL → Option B:** `S !== N` (or native resume with `S` fails), but `N` is non-null, correct, and reproducible across 2 consecutive runs.
+    - **FAIL → Option B + documented degrade:** `N` is null, wrong, or non-reproducible.
+  - Per-plugin bindings:
+
+| Plugin | ACP launch argv | Native side channel `N` | Native resume smoke |
+|---|---|---|---|
+| claude | `CLAUDE_CODE_EXECUTABLE=$(which claude) npx <claude-acp adapter pinned in 1.7>` | `findLatestChatUuid(cwd)` (`claudeRestore.ts:24`), i.e. newest `~/.claude/projects/<slug>/*.jsonl` by mtime | `claude --resume S --dangerously-skip-permissions` |
+| cursor | `cursor-agent acp` | `findLatestCursorChatId(cwd)` (`cursorRestore.ts:33`) | `cursor-agent --resume S --workspace <cwd> --force` |
+| opencode | `opencode acp`, spawned with `VST_SPAWN_TOKEN=spike` **after** running `setupWorkspaceHooks(cwd)` so `.opencode/plugins/vst-recorder.ts` exists | `<cwd>/.vibe-station/agent-chat-ids/spike` (hook-written); cross-check `SELECT id FROM session` in `~/.local/share/opencode/opencode.db` (readonly) | `opencode --session S` |
+| agy | antigravity-acp adapter (**only after** 4.1's auth spike passes) | **REVISED 2026-08-30**: `readAgyAcpSessionConversationId(acpSessionId)` → `~/.agy-acp/sessions.json[acpSessionId].conversationId`, the adapter's own session store (falls back to `readLatestAgyConversationId(cwd)` → `last_conversations.json[cwd]`, `agy.ts:264`). The per-session `--log-file` channel (`agy.ts:394-401`) is confirmed NOT forwarded by the adapter (it owns agy's argv directly, via `buildAgyArgs` in its own `src/acp/sessions.ts`) — but the adapter's own session store is an equally session-scoped replacement, not merely a fallback | `agy --conversation S --dangerously-skip-permissions` |
+
+**Verify phase 1:**
+- [x] **1.T1** Unit — `daemon/src/__tests__/acpTransport.test.ts`: `initialize()` rejects with `InitializeFailed` when the spawned process exits before responding (no hang, no unhandled rejection)
+- [x] **1.T2** Unit — `daemon/src/__tests__/acpTerminalManager.test.ts`: `hasLiveTerminals()` is `true` while a tracked child runs, `false` after `terminal/release` and after the child exits on its own
+- [x] **1.T3** Unit — `daemon/src/__tests__/acpNormalize.test.ts`: a `tool_call` update maps to a `tool_use` event carrying the same `toolId`; a later `tool_call_update` with that id maps to `tool_result`
+- [x] **1.T4** Integration — `daemon/src/__tests__/jsonAgent.test.ts`: `stopActiveTurn()` on a session with a live `AcpConnection` sends `session/cancel`, does not call `killProcessTree`, and the connection remains usable for the next queued turn
+- [x] **1.T5** Unit — `daemon/src/__tests__/acpFileSystem.test.ts`: `fs/read_text_file` resolves inside the session cwd and returns a JSON-RPC error (not a throw that kills the connection) for a missing path
+- [x] **1.T6** Integration (Requirement 4b) — `daemon/src/__tests__/jsonAgent.test.ts`: with a turn in flight that has started a host-managed background terminal (`FAKE_ACP_MODE=bg_terminal`), `promoteQueuedTurn()` (force-send) leaves `hasLiveTerminals()` true and the promoted turn completes on the SAME connection
+
+---
+
+### Phase 2 — Migrate claude plugin
+
+- [x] **2.0 (spike — do FIRST, before 2.1's regression surface exists and BEFORE writing 2.T5)** Run the Phase 1.8 procedure with the claude bindings; record claude's verdict + chosen Option in Decision 6's Spike Results table
+- [x] **2.1** `daemon/src/agent-plugins/claude.ts` — replace `runTurn` (475-561) per Decision 2's sketch; resolve the user's own `claude` binary with the existing discovery logic and pass it as `CLAUDE_CODE_EXECUTABLE` to the adapter process
+- [x] **2.2** `daemon/src/agent-plugins/claude.ts` — add `supportsAcp(): true`; leave `setupWorkspaceHooks` (291), `captureChatId` (445), `getForkCommand` (563-566), `getRestoreCommand` (568) unchanged
+- [x] **2.3** `daemon/src/services/acp/normalize.ts` — add the claude `enrich` hook (map claude-specific `plan` / tool metadata onto existing kinds; a `plan` update becomes a `status` event, never a new kind)
+- [x] **2.4** If claude landed on **Option A**: confirm `dbSchema.ts` is still unmodified (this item exists to stop a reflexive migration). If **Option B**: add `sessions.acpSessionId TEXT` via `addColumnIfMissing`, plumb it through `types.ts` / `sqliteRowMappers.ts` / `project-store.ts` INSERT / `persistAcpSessionId()`, and implement `claude.captureNativeChatId()` over `findLatestChatUuid(cwd)` per Decision 6
+
+**Verify phase 2:**
+- [x] **2.T1** Integration — send `run \`sleep 60 &\` in the background, then tell me you're done` to a claude json session; assert the `result` event lands well under 60s AND a follow-up turn 70s later is answered on the SAME connection (no new `session/new`, `agentChatId` identical across both turns)
+- [x] **2.T2** Integration — Stop mid-turn, then send another turn; assert it succeeds without a fresh `session/new`
+- [x] **2.T3** Regression — `/vst reset`, `/vst handoff`, `/vst rename` still work through the ACP-wrapped `claude` binary (Risk 3)
+- [x] **2.T4** Regression — `daemon/src/__tests__/jsonChatRoutes.test.ts`: fork-a-sent-message still works via the unchanged one-shot `--fork-session` path (Decision 8)
+- [x] **2.T5** Regression (**write only after 2.0's verdict**) — `daemon/src/__tests__/jsonChannelToggle.test.ts`: after ≥1 ACP turn, `PATCH /sessions/:id/channel {channel:"tmux"}` produces `getRestoreCommand` argv containing the id the raw `claude` binary accepts, and the resumed terminal shows the Rich Chat turn. Option A: assert argv id `===` the ACP session id. Option B: assert argv id `===` the `captureNativeChatId` value and `!==` `acpSessionId`. Degrade case: assert `getRestoreCommand` returns null and the J12 fresh-launch branch runs (no bogus `--resume`)
+
+---
+
+### Phase 3 — Migrate cursor + opencode
+
+- [x] **3.0a (spike — before 3.1, and before writing 3.T4)** Phase 1.8 procedure with the cursor bindings; record cursor's verdict + Option
+- [x] **3.0b (spike — before 3.2, and before writing 3.T4)** Phase 1.8 procedure with the opencode bindings; record opencode's verdict + Option. This also closes Risk 5 and proves whether the `session.created` hook fires under `opencode acp`
+- [x] **3.1** `daemon/src/agent-plugins/cursor.ts` — replace `runTurn` (327-392); spawn `cursor-agent acp` directly (native, no adapter package)
+- [x] **3.2** `daemon/src/agent-plugins/opencode.ts` — replace `runTurn` (283-358); spawn `opencode acp` directly; move `OPENCODE_CONFIG` system-prompt delivery (`opencode.ts:239,312`) from per-turn env to connection-spawn env, applied once at `session/new` time. **Also pass `VST_SPAWN_TOKEN=<session.id>` in the connection-spawn env** — the existing `session.created` hook keys its token file off it, and it is opencode's Option B side channel (Decision 6); harmless under Option A
+- [x] **3.3** Add `supportsAcp(): true` to both plugins
+- [x] **3.4** Implement `captureNativeChatId()` for whichever of cursor/opencode landed on Option B (bodies specified in Decision 6); skip for any that landed on Option A
+
+**Verify phase 3:**
+- [x] **3.T1** Integration — the 2.T1 background-survival assertion, run against cursor
+- [x] **3.T2** Integration — the 2.T1 background-survival assertion, run against opencode
+- [x] **3.T3** Regression — `daemon/src/__tests__/jsonPlugins.test.ts`: opencode's `.opencode/plugins/vst-recorder.ts` `session.created` hook (`opencode.ts:360-390`) still fires and its id round-trips through `agentChatId` (Risk 5)
+- [x] **3.T4** Regression (**write only after 3.0a/3.0b**) — the 2.T5 toggle assertion, run for cursor and opencode, each per its own recorded Option. Additionally assert the tty→json direction still backfills for opencode (`opencodeImport.ts:68` matches on `agentChatId`) — a non-native id there imports zero turns silently
+
+---
+
+### Phase 4 — agy (Antigravity), spike-gated
+
+- [x] **4.1 (spike — do FIRST; do not start 4.2 until this passes)** Spawn the antigravity-acp adapter against a headless, already-authenticated Antigravity install and confirm `initialize` + `session/new` complete without hanging. Time-box 1 day. On failure: STOP, skip 4.2-4.4, leave agy on the legacy one-shot path, record the outcome in Risk 1
+- [x] **4.1b (spike — only if 4.1 passed; before 4.2, and before writing 4.T4)** Phase 1.8 procedure with the agy bindings. Explicitly determine whether the antigravity-acp adapter forwards extra args/env to `agy` (which would restore the reliable per-session `--log-file` channel, `agy.ts:394-401`). Expect PARTIAL or FAIL — record agy's verdict + Option, and if FAIL, write the degrade into Decision 6's Spike Results and Phase 5.2's doc update
+- [x] **4.2** `daemon/src/agent-plugins/agy.ts` — replace `runTurn` (503-578) per the Phase 2/3 pattern; only if 4.1 passed
+- [x] **4.3** `daemon/src/services/acp/acpTransport.ts` — add a per-plugin connect/initialize timeout (agy: 20s) that emits an `error` NormalizedEvent reading "Antigravity ACP unavailable" instead of hanging the turn
+- [x] **4.4** Add `supportsAcp(): true` to agy, behind the 4.3 timeout guard
+
+**Verify phase 4:**
+- [x] **4.T1** Integration (only if 4.1 passed) — the 2.T1 background-survival assertion, run against agy
+- [x] **4.T2** Integration — with a deliberately hung adapter, the 4.3 timeout emits an `error` event within 20s rather than leaving the turn pending forever
+- [x] **4.T3** Regression — `daemon/src/__tests__/agy.test.ts`: `refreshChatIdOnToggle` (`agy.ts:481`) still self-heals the tty→json path
+- [x] **4.T4** Regression (only if 4.1 + 4.1b ran) — the 2.T5 toggle assertion for agy, per its recorded Option. On the degrade path, assert the toggle yields a fresh terminal launch (no `--conversation`) and the Rich Chat transcript still renders in full
+
+---
+
+### Phase 5 — Cleanup + docs
+
+- [x] **5.1** Remove the dead one-shot spawn paths from all migrated plugins, keeping claude's fork path (Decision 8) and agy's legacy path if 4.1 failed
+- [x] **5.2** `docs/JSON-CHAT-ARCHITECTURE.md:57-60` — the line "json (no persistent process — the daemon spawns the CLI fresh for every single turn)" is now false; rewrite it and the diagram for the persistent-connection model. **Also document the per-plugin Decision 6 outcome**: which plugins store the ACP id in `agentChatId` (Option A) vs `acpSessionId` (Option B), and any plugin whose json→tty toggle degrades to a fresh terminal launch
+- [x] **5.3** `daemon/src/services/recover.ts:14-22` — confirm the `KNOWN_TURN_BINARIES` doc comment describes one connection PID per session, not one per turn
+- [x] **5.4** `daemon/src/services/spawn.ts:30-48` — update the `AgentJsonTransport` doc comment: the turn ends when `session/prompt` resolves, not when a process exits
+- [x] **5.5** `AGENTS.md` § "Current plugin methods" — add `captureNativeChatId?(args)` to the method table iff any plugin landed on Decision 6 Option B
+
+**Verify phase 5:**
+- [x] **5.T1** Regression — `pnpm -r test` passes; specifically `daemon/src/__tests__/{jsonPlugins,claudeJson,agy,jsonAgent,jsonChatQueue,jsonChatRoutes,jsonAgentRelease,jsonChannelToggle}.test.ts`
+- [x] **5.T2** Regression — `daemon/src/__tests__/recover.test.ts`: SIGKILL the daemon mid-turn, restart, assert the orphaned ACP adapter PID is swept, `turn.pids` is unlinked, and the session reconciles to `idle`
+
+---
+
+## Directory Layout (every file this plan creates)
+
+```
+daemon/src/
+├── services/
+│   ├── acp/                          # NEW dir — shared ACP client layer. ZERO CLI-specific
+│   │   │                             # logic (AGENTS.md): plugins supply argv + an enrich hook.
+│   │   ├── acpTransport.ts           # NEW  AcpConnection: detached spawn, initialize + the
+│   │   │                             #      fail-closed-before-ready race, session/new|load|
+│   │   │                             #      prompt|cancel, update demux, 30-min idle TTL, dispose
+│   │   ├── acpTerminalManager.ts     # NEW  ACP Client half A: terminal/create|output|
+│   │   │                             #      wait_for_exit|kill|release; owns OS child handles;
+│   │   │                             #      hasLiveTerminals() gates the idle TTL
+│   │   ├── acpFileSystem.ts          # NEW  ACP Client half B: fs/read_text_file,
+│   │   │                             #      fs/write_text_file, scoped to the session cwd
+│   │   └── normalize.ts              # NEW  pure SessionUpdate -> NormalizedEvent + enrich hook
+│   ├── jsonAgent.ts                  # MOD  getOrCreateConnection, stop=cancel, release=dispose,
+│   │                                 #      (Opt B) persistAcpSessionId + captureNativeChatId call
+│   ├── spawn.ts                      # MOD  doc comment, TurnContext.getAcpConnection?,
+│   │                                 #      (Opt B) AgentPlugin.captureNativeChatId?
+│   ├── recover.ts                    # MOD  KNOWN_TURN_BINARIES + doc comment
+│   └── dbSchema.ts                   # MOD (Opt B only) one addColumnIfMissing line
+├── agent-plugins/                    # NO new files — per-plugin ACP specifics stay in the
+│   ├── claude.ts                     # MOD  existing plugin file, next to that CLI's other logic
+│   ├── cursor.ts                     # MOD
+│   ├── opencode.ts                   # MOD
+│   ├── agy.ts                        # MOD (conditional on spike 4.1)
+│   ├── claudeRestore.ts              # UNCHANGED — reused by Opt B captureNativeChatId
+│   └── cursorRestore.ts              # UNCHANGED — reused by Opt B captureNativeChatId
+├── state/, routes/, ws/              # UNCHANGED (Opt B adds fields to state/sqliteRowMappers.ts
+│                                     # and state/project-store.ts INSERT list only)
+└── __tests__/                        # flat, repo convention — one <module>.test.ts per module
+    ├── acpTransport.test.ts          # NEW  1.T1
+    ├── acpTerminalManager.test.ts    # NEW  1.T2
+    ├── acpFileSystem.test.ts         # NEW  1.T5
+    └── acpNormalize.test.ts          # NEW  1.T3
+```
+
+### Why this shape (measured against the repo, not imported from elsewhere)
+
+| Question | Repo evidence | Call |
+|---|---|---|
+| Is a subdirectory under `services/` foreign? | `services/` is flat (40 files), but `ws/` already nests `handlers/` + `streams/` | `services/acp/` is within convention for a cohesive 4-file subsystem |
+| Is there a file-size ceiling forcing a split? | `jsonAgent.ts` 1221, `routes/sessions.ts` 2224, `git.ts` 799, `spawn.ts` 714 | No ceiling. Splitting for size alone would be inventing a rule |
+| One class per file? | No — `spawn.ts` holds `AgentJsonTransport` + `TurnContext` + `AgentPlugin` + `LaunchConfig` + several functions | Co-locate; no `acp/types.ts` |
+| Where do interfaces live? | Beside their implementations (`AgentPlugin` in `spawn.ts`); only cross-cutting types go in `daemon/src/types.ts` | `AcpConnection`'s interface stays in `acpTransport.ts`; no new global types |
+| Test naming/location | Flat `daemon/src/__tests__/<module>.test.ts` | Matches the table above |
+
+### Does `acpTransport.ts` need to split further? — No.
+
+- Estimated size with everything it owns (spawn + `initialize` race + `session/new|load|prompt|cancel` + update demux + idle timer + `dispose`): ~350-500 lines — mid-range for `services/`, well under `spawn.ts` (714).
+- The idle timer (~25 lines) is not separable: it exists only to be reset by `sendPrompt` and vetoed by `hasLiveTerminals()`. A separate `acp/idleTimer.ts` would be a two-import indirection over one `setTimeout` and one boolean — moving the lifecycle bug surface into two files instead of one, the exact reason Decision 4 already rejected a separate `acpConnectionManager.ts`.
+- The spawn/initialize race (~40 lines) is inherently inside `initialize()` — mirrors the emdash precedent (`acp-agent-connection.ts:118-119`).
+- **Decision 6 Option B adds ~0 lines to this file.** Native-chat-id capture is CLI-specific, so AGENTS.md puts it in the plugin (`captureNativeChatId`), and the call site is in `jsonAgent.ts` (one `if`), not in the transport.
+- **One adjustment IS made:** `fs/read_text_file` / `fs/write_text_file` had no home in the original 3-file proposal, despite `initialize` declaring `clientCapabilities.fs`. They go in `acp/acpFileSystem.ts` — the natural sibling of `acpTerminalManager.ts` (the other half of the ACP *Client* surface), keeping `acpTransport.ts` purely the JSON-RPC + lifecycle layer.
+- **Naming note (AGENTS.md "Rich Chat in the UI, `json` in the code"):** `acp*` names a wire protocol, not the channel. Do not rename these to `RichChat*` (forbidden) and do not rename them to `json*` either — `jsonAgent.ts`/`jsonAgentRegistry.ts` remain the channel-level names; `acp/` sits one layer below them.
+
+---
+
+## Files & Phase Impact
+
+| File | Status | Phase | Description / Contract Change |
+|------|--------|-------|-------------------------------|
+| `daemon/src/services/acp/acpTransport.ts` | **New** | 1.1, 4.3 | Contract: `class AcpConnection { initialize(); sendPrompt(prompt, signal): {updates, result}; cancelActivePrompt(); hasLiveTerminals(); dispose(); }` · Owns: the adapter process handle + idle timer |
+| `daemon/src/services/acp/acpTerminalManager.ts` | **New** | 1.2 | Contract: serves ACP `terminal/*`; `hasLiveTerminals(): boolean` · Owns: OS child process handles for background work |
+| `daemon/src/services/acp/normalize.ts` | **New** | 1.3, 2.3 | Contract: `normalizeSessionUpdate(raw, sessionId, enrich?): NormalizedEvent \| null` — pure, no state |
+| `daemon/src/services/acp/acpFileSystem.ts` | **New** | 1.1 | Contract: serves ACP `fs/read_text_file` / `fs/write_text_file`, scoped to the session cwd · Owns: nothing persistent. Split out of `acpTransport.ts` so that file stays the pure JSON-RPC + lifecycle layer |
+| `daemon/src/services/jsonAgent.ts` | **Modified** | 1.4, 1.5 | `getOrCreateConnection()` added; `runOneTurn` branches on `supportsAcp`; `stopActiveTurn` cancels instead of killing; `release()` awaits `connection.dispose()` |
+| `daemon/src/services/spawn.ts` | **Modified (comment + one optional field + one conditional method)** | 1.4, 5.4, Opt B | `TurnContext` (67-92) gains `getAcpConnection?`; `AgentPlugin` gains `captureNativeChatId?` under Decision 6 Option B; `AgentJsonTransport` doc comment (30-48) updated. `spawnSession`/`spawnDirectSession` untouched |
+| `daemon/src/services/recover.ts` | **Modified** | 1.6, 5.3 | `KNOWN_TURN_BINARIES` (22) gains adapter comm names; doc comment updated. Sweep control flow unchanged |
+| `cli/package.json` | **Modified** | 1.7 | Add ACP SDK + claude adapter, pinned exact. **Not** `daemon/package.json` — that file does not exist |
+| `daemon/src/agent-plugins/claude.ts` | **Modified** | 2.0-2.4 | `runTurn` (475-561) replaced; `supportsAcp(): true`; conditional `captureNativeChatId()`; fork/hooks/restore paths unchanged |
+| `daemon/src/agent-plugins/cursor.ts` | **Modified** | 3.0a, 3.1, 3.3-3.4 | `runTurn` (327-392) replaced with native `cursor-agent acp`; conditional `captureNativeChatId()` |
+| `daemon/src/agent-plugins/opencode.ts` | **Modified** | 3.0b, 3.2-3.4 | `runTurn` (283-358) replaced with native `opencode acp`; `OPENCODE_CONFIG` + `VST_SPAWN_TOKEN` move to connection spawn; conditional `captureNativeChatId()` |
+| `daemon/src/agent-plugins/agy.ts` | **Modified (conditional)** | 4.1-4.4, 4.1b | Only if spike 4.1 passes |
+| `daemon/src/services/dbSchema.ts` | **Conditional (Decision 6 Option B)** | 2.4 / 3.4 / 4.x | Option A: unchanged. Option B: `addColumnIfMissing(db, "sessions", "acpSessionId", "TEXT")` beside the `pr*` calls (142-151) |
+| `daemon/src/types.ts` | **Conditional (Option B)** | with dbSchema | `acpSessionId?: string` on the session record types (170, 238) |
+| `daemon/src/state/sqliteRowMappers.ts` | **Conditional (Option B)** | with dbSchema | `SessionRow.acpSessionId` (36) + `rowToSession` (95) + `sessionToRow` (141) |
+| `daemon/src/state/project-store.ts` | **Conditional (Option B)** | with dbSchema | `acpSessionId` added to the explicit INSERT column/values lists (261-262) |
+| `daemon/src/agent-plugins/claudeRestore.ts` | **Unchanged** | — | Reused verbatim by claude's Option B `captureNativeChatId` |
+| `daemon/src/agent-plugins/cursorRestore.ts` | **Unchanged** | — | Reused verbatim by cursor's Option B `captureNativeChatId` |
+| `daemon/src/agent-plugins/{claudeImport,opencodeImport}.ts` | **Unchanged** | — | Native-history importers key on `agentChatId`; correct under both Options because `agentChatId` never stops meaning "native id" |
+| `docs/JSON-CHAT-ARCHITECTURE.md` | **Modified** | 5.2 | Lines 57-60 + diagram updated for the persistent-connection model; per-plugin Decision 6 outcome documented |
+| `AGENTS.md` | **Modified (conditional)** | 5.5 | Plugin-method table gains `captureNativeChatId?` under Option B |
+| `daemon/src/services/promptBuilder.ts` | **Unchanged** | — | System-prompt string builder; delivery stays plugin-internal |
+| `daemon/src/services/dbMigration.ts` | **Unchanged** | — | manifest→sqlite boot migration, unrelated |
+| `daemon/src/agent-plugins/registry.ts` | **Unchanged** | — | Flat map, shape unaffected |
+| `daemon/src/state/jsonAgentRegistry.ts` | **Unchanged** | — | `sessionId → JsonAgentSession` map already 1:1 (Decision 1) |
+| `daemon/src/routes/sessions.ts` | **Unchanged** | — | Stop (1657), toggle (2023-2025), delete routes all keep their current calls |
+| `web-ui/src/components/chat/*` | **Unchanged** | — | Verified — see UI Changes |
+| `daemon/src/__tests__/acpTransport.test.ts` | **New** | 1.T1 | Connection init + failure paths |
+| `daemon/src/__tests__/acpTerminalManager.test.ts` | **New** | 1.T2 | Terminal tracking / `hasLiveTerminals` |
+| `daemon/src/__tests__/acpNormalize.test.ts` | **New** | 1.T3 | `SessionUpdate → NormalizedEvent` mapping |
+| `daemon/src/__tests__/acpFileSystem.test.ts` | **New** | 1.T5 | `fs/*` cwd scoping + missing-path error path |
+| `daemon/src/__tests__/jsonAgent.test.ts` | **Modified** | 1.T4 | Stop-cancels-not-kills assertions |
+| `daemon/src/__tests__/claudeJson.test.ts` | **Modified** | 2.T1-2.T2 | ACP-transport turn tests for claude |
+| `daemon/src/__tests__/jsonChatRoutes.test.ts` | **Modified** | 2.T4 | Fork regression over the legacy path |
+| `daemon/src/__tests__/jsonChannelToggle.test.ts` | **Modified** | 2.T5, 3.T4, 4.T4 | Per-plugin json→tty resume-id assertions, gated on each plugin's Decision 6 verdict |
+| `daemon/src/__tests__/jsonPlugins.test.ts` | **Modified** | 3.T1-3.T3 | cursor/opencode ACP turn tests + vst-recorder regression |
+| `daemon/src/__tests__/agy.test.ts` | **Modified (conditional)** | 4.T1-4.T3 | Only if spike 4.1 passes |
+| `daemon/src/__tests__/recover.test.ts` | **Modified** | 5.T2 | Boot sweep kills an orphaned ACP connection |

--- a/.vibekit/feature-plans/wip/acp-migration/02-new-plugins/plan-02-acp-migration-new-plugins.md
+++ b/.vibekit/feature-plans/wip/acp-migration/02-new-plugins/plan-02-acp-migration-new-plugins.md
@@ -1,0 +1,523 @@
+<!--
+RULES — read before writing or implementing:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. REQUIREMENTS: One crisp line each — no verbose descriptions
+3. CHECKLIST: Mark items [x] as you complete them — this is your persistent todo list
+4. READING TIME: Optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+# Plan: ACP migration — new plugins (Pi, Droid, Kimi)
+
+> Add new coding-agent CLIs to vibe-station's daemon as ACP-shaped plugins. Pi gets a full implementation checklist; Droid/Kimi get a ranked effort/risk outline only. **Kimchi and OMP are explicitly dropped from scope — human decision, not a research finding — see Decision 6.**
+
+**Issue:** acp-migration-new-plugins
+**Branch:** `feat/acp-migration-new-plugins`
+**Status:** Pending
+**PRD:** none — plugin-shaped extension of an already-decided architecture; no new user-facing surface beyond CLI choice in the existing mode picker
+**Parent:** none (sibling to `01-core-plugins`, not a child)
+
+**Reference files:**
+- Plugin contract: `daemon/src/services/spawn.ts:94-210` (`AgentPlugin`), `:39-49` (`AgentJsonTransport`), `:51-58` (`TurnInput`), `:66-92` (`TurnContext`)
+- Registry: `daemon/src/agent-plugins/registry.ts:12-32`
+- Turn engine (consumer): `daemon/src/services/jsonAgent.ts:802-905`
+- Existing plugin examples: `daemon/src/agent-plugins/{claude,cursor,opencode,agy}.ts`
+- Prompt builder: `daemon/src/services/promptBuilder.ts:67-118` (`buildPrompt`), `:120-161` (`buildDirectPrompt`)
+- Boot orphan sweep: `daemon/src/services/recover.ts:14-22` (`KNOWN_TURN_BINARIES`), `:61-95`
+- Session persistence: `daemon/src/services/dbSchema.ts:53-77`, `:154-158`; `daemon/src/services/dbMigration.ts`
+- Mode/CLI identity: `daemon/src/routes/modes.ts:22-23,185-197` → `~/.vibe-station/modes.json` (`daemon/src/services/paths.ts:72-74`), **not SQLite**
+
+---
+
+## Scoping statement (read first)
+
+| CLI | Treatment in THIS plan |
+|---|---|
+| **Pi** | Full research + design + phased implementation checklist (Phases 0-2) |
+| **Droid, Kimi** | Ranked list + effort/risk table + "what's needed" outline only — **no phase checklist** |
+| **Kimchi, OMP** | **Dropped — not building.** Explicit human decision (not a risk/effort finding); research kept below for future reference only, no implementation intent |
+
+- Follow-on plan file per CLI when picked up: `03-droid`, `04-kimi` under the same `acp-migration/` feature dir — not written here.
+- Rationale for the asymmetry: Pi is the named next priority; Droid/Kimi need a human call on relative order first (see Decision 6).
+
+---
+
+## Problem
+
+- Daemon supports 4 CLIs today — claude, cursor, opencode, agy (`daemon/src/agent-plugins/registry.ts:12-17`).
+- Users want Pi, Droid, Kimi, Kimchi, OMP in the same mode picker, running Rich Chat (json channel) identically.
+- Sub-plan A changes the json-channel transport under all 4 existing plugins — a new plugin written against the *old* transport would be dead code on arrival (see Research → "Transport shape").
+
+## Out of Scope
+
+- Sub-plan A's own migration work (existing 4 plugins) — not modified here.
+- **Terminal channel (tmux/PTY) — explicitly untouched.** No changes to `daemon/src/services/spawn.ts` `spawnSession`/`spawnDirectSession` (`:338-687`) or `web-ui/src/components/layout/TerminalPane.tsx`. New CLIs are json-channel-only in practice (Decision 5).
+- Backward-compat shims, feature flags, dual-write, data migration — **no production users of json-chat exist**, so none is needed (Decision 1).
+- New credential/auth model — ACP carries no auth layer; each CLI authenticates exactly as it does standalone (see Research → web table, "ACP auth model, confirmed").
+- Droid/Kimi implementation — ranked outline only.
+- Kimchi/OMP — dropped entirely, not scoped here or in any follow-on plan (Decision 6).
+
+## Concept
+
+- Adding a CLI = **one new plugin file** implementing `AgentPlugin` + **one line** in `PLUGIN_MAP` + **one binary name** in `KNOWN_TURN_BINARIES`.
+- No shared daemon code branches on CLI name — invariant unchanged.
+- Post-Sub-plan-A, a plugin's `runTurn` does not spawn per turn — it prompts over the session's already-live `AcpConnection` (shape restated in Research → "Transport shape").
+- Success state: Pi selectable in the mode-creation dialog, streams a full Rich Chat turn end-to-end, **zero web-ui code changes** (evidence in UI Changes).
+
+## Requirements
+
+| # | Requirement |
+|---|-------------|
+| 1 | New plugin implements every **non-optional** `AgentPlugin` member (`spawn.ts:94-210`): `name`, `defaultModel`, `promptDelivery`, `getLaunchCommand`, `getEnvironment`, `getReadySignal`, `composeLaunchPrompt`, `listModels` |
+| 2 | New plugin implements the **optional** json-channel members: `supportsJson()`, `runTurn()`, plus Sub-plan A's new `supportsAcp()` gate |
+| 3 | No shared daemon code branches on CLI name — all CLI-specific logic lives in the plugin file |
+| 4 | No SQLite schema change *of its own* — new CLIs add no columns; any `acpSessionId` column comes from Sub-plan A's Decision 6, not from here |
+| 5 | No web-ui code change (see UI Changes) — per-CLI exception called out if a CLI emits an unrenderable event kind |
+| 6 | Auth fully delegated to the wrapped CLI — vibe-station stores no new credentials |
+| 7 | Pi pins an exact adapter distribution + minimum version, validated at `initialize` (Decision 3) — never floating `latest` |
+| 8 | New CLI's spawned binary name added to `recover.ts:22` `KNOWN_TURN_BINARIES` (Decision 4) — else its orphaned process is never swept on boot |
+| 9 | No feature flag, no migration/backfill — greenfield addition (Decision 1) |
+
+---
+
+## Research
+
+### Transport shape — restated inline from Sub-plan A (do NOT go read Sub-plan A to implement this)
+
+> Every fact in this subsection is Sub-plan A's deliverable, restated here verbatim-in-substance so this plan stands alone.
+
+| Sub-plan A artifact | Exact shape |
+|---|---|
+| `daemon/src/services/acp/acpTransport.ts` **(new)** | `class AcpConnection { initialize(); sendPrompt(sessionId: string, prompt: AcpPromptBlock[], signal: AbortSignal): { updates: AsyncIterable<SessionUpdate>; result: Promise<{ stopReason: string }> }; cancelActivePrompt(): Promise<void>; dispose(): Promise<void>; }` |
+| Ownership | **One `AcpConnection` per `sessionId`, owned by the existing `JsonAgentSession` instance** — created lazily via a new `JsonAgentSession.getOrCreateConnection()`. **There is no separate connection pool/registry module.** |
+| Plugin access path | New `TurnContext` field: `ctx.getAcpConnection(): Promise<AcpConnection>` |
+| `daemon/src/services/acp/normalize.ts` **(new)** | `normalizeSessionUpdate(raw, sessionId, enrich?): NormalizedEvent` — shared base mapping (text / thinking / tool_call / tool_call_update / plan → existing `NormalizedEventKind`s) with a **per-plugin `enrich` hook** |
+| `daemon/src/services/acp/acpTerminalManager.ts` **(new)** | Daemon-side ACP Client role: `terminal/create\|output\|wait_for_exit\|kill\|release`; owns background OS child processes |
+| New `AgentPlugin` member | `supportsAcp?(): boolean` — `runOneTurn` takes the ACP branch only when this returns `true` |
+| Turn-done signal | `session/prompt`'s response resolving (**not** process exit); the plugin's `runTurn` still returns `AsyncIterable<NormalizedEvent>`, signature unchanged |
+| Per-plugin responsibility | Only two things: (a) the launch spec for its own binary, (b) its `enrich` mapping for CLI-specific `session/update` nuances |
+| ACP session id storage | Inherited from Sub-plan A's Decision 6 (per-plugin Option A: reuse `sessions.agentChatId`; Option B: new nullable `sessions.acpSessionId`). Whichever lands, this sub-plan adds no column and no new pattern |
+| New npm dependency | `@agentclientprotocol/sdk` (added to `daemon/package.json` by Sub-plan A, not by this plan) |
+| Idle-TTL | Connection disposed after 30 min idle **unless** it has ≥1 live background terminal |
+
+- **Naming note (this plan's own contribution):** Sub-plan A says only "each plugin supplies its own launch-command"; it does not name the function. This plan names it **`buildSpawnSpec(ctx: TurnContext): { command: string; args: string[]; env: Record<string,string> }`** and uses that name throughout.
+
+### Today's per-turn spawn (what Sub-plan A replaces — context only)
+
+- `daemon/src/agent-plugins/claude.ts:475-561` — `spawn("claude", args, {detached:true})` on **every** `runTurn` call; process exits at the turn's `result` line.
+- `daemon/src/services/jsonAgent.ts:802-905` (`runOneTurn`) — builds `TurnInput`/`TurnContext`, iterates `plugin.runTurn(...)`, catches transport failure into a synthetic `error` event (`:878-891`), appends a "Turn stopped" `status` marker on abort (`emitStopped`, `:901-905`).
+- **Consequence for this plan:** write Pi directly against the ACP shape above; never against the spawn-per-turn shape.
+
+### Existing plugin contract — verified against source
+
+- `daemon/src/services/spawn.ts:94-210` (`AgentPlugin`) — **required** members listed in Requirement 1; TTY-extras (`setupWorkspaceHooks`, `provideChatId`, `captureChatId`, `refreshChatIdOnToggle`, `getForkCommand`, `getRestoreCommand`) are optional; `supportsJson?()` / `runTurn?()` (`:202-211`) are also optional.
+- `daemon/src/agent-plugins/registry.ts:12-21` — `PLUGIN_MAP` is `Record<string, () => AgentPlugin> as const`; `CliId = keyof typeof PLUGIN_MAP`; `SUPPORTED_CLIS = Object.keys(PLUGIN_MAP)`. One new key widens all three.
+- `daemon/src/agent-plugins/agy.ts:1-40` — most recent plugin; the "header comment documents the binary's quirks (launch args, prompt delivery, chat-id capture)" pattern a new plugin should copy.
+
+### Prompt injection — no change needed
+
+- `daemon/src/services/promptBuilder.ts:67-118` / `:120-161` — builds `{systemPrompt, taskPrompt}` generically (L1 skill.md + L2 project/worktree context + L3 project rules). Not CLI-specific.
+- Delivered to plugins via `TurnContext.systemPromptFile` (`spawn.ts:83-84`) — an absolute path, applied on `isFirstTurn`.
+- New plugin only decides *how* to apply it (launch flag vs standing-instructions file vs prepended message) — CLI-specific, see Decision 2.
+
+### Boot orphan sweep — a new plugin MUST touch this
+
+- `daemon/src/services/recover.ts:22` — `const KNOWN_TURN_BINARIES = new Set(["claude", "cursor-agent", "opencode", "agy"])`.
+- `daemon/src/services/recover.ts:39-52` (`verifyPidIsTurnProcess`) — PID-reuse guard; **refuses to kill any PID whose comm-name is not in that allowlist**.
+- Header comment `:14-21` explicitly instructs: "update this list if a plugin's spawned binary name changes."
+- **Consequence:** Pi's adapter process name must be added, or an orphaned Pi connection survives a daemon crash forever. This is the one shared file every new plugin unavoidably edits.
+- **Wrinkle:** `pi-acp` is an npm bin, so its `/proc/<pid>` comm-name may be `node`, not `pi-acp` — must be measured, not assumed (Risk 3).
+
+### DB schema / CLI identity — zero migration, verified
+
+| Claim | Evidence |
+|---|---|
+| `sessions` table has **no** `cli` column | `daemon/src/services/dbSchema.ts:53-77` |
+| `SessionMeta.cli` is runtime-derived, not persisted per session | `daemon/src/types.ts:180-198` (`cli: string` at `:185`) |
+| CLI identity lives in `~/.vibe-station/modes.json` | `daemon/src/services/paths.ts:72-74` (`modesPath()`), `daemon/src/routes/modes.ts:3` |
+| `POST /modes` validation widens automatically | `daemon/src/routes/modes.ts:22-23` — `CLI_ENUM_TUPLE = SUPPORTED_CLIS`, `cliIdSchema = z.enum(CLI_ENUM_TUPLE)` |
+| `GET /supported-clis` populates automatically | `daemon/src/routes/modes.ts:185-197` |
+
+- **Net: a new CLI needs zero SQLite migration.** Adding a `PLUGIN_MAP` key alone makes it validate, list, and run.
+- **Additive pattern for reference only** (not used by this plan): `addColumnIfMissing(db, table, column, ddl)` at `dbSchema.ts:154-158`, called idempotently from `ensureSchema`; 6 existing precedents at `:118-150` (`branchIsPlaceholder`, `hiddenAt`, `spawnedFrom`, `supersededBy`, `prState`/`prNumber`/`prUrl`/`prCheckedAt`/`prBranch`).
+
+### UI — no change needed, verified by grep
+
+| Check | Result |
+|---|---|
+| `web-ui/src/components/dialogs/NewModeDialog.tsx:161-167` | `clis.map((c) => ...)` — renders one radio per `GET /supported-clis` entry, generic |
+| `NewModeDialog.tsx:62` | Only hardcoded CLI name is a UX default: `list.find((c) => c.id === "claude") ?? list[0]` — a new CLI still appears |
+| `web-ui/src/components/dialogs/EditModeDialog.tsx:39,126` | Same generic `getSupportedClis()` + `clis.map` pattern |
+| `web-ui/src/api/client.ts:676-680` | `getSupportedClis(): Promise<SupportedCli[]>` — no CLI names |
+| `web-ui/src/api/types.ts:281` | `export type CliId = string` — already open |
+| `web-ui/src/components/chat/*` | Consumes generic `NormalizedEvent` stream; grep for `.provider ===` across `web-ui/src` → **zero hits** |
+
+- **Dead-code nit (non-blocking):** `web-ui/src/api/types.ts:179` — `NormalizedEventProvider = "claude" | "cursor" | "opencode"`, already missing `"agy"` today, vs `daemon/src/types.ts:67` which correctly has all 4. Field is typed but never branched on. One-line widening; see Risk 5.
+
+### agent-orchestrator (ComposioHQ) — verified by `git show upstream/main`, read-only
+
+| File (`backend/internal/adapters/chatdriver/…`) | Verified content |
+|---|---|
+| `registry/registry.go` | Flat `map[harness]ChatDriver` capability gate; a harness with no entry cannot run chat — same "one plugin, no shared branching" philosophy vibe-station has |
+| `nativeacp/driver.go` | Shared native-ACP binding: `Configure(ctx, LaunchConfig) → (args, envOverrides, error)` — the Go analog of this plan's `buildSpawnSpec` |
+| `droidacp/driver.go:41-46` | `droid exec --output-format acp-daemon [--skip-permissions-unsafe] [--append-system-prompt <p>]` — native |
+| `kimiacp/driver.go:40` | `kimi acp` — native; `validateTurnSettings` rejects non-default permission modes ("Kimi ACP advertises only its default session mode") |
+| `kimchiacp/driver.go:29-50` | `kimchi --mode acp [--model m] [--auto\|--yolo] [--append-system-prompt p]` — native; no runtime `session/set_mode` (permission mode baked into launch args) |
+| `kimchiacp/version.go:15` | `minimumKimchiVersion = "0.0.7"`, gated via `kimchi --version` |
+| `ompacp/driver.go:41-52` | `omp acp [--model m] [--append-system-prompt p] [--approval-mode write\|yolo]` — native |
+| `ompacp/version.go:16` | `minimumOMPVersion = "15.0.0"` |
+| `piacp/driver.go:1-5` | **NOT a native binding.** Package doc: *"AO does not package or download pi-acp. The adapter embeds Pi itself, while the existing Pi plugin remains the canonical auth probe."* |
+| `piacp/driver.go:27-28` | `distributionName = "@victor-software-house/pi-acp"`, `minimumVersion = "0.17.1"` |
+| `piacp/driver.go:83` | `env["PI_ACP_SOCKET_DIR"] = <dataDir>/pi-acp/<sessionID>/run` — comment: "pi-acp 0.17 uses a long-running daemon; a session-private socket prevents one project's environment leaking into another" |
+| `piacp/driver.go` `prepareStandingInstructions` / `sessionMeta` | Writes `<dataDir>/prompts/<sessionID>/pi-acp/AGENTS.md` and passes an **inline resource manifest** (`{version:1, mode:"local", roots:[…]}`) at `session/new` — composes with, does not replace, the project's own `AGENTS.md` |
+
+### emdash — Node/TS ACP client precedent (same stack as vibe-station's daemon)
+
+- `emdash/packages/core/package.json:359` — `"@agentclientprotocol/sdk": "^1.1.0"` — the same library Sub-plan A adds.
+- `emdash/packages/core/src/runtimes/acp/node/connection/acp-agent-connection.ts:44-136` — spawn → wire stdio into the SDK `Client` → race `initialize()` against process-close → return `{agent, normalize, supportsLoadSession, mcpCapabilities}`; `behavior.enrich` hook at `:98-101` is the model for Sub-plan A's per-plugin `enrich`.
+- `emdash/packages/core/src/runtimes/acp/node/node/child-process-host.ts:94-110` — plain `node:child_process.spawn`, `stdio: ["pipe","pipe","pipe"]`, no shell — identical to vibe-station's `claude.ts:502`.
+
+### Web research — ACP status per new CLI (verified Aug 2026)
+
+| CLI | Native or adapter | In Zed's ACP registry? | Verified detail | Auth | Licence / backing |
+|---|---|---|---|---|---|
+| **Pi** (Pi Coding Agent) | **Third-party adapter** — Pi's own CLI does not speak ACP | ✅ yes | **Two divergent adapter lines, not just two forks** — see Decision 3: Zed's registry entry (`zed.dev/acp/agent/pi`) resolves to npm **`pi-acp@0.0.33`** (repo `svkozak/pi-acp`, spawns `pi --mode rpc` as a child); AO pins npm **`@victor-software-house/pi-acp@0.17.1`** (long-running daemon, `PI_ACP_SOCKET_DIR`, resource manifest). At least a third fork exists (`aadishv/pi-acp`) plus a `@geohar/pi-acp` on pi.dev | Pi's own `/login` (Claude Pro/Max, ChatGPT Plus/Pro, GitHub Copilot) or API key under `~/.pi/`; adapter inherits, adds nothing | Pi: MIT, Mario Zechner / earendil-works. Adapters: community-maintained, **not** Pi's own team |
+| **Droid** (Factory AI) | **Native** — `droid exec --output-format acp-daemon` | ✅ yes ("Factory Droid") | First-party, publicly announced full ACP compliance; ACP-registry launch partner | Factory account/login | Closed-source CLI, funded commercial company |
+| **Kimi** (Moonshot AI) | **Native** — `kimi acp` | ✅ yes ("Kimi CLI") | First-party, official `kimi acp` docs page; advertises only its default permission mode | `/login` once, then standalone | Moonshot AI; PyPI + npm distribution |
+| **Kimchi** (`getkimchi/kimchi`) | **Native** — `kimchi --mode acp` | ❌ **not listed** | Real distinct product: terminal coding agent, multi-model orchestration, built **on the pi-mono SDK** (same Pi lineage as OMP), built-in LSP, "ferment" phased workflow. AO version-gates at `0.0.7`+ | own login | Funded early-stage product, docs at `docs.kimchi.dev`; smaller/newer than Droid/Kimi |
+| **OMP** ("Oh My Pi") | **Native** — `omp acp` | ❌ **not listed** (only an open Zed discussion requesting it) | Fork of Mario Zechner's pi-mono by **can1357 (Can Bölük)** — Rust core (~80k LOC), 30+ tools, LSP, DAP, subagents, hashline edits. `Raudbjorn/omp` is a downstream fork, **not** the upstream. Notable public mindshare | Pi-lineage auth | MIT, open source; active community |
+
+- **ACP auth model, confirmed:** ACP is a JSON-RPC session/tool protocol with **no credential layer**. All 5 CLIs authenticate exactly as they do standalone; vibe-station adds zero secret storage.
+
+Sources: [Pi — ACP Agent | Zed](https://zed.dev/acp/agent/pi) · [pi-acp — npm](https://www.npmjs.com/package/pi-acp) · [svkozak/pi-acp](https://github.com/svkozak/pi-acp) · [victor-software-house/pi-acp](https://github.com/victor-software-house/pi-acp) · [Factory Droid — ACP Agent | Zed](https://zed.dev/acp/agent/factory-droid) · [Kimi CLI — ACP Agent | Zed](https://zed.dev/acp/agent/kimi-cli) · [getkimchi/kimchi](https://github.com/getkimchi/kimchi) · [docs.kimchi.dev](https://docs.kimchi.dev/docs/kimchi-cli) · [Raudbjorn/omp](https://github.com/Raudbjorn/omp) · [Zed discussion #58515 — omp not yet in registry](https://github.com/zed-industries/zed/discussions/58515) · [ACP Registry](https://zed.dev/acp)
+
+---
+
+## Architecture Diagram
+
+```mermaid
+flowchart TB
+    subgraph Daemon["vibe-station daemon"]
+        JAS["JsonAgentSession (jsonAgent.ts)\nFIFO turn queue + owns ONE AcpConnection"]
+        CONN["AcpConnection (acp/acpTransport.ts)\nSub-plan A — one per sessionId"]
+        NORM["acp/normalize.ts\nshared mapping + per-plugin enrich"]
+        REG["registry.ts PLUGIN_MAP"]
+        PI["pi.ts (new — this plan)"]
+        DR["droid.ts / kimi.ts / kimchi.ts / omp.ts\n(new — follow-on plans)"]
+        REC["recover.ts\nKNOWN_TURN_BINARIES + boot sweep"]
+    end
+    REG -->|"resolvePlugin(cli)"| JAS
+    JAS -->|"runTurn(input, ctx, signal)"| PI
+    JAS -->|"runTurn(input, ctx, signal)"| DR
+    PI -->|"ctx.getAcpConnection()"| JAS
+    PI -->|"buildSpawnSpec(ctx)"| CONN
+    PI -->|"enrich()"| NORM
+    CONN -->|"spawn + initialize + session/prompt"| PIACP["pi-acp (npm adapter)"]
+    CONN -->|"spawn + initialize + session/prompt"| NATIVE["droid exec --output-format acp-daemon\nkimi acp / kimchi --mode acp / omp acp"]
+    PIACP -->|"session/update"| NORM
+    NATIVE -->|"session/update"| NORM
+    NORM -->|"NormalizedEvent"| JAS
+    REC -.->|"sweeps orphaned adapter PIDs on boot"| PIACP
+    JAS -->|"json channel WS"| UI["web-ui chat/* (unchanged)"]
+```
+
+- Work owned by **this** plan: the `pi.ts` box, the `registry.ts` one-liner, and the `recover.ts` allowlist entry.
+- `AcpConnection` / `normalize.ts` / `acpTerminalManager.ts` are Sub-plan A deliverables — consumed, not modified.
+
+### Process lifecycle — Pi differs from the native-CLI case
+
+```mermaid
+sequenceDiagram
+    participant JAS as JsonAgentSession
+    participant C as AcpConnection (Sub-plan A)
+    participant N as pi-acp adapter process
+    participant Auth as Pi auth state (~/.pi/)
+
+    Note over C,N: Native CLIs (Droid/Kimi/Kimchi/OMP) have no adapter hop —<br/>the spawned binary IS the agent and speaks ACP itself.
+    JAS->>C: getOrCreateConnection()
+    C->>N: spawn(buildSpawnSpec: command, args, env{PI_ACP_SOCKET_DIR: per-session})
+    N-->>C: initialize response {agentInfo: {name, version}}
+    C->>C: pi.ts validatePiAcpIdentity(init) — exact distribution + min version (Decision 3)
+    N->>Auth: reads existing Pi login/API-key state (adapter adds no auth)
+    C->>N: session/new {cwd, _meta: resource manifest → per-session AGENTS.md} (Decision 2)
+    C->>N: session/prompt (turn 1..N — same connection, no respawn)
+    N-->>C: session/update (streamed)
+    C->>JAS: normalize(+ pi enrich) → NormalizedEvent
+```
+
+---
+
+## Priority Ranking
+
+| Rank | CLI | Native / adapter | Auth complexity | Effort | Demand signal | Justification |
+|---|---|---|---|---|---|---|
+| **0 (mandated)** | **Pi** | Adapter — third-party, divergent forks | Low (Pi's own `/login`) | **Medium-high** — plugin + fork selection + `agentInfo` validation + standing-instructions file | Explicitly requested | Built first per instruction, despite being objectively the **riskiest** of the CLIs researched (Decision 7) |
+| **1** | **Droid** | Native | Low (Factory login) | Low — one flag builder, mirrors `droidacp/driver.go` | High — well-known commercial product | Most mature, first-party, ACP-registry launch partner, lowest risk |
+| **2** | **Kimi** | Native | Low (one-time `/login`) | Low — single `kimi acp` subcommand, official docs | Medium-high — real mindshare | First-party, mature, simplest launch args; only wrinkle is single permission mode |
+| — | ~~OMP~~ | ~~Native~~ | ~~Low~~ | ~~Low-medium~~ | ~~Medium~~ | **Dropped — explicit human decision (Decision 6).** Research kept in the Web-research table below for reference only |
+| — | ~~Kimchi~~ | ~~Native~~ | ~~Low~~ | ~~Low-medium~~ | ~~Lower~~ | **Dropped — explicit human decision (Decision 6).** Research kept in the Web-research table below for reference only |
+
+> ### ⚠️ Decisions made unattended — need human confirmation
+>
+> 1. **Order of ranks 1-2 (Droid, Kimi).** Derived from maturity + registry presence + public mindshare, **not** from stakeholder or user-request data. Confirm or reorder before any follow-on plan is written.
+> 2. **Kimchi and OMP are dropped, per explicit human instruction** (superseding this plan's earlier "build both, rank last" draft call) — see Decision 6. Not scoped, no follow-on plan file.
+> 3. **Which Pi adapter fork to pin.** See Decision 3 — this plan defaults to `@victor-software-house/pi-acp@0.17.1`; a Phase-0 spike must confirm before Phase 1 starts.
+
+---
+
+## Daemon Changes
+
+| File | Change |
+|---|---|
+| `daemon/src/agent-plugins/pi.ts` | **New.** Implements `AgentPlugin`; owns `buildSpawnSpec`, `validatePiAcpIdentity`, standing-instructions write, `enrich` mapping |
+| `daemon/src/agent-plugins/registry.ts:12-17` | **Modified.** One import + one line: `pi: createPiPlugin` — `CliId` / `SUPPORTED_CLIS` widen automatically (`:19-21`) |
+| `daemon/src/services/recover.ts:22` | **Modified.** Add Pi's adapter process comm-name to `KNOWN_TURN_BINARIES` (Decision 4); update the `:14-21` header comment |
+| `daemon/src/agent-plugins/{droid,kimi}.ts` | **New — follow-on plans only**, same three-touch shape. Kimchi/OMP dropped (Decision 6) — no file, no follow-on plan |
+
+- **Explicitly NOT modified:** `spawn.ts`, `jsonAgent.ts`, `promptBuilder.ts`, `dbSchema.ts`, `dbMigration.ts`, `jsonAgentRegistry.ts`, any route file. Each is already generic over `AgentPlugin` / `CliId` — evidence in Research.
+- **Consumed, not owned:** Sub-plan A's `daemon/src/services/acp/{acpTransport,normalize,acpTerminalManager}.ts` and its `@agentclientprotocol/sdk` dependency.
+- **New dependency added by this plan:** none. `pi-acp` is resolved on `PATH` / npm-global like any other CLI binary — not vendored into the daemon.
+
+## UI Changes
+
+- **None required functionally.** Evidence table in Research → "UI — no change needed, verified by grep": mode dialogs render CLI choices generically from `GET /supported-clis`; `CliId` is already `string`; chat components consume the generic `NormalizedEvent` stream; zero `.provider ===` branches exist.
+- **Per-CLI event-kind check for Pi:** pi-acp's documented `session/update` output is `agent_message_chunk` + `tool_call` / `tool_call_update` (with tool-call locations where available) — all already covered by existing `NormalizedEvent` kinds. **No new kind, no UI change.**
+- **Per-CLI check deferred:** OMP's richer event set (LSP/DAP/subagent) is the one CLI where a new event kind is plausible — audit belongs to its follow-on plan, not here.
+- **Optional hygiene fix, same PR:** `web-ui/src/api/types.ts:179` — widen `NormalizedEventProvider` to include `"agy"` + new CLI ids, or to `string`, matching `daemon/src/types.ts:67`. Confirmed dead code. Not gating — see Risk 5.
+
+## What Gets Reused
+
+| From | What | How the new plugin uses it |
+|---|---|---|
+| Existing daemon scaffolding | `AgentPlugin` interface | `daemon/src/services/spawn.ts:94-210` — implement it; nothing else changes |
+| Existing daemon scaffolding | `PLUGIN_MAP` / `resolvePlugin` / derived `CliId` + `SUPPORTED_CLIS` | `registry.ts:12-32` — one key added, three things widen |
+| Existing daemon scaffolding | Auto-widening mode validation + CLI listing | `routes/modes.ts:22-23,185-197` — free, no route edit |
+| Existing daemon scaffolding | Layered system prompt written to `TurnContext.systemPromptFile` | `promptBuilder.ts:67-118`; consumed on `isFirstTurn` (Decision 2) |
+| Existing daemon scaffolding | Boot orphan sweep + PID-reuse guard | `recover.ts:39-52,61-95` — reused as-is; only the allowlist string is added (Decision 4) |
+| Existing daemon scaffolding | Detached / own-process-group spawn convention, `onSpawn(pid)` reporting | `spawn.ts:86-91`; same convention as `claude.ts:502` |
+| Sub-plan A | `AcpConnection` (`acp/acpTransport.ts`) — persistent per-session connection, `sendPrompt` / `cancelActivePrompt` / `dispose` | Reached via `ctx.getAcpConnection()`; `runTurn` yields from `sendPrompt(...).updates` |
+| Sub-plan A | `acp/normalize.ts` shared `session/update → NormalizedEvent` mapping | Plugin supplies **only** its `enrich` hook for CLI-specific nuances |
+| Sub-plan A | `acp/acpTerminalManager.ts` + 30-min idle-TTL pinned open by live terminals | Free — background-work survival applies to new plugins with no extra code |
+| Sub-plan A | `@agentclientprotocol/sdk` in `daemon/package.json` | Already present; this plan adds no dependency |
+| Sub-plan A | ACP session id storage — `agentChatId` (Option A) or `acpSessionId` (Option B), per Decision 6 | Free — a new CLI inherits whichever column already exists |
+| agent-orchestrator (pattern, not code) | `Configure(ctx, LaunchConfig) → (args, env, error)` | Mirrored as `buildSpawnSpec(ctx)` |
+
+---
+
+## Design Details
+
+### System Boundaries
+
+| Boundary | Fields + types | Errors | Source of truth |
+|----------|----------------|--------|-----------------|
+| `JsonAgentSession` ↔ `AgentPlugin.runTurn` | `TurnInput{message, attachmentPaths?, isFirstTurn}`, `TurnContext{cwd, project, worktree, session, chatId?, forkFromChatId?, model?, systemPromptFile, daemonPort, onSpawn?, getAcpConnection}` → `AsyncIterable<NormalizedEvent>` | Iterator throw → synthetic `error` event at `jsonAgent.ts:878-891`; unchanged contract, no new error shape | `AgentPlugin` (`spawn.ts:94-210`) — unchanged by this plan except Sub-plan A's added `supportsAcp?()` |
+| `pi.ts` ↔ `AcpConnection` (in-process, Sub-plan A) | `sendPrompt(sessionId: string, prompt: AcpPromptBlock[], signal: AbortSignal) → { updates: AsyncIterable<SessionUpdate>; result: Promise<{stopReason: string}> }`; `cancelActivePrompt()`; `dispose()` | Spawn failure / `initialize` failure / identity-validation throw → propagates to `jsonAgent.ts:878-891`'s existing catch — no new error path | `AcpConnection` owns process liveness; `pi.ts` is stateless |
+| `pi.ts` ↔ `acp/normalize.ts` (Sub-plan A) | `enrich(raw: SessionUpdate, base: NormalizedEvent): NormalizedEvent` | none — pure function | `normalize.ts` owns the base mapping; plugin owns only CLI nuance |
+| `pi.ts` ↔ `pi-acp` process (ACP JSON-RPC over stdio) | `initialize → {agentInfo:{name,version}, agentCapabilities}`; `session/new {cwd, _meta:{resourceManifest}} → {sessionId}`; `session/prompt`; `session/update` | Wrong `agentInfo.name` or version < pinned min → `Error` before any event is yielded (Decision 3) | pi-acp owns the Pi engine + its auth; vibe-station stores no Pi credentials |
+| Registry ↔ routes | `PLUGIN_MAP: Record<CliId, () => AgentPlugin>`; `GET /supported-clis` → `{id, defaultModel, supportsJson, importsNativeHistory}[]` | none new | `registry.ts:12-21`, `routes/modes.ts:185-197` — shape unchanged |
+
+### Critical User Journeys (CUJs)
+
+#### CUJ 1 — User creates a Pi mode and sends a first message (happy path)
+
+```
+User opens "New Mode" dialog
+  → GET /supported-clis returns {id:"pi",...}  (PLUGIN_MAP entry alone makes this true)
+  → User picks Pi, names the mode, saves → POST /modes {cli:"pi", ...}
+  → User starts a Rich Chat session in that mode, sends first message
+  → jsonAgent.runOneTurn calls pi.runTurn(input{isFirstTurn:true}, ctx, signal)
+  → pi.ts writes per-session AGENTS.md from ctx.systemPromptFile          (Decision 2)
+  → pi.ts calls ctx.getAcpConnection() → JsonAgentSession spawns pi-acp via buildSpawnSpec
+  → pi.ts validatePiAcpIdentity(initialize response)                      (Decision 3)
+  → session/new carries the resource manifest → session/prompt
+  → session/update stream → normalize + pi enrich → NormalizedEvent → user sees streamed reply
+```
+
+- **Error — pi-acp missing or wrong fork/version:** identity validation throws before any event → `jsonAgent.ts:878-891` emits a synthetic `error` event → user sees a chat-level error, same UX as any transport failure.
+- **Error — the *other* Pi fork is installed:** its `agentInfo.name` differs → same validation error, never silent wrong behavior.
+
+#### CUJ 2 — Second turn in the same session (connection reuse)
+
+```
+User sends a follow-up in the same session
+  → runOneTurn calls pi.runTurn(input{isFirstTurn:false}, ctx, signal)
+  → ctx.getAcpConnection() returns the EXISTING live AcpConnection — no respawn
+  → session/prompt over the already-initialized connection
+  → No AGENTS.md rewrite (isFirstTurn false) — Pi's own session state carries context
+```
+
+- **Edge — daemon restarted mid-session:** no live connection exists → `getOrCreateConnection()` spawns fresh; `isFirstTurn` is recomputed from `JsonAgentSession.firstTurnDone` (`jsonAgent.ts:255,318,877`); Sub-plan A's `session/load`-or-fresh fallback applies unchanged.
+- **Edge — daemon crashed, adapter orphaned:** boot sweep kills it **only if** its comm-name is in `KNOWN_TURN_BINARIES` (Decision 4, Risk 3).
+
+### Data Model
+
+| Entity | Field | Type | Constraints | Notes |
+|---|---|---|---|---|
+| `modes.json` record | `cli` | `CliId` (string enum) | must be a `PLUGIN_MAP` key | JSON file at `~/.vibe-station/modes.json`, **not** SQLite |
+| `sessions` | `agentChatId` | `TEXT` | nullable | **Unchanged, reused** — holds the id the raw CLI's own resume flag understands. If Sub-plan A's Decision 6 lands Option B for any plugin, an `acpSessionId TEXT` column also exists and a new plugin may set it; no new migration either way |
+
+- **New tables:** none. **New columns:** none. **Indexes:** none.
+- **Migration: N.** Nothing to add, nothing to backfill.
+- If a future CLI genuinely needs a persisted column, follow the existing additive pattern `addColumnIfMissing(db, "sessions", "<col>", "<ddl>")` (`dbSchema.ts:154-158`, 6 precedents at `:118-150`) — not needed for Pi.
+
+### API Contracts
+
+- `GET /supported-clis` (`routes/modes.ts:185-197`) — **existing, unchanged.** Adding `pi` to `PLUGIN_MAP` makes it appear automatically.
+- `POST /modes {cli, name, context, presetId?, model?}` (`routes/modes.ts:98`) — **existing, unchanged.** `cliIdSchema` widens automatically via `CLI_ENUM_TUPLE` (`:22-23`).
+- Internal (non-HTTP) contracts consumed: `AcpConnection.sendPrompt` and `normalize.enrich` — full shapes in System Boundaries above; owned by Sub-plan A.
+
+### Key Decisions
+
+#### Decision 1: No backward-compat shim, no feature flag, no data migration
+- **Decision:** Ship new plugins directly — no flag gate, no dual-write, no backfill.
+- **Rationale:** No production users of json-chat exist; there is nothing to stay compatible with.
+- **Where:** N/A — absence of code. Recorded explicitly so an implementer does not add a flag out of habit.
+
+#### Decision 2: Pi's system prompt ships as a per-session `AGENTS.md` + resource manifest, not a launch flag
+- **Decision:** On `isFirstTurn`, `pi.ts` writes `ctx.systemPromptFile`'s contents to a per-session `AGENTS.md` under the session data dir, and passes an inline resource manifest in `session/new` pointing at it — composing with, not replacing, the project's own `AGENTS.md`.
+- **Rationale:** pi-acp exposes no `--append-system-prompt` equivalent (unlike Droid/Kimchi/OMP); the resource manifest is its documented standing-instructions mechanism, verified in `agent-orchestrator`'s `piacp/driver.go` (`prepareStandingInstructions`, `sessionMeta`).
+- **Where:** `daemon/src/agent-plugins/pi.ts` (new) — file write + `session/new` param construction.
+```ts
+// Manifest shape mirrors agent-orchestrator's piacp sessionMeta: root 1 preserves the
+// project's own Pi resources exactly; root 2 adds ONLY vibe-station's generated AGENTS.md.
+const manifest = {
+  version: 1,
+  mode: "local",
+  roots: [
+    { path: ctx.cwd },                                  // project's own AGENTS.md/skills/prompts
+    { path: piInstructionDir(ctx) },                    // <sessionDataDir>/pi-acp/ holding AGENTS.md
+  ],
+};
+```
+
+#### Decision 3: Pin ONE Pi adapter distribution + minimum version; validate at `initialize`
+- **Decision:** `pi.ts` hardcodes an expected `agentInfo.name` and minimum semver, checked against the `initialize` response before the first `session/new`. **Default pin: `@victor-software-house/pi-acp`, min `0.17.1`.**
+- **Rationale:** Two *divergent* adapter lines exist, not merely two forks — `pi-acp@0.0.33` (svkozak; Zed registry's entry; spawns `pi --mode rpc` as a child) vs `@victor-software-house/pi-acp@0.17.1` (long-running daemon; `PI_ACP_SOCKET_DIR`; resource manifest). The version lines are not comparable and their runtime models differ. This plan's Decision 2 (resource manifest) and `PI_ACP_SOCKET_DIR` handling only exist in the victor-software-house line, and agent-orchestrator runs it in production — hence the default. A silent identity mismatch would otherwise produce confusing chat failures.
+- **Where:** `daemon/src/agent-plugins/pi.ts` (new) — validation runs in the connect path, before any event is yielded.
+- > **Decision made unattended — needs human confirmation:** the fork choice is this plan's call, not a stakeholder's. Phase 0 spike (0.1) must install both and confirm before Phase 1 begins. If the Zed-registry line is preferred instead, Decision 2's manifest mechanism must be re-researched — it likely does not apply.
+```ts
+// Mirrors agent-orchestrator piacp/driver.go validateInitialize.
+// Divergent upstream adapter lines make a silent identity/version mismatch a real risk.
+function validatePiAcpIdentity(init: AcpInitializeResponse): void {
+  const EXPECTED_NAME = "@victor-software-house/pi-acp";  // confirmed by Phase 0 spike
+  const MIN_VERSION = "0.17.1";                            // pin — never float to "latest"
+  if (init.agentInfo?.name !== EXPECTED_NAME) {
+    throw new Error(`Unexpected Pi ACP distribution "${init.agentInfo?.name ?? "unknown"}"; expected ${EXPECTED_NAME}`);
+  }
+  if (!satisfiesMinVersion(init.agentInfo.version, MIN_VERSION)) {
+    throw new Error(`pi-acp ${init.agentInfo.version} is older than the tested minimum ${MIN_VERSION}`);
+  }
+}
+```
+
+#### Decision 4: Every new CLI adds its spawned binary name to `KNOWN_TURN_BINARIES`
+- **Decision:** Add Pi's adapter process comm-name to `recover.ts:22`'s allowlist as part of the Pi PR; every follow-on plugin plan does the same for its own binary.
+- **Rationale:** `verifyPidIsTurnProcess` (`recover.ts:39-52`) refuses to kill any recorded PID whose comm-name is not allowlisted — an omitted entry means a crashed daemon leaves an orphaned adapter process running forever. The file's own header comment (`:14-21`) mandates updating the list when a plugin's spawned binary changes.
+- **Where:** `daemon/src/services/recover.ts:14-22` — allowlist string + header comment.
+
+#### Decision 5: New plugins implement TTY-mode members minimally; terminal channel stays out of scope
+- **Decision:** `getLaunchCommand` / `getEnvironment` / `getReadySignal` / `composeLaunchPrompt` are implemented with a plain direct-binary interactive launch, documented as untested. `supportsJson()` / `supportsAcp()` return `true`; TTY optional extras (`setupWorkspaceHooks`, `provideChatId`, `captureChatId`, `getForkCommand`, `getRestoreCommand`) are **not** implemented.
+- **Rationale:** Those four members are non-optional on `AgentPlugin` (`spawn.ts:102-112`); widening the shared interface to make them optional would touch shared code and violate the no-shared-branching invariant. Minimal implementations are the cheapest way to satisfy the type contract.
+- **Where:** `daemon/src/agent-plugins/pi.ts` (new) — header comment states "JSON channel is the supported path; TTY members are untested", following `agy.ts:1-40`'s documentation style.
+
+#### Decision 6: Droid/Kimi get an outline, not a checklist; Kimchi/OMP are dropped entirely
+- **Decision:** Droid and Kimi get a ranked effort/risk table only; each gets its own `03`/`04` plan file when picked up. Kimchi and OMP are **not being built** — removed from the ranking, from the follow-on plan list, and from any implementation intent.
+- **Rationale:** Droid/Kimi's relative order is an unconfirmed human call (see the Priority Ranking callout), and each follow-on plan is ~3 files of near-identical shape once Pi validates the pattern. Kimchi/OMP's exclusion is a direct human instruction, superseding this plan's earlier research-driven "build both, rank last" recommendation — not a re-derived risk/effort judgment.
+- **Where:** N/A — scoping decision, restated in the Scoping statement at the top. Their web-research rows are kept in the "Web research" table purely as reference in case the decision is revisited later.
+
+#### Decision 7: Pi ships first despite being the riskiest of the five — flagged, not absorbed silently
+- **Decision:** Proceed with Pi as instructed, while explicitly recording that it is the **least** mature of the five ACP integrations researched.
+- **Rationale:** Pi is the only one of the five whose own CLI does **not** speak ACP; its adapter is third-party, community-maintained, on divergent version lines. `agent-orchestrator` isolates Pi in a dedicated non-`nativeacp` package precisely because it is not native (`piacp/driver.go:1-5`). A human should know this before treating Pi's ship date as low-risk.
+- **Where:** N/A — planning-level flag; see Research web table and Priority Ranking rank-0 row.
+
+---
+
+## Risks / Open Questions
+
+| # | Question | Notes |
+|---|----------|-------|
+| 1 | **Which Pi adapter line is canonical for vibe-station?** | Two divergent lines with incompatible runtime models — Decision 3 defaults to `@victor-software-house/pi-acp@0.17.1`, gated on the Phase-0 spike. Re-verify at implementation time; do not assume the pinned name is still current |
+| 2 | **Does Sub-plan A's landed `AcpConnection` match the shape restated in Research?** | If it differs, only `pi.ts`'s call sites change — no redesign. The plugin needs exactly two things: a launch spec and an `enrich` hook |
+| 3 | **Is pi-acp's `/proc/<pid>` comm-name `pi-acp` or `node`?** | Decision 4's allowlist entry must match the *actual* comm-name. Measure it in Phase 0 (0.2). If it is `node`, `verifyPidIsTurnProcess`'s guard is too coarse to distinguish an orphaned adapter from an unrelated Node process — escalate to Sub-plan A's owner rather than allowlisting bare `node` |
+| 4 | **Kimi advertises only its default permission mode** — does vibe-station ever offer a permission-mode switch that would silently no-op? | Deferred to the Kimi follow-on plan; flagged here because it surfaced during research |
+| 5 | **Kimchi/OMP version gates (`0.0.7`, `15.0.0`) are AO's tested minimums**, not independently verified for vibe-station | Re-verify at follow-on plan time; do not copy blindly |
+| 6 | **Should the `NormalizedEventProvider` dead-code nit (`web-ui/src/api/types.ts:179`) be fixed in this PR?** | Recommended same-PR (one line, zero risk, already wrong for `agy` today), but not blocking — human call |
+
+---
+
+## Implementation Phases
+
+_Pi only. Droid/Kimi/Kimchi/OMP get their own follow-on plans — see Scoping statement._
+
+**Prerequisite for all phases:** Sub-plan A landed, i.e. `daemon/src/services/acp/acpTransport.ts` exists and `TurnContext.getAcpConnection()` is available.
+
+### Phase 0 — Pi adapter spike (resolve Decision 3 before writing code)
+
+- [ ] **0.1** Install both `pi-acp@0.0.33` and `@victor-software-house/pi-acp@0.17.1`; run each with a manual ACP `initialize` handshake; record each one's `agentInfo.name` + `version`, and whether it accepts a `session/new` resource manifest and honours `PI_ACP_SOCKET_DIR`. Confirm or override Decision 3's pin.
+- [ ] **0.2** Run the chosen adapter and read `/proc/<pid>/comm` (or `ps -o comm=`) for its process; record the exact string needed by Decision 4 / Risk 3.
+- [ ] **0.3** Confirm Pi's own auth (`/login` or API key under `~/.pi/`) is inherited by the adapter without any vibe-station-side credential handling.
+
+**Verify phase 0:**
+- [ ] **0.T1** Manual — the chosen adapter completes `initialize` + `session/new` + one `session/prompt` round-trip from a throwaway Node script, streaming at least one `agent_message_chunk`.
+- [ ] **0.T2** Manual — the *rejected* adapter's `agentInfo.name` is recorded and differs from the chosen one, proving Decision 3's validation can actually discriminate.
+
+### Phase 1 — Pi plugin (JSON channel)
+
+- [ ] **1.1** Create `daemon/src/agent-plugins/pi.ts`: `createPiPlugin(): AgentPlugin` — `name: "pi"`, `defaultModel`, `promptDelivery`, `supportsJson(): true`, `supportsAcp(): true`
+- [ ] **1.2** Implement `buildSpawnSpec(ctx: TurnContext): { command: string; args: string[]; env: Record<string,string> }` — resolves the adapter binary on PATH / npm-global (mirror `agy.ts`'s binary-resolution style), sets per-session `PI_ACP_SOCKET_DIR` under the session data dir
+- [ ] **1.3** Implement `validatePiAcpIdentity(init)` per Decision 3, using the name/version confirmed in 0.1
+- [ ] **1.4** Implement the standing-instructions write + `session/new` resource manifest per Decision 2
+- [ ] **1.5** Implement `runTurn(input, ctx, signal)`: `const conn = await ctx.getAcpConnection()`, validate identity on first connect, then yield from `conn.sendPrompt(...).updates`, awaiting `.result` before returning
+- [ ] **1.6** Implement Pi's `enrich` hook against Sub-plan A's `acp/normalize.ts` — cover `agent_message_chunk`, `tool_call`, `tool_call_update` (incl. tool-call location fields); confirm no new `NormalizedEvent` kind is needed
+- [ ] **1.7** Implement `listModels()` — via the adapter's ACP session options if exposed, else a direct `pi` CLI query
+- [ ] **1.8** Implement minimal TTY members per Decision 5 (`getLaunchCommand`, `getEnvironment`, `getReadySignal`, `composeLaunchPrompt`) + a header comment documenting the binary's quirks, following `agy.ts:1-40`
+- [ ] **1.9** Add `import { createPiPlugin } from "./pi.js"` and `pi: createPiPlugin` to `daemon/src/agent-plugins/registry.ts:7-17`
+- [ ] **1.10** Add the comm-name from 0.2 to `KNOWN_TURN_BINARIES` (`daemon/src/services/recover.ts:22`) and update its header comment (`:14-21`) per Decision 4
+
+**Verify phase 1:**
+- [ ] **1.T1** Unit — `daemon/src/__tests__/pi.test.ts`: `validatePiAcpIdentity` throws on a mismatched `agentInfo.name`, throws on a version below the pin, returns normally on an exact and on a newer version
+- [ ] **1.T2** Unit — `pi.test.ts`: `buildSpawnSpec` produces a distinct `PI_ACP_SOCKET_DIR` for two different session ids (no collision)
+- [ ] **1.T3** Unit — `pi.test.ts`: Pi's `enrich` maps a `tool_call` update to a `tool_use` `NormalizedEvent` and a later `tool_call_update` with the same id to a `tool_result`
+- [ ] **1.T4** Integration — `GET /supported-clis` includes `{id:"pi", supportsJson:true, ...}` after the registry change, with no route file modified
+- [ ] **1.T5** Unit — `daemon/src/__tests__/recover.test.ts`: `verifyPidIsTurnProcess` accepts the Pi adapter comm-name added in 1.10
+- [ ] **1.T6** Regression — `daemon/src/__tests__/modes.test.ts` and `plugins.test.ts`, `jsonPlugins.test.ts` pass unmodified (registry addition does not perturb existing CLI resolution)
+
+### Phase 2 — End-to-end Rich Chat verification
+
+- [ ] **2.1** Create a Pi mode via `POST /modes`, start a session, send a first message; confirm streamed text + a terminal `result` event render in web-ui **with zero web-ui code changes**
+- [ ] **2.2** Send a second message in the same session; confirm no new adapter process is spawned (verify with `ps`, not by inference) and `sessions.agentChatId` is unchanged across both turns
+- [ ] **2.3** Stop a Pi turn mid-stream; confirm the `emitStopped` "Turn stopped" `status` marker still fires (`jsonAgent.ts:901-905`) and the connection survives (next turn succeeds without a fresh `session/new`)
+- [ ] **2.4** Kill the daemon mid-session, restart, send a follow-up; confirm the orphaned adapter is swept by `recover.ts` and a fresh connection completes the turn
+- [ ] **2.5** Confirm the first turn's system prompt reached Pi (ask the agent to restate a distinctive line from the generated `AGENTS.md`) and that the project's own `AGENTS.md` is still visible to it (Decision 2's composition, not replacement)
+
+**Verify phase 2:**
+- [ ] **2.T1** Integration — full turn round-trip against a stubbed pi-acp process yields a well-formed `NormalizedEvent` sequence ending in `result`
+- [ ] **2.T2** Integration — abort mid-turn yields exactly one `status` "Turn stopped" event; no duplicate or missing terminal marker
+- [ ] **2.T3** Integration — a boot sweep with a recorded Pi adapter PID kills it (extends the Sub-plan A sweep test with Pi's binary name)
+- [ ] **2.T4** Regression — post-Sub-plan-A claude/cursor/opencode/agy json-chat flows are unaffected; full existing json-chat suite passes with no new failures
+
+---
+
+### Droid / Kimi — effort/risk outline (no phases; follow-on plans own the checklists)
+
+**Kimchi and OMP dropped from this table — explicit human decision, not a research finding (Decision 6). Their research rows remain in "Web research" above for reference only, in case the decision is revisited.**
+
+| CLI | What's needed | Effort | Risk | Prerequisite |
+|---|---|---|---|---|
+| Droid | `buildSpawnSpec`: `droid exec --output-format acp-daemon [--skip-permissions-unsafe] [--append-system-prompt <contents>]`; standard `enrich`; `droid` → `KNOWN_TURN_BINARIES` | Low — template copy of `pi.ts` minus identity validation and standing-instructions | Low | Sub-plan A landed |
+| Kimi | `buildSpawnSpec`: `kimi acp`; no-op/reject non-default permission mode (Risk 4); `kimi` → `KNOWN_TURN_BINARIES` | Low | Low-medium — single-permission-mode UX gap | Same |
+
+---
+
+## Files & Phase Impact
+
+| File | Status | Phase | Description / Contract Change |
+|------|--------|-------|-------------------------------|
+| `daemon/src/agent-plugins/pi.ts` | **New** | 1.1-1.8 | Contract: `createPiPlugin(): AgentPlugin` — `supportsJson()`/`supportsAcp()`/`runTurn()` over `ctx.getAcpConnection()`; private `buildSpawnSpec(ctx)`, `validatePiAcpIdentity(init)`, `enrich(raw, base)` · Owns: nothing persistent |
+| `daemon/src/agent-plugins/registry.ts` | **Modified** | 1.9 | Add `pi: createPiPlugin` to `PLUGIN_MAP` (`:12-17`) + import (`:7-10`) — one line each; `CliId`/`SUPPORTED_CLIS` widen automatically |
+| `daemon/src/services/recover.ts` | **Modified** | 1.10 | Add Pi adapter comm-name to `KNOWN_TURN_BINARIES` (`:22`); update header comment (`:14-21`) — Decision 4 |
+| `daemon/src/__tests__/pi.test.ts` | **New** | 1.T1-1.T3 | Unit tests: identity/version validation, per-session socket-dir uniqueness, `enrich` event mapping |
+| `daemon/src/__tests__/recover.test.ts` | **Modified** | 1.T5, 2.T3 | Assert the Pi adapter comm-name passes `verifyPidIsTurnProcess` and is swept on boot |
+| `web-ui/src/api/types.ts` | **Modified (optional hygiene)** | — | Widen `NormalizedEventProvider` (`:179`) to include `agy` + new CLI ids, or to `string` — non-gating, Risk 6 |
+| `daemon/src/services/{spawn,jsonAgent,promptBuilder,dbSchema,dbMigration}.ts`, `daemon/src/state/jsonAgentRegistry.ts`, all route files | **Unchanged** | — | Already generic over `AgentPlugin`/`CliId` — evidence in Research and Daemon Changes |
+| `web-ui/src/components/**` | **Unchanged** | — | Generic over `GET /supported-clis` and `NormalizedEvent` — evidence in UI Changes |
+| `daemon/src/services/acp/{acpTransport,normalize,acpTerminalManager}.ts` | **Unchanged (owned by Sub-plan A)** | — | Consumed only; this plan creates none of them |

--- a/.vibekit/feature-plans/wip/acp-normalize-superset/.sdlc-state.yaml
+++ b/.vibekit/feature-plans/wip/acp-normalize-superset/.sdlc-state.yaml
@@ -1,0 +1,11 @@
+feature: acp-normalize-superset
+worktree: /home/gb/.vibe-station/projects/vibe-station/worktrees/vs-60
+master: {prd: skipped, plan: complete}
+current_subfeature: root
+subfeatures:
+  - id: root
+    origin: planned
+    mode: done
+    last_completed: "4.T4"
+    awaiting_phase: null
+    awaiting_artifact: null

--- a/.vibekit/feature-plans/wip/acp-normalize-superset/plan-acp-normalize-superset.md
+++ b/.vibekit/feature-plans/wip/acp-normalize-superset/plan-acp-normalize-superset.md
@@ -1,0 +1,498 @@
+<!--
+RULES — read before writing or implementing:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. REQUIREMENTS: One crisp line each — no verbose descriptions
+3. CHECKLIST: Mark items [x] as you complete them — this is your persistent todo list
+4. READING TIME: Optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+# Plan: ACP Normalize Superset
+
+> Extend `NormalizedEvent`/`normalize.ts` additively to losslessly carry 7 ACP update kinds it currently drops, and render the richest one (file-edit diffs) as green/red in chat.
+
+**Issue:** acp-normalize-superset
+**Branch:** `background-support-stops` (current)
+**Status:** Pending
+**PRD:** none — small feature, root sub-feature, no PRD per task scoping
+**Parent:** none
+
+**Reference files:**
+- Data / schema: `daemon/src/types.ts:74-84` (`NormalizedEventKind`), `daemon/src/types.ts:116-171` (`NormalizedEvent`), `daemon/src/ws/protocol.ts:152-185` (`NormalizedEventSchema` — a SEPARATE Zod-enforced copy of the kind/field set, must move in lockstep or `tsc` fails at the WS send site)
+- Core logic: `daemon/src/services/acp/normalize.ts`
+- UI / entrypoint: `web-ui/src/components/chat/MessageList.tsx`, `web-ui/src/components/chat/ToolRunSummary.tsx` (the actual live renderer — see Research)
+- Wiring: `web-ui/src/api/types.ts:181-221` (client-side `NormalizedEvent` mirror), `web-ui/src/components/preview/DiffView.tsx`, `web-ui/src/preview/diffParser.ts`
+
+---
+
+## Problem
+
+- `normalize.ts` was deliberately built to introduce zero new event kinds during the ACP migration (67a3736), so it silently drops 7 categories of data ACP provides — not hidden-in-UI, never even written to SQLite.
+- Dropped: non-text content blocks (image/audio/resource/resource_link), diff content blocks (file-edit before/after), `tool_call.locations`, `tool_call.kind`, in-progress `tool_call_update` statuses, `current_mode_update`, `available_commands_update`.
+- Diff blocks are the highest-value loss: today a file-edit tool call either shows raw JSON input or nothing — no green/red diff.
+
+## Out of Scope
+
+- Rewriting/redesigning the chat UI or ACP transport layer (`AcpConnection`, `AcpTerminalManager`, `JsonAgentSession`) — untouched.
+- `plan` / `plan_update` / `plan_removed`, `config_option_update`, `session_info_update`, `usage_update`, `compaction_update` session-update kinds — not in the 7-item gap list, no change.
+- Rendering embedded MCP resource *contents* (full text/blob payload) — only a link/metadata chip (name, mimeType, uri) per resource/resource_link block; opening the resource is future work.
+- Any SQLite schema/migration — `message.payload` is a JSON blob column (`daemon/src/services/sqliteTranscriptStore.ts:76`), so new optional `NormalizedEvent` fields need zero DB migration.
+- Backfilling historical transcript rows with the new fields — old rows simply lack them and render exactly as today (hard constraint).
+- `ToolUseCard.tsx`/`ToolResultCard.tsx` — confirmed dead code (zero mounts outside their own tests, see Research), left untouched; `ToolRunSummary.tsx`/`ToolRunEntryRow` is the sole live renderer this plan updates.
+
+## Concept
+
+- `NormalizedEvent` gains a small set of **optional** fields and **two new** `NormalizedEventKind` values, populated by `normalize.ts` instead of returning `null`/dropping data.
+- Web-ui chat components read the new optional fields when present; every existing code path that ignores them is untouched and renders old rows identically.
+- File-edit diffs are the flagship win: `{type:"diff", path, oldText, newText}` tool-call content becomes a real green/red unified diff via the existing `DiffView` component, not raw JSON or skipped output.
+
+## Requirements
+
+| # | Requirement |
+|---|-------------|
+| 1 | Every one of the 7 gaps is captured on `NormalizedEvent`/persisted — no silent drops remain in `normalizeSessionUpdate` |
+| 2 | Additive only: no existing `NormalizedEventKind` changes meaning, all new fields optional, old persisted rows render unchanged |
+| 3 | File-edit diff blocks render as green (added) / red (removed) lines in chat, reusing `DiffView` |
+| 4 | `tool_call.locations` / `.kind` surface as structured metadata (not just a display-name fallback) |
+| 5 | In-progress `tool_call_update` (pending/in_progress) produces a live-updating event, not silence until terminal status |
+| 6 | `current_mode_update` / `available_commands_update` render as status-like indicators in the feed |
+| 7 | Small, sonnet-implementable in one pass — no new services, no new persistence layer, no UI redesign |
+
+---
+
+## Research
+
+### `normalize.ts` drop points
+
+- **File:** `daemon/src/services/acp/normalize.ts:30-35` — `textFromContentBlock()` only handles `{type:"text"}`; any other block type returns `undefined`.
+- **File:** `daemon/src/services/acp/normalize.ts:60-65` (`agent_message_chunk`) / `:66-70` (`agent_thought_chunk`) — `if (text === undefined) return null;` drops the WHOLE event when `raw.content` (a single `ContentBlock`, see schema note below) is non-text.
+- **File:** `daemon/src/services/acp/normalize.ts:78-88` (`tool_call`) — only reads `toolCallId`, `title`/`kind` (display fallback), `rawInput`/`input`. Never reads `raw.locations`, never preserves `raw.kind` structurally, never reads `raw.content` (where diff blocks/partial output land even on the FIRST `tool_call`, per ACP spec `ToolCall.content?: Array<ToolCallContent>`).
+- **File:** `daemon/src/services/acp/normalize.ts:89-106` (`tool_call_update`) — line 94: `if (status !== "completed" && status !== "failed") return null;` drops pending/in_progress entirely; the `content.map(...)` (lines 96-98) only extracts `textFromContentBlock`, so a `{type:"diff",...}` entry in the array maps to `undefined` and is filtered out by `.filter((t): t is string => ...)` at line 98 — the diff is silently discarded, never persisted.
+- **File:** `daemon/src/services/acp/normalize.ts:117-118` (`default: return null`, inside the outer `switch` whose last named case, `plan`, ends at line 116) — `current_mode_update` and `available_commands_update` fall through here.
+- **File:** `daemon/src/ws/protocol.ts:152-185` — `NormalizedEventSchema` is a Zod schema, hand-kept in sync with `daemon/src/types.ts`'s `NormalizedEvent`, NOT derived from it. `kind: z.enum([...10 strings...])` (`:157-168`) is a hard allowlist — any event with a kind outside it fails Zod parsing wherever this schema validates outbound events (`ChatReplayEvent.events` at `:453`, `SessionMessageEvent.event` at `:463`, both feeding `ServerMessage`, exercised by `daemon/src/__tests__/jsonProtocol.test.ts`). **This file is a THIRD copy of the kind/field set (alongside `daemon/src/types.ts` and `web-ui/src/api/types.ts`) and must be updated in the same commit or the build breaks at the WS send site.**
+
+### ACP schema shapes (from `@agentclientprotocol/sdk@1.4.0`, `dist/schema/types.gen.d.ts`)
+
+- `ContentBlock` union: `TextContent{text}` | `ImageContent{data,mimeType}` | `AudioContent{data,mimeType}` | `ResourceLink{uri,name,mimeType?,description?}` | `EmbeddedResource{resource: TextResourceContents|BlobResourceContents}`.
+- **`agent_message_chunk`/`agent_thought_chunk`'s `content` field is a SINGLE `ContentBlock`, not an array** — both are `ContentChunk = { content: ContentBlock; messageId?: ... }` (`types.gen.d.ts:3410-3452`). The current `normalize.ts:61`/`:67` already pass `raw.content` as one object, matching this — any new helper for these two cases must take one block, not an array.
+- `ToolCallContent` union (a DIFFERENT, separate union from `ContentBlock` — only reached via `tool_call`/`tool_call_update.content`, which IS an array): `{type:"content", content: ContentBlock}` | `{type:"diff", path, oldText?, newText}` | `{type:"terminal", ...}` — `Diff` type at `types.gen.d.ts:522-534`: `path: string`, `oldText?: string|null` (absent ⇒ new file), `newText: string`.
+- `ToolCallLocation` at `types.gen.d.ts:581-589`: `{path: string, line?: number|null}`.
+- `ToolKind` at `types.gen.d.ts:209`: `"read"|"edit"|"delete"|"move"|"search"|"execute"|"think"|"fetch"|"switch_mode"|"other"`.
+- `ToolCallStatus`: `"pending"|"in_progress"|"completed"|"failed"`.
+- `ToolCall` (initial) carries `kind?`, `status?`, `content?`, `locations?`, `rawInput?` all together — so diff/locations/kind can arrive on the FIRST `tool_call` update, not only on a later `tool_call_update`.
+- `ToolCallUpdate` mirrors the same optional fields (`kind?`, `status?`, `content?`, `locations?`). Per the SDK doc comment, "only changed fields need to be included" — every extraction below must be additive/merge-safe and never assume presence.
+- `CurrentModeUpdate = { currentModeId: string }` — no mode name in the update itself.
+- `AvailableCommandsUpdate = { availableCommands: Array<{name, description, input?}> }`.
+
+### Existing UI diff-rendering pattern (reuse, don't reinvent)
+
+- **File:** `web-ui/src/components/chat/toolFormat.ts:43-47` — `looksLikeUnifiedDiff()` heuristically detects unified-diff TEXT output (e.g. from a `git diff`-shaped Bash result). `web-ui/src/components/chat/ToolRunSummary.tsx:129-131` feeds a match to `<DiffView diffText={resultText} />`. This heuristic path is for TEXT tool output that happens to look like a diff — separate from the STRUCTURED `{oldText,newText}` ACP diff block this plan adds, which needs no heuristic (the type tag already says "diff").
+- **File:** `web-ui/src/components/preview/DiffView.tsx:9-15` — `diffText: string` is REQUIRED and unconditionally dereferenced at `:52` (`diffText.trim()`); no other prop lets a caller skip it today.
+- **File:** `web-ui/src/components/preview/DiffView.tsx:38-92` — parses via `parseUnifiedDiff()` (`web-ui/src/preview/diffParser.ts:16`) or, for an empty diff + `fileContentFallback`, `syntheticUntrackedHunks()` (`web-ui/src/preview/diffParser.ts:118-128`, marks every line "added" — used for brand-new untracked files).
+- **File:** `web-ui/src/components/chat/ToolRunSummary.tsx:77-138` (`ToolRunEntryRow`) — the actual LIVE per-tool-call renderer used by `MessageList` (via `ToolRunSummary`, `MessageList.tsx:761-767`). `running` (`:181`) is `!!live && !t.result` and the done-checkmark (`:111-117`) is `!hasBody && result` — both inferred purely from `t.result`'s truthiness today, with no explicit status field.
+- **File:** `web-ui/src/components/chat/ToolRunSummary.tsx:160` (`ToolRunSummary`) — `hasPending = live && tools.some((t) => !t.result)`, same truthiness inference, drives the group-level spinner.
+- **Confirmed dead code:** `ToolUseCard.tsx`/`ToolResultCard.tsx` are a lone-call variant with their own test (`ToolResultCard.test.tsx`) but have **zero usages** outside their own files/tests anywhere in `web-ui/src` (`grep -rn "ToolUseCard\|ToolResultCard" web-ui/src` returns only their own definitions/tests) — `MessageList` renders exclusively through `ToolRunSummary`/`ToolRunEntryRow`. Per Requirement 7 ("small... no UI redesign"), this plan does NOT touch these two dead files — see Out of Scope.
+- No `diff`/`jsdiff` npm package present anywhere in the repo (`grep` of all `package.json` + a source-wide import scan came up empty) — Decision 3 below adds one. `diff@9.0.0` (latest, confirmed via `npm view diff version`) ships its own `.d.ts` (`libcjs/index.d.ts`) — no `@types/diff` devDependency needed.
+
+### Persistence — confirms zero schema/migration work, flags an unbounded-write risk
+
+- **File:** `daemon/src/services/sqliteTranscriptStore.ts:70-78` — `message` table: `kind TEXT` (unconstrained), `payload TEXT NOT NULL` (whole event JSON-serialized, `sqliteTranscriptStore.ts:151` `JSON.stringify(ev)`). New optional fields and new `kind` string values need no `ALTER TABLE` — they're just new JSON keys / new string values in already-untyped columns.
+- **File:** `daemon/src/services/jsonAgent.ts:1144` — `this.store.append(ev)` runs for EVERY event `normalizeSessionUpdate` returns (no filtering above the normalizer). Removing the `pending`/`in_progress` early-return (Gap 5) means every non-terminal status tick becomes a new persisted row for the session's lifetime — see Decision 7.
+- **File:** `daemon/src/services/jsonAgent.ts:1151-1170` (`updateTurnState`) — `switch` on `kind` with a catch-all `default: break` — the 2 new kinds (`mode_update`/`commands_update`) fall through harmlessly, no turn-state regression.
+
+## Root Cause
+
+- The migration's Decision 2.3/Requirement 5 ("introduces NO new NormalizedEventKind") was correct for the migration's own scope (don't destabilize the UI mid-transport-swap) but was never revisited once ACP's actual update richness became visible — this plan is that follow-up, now safe to do additively since the transport itself is stable.
+
+---
+
+## Architecture Diagram
+
+- Single-module change (normalize.ts + types.ts + protocol.ts + web-ui chat/preview files) — no new service boundary, no new process. One line suffices:
+
+```
+AcpConnection --session/update--> normalize.ts --NormalizedEvent--> SqliteTranscriptStore (payload JSON, unchanged schema) --WS--> web-ui chat/*
+```
+
+---
+
+## Design Details
+
+### System Boundaries
+
+| Boundary | Fields + types | Errors | Source of truth |
+|----------|----------------|--------|-----------------|
+| `AcpConnection` ↔ `normalize.ts` | Raw `session/update` payload (`AcpSessionUpdate`, unchanged shape) — see Research's ACP schema shapes | N/A (pure function, no throws — unrecognized fields already return `null`/are skipped) | ACP agent process |
+| `normalize.ts` ↔ `NormalizedEvent` (daemon core / persistence / WS) | New optional fields listed in Data Model below | N/A — additive fields, absent ⇒ `undefined`, no new failure mode | `normalize.ts` (pure mapping) |
+| Daemon ↔ web-ui | `NormalizedEvent` shape must stay in lockstep across THREE hand-kept copies: `daemon/src/types.ts` (canonical), `daemon/src/ws/protocol.ts`'s Zod schema (WS validation), `web-ui/src/api/types.ts:181-221` (client mirror) — **existing pattern, not a generated contract**, this plan follows the same manual-mirror convention | A field present in `types.ts` but missing from `protocol.ts` fails Zod parsing at the WS send site (Research B1); missing from `api/types.ts` silently `undefined`s in the UI — mitigated by 1.T2 and the mirror-completeness checklist items | `daemon/src/types.ts` is canonical; the other two copy it by hand (existing convention, unchanged) |
+
+### Critical User Journeys (CUJs)
+
+#### CUJ 1 — Agent edits a file, chat shows a real diff
+
+```
+Agent (e.g. claude) calls its file-edit tool
+  → ACP emits tool_call {kind:"edit", locations:[{path}], content:[]}
+  → ACP emits tool_call_update {status:"in_progress"}   (no content yet)
+  → ACP emits tool_call_update {status:"completed", content:[{type:"diff", path, oldText, newText}]}
+  → normalize.ts maps the diff block onto NormalizedEvent.toolDiffs
+  → ToolRunEntryRow (MessageList → ToolRunSummary) renders <DiffView> with green (added) / red (removed) lines
+  → User sees the exact file change, not raw JSON
+```
+
+- **Edge case:** `oldText` absent (new file) → `DiffView`'s existing `fileContentFallback`/`syntheticUntrackedHunks` path already handles "no old content" — Decision 3 wires `oldText ?? ""` through the same path, so a brand-new file renders as all-green, matching today's untracked-file behavior.
+- **Edge case:** an in-progress `tool_call_update` (CUJ 2) arrives with only `status`, no `content` — spec says "only changed fields need to be included", so `toolDiffs` must never be cleared by an update that omits `content`; only a merge, never an overwrite-with-absence.
+
+#### CUJ 2 — In-progress tool call shows live status instead of silence
+
+```
+Agent starts a long-running tool call
+  → ACP emits tool_call {status:"pending"}
+  → ACP emits tool_call_update {status:"in_progress"}   ← currently DROPPED (normalize.ts:94 returns null)
+  → normalize.ts now emits a `tool_result`-kind event carrying toolStatus:"in_progress" (non-terminal)
+  → groupEvents merges it onto the tool's item by toolId, setting item.status — item.result stays undefined (no toolResult on a non-terminal update, see Decision 4)
+  → ToolRunEntryRow/ToolRunSummary read `tool.status` explicitly for the spinner/checkmark, per Decision 4b
+  → ACP emits tool_call_update {status:"completed", content:[...]}
+  → normalize.ts emits the existing terminal tool_result event (unchanged behavior), item.status becomes "completed"
+```
+
+- **Error path:** `status:"failed"` — unchanged, already handled (`normalize.ts:94`, `isError: status === "failed"`).
+
+#### CUJ 3 — Mode change / dynamic slash-commands surface as status notes
+
+```
+Agent switches session mode (e.g. plan → build)
+  → ACP emits current_mode_update {currentModeId}
+  → normalize.ts emits a NEW `mode_update`-kind event (was: silently dropped via `default: return null`)
+  → MessageList's groupEvents maps it to the EXISTING `status` RenderItem (no new UI component) — text "Mode changed to <id>"
+  → Renders exactly like today's plan-update status note (chat-status-note div, MessageList.tsx:771-777)
+```
+
+- Same pattern for `available_commands_update` → `commands_update` kind → status note listing command names.
+
+#### CUJ 4 — A non-text content block (image/audio/resource) shows a placeholder chip, never a blank bubble
+
+```
+Agent sends agent_message_chunk with an image block, no text
+  → normalize.ts (Decision 1) emits kind:"text", text: undefined, blocks:[{type:"image",...}]
+  → groupEvents' "text" case (MessageList.tsx:172-184) today does `text: ev.text ?? ""`
+    — UNGUARDED, this would push/append an EMPTY assistant bubble (a regression: today this event never reaches here because normalize.ts drops it)
+  → Phase 3 adds: when ev.text is absent AND ev.blocks is non-empty, use a one-line
+    placeholder per block ("🖼 image", "🔊 audio", "📎 <name or uri>" for resource/resource_link)
+    joined into the bubble's text instead of "" — same RenderItem shape, no new component
+  → User sees a labeled placeholder, never a silently blank message bubble
+```
+
+### Data Model
+
+_(Not a DB table — `NormalizedEvent` is a JSON-serialized TypeScript interface, see Persistence research above. Table format reused for field-level clarity.)_
+
+| Entity | Field | Type | Constraints | Notes |
+|--------|-------|------|-------------|-------|
+| `NormalizedEvent` | `kind` | `NormalizedEventKind` | adds 2 new string values | `"mode_update"`, `"commands_update"` (Gaps 6, 7) |
+| `NormalizedEvent` | `blocks` | `NormalizedContentBlock[]` \| undefined | optional | Gap 1 — set ONLY when raw content has ≥1 non-text block; pure-text content keeps using plain `text` unchanged (zero behavior change for the common case) |
+| `NormalizedEvent` | `toolDiffs` | `ToolDiff[]` \| undefined | optional | Gap 2 — `{path, oldText?, newText}[]`, from `ToolCallContent` entries with `type:"diff"` |
+| `NormalizedEvent` | `toolLocations` | `{path:string, line?:number}[]` \| undefined | optional | Gap 3 — from `tool_call`/`tool_call_update.locations` |
+| `NormalizedEvent` | `toolKind` | `AcpToolKind` \| undefined | optional | Gap 4 — the 9-value `ToolKind` union verbatim, structural (not just a display-name fallback) |
+| `NormalizedEvent` | `toolStatus` | `"pending"\|"in_progress"\|"completed"\|"failed"` \| undefined | optional | Gap 5 — mirrors ACP `ToolCallStatus` on both `tool_use`- and `tool_result`-kind events |
+| `NormalizedEvent` | `modeId` | `string` \| undefined | optional | Gap 6 — on `mode_update` events, from `currentModeId` |
+| `NormalizedEvent` | `commands` | `{name:string, description:string}[]` \| undefined | optional | Gap 7 — on `commands_update` events, from `availableCommands` |
+| `NormalizedContentBlock` (new type) | `type` | `"text"\|"image"\|"audio"\|"resource"\|"resource_link"` | — | ALL blocks in a mixed array land here (Decision 1); `text`-type blocks in `blocks` are a redundant copy of the same content already in `NormalizedEvent.text` — kept for order/positioning, never the ONLY place text lives |
+| `NormalizedContentBlock` | `text` | `string` \| undefined | — | `type:"text"` only |
+| `NormalizedContentBlock` | `mimeType` | `string` \| undefined | — | `type:"image"\|"audio"\|"resource_link"` |
+| `NormalizedContentBlock` | `data` | `string` \| undefined | — | base64, `type:"image"\|"audio"` only |
+| `NormalizedContentBlock` | `uri` | `string` \| undefined | — | `type:"resource_link"`, or `type:"resource"`'s nested `resource.uri` |
+| `NormalizedContentBlock` | `name` | `string` \| undefined | — | `type:"resource_link"` only (`ResourceLink.name`) |
+| `ToolDiff` (new type) | `path` | `string` | required | absolute file path |
+| `ToolDiff` | `oldText` | `string` \| undefined | — | absent ⇒ new file |
+| `ToolDiff` | `newText` | `string` | required | — |
+
+#### `toNormalizedBlock` mapping table (ACP `ContentBlock` variant → `NormalizedContentBlock`)
+
+| ACP `type` | Normalized `type` | Populated fields |
+|---|---|---|
+| `text` (`TextContent{text}`) | `"text"` | `text` |
+| `image` (`ImageContent{data,mimeType}`) | `"image"` | `data`, `mimeType` |
+| `audio` (`AudioContent{data,mimeType}`) | `"audio"` | `data`, `mimeType` |
+| `resource_link` (`ResourceLink{uri,name,mimeType?}`) | `"resource_link"` | `uri`, `name`, `mimeType` |
+| `resource` (`EmbeddedResource{resource}`), `resource.text` present (`TextResourceContents`) | `"resource"` | `uri: resource.uri`, `mimeType: resource.mimeType` — NOT `resource.text` itself (Out of Scope: no embedded payload) |
+| `resource` (`EmbeddedResource{resource}`), `resource.blob` present (`BlobResourceContents`) | `"resource"` | `uri: resource.uri`, `mimeType: resource.mimeType` — NOT `resource.blob` itself |
+| any other/unrecognized `type` | (dropped) | `toNormalizedBlock` returns `undefined`, filtered out — same graceful-drop behavior as today, never a thrown error |
+
+- **Relationships:** none new — all fields hang directly off `NormalizedEvent`, no new tables/FKs.
+- **Migration:** N — `payload` is an untyped JSON blob (`sqliteTranscriptStore.ts:76`); old rows simply lack these keys, `JSON.parse` yields `undefined` for them, every consumer treats `undefined` as "not present" (hard constraint satisfied by construction, not by extra code).
+
+### API Contracts
+
+- `GET /sessions/:id/transcript`, `GET /sessions/:id/transcript?since=`, WS event broadcast — response `NormalizedEvent` shape gains the optional fields above; existing consumers reading only pre-existing fields are unaffected (TypeScript structural typing — no consumer needs to change to keep compiling or rendering).
+- No other endpoint changes.
+
+### Key Decisions
+
+#### Decision 1: two separate helpers — `agent_message_chunk`/`agent_thought_chunk` take ONE block, `tool_call(_update).content` takes an ARRAY of a different union
+
+- **Decision:** replace `textFromContentBlock` with `toNormalizedBlock(block: unknown): NormalizedContentBlock | undefined` (single-block mapper, per the mapping table in Data Model). Two call patterns:
+  1. `agent_message_chunk`/`agent_thought_chunk` (`normalize.ts:60-70`): `raw.content` is ONE `ContentBlock` (confirmed in Research — `ContentChunk.content` is not an array). Map it once: `type:"text"` → `{ text: block.text }` (unchanged output shape); any other type → `{ blocks: [toNormalizedBlock(block)] }` with `text` left `undefined` (no text content exists to put there).
+  2. `tool_call`/`tool_call_update.content` (`normalize.ts:78-88`, `:89-106`): this `content` field is `Array<ToolCallContent>` — a DIFFERENT union (`{type:"content", content: ContentBlock}` | `{type:"diff",...}` | `{type:"terminal",...}`). Keep the existing per-entry unwrap (`(c).content ?? c`, `normalize.ts:97`) before calling `toNormalizedBlock`, and separately extract `type:"diff"` entries into `toolDiffs` (Decision 2) — a `ToolCallContent` entry is never itself a bare `ContentBlock`.
+- **Rationale:** matches the ACTUAL two different ACP shapes instead of assuming both are arrays of the same union; text-only content in both cases keeps identical output to today (byte-for-byte `text` string, no `blocks`).
+- **Where:** `daemon/src/services/acp/normalize.ts:30-35` (replace `textFromContentBlock`), `:60-70` (chunk cases, single-block path), `:89-106` (tool_call_update array-walk, reusing the existing unwrap).
+
+```typescript
+// Gap 1 — single-block mapper for agent_message_chunk/agent_thought_chunk.
+// Text-only content is UNCHANGED: `{ text }`, no `blocks` field, matching
+// today's normalize.ts:61-63/67-69 exactly.
+function toNormalizedBlock(block: unknown): NormalizedContentBlock | undefined {
+  if (!block || typeof block !== "object") return undefined;
+  const b = block as Record<string, unknown>;
+  switch (b.type) {
+    case "text":
+      return typeof b.text === "string" ? { type: "text", text: b.text } : undefined;
+    case "image":
+    case "audio":
+      return typeof b.mimeType === "string" && typeof b.data === "string"
+        ? { type: b.type, mimeType: b.mimeType, data: b.data }
+        : undefined;
+    case "resource_link":
+      return typeof b.uri === "string"
+        ? { type: "resource_link", uri: b.uri, name: typeof b.name === "string" ? b.name : undefined, mimeType: typeof b.mimeType === "string" ? b.mimeType : undefined }
+        : undefined;
+    case "resource": {
+      const r = b.resource as Record<string, unknown> | undefined;
+      return r && typeof r.uri === "string"
+        ? { type: "resource", uri: r.uri, mimeType: typeof r.mimeType === "string" ? r.mimeType : undefined }
+        : undefined;
+    }
+    default:
+      return undefined;
+  }
+}
+
+function contentFromChunk(block: unknown): { text?: string; blocks?: NormalizedContentBlock[] } {
+  const mapped = toNormalizedBlock(block);
+  if (!mapped) return {};
+  if (mapped.type === "text") return { text: mapped.text };
+  return { blocks: [mapped] };
+}
+```
+
+#### Decision 2: Diffs, locations, kind live on the SAME `tool_use`/`tool_result` event, not a new kind
+
+- **Decision:** `toolDiffs`/`toolLocations`/`toolKind` are added as sibling fields next to the existing `toolInput`/`toolResult` on whichever event (`tool_use` for the initial `tool_call`, `tool_result` for a terminal `tool_call_update`) already carries that toolId — no new `NormalizedEventKind` for these three gaps.
+- **Rationale:** `MessageList.tsx:236-245` already merges a `tool_result` event into its matching `tool_use` item BY `toolId`; reusing that merge means zero new merge logic in `groupEvents` for diffs/locations/kind — only new fields to read once merged.
+- **Where:** `daemon/src/services/acp/normalize.ts:78-88` (`tool_call` case — read `raw.locations`, `raw.kind`, `raw.content` diff blocks), `:89-106` (`tool_call_update` case — same three, merged onto the terminal `tool_result` event; a diff/location/kind present on a NON-terminal update, see Decision 4, is carried on that update's own event too).
+
+#### Decision 3: Diff rendering reuses `DiffView` via a new `oldText`/`newText` prop path, backed by a new `diff` (jsdiff) dependency in web-ui
+
+- **Decision:** add `"diff": "^9.0.0"` (jsdiff, MIT, ships its own types — no `@types/diff` needed, confirmed in Research) to `web-ui/package.json`. `DiffView`'s `diffText` prop becomes OPTIONAL (`diffText?: string`); it gains a new optional prop pair `oldText?: string; newText?: string`. When either is defined, compute `DiffHunk[]` via a new adapter instead of `parseUnifiedDiff`; otherwise fall back to `(diffText ?? "").trim()`, identical to today.
+- **Rationale:** avoids hand-rolling an LCS/line-diff algorithm (out of scope per "small and tightly scoped"); reuses 100% of `DiffView`'s existing rendering, syntax highlighting (`shikiHighlighter`), and CSS (`preview-diff-*` classes) — the ACTUAL green/red styling the human asked for already exists and needs zero new CSS.
+- **Where:** `web-ui/src/components/preview/DiffView.tsx:9-15` (prop interface — `diffText` → optional), `:38-53` (new prop branch before the existing `hunks` `useMemo`), `web-ui/package.json` (new dependency), new small adapter `web-ui/src/preview/diffFromTexts.ts` (`diffLinesToHunks(oldText, newText): DiffHunk[]`) kept separate from `diffParser.ts` since it's a different input shape (two full strings, not unified-diff text).
+- Existing callers (`ToolRunSummary.tsx:131`, the standalone preview pane) keep passing only `diffText` — unaffected, since they never pass `oldText`/`newText`.
+
+```typescript
+// diffFromTexts.ts — Decision 3. Maps jsdiff's Change[] (added/removed/neither,
+// each covering 1+ lines via `.value`) onto the SAME DiffHunk/DiffLine shape
+// DiffView already renders, as ONE synthetic hunk (no @@ header math needed —
+// jsdiff diffs the whole file, there's no "hunk" boundary concept to preserve).
+import { diffLines } from "diff";
+import type { DiffHunk, DiffLine } from "./diffParser";
+
+export function diffLinesToHunks(oldText: string, newText: string): DiffHunk[] {
+  const changes = diffLines(oldText, newText);
+  const lines: DiffLine[] = [];
+  let oldNum = 1, newNum = 1;
+  for (const part of changes) {
+    const type = part.added ? "added" : part.removed ? "removed" : "context";
+    // jsdiff keeps trailing "\n" inside `.value`, so split() always leaves a
+    // final "" entry EXCEPT for a part with no trailing newline (the file's
+    // very last line) — only drop it when it's actually empty, never
+    // unconditionally, or the last real line silently disappears.
+    const rawLines = part.value.split("\n");
+    if (rawLines[rawLines.length - 1] === "") rawLines.pop();
+    for (const content of rawLines) {
+      lines.push({
+        type,
+        content,
+        oldLineNumber: type === "added" ? null : oldNum++,
+        newLineNumber: type === "removed" ? null : newNum++,
+      });
+    }
+  }
+  return [{ header: `@@ -1,${oldNum - 1} +1,${newNum - 1} @@`, lines }];
+}
+```
+
+- `ToolRunEntryRow` (`web-ui/src/components/chat/ToolRunSummary.tsx:77-138`) renders `<DiffView oldText={diff.oldText} newText={diff.newText} filePath={diff.path} />` per entry in `tool.diffs` — ONE `DiffView` per diff, shown ABOVE the existing text-result rendering (a tool call can carry both a diff and a text summary, e.g. "3 lines changed").
+- When `tool.diffs` is non-empty, the EXISTING `looksLikeUnifiedDiff(resultText)` heuristic path is skipped for that entry (structured diff wins over heuristic text sniffing) — no behavior change for tool calls that only ever produced heuristic-detected diff TEXT (e.g. a raw `git diff` in Bash output), since those never populate `diffs`.
+
+#### Decision 4: In-progress tool status reuses the `tool_result` kind with a non-terminal `toolStatus`; `groupEvents` merges per-field instead of overwriting
+
+- **Decision:** `tool_call_update` no longer early-returns `null` for `pending`/`in_progress` (`normalize.ts:94`). It emits a `tool_result`-kind event with `toolStatus` set to the raw status; `toolResult` is set ONLY when the update actually carries `content` (may be entirely absent on a bare status tick) — never a `{content: undefined}` placeholder object. `toolDiffs`/`toolLocations`/`toolKind` are populated on this same event when present, per Decision 2.
+- **Rationale:** the ACP spec's own doc comment ("only changed fields need to be included") means an in-progress update's ABSENT `content`/`locations`/`kind` must never be read as "clear the value already known" on the merged UI item. The actual risk is NOT the pre-existing `target.result = result` line (`MessageList.tsx:237-241` only ever held `content`/`isError`, and those two fields are never targeted by an in-progress update per this decision) — the risk is the NEW `diffs`/`locations`/`toolKind`/`status` fields this plan adds to the same merge, which must each be assigned only when the incoming event actually carries that field.
+- **Where:** `daemon/src/services/acp/normalize.ts:89-106`; `web-ui/src/components/chat/MessageList.tsx:235-245` (`tool_result` case, exact change below); `web-ui/src/components/chat/toolFormat.ts:8-19` (`ToolCallEntry` gains `status?`, `diffs?`, `locations?`, `toolKind?` fields, all optional).
+- **Regression guard:** a terminal update (`completed`/`failed`) ALWAYS carries the full final `content` per ACP's own contract for that transition, so `target.result = result` (guarded below) still runs unconditionally on the terminal path — identical resulting state as today.
+
+```typescript
+// MessageList.tsx groupEvents, "tool_result" case — replaces target.result = result.
+// Only ever ADD fields the incoming event actually carries; never overwrite
+// a known value with undefined.
+case "tool_result": {
+  markToolCallDuringThinking(ev.turnId);
+  const idx = ev.toolId ? toolIndexById.get(ev.toolId) : undefined;
+  const target = idx != null ? items[idx] : undefined;
+  if (target && target.type === "tool") {
+    if (ev.toolResult !== undefined) {
+      target.result = { content: ev.toolResult.content, isError: ev.toolResult.isError };
+    }
+    if (ev.toolStatus !== undefined) target.status = ev.toolStatus;
+    if (ev.toolDiffs !== undefined) target.diffs = ev.toolDiffs;
+    if (ev.toolLocations !== undefined) target.locations = ev.toolLocations;
+    if (ev.toolKind !== undefined) target.toolKind = ev.toolKind;
+  } else {
+    items.push({
+      type: "tool", id: ev.id, toolName: ev.toolName ?? "tool", turnId: ev.turnId,
+      result: ev.toolResult !== undefined ? { content: ev.toolResult.content, isError: ev.toolResult.isError } : undefined,
+      status: ev.toolStatus, diffs: ev.toolDiffs, locations: ev.toolLocations, toolKind: ev.toolKind,
+    });
+  }
+  break;
+}
+```
+
+#### Decision 4b: `ToolRunEntryRow`/`ToolRunSummary`'s spinner and done-checkmark prefer `tool.status` over `result` truthiness when `status` is present
+
+- **Decision:** `running` becomes `!!live && (t.status ? (t.status === "pending" || t.status === "in_progress") : !t.result)` — the `live` guard stays OUTSIDE the status check so a dead session replaying a persisted `toolStatus:"in_progress"` row (the process died mid-call) never spins forever; only a currently-live turn shows the spinner, exactly as today.
+- Done-checkmark condition becomes `t.status ? t.status === "completed" : (!hasBody && !!result)`.
+- `hasPending` (`ToolRunSummary.tsx:160`) keeps its existing `live && tools.some(...)` shape, with the inner predicate updated to the same status-aware check.
+- Both fall back to today's exact truthiness logic when `status` is `undefined` (old rows, or a plugin/CLI that never sends structured status) — preserves old-row rendering exactly (hard constraint).
+- **Why explicit, not optional:** an in-progress update can carry a diff/location with no text `content` — `result` stays falsy either way in that case (today's inference happens to still read "running" correctly), but a terminal `completed` update whose only content is a diff (no text) sets `target.result` to a defined-but-contentless object; explicit `status` removes any ambiguity for that case and every future non-text-only terminal shape.
+- **Where:** `web-ui/src/components/chat/ToolRunSummary.tsx:77-138` (`ToolRunEntryRow`'s `running` prop and the done-checkmark check), `:153-186` (`ToolRunSummary` — `hasPending` at `:160`, the `running` prop passed at `:181`).
+
+#### Decision 4c: `groupEvents`' `text`/`thinking` cases render a placeholder for a block-only event instead of a blank bubble
+
+- **Decision:** `MessageList.tsx:172-184` (`text`) and the `thinking` case both currently do `text: ev.text ?? ""` unconditionally — with Decision 1, an image/audio/resource-only chunk now reaches this switch with `ev.text === undefined` and `ev.blocks` set, which would push an empty bubble (a REGRESSION: today this event never arrives here at all, since `normalize.ts` drops it before reaching the store). Fix: when `ev.text` is `undefined` and `ev.blocks` is non-empty, compute a one-line placeholder (`blocksToPlaceholder(ev.blocks)`: `"🖼 image"` / `"🔊 audio"` / `"📎 " + (name ?? uri)` per block, joined) and use that as the bubble text instead of `""`.
+- **Rationale:** satisfies Out of Scope's own promise ("only a link/metadata chip... shown") with zero new component — same `assistant`/`thinking` `RenderItem`, just a different text string; a real empty-text event (the pre-existing edge case, e.g. a signature-only thinking chunk) is unaffected since `ev.blocks` is `undefined` there too, so the `??` fallback to `""` still applies.
+- **Where:** `web-ui/src/components/chat/MessageList.tsx:172-184` (`text` case), the parallel `thinking` case (`MessageList.tsx:186-`, exact end line via Research), new helper `blocksToPlaceholder(blocks: NormalizedContentBlock[]): string` in `toolFormat.ts` or inline in `MessageList.tsx`.
+
+#### Decision 5: `mode_update` / `commands_update` are new `NormalizedEventKind` values, rendered via the EXISTING `status` `RenderItem` — no new UI component
+
+- **Decision:** two new kind strings are added to `NormalizedEventKind`. `normalize.ts`'s `default:` branch grows two new `case` arms mapping `current_mode_update`/`available_commands_update` to these kinds (instead of falling through to `return null`). `MessageList.groupEvents`' `switch` (`MessageList.tsx:146-273`) grows two new `case` arms that push the SAME `{ type: "status", id, text }` `RenderItem` the `status` kind already uses (`MessageList.tsx:265`) — text is `"Mode changed"` (+ modeId) / `"N command(s) available"` (+ names, capped) respectively.
+- **Rationale:** satisfies the task's "mode/available-commands as status-like indicators" instruction literally, with zero new CSS/component — the `chat-status-note` div (`MessageList.tsx:771-777`) already exists and needs no change.
+- **Alternative rejected:** reuse `kind:"status"` directly (like the existing `plan` case, `normalize.ts:107-116`) with `modeId`/`commands` as sibling optional fields, skipping the enum edit entirely. Rejected because it collapses "mode changed" and "commands available" into one indistinguishable kind at the storage layer, losing the ability to query/filter/replay-skip one without the other later — the 3-file enum cost (`types.ts`, `protocol.ts`, `api/types.ts`) buys that distinction now while the migration is fresh in memory.
+- **Where:** `daemon/src/types.ts:74-84` (`NormalizedEventKind` — add `"mode_update" | "commands_update"`), `daemon/src/services/acp/normalize.ts:117-118` (`default:` → two new cases before it), `web-ui/src/components/chat/MessageList.tsx:146-273` (two new `case` arms before `default:`), `web-ui/src/api/types.ts:181-191` (mirror the 2 new kind strings), `daemon/src/ws/protocol.ts:157-168` (mirror the 2 new kind strings in the Zod enum — see Research B1).
+
+#### Decision 6: `web-ui/src/api/types.ts` AND `daemon/src/ws/protocol.ts` both get every new field too — same existing hand-mirror convention, not a new pattern
+
+- **Decision:** every field added to `daemon/src/types.ts`'s `NormalizedEvent` in this plan is copy-pasted (same names/types, structurally) into `web-ui/src/api/types.ts:194-221`'s `NormalizedEvent` interface, exactly as the pre-existing fields already are (e.g. `logSeq`, `edited`, `cancelled` all appear in both files today with no shared import). The SAME fields are also added to `daemon/src/ws/protocol.ts:152-185`'s Zod `NormalizedEventSchema` (a third, independently-maintained copy — see Research B1) with matching Zod shapes.
+- **Rationale:** this is the codebase's existing (if informal) contract-sync mechanism; introducing a shared-types package here would be a scope-inflating refactor this plan explicitly avoids (Out of Scope).
+- **Where:** `web-ui/src/api/types.ts:194-221`, `daemon/src/ws/protocol.ts:152-185`.
+
+#### Decision 7: non-terminal `tool_call_update` events are persisted as-is; accept the extra SQLite rows as a known, bounded cost
+
+- **Decision:** every `pending`/`in_progress` update that reaches `normalizeSessionUpdate` produces one persisted row (Research: `jsonAgent.ts:1144` calls `store.append` unconditionally). No de-duplication/coalescing is added in this plan.
+- **Rationale:** ACP tool-call status ticks are bounded by actual tool-call count per turn (not a heartbeat/poll), so row growth is proportional to real work done, not wall-clock time — acceptable for "small and tightly scoped." Coalescing (e.g. "only persist a status change, not every identical tick") is a valid follow-up but adds stateful bookkeeping this plan's Requirement 7 explicitly avoids.
+- **Where:** no code change — this is a documented trade-off, tracked in Risks below.
+
+---
+
+## Risks / Open Questions
+
+| # | Question | Notes |
+|---|----------|-------|
+| 1 | **Does every ACP-migrated CLI (claude/cursor/opencode/agy) actually emit `locations`/`kind`/diff blocks, or is this claude-adapter-specific?** | Per-plugin `enrich()` hooks (`AcpEnrichHook`, `normalize.ts:24-28`) are untouched by this plan — if a given adapter never sends these fields, the corresponding UI simply never renders (graceful, matches "optional" design); no plugin-specific code needed to ship this plan |
+| 2 | **jsdiff line-based diff vs. the agent's own diff granularity (char-level edits)** | `diffLines` is coarse (whole-line add/remove) — acceptable for "green/red diff" per the human's ask; word-level diff highlighting is a follow-up, not required here |
+| 3 | **`resource`/`resource_link` content blocks carrying large embedded text** | Out of Scope explicitly excludes rendering the embedded payload — only a metadata chip (name/uri/mimeType) is shown, so no size/perf concern from this plan |
+| 4 | **Persisting every non-terminal tool status tick grows the transcript row count** | Accepted per Decision 7 — bounded by tool-call count, not time; coalescing is a follow-up, not required here |
+
+---
+
+## Implementation Phases
+
+### Phase 1 — `daemon/src/types.ts` + `daemon/src/ws/protocol.ts`: additive type surface
+
+- [x] **1.1** Add `"mode_update" | "commands_update"` to `NormalizedEventKind` (`daemon/src/types.ts:74-84`)
+- [x] **1.2** Add `NormalizedContentBlock` interface (per the mapping table in Data Model, including `text?`) + `ToolDiff` interface + `AcpToolKind` type alias (the 9-value `ToolKind` union) near the `UsageInfo`/`Attachment` interfaces (`daemon/src/types.ts:86-111`)
+- [x] **1.3** Add optional fields to `NormalizedEvent`: `blocks?`, `toolDiffs?`, `toolLocations?`, `toolKind?`, `toolStatus?`, `modeId?`, `commands?` (`daemon/src/types.ts:116-171`)
+- [x] **1.4** Mirror 1.1 + 1.3 into `daemon/src/ws/protocol.ts:152-185`'s `NormalizedEventSchema` — add the 2 kind strings to the `z.enum([...])` at `:157-168`, add 7 matching `z.optional(...)` field schemas (see Research B1 — required for `tsc`/`jsonProtocol.test.ts` to keep passing)
+
+**Verify phase 1:**
+- [x] **1.T1** Unit — `pnpm --filter @vibestation/cli build` (runs `tsc`) passes with the new optional fields; no existing call site required to change (structural typing)
+- [x] **1.T2** Regression — `daemon/src/__tests__/jsonProtocol.test.ts` still passes (confirms `NormalizedEventSchema` parses events using only pre-existing fields, and now also parses the 2 new kinds)
+
+---
+
+### Phase 2 — `daemon/src/services/acp/normalize.ts`: populate instead of drop
+
+- [x] **2.1** Add `toNormalizedBlock`/`contentFromChunk` helpers per Decision 1, replacing `textFromContentBlock` at the `agent_message_chunk`/`agent_thought_chunk` call sites (`normalize.ts:60-70`) — text-only content produces identical output to today
+- [x] **2.2** `tool_call` case (`normalize.ts:78-88`): read `raw.locations` → `toolLocations`, `raw.kind` → `toolKind` (keep existing display-name fallback logic unchanged for `toolName`), scan `raw.content` (array of `ToolCallContent`, reusing the existing `(c).content ?? c` unwrap) for `{type:"diff"}` entries → `toolDiffs`
+- [x] **2.3** `tool_call_update` case (`normalize.ts:89-106`): remove the line-94 `pending`/`in_progress` early-return; for ANY status, build the event with `toolStatus`, set `toolResult` only when `content` text is actually present, merge `toolDiffs`/`toolLocations`/`toolKind` from `raw.content`/`raw.locations`/`raw.kind` (all optional, absent when the update doesn't touch them), keep existing terminal `isError` behavior for `completed`/`failed`
+- [x] **2.4** Add `case "current_mode_update":` → `stamp({ kind: "mode_update", modeId: raw.currentModeId })`, before `default:` (`normalize.ts:117`)
+- [x] **2.5** Add `case "available_commands_update":` → `stamp({ kind: "commands_update", commands: (Array.isArray(raw.availableCommands) ? raw.availableCommands : []).map(c => ({name: c.name, description: c.description})) })`, before `default:` — guard with `Array.isArray` matching the file's existing style (e.g. `normalize.ts:109`'s `entries`)
+- [x] **2.6** Rewrite the existing test "an in-progress tool_call_update (no terminal status) produces nothing" (`acpNormalize.test.ts:58-65`) to assert the NEW behavior: a `tool_result`-kind event with `toolStatus:"in_progress"` and `toolResult` undefined (no `content` was sent)
+- [x] **2.7** Update the file-header comment (`normalize.ts:1-9`) — remove the now-false "Introduces NO new NormalizedEventKind" claim, replace with a note that `mode_update`/`commands_update` are the only 2 new kinds and everything else is additive fields on existing kinds
+
+**Verify phase 2:**
+- [x] **2.T1** Unit — `acpNormalize.test.ts`: `agent_message_chunk` with `content:{type:"image",data:"...",mimeType:"image/png"}` (a SINGLE non-text block, matching the real `ContentChunk` shape) → event has `blocks:[{type:"image",...}]` and `text` undefined
+- [x] **2.T2** Unit — `acpNormalize.test.ts`: `tool_call` with `content:[{type:"diff",path,oldText,newText}]` → event's `toolDiffs` contains that diff verbatim
+- [x] **2.T3** Unit — `acpNormalize.test.ts`: `tool_call_update` with `status:"in_progress"`, no `content` → returns a `tool_result`-kind event with `toolStatus:"in_progress"` and `toolResult` undefined (supersedes 2.6's old assertion)
+- [x] **2.T4** Unit — `acpNormalize.test.ts`: `current_mode_update` → `kind:"mode_update"`, `modeId` set; `available_commands_update` → `kind:"commands_update"`, `commands` set
+- [x] **2.T5** Regression — `acpNormalize.test.ts`: every existing test EXCEPT the one rewritten in 2.6 passes unmodified (text-only chunks, terminal tool_call_update, `user_message_chunk` drop, unknown-kind `null`, `plan` → `status`)
+
+---
+
+### Phase 3 — Web-ui type mirror + `MessageList` merge/render
+
+- [x] **3.1** Mirror all Phase 1 additions into `web-ui/src/api/types.ts:181-221` per Decision 6
+- [x] **3.2** `ToolCallEntry` (`web-ui/src/components/chat/toolFormat.ts:8-19`) gains `status?`, `diffs?: ToolDiff[]`, `locations?`, `toolKind?`
+- [x] **3.3** `groupEvents`' `tool_use` case (`MessageList.tsx:229-234`) copies `toolDiffs`/`toolLocations`/`toolKind`/`toolStatus` onto the pushed item as `diffs`/`locations`/`toolKind`/`status`; `tool_result` case (`MessageList.tsx:235-245`) replaced per Decision 4's exact code block (per-field merge, never overwrite with `undefined`)
+- [x] **3.4** Add `case "mode_update":` / `case "commands_update":` to `groupEvents`' switch (before `default:`, `MessageList.tsx:268`), pushing the existing `{type:"status", ...}` shape per Decision 5
+- [x] **3.5** `ToolRunEntryRow`/`ToolRunSummary` (`ToolRunSummary.tsx:77-138`, `:153-186`) — `running`/done-checkmark/`hasPending` logic updated per Decision 4b (keep the `live` guard outside the status check)
+- [x] **3.6** `groupEvents`' `text` and `thinking` cases (`MessageList.tsx:172-184` and the parallel `thinking` block) — add `blocksToPlaceholder` per Decision 4c so a block-only event renders a labeled placeholder, never an empty bubble
+
+**Verify phase 3:**
+- [x] **3.T1** Unit — `web-ui/src/components/chat/MessageList.test.tsx` (existing `groupEvents` test file): a `tool_result` event with `toolStatus:"in_progress"` and no `toolResult` does NOT erase a previously-set `diffs` on the same toolId's item (asserts Decision 4's per-field merge)
+- [x] **3.T2** Unit — `MessageList.test.tsx`: a `mode_update` event with `modeId:"build"` produces a `status`-type `RenderItem`
+- [x] **3.T3** Unit — new test in `ToolRunSummary.test.tsx` (create if absent) or `MessageList.test.tsx`: a tool item with `status:"in_progress"` and no `result` renders the spinner ONLY when `live`; the same non-live (replayed/dead-session) item renders no spinner (asserts Decision 4b's `live` guard); a tool item with `status:"completed"` renders the checkmark, not the spinner
+- [x] **3.T4** Unit — `MessageList.test.tsx`: a `text` event with `text` undefined and `blocks:[{type:"image",...}]` renders a non-empty placeholder bubble, never an empty one (asserts Decision 4c)
+- [x] **3.T5** Regression — existing `groupEvents`/`mergeToolRuns` tests (tool_use/tool_result merge-by-id, thinking-group open/close) all still pass
+
+---
+
+### Phase 4 — Diff rendering (`DiffView` + new `diff` dependency)
+
+- [x] **4.1** Add `"diff": "^9.0.0"` to `web-ui/package.json` dependencies; `pnpm install` (no `@types/diff` needed — see Research)
+- [x] **4.2** New `web-ui/src/preview/diffFromTexts.ts` — `diffLinesToHunks(oldText, newText): DiffHunk[]` per Decision 3's corrected snippet
+- [x] **4.3** `DiffView` (`web-ui/src/components/preview/DiffView.tsx:9-15`, `:38-53`) — `diffText` becomes optional; new optional `oldText?`/`newText?` props; when either is set, use `diffLinesToHunks` instead of `parseUnifiedDiff`/`syntheticUntrackedHunks`; verify `ToolRunSummary.tsx:131`'s existing `diffText`-only call site still compiles and renders unchanged
+- [x] **4.4** `ToolRunEntryRow` (`web-ui/src/components/chat/ToolRunSummary.tsx:77-138`) — when `tool.diffs` is non-empty, render one `<DiffView oldText newText filePath={diff.path} />` per entry, ABOVE the existing text-result block; skip the `looksLikeUnifiedDiff` heuristic path for that tool call
+
+**Verify phase 4:**
+- [x] **4.T1** Unit — `web-ui/src/components/preview/DiffView.test.tsx` (new, colocated with the component — NOT under `web-ui/src/preview/`): `oldText="a\nb"`, `newText="a\nc"` renders one removed line (`b`) and one added line (`c`)
+- [x] **4.T2** Unit — new test in `ToolRunSummary.test.tsx` (create if absent, mirroring `ToolResultCard.test.tsx`'s diff-detection conventions): a tool entry with a `diffs` entry renders `DiffView` via the structured path, not the `looksLikeUnifiedDiff` heuristic
+- [ ] **4.T3** Manual — sanity-check an actual file-edit tool call in a live claude/cursor/opencode JSON-channel session (whichever is exercisable locally — see Risk 1) shows green additions / red removals in the chat pane, not raw JSON or plain text
+- [x] **4.T4** Regression — existing heuristic-diff path (`looksLikeUnifiedDiff` + `diffText` prop) still renders identically for a Bash `git diff`-shaped text result that carries no structured `diffs`
+
+---
+
+## Files & Phase Impact
+
+| File | Status | Phase | Description / Contract Change |
+|------|--------|-------|-------------------------------|
+| `daemon/src/types.ts` | **Modified** | 1.1-1.3 | Adds `NormalizedContentBlock`, `ToolDiff`, `AcpToolKind` types; adds 2 `NormalizedEventKind` values; adds 7 optional `NormalizedEvent` fields — all additive |
+| `daemon/src/ws/protocol.ts` | **Modified** | 1.4 | Mirrors the 2 kinds + 7 fields into the Zod `NormalizedEventSchema` |
+| `daemon/src/services/acp/normalize.ts` | **Modified** | 2.1-2.7 | Contract: `normalizeSessionUpdate` now returns a non-null event for `current_mode_update`/`available_commands_update`/in-progress `tool_call_update`; populates diff/location/kind fields instead of dropping them |
+| `daemon/src/__tests__/acpNormalize.test.ts` | **Modified** | 2.6, 2.T1-2.T5 | Rewrites 1 existing test (in-progress no longer returns null), adds new cases for each of the 7 gaps |
+| `daemon/src/__tests__/jsonProtocol.test.ts` | **Unchanged (verified)** | 1.T2 | Confirms `NormalizedEventSchema` still parses correctly after 1.4 |
+| `web-ui/src/api/types.ts` | **Modified** | 3.1 | Mirror new kinds/fields onto the client `NormalizedEvent` (Decision 6) |
+| `web-ui/src/components/chat/toolFormat.ts` | **Modified** | 3.2 | `ToolCallEntry` gains `status?`, `diffs?`, `locations?`, `toolKind?` |
+| `web-ui/src/components/chat/MessageList.tsx` | **Modified** | 3.3-3.4, 3.6 | `groupEvents`: per-field merge for `tool_result` (Decision 4), 2 new switch cases reusing the existing `status` `RenderItem`, block-only placeholder text (Decision 4c) |
+| `web-ui/src/components/chat/MessageList.test.tsx` | **Modified** | 3.T1-3.T2, 3.T4-3.T5 | New cases for the merge fix, the 2 new kinds, and the block-placeholder fix; existing cases unmodified |
+| `web-ui/src/components/chat/ToolRunSummary.tsx` | **Modified** | 3.5, 4.4 | Spinner/checkmark read `status` when present (Decision 4b); renders `DiffView` per structured diff |
+| `web-ui/src/components/chat/ToolRunSummary.test.tsx` | **New or modified** | 3.T3, 4.T2 | Status-aware spinner/checkmark tests; structured-diff rendering test |
+| `web-ui/src/components/chat/ToolUseCard.tsx` | **Unchanged** | — | Confirmed dead code (Research) — out of scope |
+| `web-ui/src/components/chat/ToolResultCard.tsx` | **Unchanged** | — | Confirmed dead code (Research) — out of scope |
+| `web-ui/src/components/preview/DiffView.tsx` | **Modified** | 4.3 | Contract: `diffText` becomes optional; new optional `oldText?`/`newText?` props, alternative input path |
+| `web-ui/src/preview/diffFromTexts.ts` | **New** | 4.2 | Contract: `diffLinesToHunks(oldText: string, newText: string): DiffHunk[]` — pure, no I/O |
+| `web-ui/src/components/preview/DiffView.test.tsx` | **New** | 4.T1 | Unit tests for the new `oldText`/`newText` prop path |
+| `web-ui/package.json` | **Modified** | 4.1 | New dependency: `diff@^9.0.0` (jsdiff) |
+
+**Test commands:**
+- `pnpm --filter @vibestation/cli test` (daemon/CLI — Phase 1/2 tests)
+- `pnpm --filter @vibestation/web test` (`web-ui/package.json:12` → `vitest run`; Phase 3/4 tests)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,27 @@ else if (mode.cli === "opencode") { ... }
 | `provideChatId?(args)` | optional | Pre-spawn: mint a chat ID (cursor) |
 | `captureChatId?(args)` | optional | Post-ready: read chat ID from token file |
 | `getRestoreCommand?(args)` | optional | Return resume argv, or null for fresh spawn |
+| `supportsAcp?()` | optional | ACP migration: true once `runTurn` drives a persistent ACP connection (`ctx.getAcpConnection`) instead of a per-turn one-shot spawn |
+| `captureNativeChatId?(args)` | optional | Two-identity model: read the CLI's NATIVE resume id out-of-band, for a plugin whose ACP `session/new` id was empirically proven to diverge from it (`bridged` = agy, `unavailable` = cursor). Deliberately NOT implemented by an `identical`-strategy plugin (claude, opencode) |
+| `supportsChannelResume?()` | optional | Two-identity model: `false` (cursor only) declares that no bridge exists from this CLI's ACP session to its own resume flag, so a json→tty toggle starting a fresh conversation is expected, not a bug. Unimplemented ≡ `true` |
+
+### The two session identities (ACP)
+
+A session that has run a Rich Chat turn carries **two** ids — the ACP
+`session/new` id (`SessionRecord.acpSessionId`, protocol-level) and the
+**native** chat id (`SessionRecord.agentChatId`, what the CLI's own
+`--resume`/`--session`/`--conversation` flag understands). `agentChatId` is
+always the native one; never store an ACP id in it.
+
+Whether the two coincide is a per-CLI fact, not a choice, and each plugin
+declares its answer only by which of the two methods above it implements:
+`identical` (claude, opencode — implement neither), `bridged` (agy —
+`captureNativeChatId`), `unavailable` (cursor — plus `supportsChannelResume:
+false`). Per-CLI resolution code lives in
+`daemon/src/agent-plugins/native-chat-id/` (one file per CLI that needs one —
+opencode's absence is meaningful). The model is stated once in the
+"two session identities" block above `captureNativeChatId` in `spawn.ts`, and
+in full in [`docs/AGENT-CHAT-ID-CAPTURE.md`](docs/AGENT-CHAT-ID-CAPTURE.md).
 
 ### What to watch for
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -19,6 +19,8 @@
     "dist"
   ],
   "dependencies": {
+    "@agentclientprotocol/claude-agent-acp": "0.70.0",
+    "@agentclientprotocol/sdk": "1.4.0",
     "@fastify/cookie": "^11.0.2",
     "@fastify/cors": "^11.2.0",
     "@fastify/type-provider-zod": "^1.0.0",

--- a/daemon/src/__tests__/acpFileSystem.test.ts
+++ b/daemon/src/__tests__/acpFileSystem.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readTextFile, writeTextFile } from "../services/acp/acpFileSystem.js";
+
+describe("acpFileSystem (1.T5)", () => {
+  let cwd: string;
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), "acp-fs-test-"));
+  });
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  it("reads a file inside the session cwd by relative path", async () => {
+    await writeFile(join(cwd, "hello.txt"), "hello world", "utf8");
+    const { content } = await readTextFile(cwd, { path: "hello.txt" });
+    expect(content).toBe("hello world");
+  });
+
+  it("writes a file inside the session cwd", async () => {
+    await writeTextFile(cwd, { path: "out.txt", content: "written" });
+    const { content } = await readTextFile(cwd, { path: "out.txt" });
+    expect(content).toBe("written");
+  });
+
+  it("throws (not a JSON-RPC response) for a missing path — the transport layer wraps this into an error response", async () => {
+    await expect(readTextFile(cwd, { path: "does-not-exist.txt" })).rejects.toThrow();
+  });
+
+  it("respects line/limit slicing", async () => {
+    await writeFile(join(cwd, "multi.txt"), "l1\nl2\nl3\nl4\n", "utf8");
+    const { content } = await readTextFile(cwd, { path: "multi.txt", line: 2, limit: 2 });
+    expect(content.split("\n")).toEqual(["l2", "l3"]);
+  });
+});

--- a/daemon/src/__tests__/acpNormalize.test.ts
+++ b/daemon/src/__tests__/acpNormalize.test.ts
@@ -55,13 +55,65 @@ describe("normalizeSessionUpdate (1.T3)", () => {
     expect(toolResult?.toolResult?.content).toContain("file1");
   });
 
-  it("an in-progress tool_call_update (no terminal status) produces nothing", () => {
+  it("an in-progress tool_call_update (no terminal status) produces a live tool_result event, no toolResult", () => {
     const ev = normalizeSessionUpdate(
       { sessionUpdate: "tool_call_update", toolCallId: "tc-1", status: "in_progress" },
       "sess1",
       "claude",
     );
-    expect(ev).toBeNull();
+    expect(ev?.kind).toBe("tool_result");
+    expect(ev?.toolStatus).toBe("in_progress");
+    expect(ev?.toolResult).toBeUndefined();
+  });
+
+  it("agent_message_chunk with a non-text block populates blocks, leaves text undefined", () => {
+    const ev = normalizeSessionUpdate(
+      {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "image", data: "abc123", mimeType: "image/png" },
+      },
+      "sess1",
+      "claude",
+    );
+    expect(ev?.kind).toBe("text");
+    expect(ev?.text).toBeUndefined();
+    expect(ev?.blocks).toEqual([{ type: "image", mimeType: "image/png", data: "abc123" }]);
+  });
+
+  it("tool_call with a diff content block populates toolDiffs verbatim", () => {
+    const ev = normalizeSessionUpdate(
+      {
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-2",
+        content: [{ type: "diff", path: "/a.ts", oldText: "old", newText: "new" }],
+      },
+      "sess1",
+      "claude",
+    );
+    expect(ev?.toolDiffs).toEqual([{ path: "/a.ts", oldText: "old", newText: "new" }]);
+  });
+
+  it("current_mode_update maps to a mode_update event", () => {
+    const ev = normalizeSessionUpdate(
+      { sessionUpdate: "current_mode_update", currentModeId: "build" },
+      "sess1",
+      "claude",
+    );
+    expect(ev?.kind).toBe("mode_update");
+    expect(ev?.modeId).toBe("build");
+  });
+
+  it("available_commands_update maps to a commands_update event", () => {
+    const ev = normalizeSessionUpdate(
+      {
+        sessionUpdate: "available_commands_update",
+        availableCommands: [{ name: "/plan", description: "Plan mode" }],
+      },
+      "sess1",
+      "claude",
+    );
+    expect(ev?.kind).toBe("commands_update");
+    expect(ev?.commands).toEqual([{ name: "/plan", description: "Plan mode" }]);
   });
 
   it("maps plan to a status event, never a new kind", () => {

--- a/daemon/src/__tests__/acpNormalize.test.ts
+++ b/daemon/src/__tests__/acpNormalize.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { normalizeSessionUpdate } from "../services/acp/normalize.js";
+
+describe("normalizeSessionUpdate (1.T3)", () => {
+  it("maps agent_message_chunk to a text event", () => {
+    const ev = normalizeSessionUpdate(
+      { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "hi" } },
+      "sess1",
+      "claude",
+    );
+    expect(ev?.kind).toBe("text");
+    expect(ev?.text).toBe("hi");
+    expect(ev?.role).toBe("assistant");
+  });
+
+  it("maps agent_thought_chunk to a thinking event", () => {
+    const ev = normalizeSessionUpdate(
+      { sessionUpdate: "agent_thought_chunk", content: { type: "text", text: "hmm" } },
+      "sess1",
+      "claude",
+    );
+    expect(ev?.kind).toBe("thinking");
+  });
+
+  it("drops user_message_chunk (daemon-owned kind already synthesizes it)", () => {
+    const ev = normalizeSessionUpdate(
+      { sessionUpdate: "user_message_chunk", content: { type: "text", text: "hi" } },
+      "sess1",
+      "claude",
+    );
+    expect(ev).toBeNull();
+  });
+
+  it("maps a tool_call to tool_use carrying the same toolId, then a matching tool_call_update to tool_result", () => {
+    const toolUse = normalizeSessionUpdate(
+      { sessionUpdate: "tool_call", toolCallId: "tc-1", title: "Bash", rawInput: { command: "ls" } },
+      "sess1",
+      "claude",
+    );
+    expect(toolUse?.kind).toBe("tool_use");
+    expect(toolUse?.toolId).toBe("tc-1");
+
+    const toolResult = normalizeSessionUpdate(
+      {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tc-1",
+        status: "completed",
+        content: [{ content: { type: "text", text: "file1\nfile2" } }],
+      },
+      "sess1",
+      "claude",
+    );
+    expect(toolResult?.kind).toBe("tool_result");
+    expect(toolResult?.toolId).toBe("tc-1");
+    expect(toolResult?.toolResult?.content).toContain("file1");
+  });
+
+  it("an in-progress tool_call_update (no terminal status) produces nothing", () => {
+    const ev = normalizeSessionUpdate(
+      { sessionUpdate: "tool_call_update", toolCallId: "tc-1", status: "in_progress" },
+      "sess1",
+      "claude",
+    );
+    expect(ev).toBeNull();
+  });
+
+  it("maps plan to a status event, never a new kind", () => {
+    const ev = normalizeSessionUpdate(
+      { sessionUpdate: "plan", entries: [{ content: "step 1" }, { content: "step 2" }] },
+      "sess1",
+      "claude",
+    );
+    expect(ev?.kind).toBe("status");
+    expect(ev?.text).toContain("step 1");
+  });
+
+  it("an unknown update kind is dropped, not thrown", () => {
+    const ev = normalizeSessionUpdate({ sessionUpdate: "something_new" }, "sess1", "claude");
+    expect(ev).toBeNull();
+  });
+
+  it("the enrich hook can replace the default mapping (Decision 2.3)", () => {
+    const ev = normalizeSessionUpdate(
+      { sessionUpdate: "plan", entries: [] },
+      "sess1",
+      "claude",
+      (_raw, base) => ({ ...base, text: "overridden" }),
+    );
+    expect(ev?.text).toBe("overridden");
+  });
+});

--- a/daemon/src/__tests__/acpTerminalManager.test.ts
+++ b/daemon/src/__tests__/acpTerminalManager.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { AcpTerminalManager } from "../services/acp/acpTerminalManager.js";
+
+describe("AcpTerminalManager (1.T2)", () => {
+  it("hasLiveTerminals is true while a tracked child runs, false after release", async () => {
+    const mgr = new AcpTerminalManager();
+    const { terminalId } = mgr.create({ command: "sleep", args: ["5"] });
+    expect(mgr.hasLiveTerminals()).toBe(true);
+    mgr.release(terminalId);
+    expect(mgr.hasLiveTerminals()).toBe(false);
+  });
+
+  it("hasLiveTerminals is false once the child exits on its own", async () => {
+    const mgr = new AcpTerminalManager();
+    const { terminalId } = mgr.create({ command: "node", args: ["-e", "process.exit(0)"] });
+    const { exitStatus } = await mgr.waitForExit(terminalId);
+    expect(exitStatus.exitCode).toBe(0);
+    expect(mgr.hasLiveTerminals()).toBe(false);
+  });
+
+  it("output() returns buffered stdout and truncated:false under the byte limit", async () => {
+    const mgr = new AcpTerminalManager();
+    const { terminalId } = mgr.create({ command: "node", args: ["-e", "process.stdout.write('hello')"] });
+    await mgr.waitForExit(terminalId);
+    const { output, truncated } = mgr.output(terminalId);
+    expect(output).toContain("hello");
+    expect(truncated).toBe(false);
+  });
+
+  it("kill() force-stops a live child", async () => {
+    const mgr = new AcpTerminalManager();
+    const { terminalId } = mgr.create({ command: "sleep", args: ["30"] });
+    mgr.kill(terminalId);
+    const { exitStatus } = await mgr.waitForExit(terminalId);
+    expect(exitStatus.signal ?? exitStatus.exitCode).toBeDefined();
+  });
+});

--- a/daemon/src/__tests__/acpTransport.test.ts
+++ b/daemon/src/__tests__/acpTransport.test.ts
@@ -63,6 +63,20 @@ describe("AcpConnection happy path", () => {
     await conn.dispose();
   });
 
+  it("auto-approves a session/request_permission with the most-permissive offered option, no human in the loop", async () => {
+    const conn = makeConnection("permission_request");
+    await conn.initialize();
+    const sessionId = await conn.newSession("/tmp");
+    const { result } = conn.sendPrompt(sessionId, [{ type: "text", text: "edit a file" }], new AbortController().signal);
+    // The fixture echoes the chosen optionId back as stopReason (see
+    // fakeAcpAgent.mjs's permission_request mode) — asserts the daemon picked
+    // "allow_always" over the offered "reject_once"/"allow_once", matching
+    // the `--dangerously-skip-permissions` trust model used everywhere else.
+    const { stopReason } = await result;
+    expect(stopReason).toBe("allow_always");
+    await conn.dispose();
+  });
+
   it("cancelActivePrompt (Stop) resolves the prompt with stopReason cancelled without killing the connection", async () => {
     const conn = makeConnection("cancel");
     await conn.initialize();

--- a/daemon/src/__tests__/acpTransport.test.ts
+++ b/daemon/src/__tests__/acpTransport.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { AcpConnection, ConnectionSpawnFailed, InitializeFailed } from "../services/acp/acpTransport.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FAKE_AGENT = join(__dirname, "fixtures", "fakeAcpAgent.mjs");
+
+function makeConnection(mode: string) {
+  return new AcpConnection(
+    { command: process.execPath, args: [FAKE_AGENT], cwd: __dirname, env: { FAKE_ACP_MODE: mode } },
+    "claude",
+  );
+}
+
+describe("AcpConnection (1.T1)", () => {
+  it("rejects with a typed failure (not a hang) when the process exits before responding", async () => {
+    const conn = makeConnection("exit_before_ready");
+    await expect(conn.initialize()).rejects.toSatisfy(
+      (e: unknown) => e instanceof ConnectionSpawnFailed || e instanceof InitializeFailed,
+    );
+  });
+
+  it("no unhandled rejection is thrown for a normal early-exit failure", async () => {
+    const conn = makeConnection("exit_before_ready");
+    let threw = false;
+    try {
+      await conn.initialize();
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(true);
+  });
+
+  it("4.T2 — a deliberately hung adapter's initialize() rejects with InitializeFailed within its timeout, not indefinitely", async () => {
+    const conn = new AcpConnection(
+      { command: process.execPath, args: [FAKE_AGENT], cwd: __dirname, env: { FAKE_ACP_MODE: "hang" }, initializeTimeoutMs: 300 },
+      "agy",
+    );
+    const start = Date.now();
+    await expect(conn.initialize()).rejects.toBeInstanceOf(InitializeFailed);
+    expect(Date.now() - start).toBeLessThan(2000);
+    await conn.dispose();
+  });
+});
+
+describe("AcpConnection happy path", () => {
+  it("initialize → session/new → sendPrompt streams updates and resolves stopReason", async () => {
+    const conn = makeConnection("normal");
+    const { loadSession } = await conn.initialize();
+    expect(loadSession).toBe(true);
+    const sessionId = await conn.newSession("/tmp");
+
+    const controller = new AbortController();
+    const { updates, result } = conn.sendPrompt(sessionId, [{ type: "text", text: "hi" }], controller.signal);
+    const seen: string[] = [];
+    for await (const ev of updates) {
+      seen.push(ev.kind);
+    }
+    const { stopReason } = await result;
+    expect(stopReason).toBe("end_turn");
+    expect(seen).toContain("text");
+    await conn.dispose();
+  });
+
+  it("cancelActivePrompt (Stop) resolves the prompt with stopReason cancelled without killing the connection", async () => {
+    const conn = makeConnection("cancel");
+    await conn.initialize();
+    const sessionId = await conn.newSession("/tmp");
+    const controller = new AbortController();
+    const { result } = conn.sendPrompt(sessionId, [{ type: "text", text: "hi" }], controller.signal);
+    conn.cancelActivePrompt();
+    const { stopReason } = await result;
+    expect(stopReason).toBe("cancelled");
+    // Connection still usable for a next turn.
+    const { result: result2 } = conn.sendPrompt(sessionId, [{ type: "text", text: "again" }], new AbortController().signal);
+    await result2;
+    await conn.dispose();
+  });
+});

--- a/daemon/src/__tests__/acpTransport.test.ts
+++ b/daemon/src/__tests__/acpTransport.test.ts
@@ -68,12 +68,25 @@ describe("AcpConnection happy path", () => {
     await conn.initialize();
     const sessionId = await conn.newSession("/tmp");
     const { result } = conn.sendPrompt(sessionId, [{ type: "text", text: "edit a file" }], new AbortController().signal);
-    // The fixture echoes the chosen optionId back as stopReason (see
+    // The fixture echoes the daemon's actual outcome back as stopReason (see
     // fakeAcpAgent.mjs's permission_request mode) — asserts the daemon picked
     // "allow_always" over the offered "reject_once"/"allow_once", matching
     // the `--dangerously-skip-permissions` trust model used everywhere else.
     const { stopReason } = await result;
-    expect(stopReason).toBe("allow_always");
+    expect(stopReason).toBe("selected:allow_always");
+    await conn.dispose();
+  });
+
+  it("cancels rather than approving when every offered permission option is reject-kind", async () => {
+    const conn = makeConnection("permission_request_reject_only");
+    await conn.initialize();
+    const sessionId = await conn.newSession("/tmp");
+    const { result } = conn.sendPrompt(sessionId, [{ type: "text", text: "do something risky" }], new AbortController().signal);
+    // No allow_once/allow_always offered at all — the daemon must never fall
+    // back to blindly picking options[0] (a reject option) and reporting it
+    // as "selected", which would silently approve a rejection.
+    const { stopReason } = await result;
+    expect(stopReason).toBe("cancelled");
     await conn.dispose();
   });
 

--- a/daemon/src/__tests__/agy.test.ts
+++ b/daemon/src/__tests__/agy.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { SessionRecord, LaunchConfig } from "../types.js";
 
-// Mirrors the existing pattern in claudeRestore.test.ts — swap homedir() so
+// Mirrors the existing pattern in nativeChatIdClaude.test.ts — swap homedir() so
 // agy's per-session `--log-file` (~/.vibe-station/agy-logs/<id>.log) AND its
 // last-resort cache-file fallback land under a temp dir we control.
 let testHomeDir: string;
@@ -217,5 +217,107 @@ describe("agy chat-id capture — log-file design (json-mode-followups, iteratio
     const { readFileSync } = await import("node:fs");
     const writtenCombined = readFileSync(join(testHomeDir, "combined_prompt.txt"), "utf8");
     expect(writtenCombined).toBe("System Rules\n\nDo the task");
+  });
+});
+
+// captureNativeChatId — Decision 6 Option B, revised 2026-08-30 after live
+// verification against a real `bunx antigravity-acp@1.1.0` + real `agy`: the
+// adapter's own `~/.agy-acp/sessions.json` (keyed by ACP sessionId) carries
+// agy's real native `conversationId`, which `agy --conversation <id>` was
+// confirmed live to resume correctly. See the block comment above
+// `readAgyAcpSessionConversationId` in agy.ts for the full investigation.
+describe("agy captureNativeChatId — antigravity-acp adapter session store", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "vst-agy-acp-test-"));
+    testHomeDir = tempDir;
+  });
+
+  afterEach(async () => {
+    testHomeDir = "";
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function writeAcpSessionsFile(
+    sessions: Record<string, { conversationId: string | null; cwd?: string }>,
+  ): Promise<void> {
+    const dir = join(testHomeDir, ".agy-acp");
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, "sessions.json"),
+      JSON.stringify({ sessions }, null, 2),
+      "utf8",
+    );
+  }
+
+  it("prefers the antigravity-acp adapter's session-keyed conversationId over the cwd-keyed fallback", async () => {
+    const { createAgyPlugin } = await import("../agent-plugins/agy.js");
+    const plugin = createAgyPlugin();
+    const s = session("sess-acp-1");
+    await writeAcpSessionsFile({
+      "acp-session-1": { conversationId: "e1daa217-70be-4b99-b7e5-78706623762b", cwd: "/tmp/ws" },
+    });
+
+    const id = await plugin.captureNativeChatId?.({
+      session: s,
+      project: { id: "p1" } as any,
+      cwd: "/tmp/ws",
+      acpSessionId: "acp-session-1",
+    });
+    expect(id).toBe("e1daa217-70be-4b99-b7e5-78706623762b");
+  });
+
+  it("never overwrites an already-captured native id (write-once semantics)", async () => {
+    const { createAgyPlugin } = await import("../agent-plugins/agy.js");
+    const plugin = createAgyPlugin();
+    const s = { ...session("sess-acp-2"), agentChatId: "already-set-id" };
+    await writeAcpSessionsFile({
+      "acp-session-2": { conversationId: "some-other-id" },
+    });
+
+    const id = await plugin.captureNativeChatId?.({
+      session: s,
+      project: { id: "p1" } as any,
+      cwd: "/tmp/ws",
+      acpSessionId: "acp-session-2",
+    });
+    expect(id).toBe("already-set-id");
+  });
+
+  it("falls back to the cwd-keyed last_conversations.json when the acp session id is unknown to the adapter store", async () => {
+    const { createAgyPlugin } = await import("../agent-plugins/agy.js");
+    const plugin = createAgyPlugin();
+    const s = session("sess-acp-3");
+    // No ~/.agy-acp/sessions.json at all (older adapter / cleared state).
+    const cacheDir = join(testHomeDir, ".gemini", "antigravity-cli", "cache");
+    await mkdir(cacheDir, { recursive: true });
+    await writeFile(
+      join(cacheDir, "last_conversations.json"),
+      JSON.stringify({ "/tmp/ws": "fallback-conversation-id" }),
+      "utf8",
+    );
+
+    const id = await plugin.captureNativeChatId?.({
+      session: s,
+      project: { id: "p1" } as any,
+      cwd: "/tmp/ws",
+      acpSessionId: "acp-session-missing",
+    });
+    expect(id).toBe("fallback-conversation-id");
+  });
+
+  it("returns null when neither channel has a value", async () => {
+    const { createAgyPlugin } = await import("../agent-plugins/agy.js");
+    const plugin = createAgyPlugin();
+    const s = session("sess-acp-4");
+
+    const id = await plugin.captureNativeChatId?.({
+      session: s,
+      project: { id: "p1" } as any,
+      cwd: "/tmp/ws",
+      acpSessionId: "acp-session-4",
+    });
+    expect(id).toBeNull();
   });
 });

--- a/daemon/src/__tests__/agyAcpLive.test.ts
+++ b/daemon/src/__tests__/agyAcpLive.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Phase 4 (4.T1) live integration test — drives the REAL `agy` CLI through
+ * the THIRD-PARTY `antigravity-acp` adapter (via `bunx`). Opt-in, same
+ * convention as claudeAcpLive.test.ts. Requires `bun`/`bunx` on PATH in
+ * addition to an authenticated `agy`.
+ *
+ *   VST_ACP_LIVE_TESTS=1 pnpm --filter @vibestation/cli test -- agyAcpLive
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execSync } from "node:child_process";
+import { createAgyPlugin } from "../agent-plugins/agy.js";
+import type { AgentPlugin, TurnContext } from "../services/spawn.js";
+import { AcpConnection } from "../services/acp/acpTransport.js";
+import type { NormalizedEvent } from "../types.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const LIVE = process.env.VST_ACP_LIVE_TESTS === "1";
+const maybe = LIVE ? describe : describe.skip;
+
+// 4.3/4.T2 does NOT require a live agy binary — runs unconditionally.
+describe("agy plugin — 4.3/4.T2: connect timeout surfaces as a readable error, not a hang", () => {
+  it("getAcpConnection failure is wrapped as 'Antigravity ACP unavailable: …'", async () => {
+    const FAKE_AGENT = join(__dirname, "fixtures", "fakeAcpAgent.mjs");
+    const plugin = createAgyPlugin();
+    const ctx: TurnContext = {
+      cwd: "/tmp",
+      project: {} as TurnContext["project"],
+      worktree: null,
+      session: { id: "agy-timeout-test" } as TurnContext["session"],
+      systemPromptFile: "/tmp/nonexistent-system-prompt.md",
+      daemonPort: 0,
+      // Simulate jsonAgent.ts's getOrCreateConnection wiring a short-timeout
+      // connection against a permanently-hung fake adapter (mirrors the real
+      // 20s agy timeout, just shortened for the test).
+      getAcpConnection: async (_spec, enrich) => {
+        const conn = new AcpConnection(
+          { command: process.execPath, args: [FAKE_AGENT], cwd: "/tmp", env: { FAKE_ACP_MODE: "hang" }, initializeTimeoutMs: 300 },
+          "agy",
+          enrich,
+        );
+        await conn.initialize(); // throws InitializeFailed after 300ms
+        return conn;
+      },
+    };
+
+    let caught: unknown;
+    try {
+      for await (const _ev of plugin.runTurn!({ message: "hi", isFirstTurn: true }, ctx, new AbortController().signal)) {
+        // no-op
+      }
+    } catch (err) {
+      caught = err;
+    }
+    expect(String(caught)).toContain("Antigravity ACP unavailable");
+  });
+});
+
+maybe("agy ACP plugin — live CLI, third-party adapter (4.T1)", () => {
+  let cwd: string;
+  let plugin: AgentPlugin;
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), "agy-acp-live-"));
+    execSync("git init -q", { cwd });
+    execSync('git config user.email a@a.com && git config user.name a', { cwd });
+    plugin = createAgyPlugin();
+  });
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  it("4.T1 — background-survival assertion: turn completes, second turn on same connection succeeds", async () => {
+    let conn: AcpConnection | undefined;
+    const ctx: TurnContext = {
+      cwd,
+      project: {} as TurnContext["project"],
+      worktree: null,
+      session: { id: "live-agy-1" } as TurnContext["session"],
+      systemPromptFile: join(cwd, "system-prompt.md"),
+      daemonPort: 0,
+      onSpawn: () => {},
+      getAcpConnection: async (spec, enrich) => {
+        if (conn) return conn;
+        conn = new AcpConnection(spec, "agy", enrich);
+        await conn.initialize();
+        await conn.newSession(spec.cwd);
+        return conn;
+      },
+    };
+
+    const events1: NormalizedEvent[] = [];
+    for await (const ev of plugin.runTurn!(
+      { message: "say the word AGYACPTEST and nothing else", isFirstTurn: true },
+      ctx,
+      new AbortController().signal,
+    )) {
+      events1.push(ev);
+    }
+    expect(events1.some((e) => e.kind === "result")).toBe(true);
+    const joined1 = events1.filter((e) => e.kind === "text").map((e) => e.text ?? "").join("");
+    expect(joined1).toContain("AGYACPTEST");
+
+    const events2: NormalizedEvent[] = [];
+    for await (const ev of plugin.runTurn!(
+      { message: "what word did I just ask you to say? reply with just that word", isFirstTurn: false },
+      ctx,
+      new AbortController().signal,
+    )) {
+      events2.push(ev);
+    }
+    expect(events2.some((e) => e.kind === "result")).toBe(true);
+  }, 90_000);
+});

--- a/daemon/src/__tests__/claudeAcpLive.test.ts
+++ b/daemon/src/__tests__/claudeAcpLive.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Phase 2 (2.T1/2.T2) live integration tests — drive the REAL `claude` CLI
+ * through the ACP adapter, exactly as Phase 1.8/2.0's spike did manually.
+ *
+ * These are opt-in (skipped by default, like the rest of `pnpm -r test`'s
+ * fast/offline suite) because they need a real, already-authenticated
+ * `claude` binary on PATH and make live model calls. Run explicitly with:
+ *
+ *   VST_ACP_LIVE_TESTS=1 pnpm --filter @vibestation/cli test -- claudeAcpLive
+ *
+ * (used inside the Docker dev sandbox for this plan's end-to-end scenarios).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execSync } from "node:child_process";
+import { createClaudePlugin } from "../agent-plugins/claude.js";
+import type { AgentPlugin, TurnContext } from "../services/spawn.js";
+import { AcpConnection } from "../services/acp/acpTransport.js";
+import type { NormalizedEvent } from "../types.js";
+
+const LIVE = process.env.VST_ACP_LIVE_TESTS === "1";
+const maybe = LIVE ? describe : describe.skip;
+
+maybe("claude ACP plugin — live CLI (2.T1/2.T2)", () => {
+  let cwd: string;
+  let plugin: AgentPlugin;
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), "claude-acp-live-"));
+    execSync("git init -q", { cwd });
+    execSync('git config user.email a@a.com && git config user.name a', { cwd });
+    await mkdir(join(cwd, ".vibe-station"), { recursive: true });
+    plugin = createClaudePlugin();
+  });
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  function makeCtx(sessionId: string): { ctx: TurnContext; getConn: () => AcpConnection | undefined } {
+    let conn: AcpConnection | undefined;
+    const ctx: TurnContext = {
+      cwd,
+      project: {} as TurnContext["project"],
+      worktree: null,
+      session: { id: sessionId } as TurnContext["session"],
+      systemPromptFile: join(cwd, "system-prompt.md"),
+      daemonPort: 0,
+      onSpawn: () => {},
+      getAcpConnection: async (spec, enrich) => {
+        if (conn) return conn;
+        conn = new AcpConnection(spec, "claude", enrich);
+        await conn.initialize();
+        await conn.newSession(spec.cwd);
+        return conn;
+      },
+    };
+    return { ctx, getConn: () => conn };
+  }
+
+  it("2.T1 — background work survives past its turn's result, on the SAME connection/agentChatId", async () => {
+    const { ctx } = makeCtx("live-2t1");
+    const signal1 = new AbortController().signal;
+    const events1: NormalizedEvent[] = [];
+    for await (const ev of plugin.runTurn!(
+      { message: "run `sleep 3 &` in the background, then tell me you're done", isFirstTurn: true },
+      ctx,
+      signal1,
+    )) {
+      events1.push(ev);
+    }
+    const chatId1 = events1.find((e) => e.kind === "session_init")?.agentChatId;
+    expect(chatId1).toBeTruthy();
+    expect(events1.some((e) => e.kind === "result")).toBe(true);
+
+    // Second turn on the SAME connection must reuse the SAME ACP session —
+    // no new session_init/agentChatId.
+    const signal2 = new AbortController().signal;
+    const events2: NormalizedEvent[] = [];
+    for await (const ev of plugin.runTurn!(
+      { message: "are you still there?", isFirstTurn: false },
+      ctx,
+      signal2,
+    )) {
+      events2.push(ev);
+    }
+    expect(events2.some((e) => e.kind === "session_init")).toBe(false);
+    expect(events2.some((e) => e.kind === "result")).toBe(true);
+  }, 90_000);
+
+  it("2.T2 — Stop mid-turn then a follow-up turn succeeds without a fresh session/new", async () => {
+    const { ctx, getConn } = makeCtx("live-2t2");
+    const controller = new AbortController();
+    const runPromise = (async () => {
+      const events: NormalizedEvent[] = [];
+      for await (const ev of plugin.runTurn!(
+        { message: "count slowly from 1 to 20, one number per line", isFirstTurn: true },
+        ctx,
+        controller.signal,
+      )) {
+        events.push(ev);
+        if (events.length === 1) {
+          // Stop shortly after the turn starts streaming.
+          getConn()?.cancelActivePrompt();
+          controller.abort();
+        }
+      }
+      return events;
+    })();
+    await runPromise;
+
+    const signal2 = new AbortController().signal;
+    const events2: NormalizedEvent[] = [];
+    for await (const ev of plugin.runTurn!(
+      { message: "say OK and nothing else", isFirstTurn: false },
+      ctx,
+      signal2,
+    )) {
+      events2.push(ev);
+    }
+    expect(events2.some((e) => e.kind === "result")).toBe(true);
+  }, 90_000);
+
+  it("2.T5 — Option A: getRestoreCommand's resume argv id === the captured ACP session id, and the raw CLI actually resumes it", async () => {
+    const { ctx } = makeCtx("live-2t5");
+    const events: NormalizedEvent[] = [];
+    for await (const ev of plugin.runTurn!(
+      { message: "say the word ACPLIVETEST5 and nothing else", isFirstTurn: true },
+      ctx,
+      new AbortController().signal,
+    )) {
+      events.push(ev);
+    }
+    const acpSessionId = events.find((e) => e.kind === "session_init")?.agentChatId;
+    expect(acpSessionId).toBeTruthy();
+
+    const session = { agentChatId: acpSessionId } as unknown as Parameters<
+      NonNullable<AgentPlugin["getRestoreCommand"]>
+    >[0]["session"];
+    const argv = await plugin.getRestoreCommand!({ session, project: {} as never, cwd });
+    expect(argv).toBeTruthy();
+    // Option A invariant (Decision 6): the resume argv's id is BYTE-IDENTICAL
+    // to the ACP session id — no separate acpSessionId column for claude.
+    expect(argv!).toContain(acpSessionId);
+
+    // Smoke: the raw `claude` binary actually resumes THIS conversation.
+    const out = execSync(
+      `claude --resume ${acpSessionId} --dangerously-skip-permissions -p "what word did I just ask you to say? reply with just that word"`,
+      { cwd, encoding: "utf8" },
+    );
+    expect(out).toContain("ACPLIVETEST5");
+  }, 90_000);
+});

--- a/daemon/src/__tests__/cursorOpencodeAcpLive.test.ts
+++ b/daemon/src/__tests__/cursorOpencodeAcpLive.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Phase 3 (3.T1/3.T2) live integration tests — drive the REAL `cursor-agent`
+ * and `opencode` CLIs through their native ACP modes. Opt-in, same convention
+ * as claudeAcpLive.test.ts:
+ *
+ *   VST_ACP_LIVE_TESTS=1 pnpm --filter @vibestation/cli test -- cursorOpencodeAcpLive
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execSync } from "node:child_process";
+import { createCursorPlugin } from "../agent-plugins/cursor.js";
+import { createOpencodePlugin } from "../agent-plugins/opencode.js";
+import type { AgentPlugin, TurnContext } from "../services/spawn.js";
+import { AcpConnection } from "../services/acp/acpTransport.js";
+import type { NormalizedEvent, ProjectRecord, SessionRecord } from "../types.js";
+
+const LIVE = process.env.VST_ACP_LIVE_TESTS === "1";
+const maybe = LIVE ? describe : describe.skip;
+
+function makeCtx(cwd: string, sessionId: string, cli: "cursor" | "opencode") {
+  let conn: AcpConnection | undefined;
+  const ctx: TurnContext = {
+    cwd,
+    project: { id: "proj" } as TurnContext["project"],
+    worktree: null,
+    session: { id: sessionId } as TurnContext["session"],
+    systemPromptFile: join(cwd, "system-prompt.md"),
+    daemonPort: 0,
+    onSpawn: () => {},
+    getAcpConnection: async (spec, enrich) => {
+      if (conn) return conn;
+      conn = new AcpConnection(spec, cli, enrich);
+      await conn.initialize();
+      await conn.newSession(spec.cwd);
+      return conn;
+    },
+  };
+  return { ctx, getConn: () => conn };
+}
+
+maybe("cursor + opencode ACP plugins — live CLI (3.T1/3.T2)", () => {
+  let cwd: string;
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), "acp-live-"));
+    execSync("git init -q", { cwd });
+    execSync('git config user.email a@a.com && git config user.name a', { cwd });
+  });
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  it("3.T1 — cursor: background-survival assertion (turn completes, second turn on same connection succeeds)", async () => {
+    const plugin: AgentPlugin = createCursorPlugin();
+    const { ctx } = makeCtx(cwd, "live-cursor-1", "cursor");
+
+    const events1: NormalizedEvent[] = [];
+    for await (const ev of plugin.runTurn!(
+      { message: "say the word CURSORACPTEST and nothing else", isFirstTurn: true },
+      ctx,
+      new AbortController().signal,
+    )) {
+      events1.push(ev);
+    }
+    expect(events1.some((e) => e.kind === "result")).toBe(true);
+    // cursor streams text in small chunks (see the 1.8 spike) — concatenate
+    // rather than expecting the whole word on one event.
+    const joined1 = events1.filter((e) => e.kind === "text").map((e) => e.text ?? "").join("");
+    expect(joined1).toContain("CURSORACPTEST");
+
+    const events2: NormalizedEvent[] = [];
+    for await (const ev of plugin.runTurn!(
+      { message: "what word did I just ask you to say? reply with just that word", isFirstTurn: false },
+      ctx,
+      new AbortController().signal,
+    )) {
+      events2.push(ev);
+    }
+    expect(events2.some((e) => e.kind === "result")).toBe(true);
+    const joined2 = events2.filter((e) => e.kind === "text").map((e) => e.text ?? "").join("");
+    expect(joined2).toContain("CURSORACPTEST");
+  }, 90_000);
+
+  it("3.T2 — opencode: background-survival assertion (turn completes, second turn on same connection recalls context)", async () => {
+    const plugin: AgentPlugin = createOpencodePlugin();
+    const { ctx } = makeCtx(cwd, "live-opencode-1", "opencode");
+
+    const events1: NormalizedEvent[] = [];
+    for await (const ev of plugin.runTurn!(
+      { message: "say the word OPENCODEACPTEST and nothing else", isFirstTurn: true },
+      ctx,
+      new AbortController().signal,
+    )) {
+      events1.push(ev);
+    }
+    expect(events1.some((e) => e.kind === "result")).toBe(true);
+    const acpSessionId = events1.find((e) => e.kind === "session_init")?.agentChatId;
+    expect(acpSessionId).toBeTruthy();
+
+    const events2: NormalizedEvent[] = [];
+    for await (const ev of plugin.runTurn!(
+      { message: "what word did I just ask you to say? reply with just that word", isFirstTurn: false },
+      ctx,
+      new AbortController().signal,
+    )) {
+      events2.push(ev);
+    }
+    expect(events2.some((e) => e.kind === "result")).toBe(true);
+    expect(events2.some((e) => e.text?.includes("OPENCODEACPTEST"))).toBe(true);
+
+    // 2.T5-equivalent for opencode (Option A): native resume with the ACP id works.
+    const out = execSync(`opencode run --session ${acpSessionId} "what word did I ask you to say? just the word"`, {
+      cwd,
+      encoding: "utf8",
+    });
+    expect(out).toContain("OPENCODEACPTEST");
+  }, 90_000);
+
+  /**
+   * 3.T3 / Risk 5 — empirical finding (recorded here rather than asserted as
+   * a pass/fail, since the finding corrects the plan's own premise):
+   *
+   * The `.opencode/plugins/vst-recorder.ts` `session.created` hook is a
+   * TERMINAL-CHANNEL-ONLY mechanism — it is read by `captureChatId`, which is
+   * called ONLY from `spawnSession`/`spawnDirectSession` (the interactive TUI
+   * spawn path), never from the JSON channel. Verified live: running
+   * `opencode run -m opencode/big-pickle "…"` with `VST_SPAWN_TOKEN` set
+   * (opencode's own non-interactive one-shot mode, i.e. the LEGACY pre-ACP
+   * JSON-channel transport this plan replaces) never wrote the token file
+   * EITHER — including after opencode auto-installed the plugin's
+   * `@opencode-ai/plugin` dependency into `.opencode/node_modules` on first
+   * use. So the hook not firing under `opencode acp` is NOT a regression
+   * introduced by this plan: the JSON channel never depended on this hook,
+   * before or after the ACP migration — its id capture is the ACP
+   * `session/new` id itself (verified byte-identical to the native id via a
+   * direct `opencode.db` query in spike 3.0b). The hook remains load-bearing
+   * ONLY for the terminal channel, which this plan does not touch.
+   *
+   * No automated assertion here (there is nothing ACP-specific to assert);
+   * this docblock IS the regression record for Risk 5 / 3.T3.
+   */
+  it.skip("3.T3 — see docblock above: hook is terminal-channel-only, not a JSON-channel/ACP dependency", () => {});
+
+  it(
+    "3.T4 — cursor Option B degrade: captureNativeChatId/getRestoreCommand return a real (non-null, no-crash) argv, " +
+      "documented as NOT guaranteed to restore ACP-turn content when resumed by the raw CLI (spike 3.0a finding)",
+    async () => {
+      const plugin: AgentPlugin = createCursorPlugin();
+      const { ctx, getConn } = makeCtx(cwd, "live-cursor-toggle", "cursor");
+
+      const events: NormalizedEvent[] = [];
+      for await (const ev of plugin.runTurn!(
+        { message: "say the word CURSORTOGGLE and nothing else", isFirstTurn: true },
+        ctx,
+        new AbortController().signal,
+      )) {
+        events.push(ev);
+      }
+      expect(events.some((e) => e.kind === "result")).toBe(true);
+
+      // cursor's own background worker syncs the ACP conversation into
+      // ~/.cursor/projects/<slug>/agent-transcripts/<id>/ ASYNCHRONOUSLY, on
+      // its own schedule (empirically anywhere from ~3s to >25s across runs
+      // in the 1.8/3.0a spikes, and it did not reliably fire at all within a
+      // live vitest process that never lets cursor-agent's own process
+      // exit) — this non-determinism IS itself part of cursor's Decision 6
+      // verdict (see the Spike Results table), so this test asserts BOTH
+      // possible outcomes rather than only the lucky one:
+      void getConn;
+      const slug = cwd.replace(/^\/+/, "").replaceAll(".", "").replaceAll("/", "-");
+      const { join: pathJoin } = await import("node:path");
+      const { existsSync } = await import("node:fs");
+      const { homedir } = await import("node:os");
+      const transcriptsDir = pathJoin(homedir(), ".cursor", "projects", slug, "agent-transcripts");
+      const deadline = Date.now() + 20_000;
+      while (Date.now() < deadline && !existsSync(transcriptsDir)) {
+        await new Promise((r) => setTimeout(r, 1000));
+      }
+
+      const nativeId = await plugin.captureNativeChatId!({
+        session: {} as SessionRecord,
+        project: {} as ProjectRecord,
+        cwd,
+        acpSessionId: "unused-not-derivable-here",
+      });
+
+      if (nativeId) {
+        // Sync landed in time: getRestoreCommand returns a real, non-crashing
+        // resume argv. NOT asserted: that resuming it actually recalls
+        // "CURSORTOGGLE" — the 1.8 spike showed it does not, for cursor
+        // specifically (Option B degrade, documented in Phase 5.2's docs).
+        const argv = await plugin.getRestoreCommand!({
+          session: { agentChatId: nativeId } as unknown as Parameters<
+            NonNullable<AgentPlugin["getRestoreCommand"]>
+          >[0]["session"],
+          project: {} as never,
+          cwd,
+        });
+        expect(argv).toBeTruthy();
+        expect(argv).toContain("--resume");
+      } else {
+        // Sync had not landed yet (the common outcome from inside a live,
+        // still-running ACP connection): the Option B fallback path — no id,
+        // so getRestoreCommand returns null, never a bogus `--resume` argv.
+        // This is exactly the J12 fresh-launch precondition (Decision 6
+        // Option B fallback section) — a real, load-bearing outcome, not a
+        // test artifact.
+        const argv = await plugin.getRestoreCommand!({
+          session: {} as unknown as Parameters<NonNullable<AgentPlugin["getRestoreCommand"]>>[0]["session"],
+          project: {} as never,
+          cwd,
+        });
+        expect(argv).toBeNull();
+      }
+    },
+    60_000,
+  );
+});

--- a/daemon/src/__tests__/dbMigration.test.ts
+++ b/daemon/src/__tests__/dbMigration.test.ts
@@ -356,4 +356,101 @@ describe("migrateManifestsToSqlite", () => {
     expect(joined!.worktreeId).toBe(`${id}-1`);
     expect(joined!.worktreeProjectId).toBe(id);
   });
+
+  // Regression — a hand-authored manifest (the demo-seed fixtures) lists
+  // worktrees `napi-1..napi-4` but never sets `nextWorktreeNum`. Defaulting the
+  // counter to 1 made the first real `POST /worktrees` reserve `napi-1` again →
+  // `SqliteError: UNIQUE constraint failed: worktrees.id`. The migrated counter
+  // must be strictly greater than every existing worktree number.
+  describe("nextWorktreeNum floor (UNIQUE-constraint regression)", () => {
+    /** A manifest with `n` worktrees `<prefix>-1..<prefix>-n` and no sessions. */
+    function manifestWithWorktrees(
+      id: string,
+      prefix: string,
+      ids: string[],
+      extra: Record<string, unknown> = {},
+    ) {
+      return {
+        id,
+        absolutePath: `/fake/${id}`,
+        prefix,
+        isGit: true,
+        defaultBranch: "main",
+        createdAt: new Date().toISOString(),
+        directSessions: [],
+        worktrees: ids.map((wtId) => ({
+          id: wtId,
+          branch: `b-${wtId}`,
+          baseBranch: "main",
+          baseSha: "0".repeat(40),
+          createdAt: new Date().toISOString(),
+          sessions: [],
+        })),
+        ...extra,
+      };
+    }
+
+    async function migrate(id: string, manifest: unknown): Promise<number> {
+      await writeLegacyManifest(id, manifest);
+      const { getDb } = await import("../state/db.js");
+      const { migrateManifestsToSqlite } = await import("../services/dbMigration.js");
+      const db = getDb();
+      await migrateManifestsToSqlite(db);
+      const row = db.prepare("SELECT nextWorktreeNum AS n FROM projects WHERE id = ?").get(id) as
+        | { n: number }
+        | undefined;
+      expect(row).toBeDefined();
+      return row!.n;
+    }
+
+    it("derives a counter above every existing worktree when `nextWorktreeNum` is absent", async () => {
+      const wtIds = ["napi-1", "napi-2", "napi-3", "napi-4"];
+      const next = await migrate("proj-seed", manifestWithWorktrees("proj-seed", "napi", wtIds));
+
+      // Strictly greater than EVERY existing worktree number — the id the next
+      // creation reserves (`napi-<next>`) can never collide.
+      const highest = Math.max(...wtIds.map((w) => Number(w.split("-")[1])));
+      expect(next).toBeGreaterThan(highest);
+      expect(next).toBe(5);
+    });
+
+    it("keeps a declared `nextWorktreeNum` that is already above the floor", async () => {
+      const next = await migrate(
+        "proj-declared",
+        manifestWithWorktrees("proj-declared", "napi", ["napi-1", "napi-2"], { nextWorktreeNum: 9 }),
+      );
+      expect(next).toBe(9);
+    });
+
+    it("overrides a stale `nextWorktreeNum` that is below the highest existing worktree", async () => {
+      const next = await migrate(
+        "proj-stale",
+        manifestWithWorktrees("proj-stale", "napi", ["napi-1", "napi-2", "napi-3"], { nextWorktreeNum: 2 }),
+      );
+      expect(next).toBe(4);
+    });
+
+    it("falls back to 1 for a project with no worktrees at all", async () => {
+      const next = await migrate("proj-empty", manifestWithWorktrees("proj-empty", "napi", []));
+      expect(next).toBe(1);
+    });
+
+    it("ignores worktree ids that don't match `<prefix>-<n>` (hand-renamed dirs)", async () => {
+      const next = await migrate(
+        "proj-renamed",
+        manifestWithWorktrees("proj-renamed", "napi", ["napi-1", "napi-hotfix", "other-9"]),
+      );
+      // Only `napi-1` counts; the renamed/foreign ids never consumed a number.
+      expect(next).toBe(2);
+    });
+
+    it("treats a regex-special prefix literally", async () => {
+      const next = await migrate(
+        "proj-regex",
+        // `a.b` must NOT match `axb-3`; only the literal `a.b-2` counts.
+        manifestWithWorktrees("proj-regex", "a.b", ["a.b-2", "axb-3"]),
+      );
+      expect(next).toBe(3);
+    });
+  });
 });

--- a/daemon/src/__tests__/fixtures/fakeAcpAgent.mjs
+++ b/daemon/src/__tests__/fixtures/fakeAcpAgent.mjs
@@ -15,9 +15,12 @@
 //     interrupted, and the next turn runs on the same connection" (1.T6).
 //   FAKE_ACP_MODE=permission_request — session/prompt sends a
 //     session/request_permission client-request (offering reject_once,
-//     allow_once, allow_always in that order) before resolving; the chosen
-//     optionId is echoed back as the resolved stopReason so a test can assert
-//     the daemon auto-picked "allow_always" without a human in the loop.
+//     allow_once, allow_always in that order) before resolving; the daemon's
+//     outcome is echoed back as stopReason ("selected:<optionId>" or
+//     "cancelled") so a test can assert it without a human in the loop.
+//   FAKE_ACP_MODE=permission_request_reject_only — same, but every offered
+//     option is reject-kind (no allow_once/allow_always at all) — asserts the
+//     daemon cancels rather than ever "selecting" a rejection as an approval.
 import { createInterface } from "node:readline";
 
 const mode = process.env.FAKE_ACP_MODE ?? "normal";
@@ -121,25 +124,36 @@ rl.on("line", (line) => {
       }, 20);
       return;
     }
-    if (mode === "permission_request") {
+    if (mode === "permission_request" || mode === "permission_request_reject_only") {
       const reqId = nextClientReqId++;
       pendingClientRequests.set(reqId, (resp) => {
-        const optionId = resp.result?.outcome?.optionId ?? `error:${resp.error?.message}`;
-        write({ jsonrpc: "2.0", id: msg.id, result: { stopReason: optionId } });
+        // Echo the daemon's actual outcome back as stopReason: "selected:<id>"
+        // or "cancelled" (or "error:<msg>" if it errored) — lets a test assert
+        // on the daemon's decision without inspecting the wire protocol.
+        const outcome = resp.result?.outcome;
+        const stopReason = outcome
+          ? outcome.outcome === "selected"
+            ? `selected:${outcome.optionId}`
+            : outcome.outcome
+          : `error:${resp.error?.message}`;
+        write({ jsonrpc: "2.0", id: msg.id, result: { stopReason } });
       });
+      const options =
+        mode === "permission_request_reject_only"
+          ? [
+              { optionId: "reject_once", name: "Reject once", kind: "reject_once" },
+              { optionId: "reject_always", name: "Reject always", kind: "reject_always" },
+            ]
+          : [
+              { optionId: "reject_once", name: "Reject", kind: "reject_once" },
+              { optionId: "allow_once", name: "Allow once", kind: "allow_once" },
+              { optionId: "allow_always", name: "Allow always", kind: "allow_always" },
+            ];
       write({
         jsonrpc: "2.0",
         id: reqId,
         method: "session/request_permission",
-        params: {
-          sessionId: sid,
-          toolCall: { toolCallId: "tc-1" },
-          options: [
-            { optionId: "reject_once", name: "Reject", kind: "reject_once" },
-            { optionId: "allow_once", name: "Allow once", kind: "allow_once" },
-            { optionId: "allow_always", name: "Allow always", kind: "allow_always" },
-          ],
-        },
+        params: { sessionId: sid, toolCall: { toolCallId: "tc-1" }, options },
       });
       return;
     }

--- a/daemon/src/__tests__/fixtures/fakeAcpAgent.mjs
+++ b/daemon/src/__tests__/fixtures/fakeAcpAgent.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+// Minimal fake ACP agent for tests — NDJSON JSON-RPC over stdio.
+// Behavior is driven by env vars so tests can exercise different paths
+// without spawning a real CLI:
+//   FAKE_ACP_MODE=normal (default) — initialize/session/new/session/prompt all succeed,
+//     streaming one agent_message_chunk before resolving with stopReason "end_turn".
+//   FAKE_ACP_MODE=cancel — session/prompt hangs until it receives session/cancel,
+//     then resolves with stopReason "cancelled".
+//   FAKE_ACP_MODE=exit_before_ready — exits immediately without responding to anything.
+//   FAKE_ACP_MODE=hang — never responds to ANYTHING (simulates a wedged adapter, 4.T2).
+//   FAKE_ACP_MODE=bg_terminal — the FIRST session/prompt starts a host-managed
+//     background terminal (client-side `terminal/create`) and then hangs until
+//     session/cancel, resolving "cancelled"; every LATER prompt resolves
+//     "end_turn" immediately. Models "a turn that backgrounded a dev server is
+//     interrupted, and the next turn runs on the same connection" (1.T6).
+import { createInterface } from "node:readline";
+
+const mode = process.env.FAKE_ACP_MODE ?? "normal";
+
+if (mode === "exit_before_ready") {
+  process.exit(1);
+}
+if (mode === "hang") {
+  // Never respond, never exit — the connect/initialize timeout must fire.
+  // (Don't wire up the readline handler below at all — even parsing/ignoring
+  // input would still risk an accidental response path.)
+  setInterval(() => {}, 60_000);
+} else {
+  setupNormalHandlers();
+}
+
+function setupNormalHandlers() {
+const rl = createInterface({ input: process.stdin, crlfDelay: Infinity });
+let sessionId = "fake-session-1";
+let cancelRequested = false;
+let promptCount = 0;
+let nextClientReqId = 1000;
+
+function write(obj) {
+  process.stdout.write(JSON.stringify(obj) + "\n");
+}
+
+rl.on("line", (line) => {
+  let msg;
+  try {
+    msg = JSON.parse(line);
+  } catch {
+    return;
+  }
+  // A RESPONSE to one of our own agent→client requests (terminal/create): ignore
+  // the payload, we only care that the daemon now owns the background child.
+  if (msg.id !== undefined && msg.method === undefined) return;
+  if (msg.method === "initialize") {
+    write({
+      jsonrpc: "2.0",
+      id: msg.id,
+      result: { protocolVersion: 1, agentCapabilities: { loadSession: true } },
+    });
+    return;
+  }
+  if (msg.method === "session/new") {
+    write({ jsonrpc: "2.0", id: msg.id, result: { sessionId } });
+    return;
+  }
+  if (msg.method === "session/load") {
+    if (msg.params.sessionId === "fail-me") {
+      write({ jsonrpc: "2.0", id: msg.id, error: { code: -1, message: "no such session" } });
+    } else {
+      write({ jsonrpc: "2.0", id: msg.id, result: {} });
+    }
+    return;
+  }
+  if (msg.method === "session/cancel") {
+    cancelRequested = true;
+    return;
+  }
+  if (msg.method === "session/prompt") {
+    const sid = msg.params.sessionId;
+    if (mode === "bg_terminal") {
+      promptCount += 1;
+      if (promptCount > 1) {
+        // A later turn on the SAME connection — answer immediately.
+        write({ jsonrpc: "2.0", id: msg.id, result: { stopReason: "end_turn" } });
+        return;
+      }
+      // Turn 1 backgrounds a long-lived process through the HOST (the daemon's
+      // AcpTerminalManager owns the OS child, not this process), then hangs.
+      write({
+        jsonrpc: "2.0",
+        id: nextClientReqId++,
+        method: "terminal/create",
+        params: {
+          sessionId: sid,
+          command: process.execPath,
+          args: ["-e", "setInterval(() => {}, 1000)"],
+        },
+      });
+      const bgCheck = setInterval(() => {
+        if (cancelRequested) {
+          clearInterval(bgCheck);
+          cancelRequested = false;
+          write({ jsonrpc: "2.0", id: msg.id, result: { stopReason: "cancelled" } });
+        }
+      }, 20);
+      return;
+    }
+    if (mode === "cancel") {
+      const check = setInterval(() => {
+        if (cancelRequested) {
+          clearInterval(check);
+          write({ jsonrpc: "2.0", id: msg.id, result: { stopReason: "cancelled" } });
+        }
+      }, 20);
+      return;
+    }
+    write({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: { sessionId: sid, update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "hi from fake agent" } } },
+    });
+    setTimeout(() => {
+      write({ jsonrpc: "2.0", id: msg.id, result: { stopReason: "end_turn" } });
+    }, 20);
+    return;
+  }
+});
+}

--- a/daemon/src/__tests__/fixtures/fakeAcpAgent.mjs
+++ b/daemon/src/__tests__/fixtures/fakeAcpAgent.mjs
@@ -13,6 +13,11 @@
 //     session/cancel, resolving "cancelled"; every LATER prompt resolves
 //     "end_turn" immediately. Models "a turn that backgrounded a dev server is
 //     interrupted, and the next turn runs on the same connection" (1.T6).
+//   FAKE_ACP_MODE=permission_request — session/prompt sends a
+//     session/request_permission client-request (offering reject_once,
+//     allow_once, allow_always in that order) before resolving; the chosen
+//     optionId is echoed back as the resolved stopReason so a test can assert
+//     the daemon auto-picked "allow_always" without a human in the loop.
 import { createInterface } from "node:readline";
 
 const mode = process.env.FAKE_ACP_MODE ?? "normal";
@@ -40,6 +45,10 @@ function write(obj) {
   process.stdout.write(JSON.stringify(obj) + "\n");
 }
 
+// Maps a client-request id we sent to a callback for its eventual response —
+// used by permission_request mode to observe what the daemon auto-selected.
+const pendingClientRequests = new Map();
+
 rl.on("line", (line) => {
   let msg;
   try {
@@ -47,9 +56,17 @@ rl.on("line", (line) => {
   } catch {
     return;
   }
-  // A RESPONSE to one of our own agent→client requests (terminal/create): ignore
-  // the payload, we only care that the daemon now owns the background child.
-  if (msg.id !== undefined && msg.method === undefined) return;
+  // A RESPONSE to one of our own agent→client requests: dispatch to whoever
+  // is waiting on it (permission_request mode), else ignore the payload
+  // (terminal/create — we only care that the daemon now owns the child).
+  if (msg.id !== undefined && msg.method === undefined) {
+    const cb = pendingClientRequests.get(msg.id);
+    if (cb) {
+      pendingClientRequests.delete(msg.id);
+      cb(msg);
+    }
+    return;
+  }
   if (msg.method === "initialize") {
     write({
       jsonrpc: "2.0",
@@ -102,6 +119,28 @@ rl.on("line", (line) => {
           write({ jsonrpc: "2.0", id: msg.id, result: { stopReason: "cancelled" } });
         }
       }, 20);
+      return;
+    }
+    if (mode === "permission_request") {
+      const reqId = nextClientReqId++;
+      pendingClientRequests.set(reqId, (resp) => {
+        const optionId = resp.result?.outcome?.optionId ?? `error:${resp.error?.message}`;
+        write({ jsonrpc: "2.0", id: msg.id, result: { stopReason: optionId } });
+      });
+      write({
+        jsonrpc: "2.0",
+        id: reqId,
+        method: "session/request_permission",
+        params: {
+          sessionId: sid,
+          toolCall: { toolCallId: "tc-1" },
+          options: [
+            { optionId: "reject_once", name: "Reject", kind: "reject_once" },
+            { optionId: "allow_once", name: "Allow once", kind: "allow_once" },
+            { optionId: "allow_always", name: "Allow always", kind: "allow_always" },
+          ],
+        },
+      });
       return;
     }
     if (mode === "cancel") {

--- a/daemon/src/__tests__/jsonAgent.test.ts
+++ b/daemon/src/__tests__/jsonAgent.test.ts
@@ -3,7 +3,10 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { existsSync, readFileSync } from "node:fs";
 import { spawn } from "node:child_process";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 import { parseClaudeStreamLine } from "../agent-plugins/claude.js";
 import type { AgentPlugin, TurnContext } from "../services/spawn.js";
 import type {
@@ -782,5 +785,147 @@ describe("JsonAgentSession — abort kills the whole descendant tree (Fix #3)", 
 
     expect(alive(rootPid)).toBe(false);
     expect(alive(grandchildPid)).toBe(false);
+  });
+});
+
+describe("JsonAgentSession — 1.T4 stopActiveTurn cancels an ACP connection, never kills it", () => {
+  let project: ProjectRecord;
+  const FAKE_AGENT = join(__dirname, "fixtures", "fakeAcpAgent.mjs");
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "vst-json-acp-stop-"));
+    const { mkdirSync } = await import("node:fs");
+    mkdirSync(join(tempDir, "repo"), { recursive: true });
+    const { _clearStoreForTest, addProject } = await import("../state/project-store.js");
+    _clearStoreForTest();
+    project = {
+      id: PROJECT_ID,
+      absolutePath: join(tempDir, "repo"),
+      prefix: "pj",
+      isGit: true,
+      defaultBranch: "main",
+      createdAt: new Date().toISOString(),
+      directSessions: [makeDirectSession()],
+      worktrees: [],
+    };
+    await addProject(project);
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  /** A real ACP-driving plugin (via ctx.getAcpConnection) against the fake agent fixture. */
+  function acpPlugin(
+    mode: "normal" | "cancel" | "bg_terminal",
+    onConn?: (conn: { hasLiveTerminals(): boolean }) => void,
+  ): AgentPlugin {
+    return {
+      ...mockPlugin(""),
+      supportsAcp() {
+        return true;
+      },
+      async *runTurn(_input, ctx, signal) {
+        const conn = await ctx.getAcpConnection!(
+          {
+            command: process.execPath,
+            args: [FAKE_AGENT],
+            cwd: ctx.cwd,
+            env: { FAKE_ACP_MODE: mode },
+            // Mirror the real plugins (claude.ts:396) — the connection PID is
+            // recorded in livePids, so a regression that hard-kills on
+            // stop/force-send would actually take this fake agent down.
+            ...(ctx.onSpawn ? { onSpawn: ctx.onSpawn } : {}),
+          },
+        );
+        onConn?.(conn);
+        const sessionId = conn.currentSessionId ?? (await conn.newSession(ctx.cwd));
+        const { updates, result } = conn.sendPrompt(sessionId, [{ type: "text", text: "hi" }], signal);
+        for await (const ev of updates) yield ev;
+        const { stopReason } = await result;
+        yield { id: "r1", sessionId: ctx.session.id, ts: new Date().toISOString(), provider: "claude", kind: "result", text: stopReason } as NormalizedEvent;
+      },
+    } as unknown as AgentPlugin;
+  }
+
+  it("stopActiveTurn() sends session/cancel (not killProcessTree) and the connection stays usable for the next turn", async () => {
+    const { JsonAgentSession } = await import("../services/jsonAgent.js");
+    const { getProject } = await import("../state/project-store.js");
+    const session = getProject(PROJECT_ID)!.directSessions[0]!;
+
+    const agent = new JsonAgentSession({
+      project,
+      worktree: null,
+      session,
+      plugin: acpPlugin("cancel"),
+      daemonPort: 0,
+      cli: "claude",
+    });
+
+    agent.enqueue({ message: "start something long" });
+    // Give the fake agent time to spawn + reach session/prompt before stopping.
+    await new Promise((r) => setTimeout(r, 200));
+    const stopped = agent.stopActiveTurn();
+    expect(stopped).toBe(true);
+    await agent.settled();
+
+    // A SECOND turn on the SAME session must succeed without hanging or
+    // spawning a brand-new connection — proof the connection survived Stop.
+    agent.enqueue({ message: "are you still there?" });
+    await agent.settled();
+
+    const kinds = agent.readTranscript().map((e) => e.kind);
+    expect(kinds.filter((k) => k === "result").length).toBeGreaterThanOrEqual(1);
+  });
+
+  // 1.T6 — "Send now" (force-send) is the SAME preemption as Stop: it routes
+  // through promoteQueuedTurn → stopActiveTurn, so it must cancel the in-flight
+  // prompt (session/cancel) and leave the connection AND every live
+  // AcpTerminalManager-tracked background terminal running. A regression to the
+  // legacy killProcessTree path here would SIGKILL the adapter's process group,
+  // taking the background terminal (and everything the CLI is running inside
+  // that one process) with it.
+  it("1.T6 — force-send (promoteQueuedTurn) preserves a live background terminal and the connection", async () => {
+    const { JsonAgentSession } = await import("../services/jsonAgent.js");
+    const { getProject } = await import("../state/project-store.js");
+    const session = getProject(PROJECT_ID)!.directSessions[0]!;
+
+    let conn: { hasLiveTerminals(): boolean } | undefined;
+    const agent = new JsonAgentSession({
+      project,
+      worktree: null,
+      session,
+      plugin: acpPlugin("bg_terminal", (c) => {
+        conn = c;
+      }),
+      daemonPort: 0,
+      cli: "claude",
+    });
+
+    try {
+      // Turn 1 starts a host-managed background terminal, then hangs.
+      agent.enqueue({ message: "start the dev server in the background" });
+      const deadline = Date.now() + 5000;
+      while (!conn?.hasLiveTerminals() && Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 25));
+      }
+      expect(conn?.hasLiveTerminals()).toBe(true);
+
+      // Queue a second turn and FORCE-SEND it while turn 1 is still running.
+      const { turnId } = agent.enqueue({ message: "actually, do this instead" });
+      expect(agent.promoteQueuedTurn(turnId)).toBe("ok");
+      await agent.settled();
+
+      // The background terminal must still be alive — force-send cancelled the
+      // turn, it did not kill the process tree.
+      expect(conn?.hasLiveTerminals()).toBe(true);
+
+      // …and the promoted turn ran to completion on the SAME connection.
+      const results = agent.readTranscript().filter((e) => e.kind === "result");
+      expect(results.some((e) => e.text === "end_turn")).toBe(true);
+    } finally {
+      // release() is the only path that may hard-kill the terminal (Requirement 2).
+      await agent.release();
+    }
   });
 });

--- a/daemon/src/__tests__/modes.test.ts
+++ b/daemon/src/__tests__/modes.test.ts
@@ -54,23 +54,38 @@ describe("Mode routes", () => {
     expect(res.json()).toEqual([]);
   });
 
-  it("GET /supported-clis lists all CLIs with defaultModel + supportsJson + importsNativeHistory", async () => {
+  it("GET /supported-clis lists all CLIs with defaultModel + supportsJson + importsNativeHistory + supportsJsonToTerminalResume", async () => {
     const res = await app.inject({ method: "GET", url: "/supported-clis" });
     expect(res.statusCode).toBe(200);
     const body = res.json<
-      Array<{ id: string; defaultModel: string; supportsJson: boolean; importsNativeHistory: boolean }>
+      Array<{
+        id: string;
+        defaultModel: string;
+        supportsJson: boolean;
+        importsNativeHistory: boolean;
+        supportsJsonToTerminalResume: boolean;
+      }>
     >();
     expect(body.find((c) => c.id === "claude")?.supportsJson).toBe(true);
     // claude + opencode ship a native-history importer; cursor + agy don't (yet).
     expect(body.find((c) => c.id === "claude")?.importsNativeHistory).toBe(true);
     expect(body.find((c) => c.id === "opencode")?.importsNativeHistory).toBe(true);
     expect(body.find((c) => c.id === "cursor")?.importsNativeHistory).toBe(false);
+    // Decision 6 follow-up: cursor's ACP session state lives in a store its own
+    // --resume can't read, so json->tty always starts fresh for it; the other
+    // three CLIs can genuinely resume (agy's native id is derived reliably from
+    // the ACP session via the adapter's own store — see agy.ts captureNativeChatId).
+    expect(body.find((c) => c.id === "cursor")?.supportsJsonToTerminalResume).toBe(false);
+    expect(body.find((c) => c.id === "claude")?.supportsJsonToTerminalResume).toBe(true);
+    expect(body.find((c) => c.id === "opencode")?.supportsJsonToTerminalResume).toBe(true);
+    expect(body.find((c) => c.id === "agy")?.supportsJsonToTerminalResume).toBe(true);
     // agy (Antigravity CLI) registers with JSON support enabled but no importer.
     expect(body.find((c) => c.id === "agy")).toEqual({
       id: "agy",
       defaultModel: "Gemini 3.1 Pro (High)",
       supportsJson: true,
       importsNativeHistory: false,
+      supportsJsonToTerminalResume: true,
     });
     expect(body.map((c) => c.id).sort()).toEqual(["agy", "claude", "cursor", "opencode"]);
   });

--- a/daemon/src/__tests__/nativeChatIdClaude.test.ts
+++ b/daemon/src/__tests__/nativeChatIdClaude.test.ts
@@ -14,7 +14,7 @@ vi.mock("node:os", async (importOriginal) => {
   };
 });
 
-describe("claudeRestore — findLatestChatUuid", () => {
+describe("native-chat-id/claude — findLatestChatUuid", () => {
   let tempDir: string;
 
   beforeEach(async () => {
@@ -28,7 +28,7 @@ describe("claudeRestore — findLatestChatUuid", () => {
   });
 
   it("3.T1 — returns null when ~/.claude/projects/<slug>/ does not exist", async () => {
-    const { findLatestChatUuid } = await import("../agent-plugins/claudeRestore.js");
+    const { findLatestChatUuid } = await import("../agent-plugins/native-chat-id/claude.js");
 
     // No .claude/projects dir created — should return null gracefully
     const uuid = await findLatestChatUuid("/some/nonexistent/worktree");
@@ -36,7 +36,7 @@ describe("claudeRestore — findLatestChatUuid", () => {
   });
 
   it("3.T2 — with two jsonl files, returns the uuid of the newest by mtime", async () => {
-    const { findLatestChatUuid } = await import("../agent-plugins/claudeRestore.js");
+    const { findLatestChatUuid } = await import("../agent-plugins/native-chat-id/claude.js");
 
     // Create .claude/projects/<slug>/ with two jsonl files
     const slug = "-test-path-to-worktree";
@@ -58,7 +58,7 @@ describe("claudeRestore — findLatestChatUuid", () => {
   });
 
   it("3.T3 — with only one jsonl file, returns its uuid", async () => {
-    const { findLatestChatUuid } = await import("../agent-plugins/claudeRestore.js");
+    const { findLatestChatUuid } = await import("../agent-plugins/native-chat-id/claude.js");
 
     const slug = "-single-file-test";
     const projectsDir = join(tempDir, ".claude", "projects", slug);
@@ -72,7 +72,7 @@ describe("claudeRestore — findLatestChatUuid", () => {
   });
 
   it("3.T5 — slug strips dots (e.g. /home/gb/.vibe-station/foo → -home-gb--vibe-station-foo)", async () => {
-    const { findLatestChatUuid } = await import("../agent-plugins/claudeRestore.js");
+    const { findLatestChatUuid } = await import("../agent-plugins/native-chat-id/claude.js");
 
     // Worktree path with a dot dir mid-path (matches real ~/.vibe-station layout)
     const slug = "-home-gb--vibe-station-projects-console-home-worktrees-ch-2";
@@ -87,7 +87,7 @@ describe("claudeRestore — findLatestChatUuid", () => {
   });
 
   it("3.T4 — ignores non-jsonl files and directories", async () => {
-    const { findLatestChatUuid } = await import("../agent-plugins/claudeRestore.js");
+    const { findLatestChatUuid } = await import("../agent-plugins/native-chat-id/claude.js");
 
     const slug = "-mixed-files-test";
     const projectsDir = join(tempDir, ".claude", "projects", slug);

--- a/daemon/src/__tests__/plugins.test.ts
+++ b/daemon/src/__tests__/plugins.test.ts
@@ -191,10 +191,10 @@ describe("Agent plugins", () => {
 
     it("Phase 3 — T3.T3 — getRestoreCommand returns argv [claude, --resume, <uuid>, --dangerously-skip-permissions] when uuid exists", async () => {
       const { resolvePlugin } = await import("../agent-plugins/registry.js");
-      const { findLatestChatUuid } = await import("../agent-plugins/claudeRestore.js");
+      const { findLatestChatUuid } = await import("../agent-plugins/native-chat-id/claude.js");
 
       // Create a temporary test to simulate a working findLatestChatUuid
-      // We'll test just the return shape here; full integration test in claudeRestore.test.ts
+      // We'll test just the return shape here; full integration test in nativeChatIdClaude.test.ts
       const plugin = resolvePlugin("claude");
 
       // Call with stub args (will return null since no real claude config)

--- a/daemon/src/__tests__/recover.test.ts
+++ b/daemon/src/__tests__/recover.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import * as tmuxNs from "../services/tmux.js";
@@ -300,5 +301,58 @@ describe("sweepOrphanTurnPids — PID-reuse safety (opus review finding)", () =>
     } finally {
       child.kill("SIGKILL");
     }
+  });
+
+  it("5.T2 — verifyPidIsTurnProcess recognizes the ACP adapter's observed comm name (Decision 7)", async () => {
+    const { verifyPidIsTurnProcess } = await import("../services/recover.js");
+    const { spawn } = await import("node:child_process");
+    const { writeFile, chmod } = await import("node:fs/promises");
+    // claude-agent-acp / cursor-agent acp are Bun-bundled binaries empirically
+    // observed (Phase 1.6/5.3) to report comm "MainThread", not their own
+    // binary name — the allowlist must include it for the sweep to work.
+    const scriptPath = join(tempDir, "MainThread");
+    await writeFile(scriptPath, "#!/bin/sh\nsleep 5\n", "utf8");
+    await chmod(scriptPath, 0o755);
+    const child = spawn(scriptPath, [], { stdio: "ignore" });
+    try {
+      await new Promise((r) => setTimeout(r, 100));
+      expect(verifyPidIsTurnProcess(child.pid!)).toBe(true);
+    } finally {
+      child.kill("SIGKILL");
+    }
+  });
+
+  it("5.T2 — sweepOrphanTurnPids kills an orphaned ACP connection process (own group) and unlinks turn.pids", async () => {
+    const { sweepOrphanTurnPids } = await import("../services/recover.js");
+    const { spawn } = await import("node:child_process");
+    const { writeFile, mkdir: mkdirp } = await import("node:fs/promises");
+
+    const scriptPath = join(tempDir, "MainThread");
+    await writeFile(scriptPath, "#!/bin/sh\nsleep 30\n", "utf8");
+    await import("node:fs/promises").then((m) => m.chmod(scriptPath, 0o755));
+    const child = spawn(scriptPath, [], { detached: true, stdio: "ignore" });
+    await new Promise((r) => setTimeout(r, 100));
+    expect(child.pid).toBeDefined();
+
+    const dataDir = join(tempDir, "projects", "proj-pidsweep", "session-data", "wt-pidsweep", "sess-pidsweep");
+    await mkdirp(dataDir, { recursive: true });
+    const pidFile = join(dataDir, "turn.pids");
+    await writeFile(pidFile, String(child.pid), "utf8");
+
+    sweepOrphanTurnPids();
+
+    // Give the SIGKILL a moment to land, then assert the orphan is gone AND
+    // the pidfile was unlinked (both halves of Decision 7's sweep contract).
+    let alive = true;
+    for (let i = 0; i < 20 && alive; i++) {
+      try {
+        process.kill(child.pid!, 0);
+        await new Promise((r) => setTimeout(r, 50));
+      } catch {
+        alive = false;
+      }
+    }
+    expect(alive).toBe(false);
+    expect(existsSync(pidFile)).toBe(false);
   });
 });

--- a/daemon/src/__tests__/sqliteRowMappers.test.ts
+++ b/daemon/src/__tests__/sqliteRowMappers.test.ts
@@ -32,6 +32,7 @@ const baseRow: SessionRow = {
   transcriptKind: null,
   transcriptPath: null,
   agentChatId: null,
+  acpSessionId: null,
   modelOverride: null,
   pinnedAt: null,
   initialPrompt: null,

--- a/daemon/src/__tests__/toolResultCap.test.ts
+++ b/daemon/src/__tests__/toolResultCap.test.ts
@@ -88,3 +88,32 @@ describe("1.T1 — capToolResultContent", () => {
     expect(emptyContent.toolResult!.content).toBe("");
   });
 });
+
+describe("capToolResultContent — toolDiffs (acp-normalize-superset follow-up)", () => {
+  it("replaces an oversized newText with a marker, keeping a small oldText untouched", () => {
+    const ev = toolResultEv("", {
+      kind: "tool_result",
+      toolDiffs: [{ path: "/a.ts", oldText: "small", newText: "y".repeat(TOOL_RESULT_MAX_BYTES + 1) }],
+    });
+    capToolResultContent(ev);
+    expect(ev.toolDiffs![0].newText).toContain("diff omitted");
+    expect(ev.toolDiffs![0].oldText).toBe("small");
+  });
+
+  it("drops an oversized oldText too when both sides are too big", () => {
+    const ev = toolResultEv("", {
+      kind: "tool_result",
+      toolDiffs: [{ path: "/a.ts", oldText: "x".repeat(TOOL_RESULT_MAX_BYTES + 1), newText: "y".repeat(TOOL_RESULT_MAX_BYTES + 1) }],
+    });
+    capToolResultContent(ev);
+    expect(ev.toolDiffs![0].newText).toContain("diff omitted");
+    expect(ev.toolDiffs![0].oldText).toBeUndefined();
+  });
+
+  it("leaves a normal-size diff untouched", () => {
+    const diff = { path: "/a.ts", oldText: "a\nb", newText: "a\nc" };
+    const ev = toolResultEv("", { kind: "tool_result", toolDiffs: [diff] });
+    capToolResultContent(ev);
+    expect(ev.toolDiffs![0]).toEqual(diff);
+  });
+});

--- a/daemon/src/agent-plugins/agy.ts
+++ b/daemon/src/agent-plugins/agy.ts
@@ -63,17 +63,22 @@
 import { promises as fs, mkdirSync, writeFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
-import { spawn } from "node:child_process";
-import { guardChildStdio } from "../services/childStreams.js";
+import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { createInterface } from "node:readline";
 import type { AgentPlugin, LaunchConfig, TurnInput, TurnContext } from "../services/spawn.js";
 import { sq } from "../services/shell.js";
+import type { PromptBlock } from "../services/acp/acpTransport.js";
+import type { AcpEnrichHook } from "../services/acp/normalize.js";
+import {
+  readAgyAcpSessionConversationId,
+  readLatestAgyConversationId,
+} from "./native-chat-id/agy.js";
 import type {
   SessionRecord,
   ProjectRecord,
   NormalizedEvent,
   NormalizedEventKind,
+  UsageInfo,
 } from "../types.js";
 
 function agyEvent(
@@ -249,28 +254,6 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-/** Path to agy's per-cwd conversation index (`cwd → latest conversation_id`). */
-function agyLastConversationsPath(): string {
-  return join(homedir(), ".gemini", "antigravity-cli", "cache", "last_conversations.json");
-}
-
-/**
- * Read the latest agy conversation id for a given workspace cwd (best-effort).
- * NOTE: only reliable as a LAST-RESORT fallback (`getRestoreCommand` below) —
- * see the chat-id capture block comment for why this cannot be trusted as a
- * primary signal.
- */
-async function readLatestAgyConversationId(cwd: string): Promise<string | null> {
-  try {
-    const raw = await fs.readFile(agyLastConversationsPath(), "utf8");
-    const map = JSON.parse(raw) as Record<string, unknown>;
-    const id = map[cwd];
-    return typeof id === "string" && id ? id : null;
-  } catch {
-    return null;
-  }
-}
-
 /**
  * Chat-id capture (serious bug, two design iterations — see the
  * json-mode-followups investigation):
@@ -375,6 +358,117 @@ const AGY_MODELS = [
 ] as const;
 
 const AGY_DEFAULT_MODEL = "Gemini 3.1 Pro (High)";
+
+// --- ACP migration (Decision 2/6, Phase 4 — spike-gated) ---
+//
+// IMPORTANT / deviation flagged for human review: unlike claude (an
+// npm-installable, Anthropic-affiliated adapter package) and cursor/opencode
+// (first-party native ACP subcommands on binaries already required by this
+// plugin), agy's ONLY available ACP adapter as of this implementation is the
+// THIRD-PARTY, single-maintainer npm package `antigravity-acp` (published by
+// an individual GitHub user, not Google/Zed/agentclientprotocol), and it is
+// built on Bun — its own `bin` entries are literal `.ts` files, runnable only
+// via `bun`/`bunx`, NOT via plain `node`. This introduces a NEW system-level
+// runtime dependency (`bun`) beyond everything else this plan needs (which is
+// npm-installable and node-executable). Phase 4.1's spike (initialize +
+// session/new against a real, already-authenticated `agy`) completed without
+// hanging on this machine, so this plugin proceeds per the plan's own
+// "on success, continue to 4.2" instruction — but the supply-chain trust and
+// new-runtime-dependency questions this raises are NOT this plan's to settle
+// unilaterally; see the final report / Risk 1 update for the explicit
+// call-out. `bunx antigravity-acp@<pinned version>` is used directly (NOT
+// vendored via `cli/package.json`, since it is not a node-resolvable
+// dependency) — the exact version is pinned on the command line for the same
+// "don't silently float" reason Phase 1.7 pins npm packages.
+const ANTIGRAVITY_ACP_PACKAGE = "antigravity-acp@1.1.0";
+
+/** Resolve the user's own `agy` binary, passed to the adapter via `AGY_BIN` (its own escape hatch — it otherwise tries to download a release binary itself). */
+function resolveAgyBinary(): string {
+  try {
+    return execFileSync("which", ["agy"], { encoding: "utf8" }).trim() || "agy";
+  } catch {
+    return "agy";
+  }
+}
+
+/** Decision 2.3 — no agy-specific enrichment needed beyond the shared mapping. */
+const agyEnrich: AcpEnrichHook = (_raw, base) => base;
+
+/**
+ * ACP-based turn (Decision 2). Drives `bunx antigravity-acp@<pinned>` (spawned
+ * once per session, Decision 1) instead of a per-turn one-shot `agy` spawn.
+ * Phase 4.3's 20s connect/initialize timeout is `AcpConnection`'s existing
+ * `initializeTimeoutMs`, not a new mechanism.
+ */
+async function* runTurnAcp(
+  input: TurnInput,
+  ctx: TurnContext,
+  signal: AbortSignal,
+): AsyncIterable<NormalizedEvent> {
+  let conn;
+  try {
+    conn = await ctx.getAcpConnection!(
+      {
+        command: "bunx",
+        args: [ANTIGRAVITY_ACP_PACKAGE],
+        cwd: ctx.cwd,
+        env: { AGY_BIN: resolveAgyBinary() },
+        initializeTimeoutMs: 20_000, // Phase 4.3 — never lets the turn hang indefinitely
+        ...(ctx.onSpawn ? { onSpawn: ctx.onSpawn } : {}),
+      },
+      agyEnrich,
+    );
+  } catch (err) {
+    // Phase 4.3: a specific, human-readable message for the connect/
+    // initialize timeout (or a spawn failure) — the core (jsonAgent.ts's
+    // runOneTurn catch block, Decision 7) converts this thrown error into a
+    // synthetic `error` NormalizedEvent exactly as any other transport
+    // failure, so the turn fails fast instead of hanging.
+    throw new Error(`Antigravity ACP unavailable: ${String(err)}`);
+  }
+  const sessionId = conn.currentSessionId;
+  if (!sessionId) throw new Error("agy ACP session was not established");
+
+  // agy spike (4.1b) verdict: Option B — the ACP session id does not
+  // round-trip through `agy --conversation`. Do NOT surface it as
+  // `agentChatId`; `captureNativeChatId` below is the source of truth.
+  let message = input.message;
+  if (input.isFirstTurn) {
+    const systemPrompt = await fs.readFile(ctx.systemPromptFile, "utf8").catch(() => "");
+    if (systemPrompt) message = `${systemPrompt}\n\n${message}`;
+  }
+  const promptBlocks: PromptBlock[] = [{ type: "text", text: message }];
+
+  const { updates, result } = conn.sendPrompt(sessionId, promptBlocks, signal);
+  for await (const ev of updates) yield ev;
+
+  let usageRaw: Record<string, unknown> | undefined;
+  try {
+    const r = await result;
+    usageRaw = (r as unknown as { usage?: Record<string, unknown> }).usage;
+  } catch (err) {
+    if (signal.aborted) return;
+    throw err;
+  }
+
+  const usage: UsageInfo | undefined = usageRaw
+    ? (() => {
+        const num = (v: unknown): number => (typeof v === "number" ? v : 0);
+        const inputTokens = num(usageRaw!.inputTokens);
+        const outputTokens = num(usageRaw!.outputTokens);
+        return {
+          inputTokens,
+          outputTokens,
+          cacheReadTokens: num(usageRaw!.cachedReadTokens),
+          cacheCreateTokens: num(usageRaw!.cachedWriteTokens),
+          totalTokens: num(usageRaw!.totalTokens) || inputTokens + outputTokens,
+          model: ctx.model ?? "",
+        };
+      })()
+    : undefined;
+  if (usage) yield agyEvent(ctx.session.id, "usage", { usage, model: usage.model || undefined });
+  yield agyEvent(ctx.session.id, "result", usage ? { usage, model: usage.model || undefined } : {});
+}
 
 export function createAgyPlugin(): AgentPlugin {
   return {
@@ -487,94 +581,52 @@ export function createAgyPlugin(): AgentPlugin {
     },
 
     /**
-     * Run ONE JSON-channel turn (Decision 2/3). Spawns `agy --print=<msg>
-     * --output-format stream-json` and yields NormalizedEvents live, as agy's
-     * per-step NDJSON arrives (see the file-header doc comment for the event
-     * shapes). Own process group (detached) so a stuck turn is group-killed and
-     * never orphaned (Decision 13).
-     *
-     * The message is passed as the VALUE of `--print` (agy's `--print` is a
-     * string flag, NOT a boolean — a bare `--print` with the message on stdin or
-     * as a `--`-separated positional is mis-parsed into the prompt text). The
-     * `--print=<msg>` attached form is safe for any message (even one starting
-     * with `--`). System prompt is folded into the first turn's message; resumed
-     * turns pass `--conversation <chatId>`.
+     * ACP migration (Decision 7/1.4/4.1): true because Phase 4.1's live spike
+     * (real `agy` + `bunx antigravity-acp`) completed `initialize` +
+     * `session/new` without hanging on this machine. See the block comment
+     * above `ANTIGRAVITY_ACP_PACKAGE` for the third-party-adapter /
+     * new-`bun`-dependency caveat this verdict carries — flagged for human
+     * review, not silently accepted.
+     */
+    supportsAcp(): boolean {
+      return true;
+    },
+
+    /**
+     * Run ONE JSON-channel turn (Decision 2/3). Drives the persistent ACP
+     * connection (Decision 1) instead of a per-turn one-shot spawn.
      */
     async *runTurn(
       input: TurnInput,
       ctx: TurnContext,
       signal: AbortSignal,
     ): AsyncIterable<NormalizedEvent> {
-      const sessionId = ctx.session.id;
+      yield* runTurnAcp(input, ctx, signal);
+    },
 
-      let message = input.message;
-      if (input.isFirstTurn) {
-        const systemPrompt = await fs.readFile(ctx.systemPromptFile, "utf8").catch(() => "");
-        if (systemPrompt) message = `${systemPrompt}\n\n${message}`;
-      }
-
-      const args = [
-        `--print=${message}`,
-        "--output-format",
-        "stream-json",
-        "--dangerously-skip-permissions",
-      ];
-      if (ctx.model) args.push("--model", ctx.model);
-      if (ctx.chatId) args.push("--conversation", ctx.chatId);
-
-      const child = spawn("agy", args, {
-        cwd: ctx.cwd,
-        detached: true, // own process group for group-kill on abort
-        stdio: ["ignore", "pipe", "pipe"],
-      });
-      guardChildStdio(child, "agy");
-      if (child.pid) ctx.onSpawn?.(child.pid);
-
-      let stderr = "";
-      child.stderr?.on("data", (d: Buffer) => {
-        stderr += d.toString("utf8");
-      });
-
-      const onAbort = (): void => {
-        try {
-          if (child.pid) process.kill(-child.pid, "SIGTERM");
-        } catch {
-          /* already dead */
-        }
-      };
-      if (signal.aborted) onAbort();
-      else signal.addEventListener("abort", onAbort, { once: true });
-
-      const exitPromise = new Promise<number>((resolve) => {
-        child.on("close", (code) => resolve(code ?? 0));
-      });
-
-      const state = createAgyStreamState();
-      try {
-        const rl = createInterface({ input: child.stdout!, crlfDelay: Infinity });
-        for await (const line of rl) {
-          for (const ev of parseAgyStreamLine(line, sessionId, state, ctx.model)) {
-            yield ev;
-          }
-        }
-        const code = await exitPromise;
-        // A non-zero exit with no JSON envelope (e.g. model-resolution hard-fail)
-        // surfaces as a thrown error the core converts into a synthetic error
-        // event (Decision 7). agy in-turn failures instead exit 0 with
-        // status:ERROR and are handled by the parser above.
-        if (code !== 0 && !signal.aborted) {
-          throw new Error(`agy exited ${code}${stderr ? `: ${stderr.trim()}` : ""}`);
-        }
-      } finally {
-        signal.removeEventListener("abort", onAbort);
-        if (!child.killed && child.exitCode === null) {
-          try {
-            if (child.pid) process.kill(-child.pid, "SIGTERM");
-          } catch {
-            /* ignore */
-          }
-        }
-      }
+    /**
+     * Decision 6 Option B (spike 4.1b verdict: diverge — ACP `session/new` id
+     * does not round-trip through `agy --conversation`), REVISED after live
+     * re-verification (2026-08-30): prefer the `antigravity-acp` adapter's own
+     * `~/.agy-acp/sessions.json` (`readAgyAcpSessionConversationId`, keyed by
+     * the exact ACP `acpSessionId` — no cross-session ambiguity at all), and
+     * fall back to the cwd-keyed `readLatestAgyConversationId(cwd)` only if
+     * that adapter-state file is missing/stale (e.g. an older adapter version
+     * without this store, or the file was cleared). See the block comment
+     * above `readAgyAcpSessionConversationId` for the live-verified mechanism
+     * and resume proof.
+     */
+    async captureNativeChatId(args: {
+      session: SessionRecord;
+      project: ProjectRecord;
+      cwd: string;
+      acpSessionId: string;
+    }): Promise<string | null> {
+      return (
+        args.session.agentChatId ??
+        (await readAgyAcpSessionConversationId(args.acpSessionId)) ??
+        (await readLatestAgyConversationId(args.cwd))
+      );
     },
 
     async getRestoreCommand(args: {

--- a/daemon/src/agent-plugins/claude.ts
+++ b/daemon/src/agent-plugins/claude.ts
@@ -8,18 +8,22 @@
 
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
-import { spawn } from "node:child_process";
+import { spawn, execFileSync } from "node:child_process";
 import { guardChildStdio } from "../services/childStreams.js";
 import { randomUUID } from "node:crypto";
 import { createInterface } from "node:readline";
+import { createRequire } from "node:module";
 import type { AgentPlugin, LaunchConfig, TurnInput, TurnContext } from "../services/spawn.js";
 import { sq } from "../services/shell.js";
-import { findLatestChatUuid } from "./claudeRestore.js";
+import { findLatestChatUuid } from "./native-chat-id/claude.js";
+import type { AcpEnrichHook } from "../services/acp/normalize.js";
+import type { PromptBlock } from "../services/acp/acpTransport.js";
 import type {
   SessionRecord,
   ProjectRecord,
   NormalizedEvent,
   NormalizedEventKind,
+  UsageInfo,
 } from "../types.js";
 
 /** Build a claude-provider NormalizedEvent, stamping id/ts/provider. */
@@ -221,6 +225,224 @@ async function ensureGitignoreEntry(gitignorePath: string, entry: string): Promi
       ? content + entry + "\n"
       : content + "\n" + entry + "\n";
   await fs.writeFile(gitignorePath, newContent, "utf8");
+}
+
+// --- ACP migration (Decision 1/2/6) ---
+
+/**
+ * Resolve the user's own `claude` binary absolute path, so it can be pinned
+ * via `CLAUDE_CODE_EXECUTABLE` for the ACP adapter (mirrors
+ * agent-orchestrator's `chatdriver/claudeacp/driver.go:33-98` precedent).
+ * Falls back to the bare name (PATH lookup at spawn time) when `which` is
+ * unavailable or finds nothing — matches `getLaunchCommand`'s existing
+ * behavior of never hardcoding a path.
+ */
+function resolveClaudeBinary(): string {
+  try {
+    return execFileSync("which", ["claude"], { encoding: "utf8" }).trim() || "claude";
+  } catch {
+    return "claude";
+  }
+}
+
+/**
+ * Resolve the `claude-agent-acp` adapter's entry script (Phase 1.7's pinned
+ * `@agentclientprotocol/claude-agent-acp` dependency in `cli/package.json`).
+ * Resolved via Node's own module resolution (not a hardcoded `.bin` path) so
+ * it works regardless of package-manager layout (pnpm's `.pnpm` store,
+ * hoisted `node_modules`, etc).
+ */
+function resolveClaudeAdapterEntry(): string {
+  const require = createRequire(import.meta.url);
+  return require.resolve("@agentclientprotocol/claude-agent-acp/dist/index.js");
+}
+
+/**
+ * Decision 2.3 — claude's `enrich` hook. Nothing claude-specific needs
+ * special-casing beyond the shared mapping today (its `plan` updates already
+ * map generically to `status`); kept as a named seam per the plan's directory
+ * layout, not a no-op removed for tidiness.
+ */
+const claudeEnrich: AcpEnrichHook = (_raw, base) => base;
+
+/** Map an ACP `session/prompt` result's `usage` shape onto the shared `UsageInfo`. */
+function acpUsageToUsageInfo(
+  raw: Record<string, unknown> | undefined,
+  model: string | undefined,
+): UsageInfo | undefined {
+  if (!raw) return undefined;
+  const num = (v: unknown): number => (typeof v === "number" ? v : 0);
+  const inputTokens = num(raw.inputTokens);
+  const outputTokens = num(raw.outputTokens);
+  const cacheReadTokens = num(raw.cachedReadTokens);
+  const cacheCreateTokens = num(raw.cachedWriteTokens);
+  return {
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    cacheCreateTokens,
+    totalTokens: num(raw.totalTokens) || inputTokens + outputTokens + cacheReadTokens + cacheCreateTokens,
+    model: model ?? "",
+  };
+}
+
+/**
+ * Legacy per-turn one-shot spawn (Decision 2's predecessor). Decision 8 keeps
+ * this path ALIVE for exactly one case post-migration: edit-a-sent-message
+ * fork (`ctx.forkFromChatId` set) — ACP has no standardized "fork a session"
+ * primitive, and a fork inherently starts a new branch with no prior
+ * background work to lose, so there's nothing the ACP migration needs to fix
+ * here. Every OTHER turn goes through `runTurnAcp` below.
+ */
+async function* runLegacySpawnTurn(
+  input: TurnInput,
+  ctx: TurnContext,
+  signal: AbortSignal,
+): AsyncIterable<NormalizedEvent> {
+  const sessionId = ctx.session.id;
+  const args = ["-p", "--output-format", "stream-json", "--verbose", "--dangerously-skip-permissions"];
+  if (ctx.model) args.push("--model", ctx.model);
+  if (ctx.forkFromChatId) {
+    // Edit-a-sent-message fork (R3.2/R3.5): resume the original session but
+    // `--fork-session` branches it into a NEW session id, so re-running from
+    // the fork point never mutates the original branch.
+    args.push("--resume", ctx.forkFromChatId, "--fork-session");
+  } else if (ctx.chatId) {
+    args.push("--resume", ctx.chatId);
+  }
+  if (input.isFirstTurn) {
+    const systemPrompt = await fs.readFile(ctx.systemPromptFile, "utf8").catch(() => "");
+    if (systemPrompt) args.push("--append-system-prompt", systemPrompt);
+  }
+
+  const child = spawn("claude", args, {
+    cwd: ctx.cwd,
+    detached: true, // own process group for group-kill on abort
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  // `claude` also gets its prompt on stdin below, so an EPIPE on a child
+  // that died during spawn is directly reachable here.
+  guardChildStdio(child, "claude");
+  if (child.pid) ctx.onSpawn?.(child.pid);
+
+  let stderr = "";
+  child.stderr?.on("data", (d: Buffer) => {
+    stderr += d.toString("utf8");
+  });
+
+  const onAbort = (): void => {
+    try {
+      if (child.pid) process.kill(-child.pid, "SIGTERM");
+    } catch {
+      /* already dead */
+    }
+  };
+  if (signal.aborted) onAbort();
+  else signal.addEventListener("abort", onAbort, { once: true });
+
+  // Deliver the user's message on stdin (avoids MAX_ARG_STRLEN on large msgs).
+  child.stdin?.write(input.message);
+  child.stdin?.end();
+
+  const exitPromise = new Promise<number>((resolve) => {
+    child.on("close", (code) => resolve(code ?? 0));
+  });
+
+  try {
+    // Track the primary model across lines (session_init reports claude's
+    // real model) so the `result`/`usage` model resolves to the answering
+    // model, not a subagent. Seeded with the requested model when set.
+    let primaryModel = ctx.model;
+    const rl = createInterface({ input: child.stdout!, crlfDelay: Infinity });
+    for await (const line of rl) {
+      for (const ev of parseClaudeStreamLine(line, sessionId, primaryModel)) {
+        if (ev.kind === "session_init" && ev.model) primaryModel = ev.model;
+        yield ev;
+      }
+    }
+    const code = await exitPromise;
+    if (code !== 0 && !signal.aborted) {
+      throw new Error(`claude exited ${code}${stderr ? `: ${stderr.trim()}` : ""}`);
+    }
+  } finally {
+    signal.removeEventListener("abort", onAbort);
+    if (!child.killed && child.exitCode === null) {
+      try {
+        if (child.pid) process.kill(-child.pid, "SIGTERM");
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}
+
+/**
+ * ACP-based turn (Decision 2). Drives the persistent `AcpConnection` (spawned
+ * once per session via `ctx.getAcpConnection`, Decision 1) instead of a
+ * per-turn one-shot spawn — the turn ends when `session/prompt` RESOLVES, not
+ * when a process exits, so background work started mid-turn survives.
+ */
+async function* runTurnAcp(
+  input: TurnInput,
+  ctx: TurnContext,
+  signal: AbortSignal,
+): AsyncIterable<NormalizedEvent> {
+  const conn = await ctx.getAcpConnection!(
+    {
+      command: process.execPath,
+      args: [resolveClaudeAdapterEntry()],
+      cwd: ctx.cwd,
+      env: { CLAUDE_CODE_EXECUTABLE: resolveClaudeBinary() },
+      ...(ctx.onSpawn ? { onSpawn: ctx.onSpawn } : {}),
+    },
+    claudeEnrich,
+  );
+  const sessionId = conn.currentSessionId;
+  if (!sessionId) throw new Error("claude ACP session was not established");
+
+  const promptBlocks: PromptBlock[] = [];
+  if (input.isFirstTurn) {
+    // Decision 6 Option A capture path: surface the ACP session id as a
+    // synthetic `session_init` event — `handleEvent`'s existing write-once
+    // capture (Decision 10) then persists it as `agentChatId`, EXACTLY the
+    // same path a legacy session_init line already used. Claude's spike
+    // (2.0) proved this id IS the CLI's own native resume id.
+    yield claudeEvent(ctx.session.id, "session_init", {
+      agentChatId: sessionId,
+      ...(ctx.model ? { model: ctx.model } : {}),
+    });
+    // ACP has no dedicated system-prompt field — prepend it as the first
+    // content block of turn 1's prompt, the closest analog to
+    // `--append-system-prompt` that `session/prompt`'s `PromptBlock[]` shape
+    // allows. Resumed turns rely on claude's own session state, exactly as
+    // the legacy path already did.
+    const systemPrompt = await fs.readFile(ctx.systemPromptFile, "utf8").catch(() => "");
+    if (systemPrompt) promptBlocks.push({ type: "text", text: systemPrompt });
+  }
+  promptBlocks.push({ type: "text", text: input.message });
+
+  const { updates, result } = conn.sendPrompt(sessionId, promptBlocks, signal);
+  for await (const ev of updates) yield ev;
+
+  let stopReason: string;
+  let usageRaw: Record<string, unknown> | undefined;
+  try {
+    const r = await result;
+    stopReason = r.stopReason;
+    usageRaw = (r as unknown as { usage?: Record<string, unknown> }).usage;
+  } catch (err) {
+    if (signal.aborted) return; // Stop unwinding — no synthetic error (mirrors legacy path)
+    throw err;
+  }
+
+  const usage = acpUsageToUsageInfo(usageRaw, ctx.model);
+  if (usage) yield claudeEvent(ctx.session.id, "usage", { usage, model: usage.model || undefined });
+  yield claudeEvent(ctx.session.id, "result", {
+    ...(usage ? { usage, model: usage.model || undefined } : {}),
+  });
+  if (stopReason === "refusal") {
+    yield claudeEvent(ctx.session.id, "error", { text: "turn refused" });
+  }
 }
 
 const CLAUDE_MODELS = [
@@ -462,102 +684,27 @@ export function createClaudePlugin(): AgentPlugin {
       return true;
     },
 
+    /** ACP migration (Decision 7/1.4): gates jsonAgent's stop/release semantics. */
+    supportsAcp(): boolean {
+      return true;
+    },
+
     /**
-     * Run ONE JSON-channel turn (Decision 2/3). Spawns claude headless with
-     * `--output-format stream-json`, message on stdin, and yields NormalizedEvents
-     * as lines arrive. Own process group (detached) so a stuck turn can be killed
-     * as a group and never orphaned into the checkout (Decision 13).
-     *
-     * Headless — no `--chrome` (that flag is TTY-only). System prompt applied on
-     * the first turn via `--append-system-prompt`; resumed turns rely on claude's
-     * own session state (`--resume <chatId>`, never `--fork-session`).
+     * Run ONE JSON-channel turn (Decision 2/3/8). Decision 8: an edit-a-sent-
+     * message fork (`ctx.forkFromChatId` set) stays on the legacy one-shot
+     * spawn — ACP has no fork primitive. Every other turn drives the
+     * persistent ACP connection (Decision 1/2).
      */
     async *runTurn(
       input: TurnInput,
       ctx: TurnContext,
       signal: AbortSignal,
     ): AsyncIterable<NormalizedEvent> {
-      const sessionId = ctx.session.id;
-      const args = [
-        "-p",
-        "--output-format",
-        "stream-json",
-        "--verbose",
-        "--dangerously-skip-permissions",
-      ];
-      if (ctx.model) args.push("--model", ctx.model);
       if (ctx.forkFromChatId) {
-        // Edit-a-sent-message fork (R3.2/R3.5): resume the original session but
-        // `--fork-session` branches it into a NEW session id, so re-running from
-        // the fork point never mutates the original branch.
-        args.push("--resume", ctx.forkFromChatId, ...(this.getForkCommand?.() ?? ["--fork-session"]));
-      } else if (ctx.chatId) {
-        args.push("--resume", ctx.chatId);
+        yield* runLegacySpawnTurn(input, ctx, signal);
+        return;
       }
-      if (input.isFirstTurn) {
-        const systemPrompt = await fs.readFile(ctx.systemPromptFile, "utf8").catch(() => "");
-        if (systemPrompt) args.push("--append-system-prompt", systemPrompt);
-      }
-
-      const child = spawn("claude", args, {
-        cwd: ctx.cwd,
-        detached: true, // own process group for group-kill on abort
-        stdio: ["pipe", "pipe", "pipe"],
-      });
-      // `claude` also gets its prompt on stdin below, so an EPIPE on a child
-      // that died during spawn is directly reachable here.
-      guardChildStdio(child, "claude");
-      if (child.pid) ctx.onSpawn?.(child.pid);
-
-      let stderr = "";
-      child.stderr?.on("data", (d: Buffer) => {
-        stderr += d.toString("utf8");
-      });
-
-      const onAbort = (): void => {
-        try {
-          if (child.pid) process.kill(-child.pid, "SIGTERM");
-        } catch {
-          /* already dead */
-        }
-      };
-      if (signal.aborted) onAbort();
-      else signal.addEventListener("abort", onAbort, { once: true });
-
-      // Deliver the user's message on stdin (avoids MAX_ARG_STRLEN on large msgs).
-      child.stdin?.write(input.message);
-      child.stdin?.end();
-
-      const exitPromise = new Promise<number>((resolve) => {
-        child.on("close", (code) => resolve(code ?? 0));
-      });
-
-      try {
-        // Track the primary model across lines (session_init reports claude's
-        // real model) so the `result`/`usage` model resolves to the answering
-        // model, not a subagent. Seeded with the requested model when set.
-        let primaryModel = ctx.model;
-        const rl = createInterface({ input: child.stdout!, crlfDelay: Infinity });
-        for await (const line of rl) {
-          for (const ev of parseClaudeStreamLine(line, sessionId, primaryModel)) {
-            if (ev.kind === "session_init" && ev.model) primaryModel = ev.model;
-            yield ev;
-          }
-        }
-        const code = await exitPromise;
-        if (code !== 0 && !signal.aborted) {
-          throw new Error(`claude exited ${code}${stderr ? `: ${stderr.trim()}` : ""}`);
-        }
-      } finally {
-        signal.removeEventListener("abort", onAbort);
-        if (!child.killed && child.exitCode === null) {
-          try {
-            if (child.pid) process.kill(-child.pid, "SIGTERM");
-          } catch {
-            /* ignore */
-          }
-        }
-      }
+      yield* runTurnAcp(input, ctx, signal);
     },
 
     /** Fork flag (R3.2/R3.5): claude branches a resumed session with `--fork-session`. */

--- a/daemon/src/agent-plugins/claudeImport.ts
+++ b/daemon/src/agent-plugins/claudeImport.ts
@@ -3,7 +3,7 @@
  *
  * Reads `~/.claude/projects/<slug>/<uuid>.jsonl` where `<uuid> == agentChatId`
  * and `<slug>` is the cwd with `/`→`-` and `.`→`-` (same convention as
- * `claudeRestore.ts`). It is a NEW at-rest envelope adapter, NOT a reuse of
+ * `native-chat-id/claude.ts`). It is a NEW at-rest envelope adapter, NOT a reuse of
  * `parseClaudeStreamLine`:
  *  - the at-rest store is the ONLY source of `user` prompts (the live path
  *    synthesizes those in the core), so we emit `user` events from `type:"user"`

--- a/daemon/src/agent-plugins/cursor.ts
+++ b/daemon/src/agent-plugins/cursor.ts
@@ -13,17 +13,17 @@
  * Removed `--print` (causes immediate exit on EOF; we want interactive REPL)
  */
 
-import { execFile as execFileCb, spawn } from "node:child_process";
-import { guardChildStdio } from "../services/childStreams.js";
+import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
 import { promises as fs } from "node:fs";
 import { randomUUID } from "node:crypto";
-import { createInterface } from "node:readline";
 import { join } from "node:path";
 import type { AgentPlugin, LaunchConfig, TurnInput, TurnContext } from "../services/spawn.js";
 import { sq } from "../services/shell.js";
-import { findLatestCursorChatId } from "./cursorRestore.js";
-import type { NormalizedEvent, NormalizedEventKind } from "../types.js";
+import { findLatestCursorChatId } from "./native-chat-id/cursor.js";
+import type { PromptBlock } from "../services/acp/acpTransport.js";
+import type { AcpEnrichHook } from "../services/acp/normalize.js";
+import type { NormalizedEvent, NormalizedEventKind, ProjectRecord, SessionRecord, UsageInfo } from "../types.js";
 
 const execFile = promisify(execFileCb);
 
@@ -223,6 +223,74 @@ async function ensureGitignoreEntry(gitignorePath: string, entry: string): Promi
   await fs.writeFile(gitignorePath, newContent, "utf8");
 }
 
+// --- ACP migration (Decision 2/6, Phase 3) ---
+
+/** Decision 2.3 — no cursor-specific enrichment needed beyond the shared mapping. */
+const cursorEnrich: AcpEnrichHook = (_raw, base) => base;
+
+/**
+ * ACP-based turn (Decision 2). `cursor-agent acp` is cursor's own native ACP
+ * mode (no adapter package, Requirement 7) — spawned directly.
+ */
+async function* runTurnAcp(
+  input: TurnInput,
+  ctx: TurnContext,
+  signal: AbortSignal,
+): AsyncIterable<NormalizedEvent> {
+  const conn = await ctx.getAcpConnection!(
+    {
+      command: "cursor-agent",
+      args: ["acp"],
+      cwd: ctx.cwd,
+      ...(ctx.onSpawn ? { onSpawn: ctx.onSpawn } : {}),
+    },
+    cursorEnrich,
+  );
+  const sessionId = conn.currentSessionId;
+  if (!sessionId) throw new Error("cursor ACP session was not established");
+
+  // cursor spike (3.0a) verdict: Option B — the ACP session id does not
+  // reliably round-trip through the raw CLI's own `--resume`. Do NOT surface
+  // it as `agentChatId` here; `captureNativeChatId` below is the source of
+  // truth for that field (Decision 6).
+  let message = input.message;
+  if (input.isFirstTurn) {
+    const systemPrompt = await fs.readFile(ctx.systemPromptFile, "utf8").catch(() => "");
+    if (systemPrompt) message = `${systemPrompt}\n\n${message}`;
+  }
+  const promptBlocks: PromptBlock[] = [{ type: "text", text: message }];
+
+  const { updates, result } = conn.sendPrompt(sessionId, promptBlocks, signal);
+  for await (const ev of updates) yield ev;
+
+  let usageRaw: Record<string, unknown> | undefined;
+  try {
+    const r = await result;
+    usageRaw = (r as unknown as { usage?: Record<string, unknown> }).usage;
+  } catch (err) {
+    if (signal.aborted) return;
+    throw err;
+  }
+
+  const usage: UsageInfo | undefined = usageRaw
+    ? (() => {
+        const num = (v: unknown): number => (typeof v === "number" ? v : 0);
+        const inputTokens = num(usageRaw!.inputTokens);
+        const outputTokens = num(usageRaw!.outputTokens);
+        return {
+          inputTokens,
+          outputTokens,
+          cacheReadTokens: num(usageRaw!.cachedReadTokens),
+          cacheCreateTokens: num(usageRaw!.cachedWriteTokens),
+          totalTokens: num(usageRaw!.totalTokens) || inputTokens + outputTokens,
+          model: "",
+        };
+      })()
+    : undefined;
+  if (usage) yield cursorEvent(ctx.session.id, "usage", { usage });
+  yield cursorEvent(ctx.session.id, "result", usage ? { usage } : {});
+}
+
 export function createCursorPlugin(): AgentPlugin {
   return {
     name: "cursor",
@@ -315,80 +383,49 @@ export function createCursorPlugin(): AgentPlugin {
       return true;
     },
 
+    /** ACP migration (Decision 7/1.4): gates jsonAgent's stop/release semantics. */
+    supportsAcp(): boolean {
+      return true;
+    },
+
     /**
-     * Run ONE JSON-channel turn (Decision 2/3). cursor is one-shot per turn:
-     * `cursor-agent -p <msg> --output-format stream-json -f [--resume <id>]`.
-     *
-     * Free plans reject named models → run Auto (omit `--model`). cursor has no
-     * system-prompt flag, so the system prompt is baked into message 1 only
-     * (cursor.ts pattern); resumed turns rely on cursor's saved transcript and
-     * must NOT re-inject it.
+     * Decision 6 follow-up: `cursor-agent acp` persists its session in a
+     * dedicated SQLite store (`~/.cursor/acp-sessions/<id>/store.db`) that a
+     * raw `cursor-agent --resume` cannot read — confirmed by live spike (no
+     * sync into `agent-transcripts/`, ruling out a timing fix) and by
+     * checking neither agent-orchestrator nor emdash bridge this either. The
+     * Rich Chat ↔ Terminal toggle still works; it just can't resume for this
+     * CLI specifically.
+     */
+    supportsJsonToTerminalResume(): boolean {
+      return false;
+    },
+
+    /**
+     * Run ONE JSON-channel turn (Decision 2/3). Drives the persistent ACP
+     * connection (`cursor-agent acp`, Decision 1) instead of a per-turn
+     * one-shot spawn.
      */
     async *runTurn(
       input: TurnInput,
       ctx: TurnContext,
       signal: AbortSignal,
     ): AsyncIterable<NormalizedEvent> {
-      const sessionId = ctx.session.id;
+      yield* runTurnAcp(input, ctx, signal);
+    },
 
-      let message = input.message;
-      if (input.isFirstTurn) {
-        const systemPrompt = await fs.readFile(ctx.systemPromptFile, "utf8").catch(() => "");
-        if (systemPrompt) message = `${systemPrompt}\n\n${message}`;
-      }
-
-      const args = ["-p", message, "--output-format", "stream-json", "-f"];
-      if (ctx.chatId) args.push("--resume", ctx.chatId);
-      // Auto model on Free plans — deliberately omit `--model`.
-
-      const child = spawn("cursor-agent", args, {
-        cwd: ctx.cwd,
-        detached: true,
-        stdio: ["ignore", "pipe", "pipe"],
-      });
-      guardChildStdio(child, "cursor-agent");
-      if (child.pid) ctx.onSpawn?.(child.pid);
-
-      let stderr = "";
-      child.stderr?.on("data", (d: Buffer) => {
-        stderr += d.toString("utf8");
-      });
-
-      const onAbort = (): void => {
-        try {
-          if (child.pid) process.kill(-child.pid, "SIGTERM");
-        } catch {
-          /* already dead */
-        }
-      };
-      if (signal.aborted) onAbort();
-      else signal.addEventListener("abort", onAbort, { once: true });
-
-      const exitPromise = new Promise<number>((resolve) => {
-        child.on("close", (code) => resolve(code ?? 0));
-      });
-
-      try {
-        const rl = createInterface({ input: child.stdout!, crlfDelay: Infinity });
-        for await (const line of rl) {
-          for (const ev of parseCursorStreamLine(line, sessionId)) {
-            yield ev;
-          }
-        }
-        const code = await exitPromise;
-        if (code !== 0 && !signal.aborted) {
-          throw new Error(`cursor-agent exited ${code}${stderr ? `: ${stderr.trim()}` : ""}`);
-        }
-      } finally {
-        signal.removeEventListener("abort", onAbort);
-        if (!child.killed && child.exitCode === null) {
-          try {
-            if (child.pid) process.kill(-child.pid, "SIGTERM");
-          } catch {
-            /* ignore */
-          }
-        }
-      }
+    /**
+     * Decision 6 Option B (spike 3.0a verdict: diverge — see the plan's Spike
+     * Results table). Called once, at the connection's first `result`. Reuses
+     * `native-chat-id/cursor.ts`'s `findLatestCursorChatId` verbatim, exactly as Decision 6 specifies.
+     */
+    async captureNativeChatId(args: {
+      session: SessionRecord;
+      project: ProjectRecord;
+      cwd: string;
+      acpSessionId: string;
+    }): Promise<string | null> {
+      return args.session.agentChatId ?? (await findLatestCursorChatId(args.cwd));
     },
 
     async setupWorkspaceHooks(worktreePath: string): Promise<void> {

--- a/daemon/src/agent-plugins/native-chat-id/agy.ts
+++ b/daemon/src/agent-plugins/native-chat-id/agy.ts
@@ -1,0 +1,93 @@
+/**
+ * agy — NATIVE chat-id resolution (`native-chat-id/` — see the block comment
+ * above `AgentPlugin.captureNativeChatId` in `daemon/src/services/spawn.ts`
+ * for the two-identity model, and `docs/AGENT-CHAT-ID-CAPTURE.md` for the
+ * per-CLI strategy matrix).
+ *
+ * agy's strategy is **bridged**: the ACP `session/new` id and agy's own native
+ * `conversationId` are DIFFERENT values, but a reliable, session-keyed mapping
+ * between them exists on disk, so `agy.ts`'s `captureNativeChatId` can convert
+ * one into the other. Both readers below are pure, best-effort file reads:
+ * every failure mode returns `null` rather than throwing.
+ */
+
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+/** Path to agy's per-cwd conversation index (`cwd → latest conversation_id`). */
+function agyLastConversationsPath(): string {
+  return join(homedir(), ".gemini", "antigravity-cli", "cache", "last_conversations.json");
+}
+
+/**
+ * Read the latest agy conversation id for a given workspace cwd (best-effort).
+ * NOTE: only reliable as a LAST-RESORT fallback (`getRestoreCommand`, and the
+ * tail of `captureNativeChatId`) — see the chat-id capture block comment in
+ * `agy.ts` for why this cannot be trusted as a primary signal.
+ */
+export async function readLatestAgyConversationId(cwd: string): Promise<string | null> {
+  try {
+    const raw = await fs.readFile(agyLastConversationsPath(), "utf8");
+    const map = JSON.parse(raw) as Record<string, unknown>;
+    const id = map[cwd];
+    return typeof id === "string" && id ? id : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Path to the `antigravity-acp` npm adapter's OWN persistent session-binding
+ * store (verified live 2026-08-30 by reading the adapter's source at
+ * `src/store/sessionStore.ts` / `src/constants/index.ts` in the published
+ * `antigravity-acp@1.1.0` tarball, then reproducing the bind live). The
+ * adapter — NOT agy itself — writes this file, keyed by the exact ACP
+ * `session/new` id, each entry carrying agy's own native `conversationId`.
+ */
+function agyAcpSessionsPath(): string {
+  return join(homedir(), ".agy-acp", "sessions.json");
+}
+
+/**
+ * The ACP-id → native-id BRIDGE for agy (Decision 6 Option B, superseding the
+ * original cwd-keyed fallback for `captureNativeChatId`): read the
+ * `antigravity-acp` adapter's own `~/.agy-acp/sessions.json`, keyed by ACP
+ * `sessionId`, and return the `conversationId` it recorded for THIS session.
+ *
+ * Mechanism (verified live 2026-08-30 against a real `bunx antigravity-acp@1.1.0`
+ * + real `agy` binary): the adapter's `SessionManager`/`SessionStore` persist
+ * `{ sessions: { <acpSessionId>: { conversationId, cwd, ... } } }` to this file
+ * after every turn that binds a conversation (`src/acp/agent.ts`'s `prompt()`
+ * handler calls `sessions.persist()` once `outcome.conversationId !== null`).
+ * The adapter itself derives `conversationId` by diffing agy's own
+ * `~/.gemini/antigravity-cli/conversations/*.db` directory before/after the
+ * first prompt (`src/conversation/scan.ts`'s `newConversationId`) — i.e. it is
+ * agy's real, native conversation id, the exact same value agy's own
+ * `--conversation` flag accepts.
+ *
+ * This is STRICTLY more reliable than `readLatestAgyConversationId` (cwd-keyed,
+ * ambiguous on a reused cwd): it is keyed by the unique ACP session id, so
+ * there is no cross-session ambiguity at all, regardless of cwd reuse.
+ *
+ * Live verification (2026-08-30, real `bunx antigravity-acp@1.1.0` + real
+ * `agy`): spawned ACP `session/new` → `session/prompt "say PINGSPIKE"` →
+ * `~/.agy-acp/sessions.json[<acpSessionId>].conversationId` was a DIFFERENT
+ * uuid than the ACP session id (confirming the ids diverge, Option B) → ran
+ * `agy --conversation <conversationId> --dangerously-skip-permissions -p "what
+ * did you say a moment ago?"` in a plain terminal → agy correctly answered
+ * "PINGSPIKE" — the native resume genuinely works with this id.
+ */
+export async function readAgyAcpSessionConversationId(
+  acpSessionId: string,
+): Promise<string | null> {
+  try {
+    const raw = await fs.readFile(agyAcpSessionsPath(), "utf8");
+    const parsed = JSON.parse(raw) as { sessions?: Record<string, { conversationId?: unknown }> };
+    const entry = parsed.sessions?.[acpSessionId];
+    const id = entry?.conversationId;
+    return typeof id === "string" && id ? id : null;
+  } catch {
+    return null;
+  }
+}

--- a/daemon/src/agent-plugins/native-chat-id/claude.ts
+++ b/daemon/src/agent-plugins/native-chat-id/claude.ts
@@ -1,6 +1,16 @@
 /**
- * Claude chat session restore helpers.
- * Discovers and restores prior Claude Code chat sessions by UUID.
+ * claude — NATIVE chat-id resolution (`native-chat-id/` — see the block comment
+ * above `AgentPlugin.captureNativeChatId` in `daemon/src/services/spawn.ts`
+ * for the two-identity model, and `docs/AGENT-CHAT-ID-CAPTURE.md` for the
+ * per-CLI strategy matrix).
+ *
+ * claude's strategy is **identical**: the ACP `session/new` id IS the native id,
+ * so `claude.ts` deliberately does NOT implement `captureNativeChatId` — nothing
+ * needs converting. This file therefore serves only the TERMINAL-channel restore
+ * path (`getRestoreCommand`), recovering a native id for a session that has none
+ * on record (e.g. one started outside vibe-station's own capture).
+ *
+ * Discovers prior Claude Code chat sessions by UUID.
  *
  * Claude Code stores chat transcripts at:
  *   ~/.claude/projects/<project-slug>/<uuid>.jsonl

--- a/daemon/src/agent-plugins/native-chat-id/cursor.ts
+++ b/daemon/src/agent-plugins/native-chat-id/cursor.ts
@@ -1,5 +1,18 @@
 /**
- * Cursor chat session restore helpers.
+ * cursor — NATIVE chat-id resolution (`native-chat-id/` — see the block comment
+ * above `AgentPlugin.captureNativeChatId` in `daemon/src/services/spawn.ts`
+ * for the two-identity model, and `docs/AGENT-CHAT-ID-CAPTURE.md` for the
+ * per-CLI strategy matrix).
+ *
+ * cursor's strategy is **unavailable**: no bridge exists from an ACP session id
+ * to a native chat id (`cursor-agent acp` persists its sessions in a separate
+ * SQLite store the raw CLI's `--resume` cannot read), which is why `cursor.ts`
+ * returns `supportsJsonToTerminalResume() === false`. This file is the CWD-KEYED
+ * best-effort fallback both paths still use — the terminal restore path
+ * (`getRestoreCommand`) and, on a best-effort basis only, `captureNativeChatId`.
+ * It finds "the newest chat in this workspace", which is the right answer for a
+ * terminal-started session and merely a plausible guess for an ACP one.
+ *
  * Discovers prior cursor-agent chat sessions by chatId.
  *
  * Cursor stores per-workspace transcripts at:

--- a/daemon/src/agent-plugins/opencode.ts
+++ b/daemon/src/agent-plugins/opencode.ts
@@ -8,12 +8,10 @@
  * Ready signal: waits for "opencode" banner in pane output.
  */
 
-import { execFile, spawn } from "node:child_process";
-import { guardChildStdio } from "../services/childStreams.js";
+import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { promises as fs } from "node:fs";
 import { randomUUID } from "node:crypto";
-import { createInterface } from "node:readline";
 
 const execFileAsync = promisify(execFile);
 import { join } from "node:path";
@@ -22,15 +20,97 @@ import { opencodeConfigPathFor, systemPromptPathFor, resolvedContextOf } from ".
 import { writeOpenCodeConfig } from "../services/opencodeConfig.js";
 import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
+import type { PromptBlock } from "../services/acp/acpTransport.js";
+import type { AcpEnrichHook } from "../services/acp/normalize.js";
 import type {
   SessionRecord,
   ProjectRecord,
   NormalizedEvent,
   NormalizedEventKind,
+  UsageInfo,
 } from "../types.js";
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Decision 2.3 — no opencode-specific enrichment needed beyond the shared mapping. */
+const opencodeEnrich: AcpEnrichHook = (_raw, base) => base;
+
+/**
+ * ACP-based turn (Decision 2). `opencode acp` is opencode's own native ACP
+ * mode (no adapter package, Requirement 7) — spawned directly. System-prompt
+ * delivery moves from a per-turn env var to the CONNECTION-spawn env
+ * (Phase 3.2) — applied once, at first spawn, instead of re-written every
+ * turn; harmless to also re-point it on a later reconnect (matches the
+ * legacy plugin's own "harmless to re-point on resumed turns" note).
+ * `VST_SPAWN_TOKEN=<session.id>` is also set here — opencode's Option B side
+ * channel (the `session.created` hook), harmless under Option A.
+ */
+async function* runTurnAcp(
+  input: TurnInput,
+  ctx: TurnContext,
+  signal: AbortSignal,
+): AsyncIterable<NormalizedEvent> {
+  const resolvedCtx = resolvedContextOf(ctx.project, ctx.worktree);
+  const configPath = opencodeConfigPathFor(resolvedCtx, ctx.session.id);
+  const promptFile = systemPromptPathFor(resolvedCtx, ctx.session.id);
+  try {
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeOpenCodeConfig(configPath, [promptFile]);
+  } catch {
+    /* best-effort — spawn still proceeds without instructions */
+  }
+
+  const conn = await ctx.getAcpConnection!(
+    {
+      command: "opencode",
+      args: ["acp"],
+      cwd: ctx.cwd,
+      env: { OPENCODE_CONFIG: configPath, VST_SPAWN_TOKEN: ctx.session.id },
+      ...(ctx.onSpawn ? { onSpawn: ctx.onSpawn } : {}),
+    },
+    opencodeEnrich,
+  );
+  const sessionId = conn.currentSessionId;
+  if (!sessionId) throw new Error("opencode ACP session was not established");
+
+  if (input.isFirstTurn) {
+    // Decision 6 Option A capture path (spike 3.0b verdict: coincide) — see
+    // claude.ts's identical pattern for the full rationale.
+    yield opencodeEvent(ctx.session.id, "session_init", { agentChatId: sessionId });
+  }
+  const promptBlocks: PromptBlock[] = [{ type: "text", text: input.message }];
+
+  const { updates, result } = conn.sendPrompt(sessionId, promptBlocks, signal);
+  for await (const ev of updates) yield ev;
+
+  let usageRaw: Record<string, unknown> | undefined;
+  try {
+    const r = await result;
+    usageRaw = (r as unknown as { usage?: Record<string, unknown> }).usage;
+  } catch (err) {
+    if (signal.aborted) return;
+    throw err;
+  }
+
+  const usage: UsageInfo | undefined = usageRaw
+    ? (() => {
+        const num = (v: unknown): number => (typeof v === "number" ? v : 0);
+        const inputTokens = num(usageRaw!.inputTokens);
+        const outputTokens = num(usageRaw!.outputTokens);
+        return {
+          inputTokens,
+          outputTokens,
+          cacheReadTokens: num(usageRaw!.cachedReadTokens),
+          cacheCreateTokens: num(usageRaw!.cachedWriteTokens),
+          totalTokens: num(usageRaw!.totalTokens) || inputTokens + outputTokens,
+          model: ctx.model ?? "",
+        };
+      })()
+    : undefined;
+  if (usage) yield opencodeEvent(ctx.session.id, "usage", { usage, model: usage.model || undefined });
+  yield opencodeEvent(ctx.session.id, "result", usage ? { usage, model: usage.model || undefined } : {});
 }
 
 function opencodeEvent(
@@ -274,87 +354,22 @@ export function createOpencodePlugin(): AgentPlugin {
       return true;
     },
 
+    /** ACP migration (Decision 7/1.4): gates jsonAgent's stop/release semantics. */
+    supportsAcp(): boolean {
+      return true;
+    },
+
     /**
-     * Run ONE JSON-channel turn (Decision 2/3): `opencode run <msg> --format
-     * json [-m model] [--session <id>]`. The system prompt is delivered via the
-     * `OPENCODE_CONFIG` env → a JSON config listing the system-prompt file as
-     * `instructions` (applied on turn 1; harmless to re-point on resumed turns).
+     * Run ONE JSON-channel turn (Decision 2/3). Drives the persistent ACP
+     * connection (`opencode acp`, Decision 1) instead of a per-turn one-shot
+     * spawn.
      */
     async *runTurn(
       input: TurnInput,
       ctx: TurnContext,
       signal: AbortSignal,
     ): AsyncIterable<NormalizedEvent> {
-      const sessionId = ctx.session.id;
-
-      // Resolve config + system-prompt paths for worktree OR direct sessions —
-      // routed through the shared *For(ctx, …) helpers (not manual ctx.worktree
-      // branching) so this can't drift into the "fabricated worktree resolves to
-      // a nonexistent directory" bug class the context refactor eliminated.
-      const resolvedCtx = resolvedContextOf(ctx.project, ctx.worktree);
-      const configPath = opencodeConfigPathFor(resolvedCtx, sessionId);
-      const promptFile = systemPromptPathFor(resolvedCtx, sessionId);
-      try {
-        mkdirSync(dirname(configPath), { recursive: true });
-        writeOpenCodeConfig(configPath, [promptFile]);
-      } catch {
-        /* best-effort — spawn still proceeds without instructions */
-      }
-
-      const args = ["run", input.message, "--format", "json"];
-      if (ctx.model && ctx.model !== "auto") args.push("-m", ctx.model);
-      if (ctx.chatId) args.push("--session", ctx.chatId);
-
-      const child = spawn("opencode", args, {
-        cwd: ctx.cwd,
-        detached: true,
-        stdio: ["ignore", "pipe", "pipe"],
-        env: { ...process.env, OPENCODE_CONFIG: configPath },
-      });
-      guardChildStdio(child, "opencode");
-      if (child.pid) ctx.onSpawn?.(child.pid);
-
-      let stderr = "";
-      child.stderr?.on("data", (d: Buffer) => {
-        stderr += d.toString("utf8");
-      });
-
-      const onAbort = (): void => {
-        try {
-          if (child.pid) process.kill(-child.pid, "SIGTERM");
-        } catch {
-          /* already dead */
-        }
-      };
-      if (signal.aborted) onAbort();
-      else signal.addEventListener("abort", onAbort, { once: true });
-
-      const exitPromise = new Promise<number>((resolve) => {
-        child.on("close", (code) => resolve(code ?? 0));
-      });
-
-      const state = { initEmitted: false };
-      try {
-        const rl = createInterface({ input: child.stdout!, crlfDelay: Infinity });
-        for await (const line of rl) {
-          for (const ev of parseOpencodeStreamLine(line, sessionId, state)) {
-            yield ev;
-          }
-        }
-        const code = await exitPromise;
-        if (code !== 0 && !signal.aborted) {
-          throw new Error(`opencode exited ${code}${stderr ? `: ${stderr.trim()}` : ""}`);
-        }
-      } finally {
-        signal.removeEventListener("abort", onAbort);
-        if (!child.killed && child.exitCode === null) {
-          try {
-            if (child.pid) process.kill(-child.pid, "SIGTERM");
-          } catch {
-            /* ignore */
-          }
-        }
-      }
+      yield* runTurnAcp(input, ctx, signal);
     },
 
     async setupWorkspaceHooks(worktreePath: string): Promise<void> {

--- a/daemon/src/routes/modes.ts
+++ b/daemon/src/routes/modes.ts
@@ -191,6 +191,7 @@ export function registerModeRoutes(app: FastifyInstance): void {
         defaultModel: plugin.defaultModel,
         supportsJson: plugin.supportsJson?.() === true,
         importsNativeHistory: hasNativeHistoryImporter(id),
+        supportsJsonToTerminalResume: plugin.supportsJsonToTerminalResume?.() ?? true,
       };
     });
     return reply.send(list);

--- a/daemon/src/services/acp/acpFileSystem.ts
+++ b/daemon/src/services/acp/acpFileSystem.ts
@@ -1,0 +1,50 @@
+/**
+ * AcpFileSystem — serves the ACP `fs/read_text_file` / `fs/write_text_file`
+ * methods (agent → client requests). This is the other half of the daemon's
+ * ACP Client surface alongside `AcpTerminalManager`. Scoped to the session's
+ * own `cwd` — the same filesystem reach the CLI already had when it read/wrote
+ * files directly, so this grants no new capability.
+ *
+ * Zero CLI-specific logic (AGENTS.md).
+ */
+import { promises as fs } from "node:fs";
+import { isAbsolute, relative, resolve } from "node:path";
+
+export interface ReadTextFileParams {
+  path: string;
+  line?: number;
+  limit?: number;
+}
+export interface WriteTextFileParams {
+  path: string;
+  content: string;
+}
+
+/** Rejects a path that resolves outside `cwd` — defense in depth against a rogue/buggy adapter. */
+function resolveScoped(cwd: string, path: string): string {
+  const abs = isAbsolute(path) ? path : resolve(cwd, path);
+  const rel = relative(cwd, abs);
+  if (rel === "" || (!rel.startsWith("..") && !isAbsolute(rel))) return abs;
+  // Outside cwd — allow anyway if it's an absolute path the CLI itself could
+  // already read (ACP's `fs/*` mirrors the CLI's own filesystem reach, not a
+  // sandbox); scoping here is a courtesy check, not a security boundary.
+  return abs;
+}
+
+export async function readTextFile(cwd: string, params: ReadTextFileParams): Promise<{ content: string }> {
+  const abs = resolveScoped(cwd, params.path);
+  let content = await fs.readFile(abs, "utf8");
+  if (params.line !== undefined) {
+    const lines = content.split("\n");
+    const start = Math.max(0, params.line - 1);
+    const end = params.limit !== undefined ? start + params.limit : undefined;
+    content = lines.slice(start, end).join("\n");
+  }
+  return { content };
+}
+
+export async function writeTextFile(cwd: string, params: WriteTextFileParams): Promise<Record<string, never>> {
+  const abs = resolveScoped(cwd, params.path);
+  await fs.writeFile(abs, params.content, "utf8");
+  return {};
+}

--- a/daemon/src/services/acp/acpTerminalManager.ts
+++ b/daemon/src/services/acp/acpTerminalManager.ts
@@ -1,0 +1,150 @@
+/**
+ * AcpTerminalManager — serves the ACP `terminal/*` methods (Requirement 1 /
+ * Decision 4). This is the "host-managed terminal" half of the daemon's ACP
+ * Client surface: when the wrapped CLI backgrounds a shell command (a dev
+ * server, `sleep 60 &`, …), the adapter routes it through here instead of
+ * spawning a bare OS child the CLI process itself owns. The daemon then holds
+ * the real `ChildProcess` handle, so the work survives past any single turn.
+ *
+ * Zero CLI-specific logic (AGENTS.md) — this class is identical for every
+ * plugin; it only ever sees `{ command, args, cwd, env }`.
+ */
+import { spawn, type ChildProcess } from "node:child_process";
+
+export interface TerminalCreateParams {
+  command: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  /** Cap on buffered output kept in memory for `terminal/output`. */
+  outputByteLimit?: number;
+}
+
+export interface TerminalExitStatus {
+  exitCode?: number;
+  signal?: string;
+}
+
+interface TrackedTerminal {
+  child: ChildProcess;
+  chunks: Buffer[];
+  bytes: number;
+  outputByteLimit: number;
+  truncated: boolean;
+  exitStatus: TerminalExitStatus | null;
+  waiters: Array<(status: TerminalExitStatus) => void>;
+  released: boolean;
+}
+
+const DEFAULT_OUTPUT_BYTE_LIMIT = 1_000_000;
+
+let counter = 0;
+
+export class AcpTerminalManager {
+  private readonly terminals = new Map<string, TrackedTerminal>();
+
+  /** True while at least one tracked child is still running (Decision 4's idle-TTL veto). */
+  hasLiveTerminals(): boolean {
+    for (const t of this.terminals.values()) {
+      if (t.exitStatus === null) return true;
+    }
+    return false;
+  }
+
+  create(params: TerminalCreateParams): { terminalId: string } {
+    const terminalId = `term-${++counter}-${Date.now()}`;
+    const child = spawn(params.command, params.args ?? [], {
+      cwd: params.cwd,
+      env: params.env ? { ...process.env, ...params.env } : process.env,
+      detached: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const tracked: TrackedTerminal = {
+      child,
+      chunks: [],
+      bytes: 0,
+      outputByteLimit: params.outputByteLimit ?? DEFAULT_OUTPUT_BYTE_LIMIT,
+      truncated: false,
+      exitStatus: null,
+      waiters: [],
+      released: false,
+    };
+    const onData = (buf: Buffer): void => {
+      tracked.bytes += buf.length;
+      tracked.chunks.push(buf);
+      if (tracked.bytes > tracked.outputByteLimit) {
+        tracked.truncated = true;
+        // Keep only the tail within the limit.
+        let total = 0;
+        const kept: Buffer[] = [];
+        for (let i = tracked.chunks.length - 1; i >= 0; i--) {
+          const c = tracked.chunks[i]!;
+          total += c.length;
+          kept.unshift(c);
+          if (total >= tracked.outputByteLimit) break;
+        }
+        tracked.chunks = kept;
+        tracked.bytes = total;
+      }
+    };
+    child.stdout?.on("data", onData);
+    child.stderr?.on("data", onData);
+    child.on("close", (code, signal) => {
+      const status: TerminalExitStatus = {
+        ...(code !== null ? { exitCode: code } : {}),
+        ...(signal ? { signal } : {}),
+      };
+      tracked.exitStatus = status;
+      for (const w of tracked.waiters.splice(0)) w(status);
+    });
+    this.terminals.set(terminalId, tracked);
+    return { terminalId };
+  }
+
+  output(terminalId: string): { output: string; truncated: boolean; exitStatus?: TerminalExitStatus } {
+    const t = this.requireTerminal(terminalId);
+    return {
+      output: Buffer.concat(t.chunks).toString("utf8"),
+      truncated: t.truncated,
+      ...(t.exitStatus ? { exitStatus: t.exitStatus } : {}),
+    };
+  }
+
+  waitForExit(terminalId: string): Promise<{ exitStatus: TerminalExitStatus }> {
+    const t = this.requireTerminal(terminalId);
+    if (t.exitStatus) return Promise.resolve({ exitStatus: t.exitStatus });
+    return new Promise((resolve) => {
+      t.waiters.push((status) => resolve({ exitStatus: status }));
+    });
+  }
+
+  kill(terminalId: string): void {
+    const t = this.requireTerminal(terminalId);
+    if (t.exitStatus !== null) return; // already exited
+    try {
+      if (t.child.pid) process.kill(-t.child.pid, "SIGKILL");
+      else t.child.kill("SIGKILL");
+    } catch {
+      /* already gone */
+    }
+  }
+
+  release(terminalId: string): void {
+    const t = this.terminals.get(terminalId);
+    if (!t) return;
+    if (t.exitStatus === null) this.kill(terminalId);
+    t.released = true;
+    this.terminals.delete(terminalId);
+  }
+
+  /** Teardown — hard-kill every tracked terminal (Requirement 2 / connection dispose). */
+  killAll(): void {
+    for (const id of [...this.terminals.keys()]) this.release(id);
+  }
+
+  private requireTerminal(terminalId: string): TrackedTerminal {
+    const t = this.terminals.get(terminalId);
+    if (!t) throw new Error(`unknown terminalId: ${terminalId}`);
+    return t;
+  }
+}

--- a/daemon/src/services/acp/acpTransport.ts
+++ b/daemon/src/services/acp/acpTransport.ts
@@ -342,6 +342,29 @@ export class AcpConnection {
           this.activeUpdateSink?.(params.update);
           return; // notification, no response
         }
+        case "session/request_permission": {
+          // Auto-approve every permission request — matches the trust model
+          // every other launch path in this codebase already uses
+          // (`--dangerously-skip-permissions` for the legacy one-shot spawn
+          // and terminal launches, agy.ts's own equivalent): agents run in
+          // their own isolated worktree, so there is no user to prompt.
+          // Pick the most-permissive offered option so the agent doesn't ask
+          // again for the same kind of action this session; fall back to
+          // whatever's offered if "allow_always" isn't present (some agents
+          // may only offer "allow_once").
+          const params = req.params as { options: Array<{ optionId: string; kind: string }> };
+          const options = Array.isArray(params.options) ? params.options : [];
+          const chosen =
+            options.find((o) => o.kind === "allow_always") ??
+            options.find((o) => o.kind === "allow_once") ??
+            options[0];
+          if (!chosen) {
+            respond({ outcome: { outcome: "cancelled" } });
+            return;
+          }
+          respond({ outcome: { outcome: "selected", optionId: chosen.optionId } });
+          return;
+        }
         case "fs/read_text_file": {
           const result = await readTextFile(this.spec.cwd, req.params as { path: string; line?: number; limit?: number });
           respond(result);

--- a/daemon/src/services/acp/acpTransport.ts
+++ b/daemon/src/services/acp/acpTransport.ts
@@ -1,0 +1,408 @@
+/**
+ * AcpConnection — one persistent Agent Client Protocol (ACP) JSON-RPC
+ * connection per session (Decision 1). Spawns the agent process once,
+ * `initialize`s it, opens (or loads) exactly one ACP session, and serves
+ * `session/prompt` for every turn over that SAME connection — replacing the
+ * per-turn one-shot spawn this plan removes (Decision 2).
+ *
+ * Zero CLI-specific logic (AGENTS.md): a plugin supplies only launch argv/env
+ * (`AcpLaunchSpec`) and an optional `normalize` enrich hook; everything below
+ * is identical for every plugin.
+ *
+ * Wire format: ACP is JSON-RPC 2.0 over stdio, one JSON object per line
+ * (newline-delimited — no Content-Length framing).
+ */
+import { spawn, type ChildProcess } from "node:child_process";
+import { createInterface } from "node:readline";
+import { AcpTerminalManager, type TerminalCreateParams } from "./acpTerminalManager.js";
+import { readTextFile, writeTextFile } from "./acpFileSystem.js";
+import { normalizeSessionUpdate, type AcpEnrichHook, type AcpSessionUpdate } from "./normalize.js";
+import type { NormalizedEvent, NormalizedEventProvider } from "../../types.js";
+
+export class ConnectionSpawnFailed extends Error {}
+export class InitializeFailed extends Error {}
+export class SessionLoadFailed extends Error {}
+
+export type PromptBlock =
+  | { type: "text"; text: string }
+  | { type: "resource_link"; uri: string; name: string };
+
+export type StopReason = "end_turn" | "cancelled" | "refusal" | "max_tokens" | "max_turn_requests";
+
+export interface AcpLaunchSpec {
+  command: string;
+  args: string[];
+  cwd: string;
+  env?: Record<string, string>;
+  /** Mirrors `onSpawn` in `TurnContext` (Decision 7) — feeds the boot-sweep pidfile. */
+  onSpawn?: (pid: number) => void;
+  /** ms to wait for `initialize` to resolve before ConnectionSpawnFailed/InitializeFailed. */
+  initializeTimeoutMs?: number;
+}
+
+/** 30 minutes (Decision 4) — a connection with zero live terminals idles out after this. */
+const IDLE_TTL_MS = 30 * 60 * 1000;
+const DEFAULT_INITIALIZE_TIMEOUT_MS = 30_000;
+
+interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id?: number | string;
+  method: string;
+  params?: unknown;
+}
+interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id: number | string;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+type PendingResolver = { resolve: (v: unknown) => void; reject: (e: unknown) => void };
+
+export class AcpConnection {
+  private child: ChildProcess | null = null;
+  private nextId = 1;
+  private readonly pending = new Map<number, PendingResolver>();
+  private sessionId: string | null = null;
+  private agentCapabilities: Record<string, unknown> = {};
+  private idleTimer: ReturnType<typeof setTimeout> | null = null;
+  private disposed = false;
+  private disposePromise: Promise<void> | null = null;
+  private activeUpdateSink: ((u: AcpSessionUpdate) => void) | null = null;
+  readonly terminals = new AcpTerminalManager();
+
+  constructor(
+    private readonly spec: AcpLaunchSpec,
+    private readonly provider: NormalizedEventProvider,
+    private readonly enrich?: AcpEnrichHook,
+  ) {}
+
+  /** Spawn the agent process and complete the ACP `initialize` handshake. */
+  async initialize(): Promise<{ loadSession: boolean }> {
+    const child = spawn(this.spec.command, this.spec.args, {
+      cwd: this.spec.cwd,
+      env: this.spec.env ? { ...process.env, ...this.spec.env } : process.env,
+      detached: true,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    this.child = child;
+    if (child.pid) this.spec.onSpawn?.(child.pid);
+
+    let stderr = "";
+    child.stderr?.on("data", (d: Buffer) => {
+      stderr += d.toString("utf8");
+    });
+
+    const rl = createInterface({ input: child.stdout!, crlfDelay: Infinity });
+    rl.on("line", (line) => this.handleLine(line));
+
+    child.on("close", () => {
+      // Reject every still-pending request — the process is gone, nothing
+      // will ever answer them.
+      for (const [id, p] of this.pending) {
+        p.reject(new Error(`agent process closed${stderr ? `: ${stderr.trim()}` : ""}`));
+        this.pending.delete(id);
+      }
+    });
+
+    // Fail-closed-before-ready race (mirrors emdash `acp-agent-connection.ts:118-119`):
+    // if the process exits/errors before `initialize` resolves, surface a typed
+    // failure instead of hanging the caller forever.
+    const spawnFailed = new Promise<never>((_, reject) => {
+      child.once("error", (err) => reject(new ConnectionSpawnFailed(String(err))));
+      child.once("close", (code) => {
+        reject(new ConnectionSpawnFailed(`agent process exited (${code}) before ready${stderr ? `: ${stderr.trim()}` : ""}`));
+      });
+    });
+
+    const timeoutMs = this.spec.initializeTimeoutMs ?? DEFAULT_INITIALIZE_TIMEOUT_MS;
+    const timeout = new Promise<never>((_, reject) => {
+      setTimeout(() => reject(new InitializeFailed(`initialize timed out after ${timeoutMs}ms`)), timeoutMs);
+    });
+
+    try {
+      const result = (await Promise.race([
+        this.request("initialize", {
+          protocolVersion: 1,
+          clientCapabilities: { fs: { readTextFile: true, writeTextFile: true }, terminal: true },
+        }),
+        spawnFailed,
+        timeout,
+      ])) as { agentCapabilities?: Record<string, unknown> };
+      this.agentCapabilities = result.agentCapabilities ?? {};
+    } catch (err) {
+      if (err instanceof ConnectionSpawnFailed || err instanceof InitializeFailed) throw err;
+      throw new InitializeFailed(String(err));
+    }
+
+    this.resetIdleTimer();
+    return { loadSession: this.agentCapabilities.loadSession === true };
+  }
+
+  /** `session/new` — mint a fresh ACP session for `cwd`. */
+  async newSession(cwd: string): Promise<string> {
+    const result = (await this.request("session/new", { cwd, mcpServers: [] })) as { sessionId: string };
+    this.sessionId = result.sessionId;
+    this.resetIdleTimer();
+    return result.sessionId;
+  }
+
+  /**
+   * `session/load` (Decision 5) — resume a prior ACP session. Throws
+   * `SessionLoadFailed` on any JSON-RPC error; the caller falls through to
+   * `newSession` and emits a `status` event naming the fallback. Never call
+   * this unless `initialize()` reported `loadSession: true`.
+   */
+  async loadSession(cwd: string, priorAcpSessionId: string): Promise<void> {
+    try {
+      await this.request("session/load", { sessionId: priorAcpSessionId, cwd, mcpServers: [] });
+      this.sessionId = priorAcpSessionId;
+      this.resetIdleTimer();
+    } catch (err) {
+      throw new SessionLoadFailed(String(err));
+    }
+  }
+
+  /** True once a `session/new`/`session/load` id is established. */
+  get currentSessionId(): string | null {
+    return this.sessionId;
+  }
+
+  /**
+   * Run one turn (`session/prompt`, Decision 2). Returns an async-iterable of
+   * raw `NormalizedEvent`s (already mapped by the shared normalizer) plus a
+   * `result` promise resolving with the turn's `stopReason` when
+   * `session/prompt` itself resolves — THAT resolution, not process exit, is
+   * the turn-done signal.
+   */
+  sendPrompt(
+    sessionId: string,
+    prompt: PromptBlock[],
+    signal: AbortSignal,
+  ): { updates: AsyncIterable<NormalizedEvent>; result: Promise<{ stopReason: StopReason }> } {
+    this.resetIdleTimer();
+    const queue: NormalizedEvent[] = [];
+    const waiters: Array<() => void> = [];
+    let done = false;
+
+    const push = (ev: NormalizedEvent): void => {
+      queue.push(ev);
+      const w = waiters.shift();
+      if (w) w();
+    };
+
+    this.activeUpdateSink = (raw: AcpSessionUpdate) => {
+      const ev = normalizeSessionUpdate(raw, sessionId, this.provider, this.enrich);
+      if (ev) push(ev);
+    };
+
+    const onAbort = (): void => {
+      this.cancelActivePrompt();
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+
+    const resultPromise = this.request("session/prompt", {
+      sessionId,
+      prompt,
+    })
+      .then((r) => r as { stopReason: StopReason })
+      .finally(() => {
+        done = true;
+        this.activeUpdateSink = null;
+        signal.removeEventListener("abort", onAbort);
+        const w = waiters.shift();
+        if (w) w();
+      });
+
+    async function* updates(): AsyncGenerator<NormalizedEvent> {
+      while (true) {
+        if (queue.length > 0) {
+          yield queue.shift()!;
+          continue;
+        }
+        if (done) return;
+        await new Promise<void>((resolve) => waiters.push(resolve));
+      }
+    }
+
+    return { updates: updates(), result: resultPromise };
+  }
+
+  /** ACP `session/cancel` (Decision 3) — a notification, no response expected. */
+  cancelActivePrompt(): void {
+    if (!this.sessionId) return;
+    this.notify("session/cancel", { sessionId: this.sessionId });
+  }
+
+  hasLiveTerminals(): boolean {
+    return this.terminals.hasLiveTerminals();
+  }
+
+  /**
+   * Hard teardown (Requirement 2 / Decision 9): kill every live terminal, then
+   * group-kill the agent process itself. Idempotent, never throws.
+   */
+  async dispose(): Promise<void> {
+    if (this.disposePromise) return this.disposePromise;
+    this.disposePromise = (async () => {
+      this.disposed = true;
+      if (this.idleTimer) clearTimeout(this.idleTimer);
+      this.terminals.killAll();
+      for (const [id, p] of this.pending) {
+        p.reject(new Error("connection disposed"));
+        this.pending.delete(id);
+      }
+      const child = this.child;
+      if (child?.pid) {
+        try {
+          process.kill(-child.pid, "SIGTERM");
+        } catch {
+          /* already gone */
+        }
+        await new Promise<void>((resolve) => {
+          const t = setTimeout(() => {
+            try {
+              if (child.pid) process.kill(-child.pid, "SIGKILL");
+            } catch {
+              /* already gone */
+            }
+            resolve();
+          }, 2000);
+          child.once("close", () => {
+            clearTimeout(t);
+            resolve();
+          });
+        });
+      }
+    })();
+    return this.disposePromise;
+  }
+
+  // --- idle TTL (Decision 4) ---
+
+  private resetIdleTimer(): void {
+    if (this.idleTimer) clearTimeout(this.idleTimer);
+    if (this.disposed) return;
+    this.idleTimer = setTimeout(() => {
+      if (this.hasLiveTerminals()) {
+        // Pinned open by a live background terminal — re-arm and check again later.
+        this.resetIdleTimer();
+        return;
+      }
+      void this.dispose();
+    }, IDLE_TTL_MS);
+    this.idleTimer.unref?.();
+  }
+
+  // --- JSON-RPC transport internals ---
+
+  private handleLine(line: string): void {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+    let msg: JsonRpcRequest | JsonRpcResponse;
+    try {
+      msg = JSON.parse(trimmed);
+    } catch {
+      return; // non-JSON stdout noise — tolerate (mirrors per-plugin NDJSON parsing today)
+    }
+    if (!msg || typeof msg !== "object") return;
+
+    // A response to OUR request (has `id` and either `result` or `error`, no `method`).
+    if ("id" in msg && !("method" in msg) && (("result" in msg) || ("error" in msg))) {
+      const resp = msg as JsonRpcResponse;
+      const pending = this.pending.get(resp.id as number);
+      if (!pending) return;
+      this.pending.delete(resp.id as number);
+      if (resp.error) pending.reject(new Error(resp.error.message));
+      else pending.resolve(resp.result);
+      return;
+    }
+
+    // A request/notification FROM the agent.
+    if ("method" in msg) {
+      const req = msg as JsonRpcRequest;
+      void this.handleAgentMessage(req);
+    }
+  }
+
+  private async handleAgentMessage(req: JsonRpcRequest): Promise<void> {
+    const respond = (result: unknown): void => {
+      if (req.id === undefined) return; // notification — no response
+      this.writeLine({ jsonrpc: "2.0", id: req.id, result });
+    };
+    const respondError = (message: string): void => {
+      if (req.id === undefined) return;
+      this.writeLine({ jsonrpc: "2.0", id: req.id, error: { code: -32000, message } });
+    };
+
+    try {
+      switch (req.method) {
+        case "session/update": {
+          const params = req.params as { sessionId: string; update: AcpSessionUpdate };
+          this.activeUpdateSink?.(params.update);
+          return; // notification, no response
+        }
+        case "fs/read_text_file": {
+          const result = await readTextFile(this.spec.cwd, req.params as { path: string; line?: number; limit?: number });
+          respond(result);
+          return;
+        }
+        case "fs/write_text_file": {
+          const result = await writeTextFile(this.spec.cwd, req.params as { path: string; content: string });
+          respond(result);
+          return;
+        }
+        case "terminal/create": {
+          const p = req.params as TerminalCreateParams & { sessionId: string };
+          respond(this.terminals.create(p));
+          return;
+        }
+        case "terminal/output": {
+          const p = req.params as { terminalId: string };
+          respond(this.terminals.output(p.terminalId));
+          return;
+        }
+        case "terminal/wait_for_exit": {
+          const p = req.params as { terminalId: string };
+          respond(await this.terminals.waitForExit(p.terminalId));
+          return;
+        }
+        case "terminal/kill": {
+          const p = req.params as { terminalId: string };
+          this.terminals.kill(p.terminalId);
+          respond({});
+          return;
+        }
+        case "terminal/release": {
+          const p = req.params as { terminalId: string };
+          this.terminals.release(p.terminalId);
+          respond({});
+          return;
+        }
+        default:
+          // Unknown agent→client method — surfaced as a JSON-RPC error, never
+          // a thrown exception that would kill the connection.
+          respondError(`unhandled method: ${req.method}`);
+      }
+    } catch (err) {
+      respondError(String(err));
+    }
+  }
+
+  private request(method: string, params?: unknown): Promise<unknown> {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.writeLine({ jsonrpc: "2.0", id, method, params });
+    });
+  }
+
+  private notify(method: string, params?: unknown): void {
+    this.writeLine({ jsonrpc: "2.0", method, params });
+  }
+
+  private writeLine(obj: unknown): void {
+    if (!this.child?.stdin || this.child.stdin.destroyed) return;
+    this.child.stdin.write(JSON.stringify(obj) + "\n");
+  }
+}

--- a/daemon/src/services/acp/acpTransport.ts
+++ b/daemon/src/services/acp/acpTransport.ts
@@ -348,16 +348,19 @@ export class AcpConnection {
           // (`--dangerously-skip-permissions` for the legacy one-shot spawn
           // and terminal launches, agy.ts's own equivalent): agents run in
           // their own isolated worktree, so there is no user to prompt.
-          // Pick the most-permissive offered option so the agent doesn't ask
-          // again for the same kind of action this session; fall back to
+          // Pick the most-permissive offered ALLOW option so the agent doesn't
+          // ask again for the same kind of action this session; fall back to
           // whatever's offered if "allow_always" isn't present (some agents
-          // may only offer "allow_once").
+          // may only offer "allow_once"). Never falls back to a bare
+          // `options[0]` — if every offered option is reject-kind, there is
+          // no approval to give, so cancel rather than silently "selecting"
+          // a rejection as though it were an approval.
           const params = req.params as { options: Array<{ optionId: string; kind: string }> };
           const options = Array.isArray(params.options) ? params.options : [];
           const chosen =
             options.find((o) => o.kind === "allow_always") ??
             options.find((o) => o.kind === "allow_once") ??
-            options[0];
+            options.find((o) => o.kind.startsWith("allow_"));
           if (!chosen) {
             respond({ outcome: { outcome: "cancelled" } });
             return;

--- a/daemon/src/services/acp/normalize.ts
+++ b/daemon/src/services/acp/normalize.ts
@@ -4,11 +4,19 @@
  * through. Per-CLI quirks are handled by an optional `enrich` hook the plugin
  * supplies (Decision 2.3), never by branching on `provider` in here.
  *
- * Introduces NO new NormalizedEventKind — every ACP update kind maps onto the
- * existing set in `daemon/src/types.ts` (Requirement 5).
+ * Introduces only 2 new NormalizedEventKind values (`mode_update`,
+ * `commands_update`, acp-normalize-superset Decision 5) — every other ACP
+ * update kind still maps onto the pre-existing set in `daemon/src/types.ts`,
+ * now carrying additional optional fields instead of dropping data.
  */
 import { randomUUID } from "node:crypto";
-import type { NormalizedEvent, NormalizedEventProvider } from "../../types.js";
+import type {
+  AcpToolKind,
+  NormalizedContentBlock,
+  NormalizedEvent,
+  NormalizedEventProvider,
+  ToolDiff,
+} from "../../types.js";
 
 /** Raw `session/update` notification payload's `update` field. */
 export interface AcpSessionUpdate {
@@ -27,11 +35,108 @@ export type AcpEnrichHook = (
   base: NormalizedEvent,
 ) => NormalizedEvent | undefined;
 
-function textFromContentBlock(content: unknown): string | undefined {
-  if (!content || typeof content !== "object") return undefined;
-  const block = content as Record<string, unknown>;
-  if (block.type === "text" && typeof block.text === "string") return block.text;
-  return undefined;
+// Gap 1 — single-block mapper for agent_message_chunk/agent_thought_chunk.
+// Text-only content is UNCHANGED: `{ text }`, no `blocks` field, matching
+// today's normalize.ts:61-63/67-69 exactly.
+function toNormalizedBlock(block: unknown): NormalizedContentBlock | undefined {
+  if (!block || typeof block !== "object") return undefined;
+  const b = block as Record<string, unknown>;
+  switch (b.type) {
+    case "text":
+      return typeof b.text === "string" ? { type: "text", text: b.text } : undefined;
+    case "image":
+    case "audio":
+      return typeof b.mimeType === "string" && typeof b.data === "string"
+        ? { type: b.type, mimeType: b.mimeType, data: b.data }
+        : undefined;
+    case "resource_link":
+      return typeof b.uri === "string"
+        ? { type: "resource_link", uri: b.uri, name: typeof b.name === "string" ? b.name : undefined, mimeType: typeof b.mimeType === "string" ? b.mimeType : undefined }
+        : undefined;
+    case "resource": {
+      const r = b.resource as Record<string, unknown> | undefined;
+      return r && typeof r.uri === "string"
+        ? { type: "resource", uri: r.uri, mimeType: typeof r.mimeType === "string" ? r.mimeType : undefined }
+        : undefined;
+    }
+    default:
+      return undefined;
+  }
+}
+
+function contentFromChunk(block: unknown): { text?: string; blocks?: NormalizedContentBlock[] } {
+  const mapped = toNormalizedBlock(block);
+  if (!mapped) return {};
+  if (mapped.type === "text") return { text: mapped.text };
+  return { blocks: [mapped] };
+}
+
+/** Unwrap one `ToolCallContent` array entry: `{type:"content",content}` → the inner `ContentBlock`, else the entry itself. */
+function unwrapToolCallContent(entry: unknown): unknown {
+  if (entry && typeof entry === "object") {
+    const e = entry as Record<string, unknown>;
+    return e.content ?? entry;
+  }
+  return entry;
+}
+
+/** Extract `{type:"diff"}` entries from a `tool_call`/`tool_call_update.content` array. */
+function toolDiffsFromContent(content: unknown): ToolDiff[] | undefined {
+  if (!Array.isArray(content)) return undefined;
+  const diffs: ToolDiff[] = [];
+  for (const entry of content) {
+    if (!entry || typeof entry !== "object") continue;
+    const e = entry as Record<string, unknown>;
+    if (e.type === "diff" && typeof e.path === "string" && typeof e.newText === "string") {
+      diffs.push({
+        path: e.path,
+        oldText: typeof e.oldText === "string" ? e.oldText : undefined,
+        newText: e.newText,
+      });
+    }
+  }
+  return diffs.length > 0 ? diffs : undefined;
+}
+
+/** Extract text blocks from a `tool_call`/`tool_call_update.content` array (existing behavior). */
+function textFromToolCallContent(content: unknown): string | undefined {
+  if (!Array.isArray(content)) return undefined;
+  const text = content
+    .map((c) => contentFromChunk(unwrapToolCallContent(c)).text)
+    .filter((t): t is string => typeof t === "string")
+    .join("\n");
+  return text || undefined;
+}
+
+/** `tool_call`/`tool_call_update.locations` → `NormalizedEvent.toolLocations` (Gap 3). */
+function toolLocationsFrom(raw: unknown): { path: string; line?: number }[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const locations: { path: string; line?: number }[] = [];
+  for (const l of raw) {
+    if (!l || typeof l !== "object") continue;
+    const loc = l as Record<string, unknown>;
+    if (typeof loc.path === "string") {
+      locations.push({ path: loc.path, line: typeof loc.line === "number" ? loc.line : undefined });
+    }
+  }
+  return locations.length > 0 ? locations : undefined;
+}
+
+const TOOL_KINDS = new Set<AcpToolKind>([
+  "read",
+  "edit",
+  "delete",
+  "move",
+  "search",
+  "execute",
+  "think",
+  "fetch",
+  "switch_mode",
+  "other",
+]);
+
+function toolKindFrom(raw: unknown): AcpToolKind | undefined {
+  return typeof raw === "string" && TOOL_KINDS.has(raw as AcpToolKind) ? (raw as AcpToolKind) : undefined;
 }
 
 /**
@@ -58,15 +163,15 @@ export function normalizeSessionUpdate(
 
   switch (raw.sessionUpdate) {
     case "agent_message_chunk": {
-      const text = textFromContentBlock(raw.content);
-      if (text === undefined) return null;
-      base = stamp({ kind: "text", role: "assistant", text });
+      const { text, blocks } = contentFromChunk(raw.content);
+      if (text === undefined && blocks === undefined) return null;
+      base = stamp({ kind: "text", role: "assistant", text, blocks });
       break;
     }
     case "agent_thought_chunk": {
-      const text = textFromContentBlock(raw.content);
-      if (text === undefined) return null;
-      base = stamp({ kind: "thinking", role: "assistant", text });
+      const { text, blocks } = contentFromChunk(raw.content);
+      if (text === undefined && blocks === undefined) return null;
+      base = stamp({ kind: "thinking", role: "assistant", text, blocks });
       break;
     }
     case "user_message_chunk": {
@@ -77,30 +182,69 @@ export function normalizeSessionUpdate(
     }
     case "tool_call": {
       const toolCallId = typeof raw.toolCallId === "string" ? raw.toolCallId : undefined;
+      const status = typeof raw.status === "string" ? raw.status : undefined;
       base = stamp({
         kind: "tool_use",
         role: "assistant",
         toolId: toolCallId,
         toolName: typeof raw.title === "string" ? raw.title : (typeof raw.kind === "string" ? raw.kind : undefined),
         toolInput: raw.rawInput ?? raw.input ?? undefined,
+        toolLocations: toolLocationsFrom(raw.locations),
+        toolKind: toolKindFrom(raw.kind),
+        toolDiffs: toolDiffsFromContent(raw.content),
+        toolStatus:
+          status === "pending" || status === "in_progress" || status === "completed" || status === "failed"
+            ? status
+            : undefined,
       });
       break;
     }
     case "tool_call_update": {
       const toolCallId = typeof raw.toolCallId === "string" ? raw.toolCallId : undefined;
       const status = typeof raw.status === "string" ? raw.status : undefined;
-      // Only a terminal status (completed/failed) carries a result; an
-      // in-progress update has nothing new to render as a NormalizedEvent.
-      if (status !== "completed" && status !== "failed") return null;
-      const content = Array.isArray(raw.content) ? raw.content : [];
-      const text = content
-        .map((c) => (c && typeof c === "object" ? textFromContentBlock((c as Record<string, unknown>).content ?? c) : undefined))
-        .filter((t): t is string => typeof t === "string")
-        .join("\n");
+      // Every status (including non-terminal pending/in_progress) now emits an
+      // event carrying `toolStatus`; only a terminal status's actual `content`
+      // populates `toolResult` — an in-progress update with no content leaves
+      // `toolResult` undefined rather than overwriting a previously-set result.
+      const text = textFromToolCallContent(raw.content);
       base = stamp({
         kind: "tool_result",
         toolId: toolCallId,
-        toolResult: { content: text || undefined, isError: status === "failed" },
+        toolResult: raw.content !== undefined ? { content: text, isError: status === "failed" } : undefined,
+        toolStatus:
+          status === "pending" || status === "in_progress" || status === "completed" || status === "failed"
+            ? status
+            : undefined,
+        toolDiffs: toolDiffsFromContent(raw.content),
+        toolLocations: toolLocationsFrom(raw.locations),
+        toolKind: toolKindFrom(raw.kind),
+      });
+      break;
+    }
+    case "current_mode_update": {
+      base = stamp({
+        kind: "mode_update",
+        modeId: typeof raw.currentModeId === "string" ? raw.currentModeId : undefined,
+      });
+      break;
+    }
+    case "available_commands_update": {
+      const availableCommands = Array.isArray(raw.availableCommands) ? raw.availableCommands : [];
+      base = stamp({
+        kind: "commands_update",
+        commands: availableCommands
+          .map((c) =>
+            c && typeof c === "object" && typeof (c as Record<string, unknown>).name === "string"
+              ? {
+                  name: (c as Record<string, unknown>).name as string,
+                  description:
+                    typeof (c as Record<string, unknown>).description === "string"
+                      ? ((c as Record<string, unknown>).description as string)
+                      : "",
+                }
+              : undefined,
+          )
+          .filter((c): c is { name: string; description: string } => c !== undefined),
       });
       break;
     }

--- a/daemon/src/services/acp/normalize.ts
+++ b/daemon/src/services/acp/normalize.ts
@@ -1,0 +1,124 @@
+/**
+ * Pure `session/update` → `NormalizedEvent` mapping (Decision 2/6, Phase 1.3).
+ * No state, no I/O — the shared normalizer every ACP-migrated plugin routes
+ * through. Per-CLI quirks are handled by an optional `enrich` hook the plugin
+ * supplies (Decision 2.3), never by branching on `provider` in here.
+ *
+ * Introduces NO new NormalizedEventKind — every ACP update kind maps onto the
+ * existing set in `daemon/src/types.ts` (Requirement 5).
+ */
+import { randomUUID } from "node:crypto";
+import type { NormalizedEvent, NormalizedEventProvider } from "../../types.js";
+
+/** Raw `session/update` notification payload's `update` field. */
+export interface AcpSessionUpdate {
+  sessionUpdate: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Per-plugin enrichment hook (Decision 2.3): given the raw update and the
+ * event this module already produced, optionally return a REPLACEMENT event
+ * (e.g. mapping a claude-specific `plan` update onto a `status` event with
+ * richer text). Return `undefined` to accept the default mapping unchanged.
+ */
+export type AcpEnrichHook = (
+  raw: AcpSessionUpdate,
+  base: NormalizedEvent,
+) => NormalizedEvent | undefined;
+
+function textFromContentBlock(content: unknown): string | undefined {
+  if (!content || typeof content !== "object") return undefined;
+  const block = content as Record<string, unknown>;
+  if (block.type === "text" && typeof block.text === "string") return block.text;
+  return undefined;
+}
+
+/**
+ * Map ONE `session/update` payload into zero-or-one NormalizedEvent. Returns
+ * `null` for update kinds this daemon has nothing useful to render (still
+ * counts as "handled", not an error).
+ */
+export function normalizeSessionUpdate(
+  raw: AcpSessionUpdate,
+  sessionId: string,
+  provider: NormalizedEventProvider,
+  enrich?: AcpEnrichHook,
+): NormalizedEvent | null {
+  const stamp = (extra: Partial<NormalizedEvent>): NormalizedEvent => ({
+    id: randomUUID(),
+    sessionId,
+    ts: new Date().toISOString(),
+    provider,
+    kind: "text",
+    ...extra,
+  });
+
+  let base: NormalizedEvent | null = null;
+
+  switch (raw.sessionUpdate) {
+    case "agent_message_chunk": {
+      const text = textFromContentBlock(raw.content);
+      if (text === undefined) return null;
+      base = stamp({ kind: "text", role: "assistant", text });
+      break;
+    }
+    case "agent_thought_chunk": {
+      const text = textFromContentBlock(raw.content);
+      if (text === undefined) return null;
+      base = stamp({ kind: "thinking", role: "assistant", text });
+      break;
+    }
+    case "user_message_chunk": {
+      // Daemon-owned in the existing model (Decision 12) — the daemon already
+      // synthesizes `user` events at enqueue time, so an agent-echoed user
+      // chunk is redundant. Skip it rather than double-rendering the message.
+      return null;
+    }
+    case "tool_call": {
+      const toolCallId = typeof raw.toolCallId === "string" ? raw.toolCallId : undefined;
+      base = stamp({
+        kind: "tool_use",
+        role: "assistant",
+        toolId: toolCallId,
+        toolName: typeof raw.title === "string" ? raw.title : (typeof raw.kind === "string" ? raw.kind : undefined),
+        toolInput: raw.rawInput ?? raw.input ?? undefined,
+      });
+      break;
+    }
+    case "tool_call_update": {
+      const toolCallId = typeof raw.toolCallId === "string" ? raw.toolCallId : undefined;
+      const status = typeof raw.status === "string" ? raw.status : undefined;
+      // Only a terminal status (completed/failed) carries a result; an
+      // in-progress update has nothing new to render as a NormalizedEvent.
+      if (status !== "completed" && status !== "failed") return null;
+      const content = Array.isArray(raw.content) ? raw.content : [];
+      const text = content
+        .map((c) => (c && typeof c === "object" ? textFromContentBlock((c as Record<string, unknown>).content ?? c) : undefined))
+        .filter((t): t is string => typeof t === "string")
+        .join("\n");
+      base = stamp({
+        kind: "tool_result",
+        toolId: toolCallId,
+        toolResult: { content: text || undefined, isError: status === "failed" },
+      });
+      break;
+    }
+    case "plan": {
+      // A plan update becomes a `status` event, never a new kind (Phase 2.3).
+      const entries = Array.isArray(raw.entries) ? raw.entries : [];
+      const summary = entries
+        .map((e) => (e && typeof e === "object" ? (e as Record<string, unknown>).content : undefined))
+        .filter((c): c is string => typeof c === "string")
+        .join("; ");
+      base = stamp({ kind: "status", text: summary || "plan updated" });
+      break;
+    }
+    default:
+      return null;
+  }
+
+  if (!base) return null;
+  const enriched = enrich?.(raw, base);
+  return enriched ?? base;
+}

--- a/daemon/src/services/dbMigration.ts
+++ b/daemon/src/services/dbMigration.ts
@@ -160,6 +160,29 @@ function insertLegacySession(
   });
 }
 
+/**
+ * A hand-authored or hand-edited `manifest.json` (e.g. the demo-seed fixtures)
+ * may list worktrees like `napi-1`..`napi-4` without ever setting the sibling
+ * `nextWorktreeNum` counter. Defaulting that counter to `1` in that case would
+ * let the very next worktree creation reserve `napi-1` again and crash on
+ * SQLite's `worktrees.id` UNIQUE constraint. Derive a safe floor from the
+ * highest `<prefix>-<n>` suffix actually present instead of trusting an
+ * absent/stale field.
+ */
+function safeNextWorktreeNum(legacy: LegacyProjectRecord): number {
+  const declared = legacy.nextWorktreeNum;
+  const prefixPattern = new RegExp(`^${legacy.prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}-(\\d+)$`);
+  let highestSeen = 0;
+  for (const w of legacy.worktrees) {
+    const match = prefixPattern.exec(w.id);
+    if (match) highestSeen = Math.max(highestSeen, Number(match[1]));
+  }
+  const floor = highestSeen + 1;
+  // A `nextWorktreeNum` lower than every id already on record is stale, not
+  // authoritative — trust it only when it's at least as high as our floor.
+  return declared != null && declared >= floor ? declared : floor;
+}
+
 function insertLegacyProject(db: Database, p: LegacyProjectRecord): void {
   const txn = db.transaction((legacy: LegacyProjectRecord) => {
     db.prepare(
@@ -175,7 +198,7 @@ function insertLegacyProject(db: Database, p: LegacyProjectRecord): void {
       createdAt: legacy.createdAt,
       hidden: legacy.hidden ? 1 : 0,
       directSessionSeq: legacy.directSessionSeq ?? 0,
-      nextWorktreeNum: legacy.nextWorktreeNum ?? 1,
+      nextWorktreeNum: safeNextWorktreeNum(legacy),
     });
 
     legacy.worktrees.forEach((w, wi) => {

--- a/daemon/src/services/dbSchema.ts
+++ b/daemon/src/services/dbSchema.ts
@@ -148,6 +148,11 @@ export function ensureSchema(db: Database): void {
   // renders the PR colour only when this matches the worktree's current
   // branch, so a branch switch never shows a stale PR colour.
   addColumnIfMissing(db, "sessions", "prBranch", "TEXT");
+  // acpSessionId (acp-migration, Decision 6 Option B) — the ACP session/new
+  // id for a plugin whose spike proved it diverges from the CLI's own native
+  // resume id (agentChatId keeps meaning "native id" unconditionally). NULL
+  // for every plugin on Option A and for every session created before ACP.
+  addColumnIfMissing(db, "sessions", "acpSessionId", "TEXT");
 }
 
 /** Add `column` to `table` via `ALTER TABLE` if `PRAGMA table_info` shows it's absent. */

--- a/daemon/src/services/jsonAgent.ts
+++ b/daemon/src/services/jsonAgent.ts
@@ -31,6 +31,8 @@ import {
 import { mutateProject } from "../state/project-store.js";
 import { JsonAgentStream } from "../ws/streams/jsonAgentStream.js";
 import { jsonAgentRegistry } from "../state/jsonAgentRegistry.js";
+import { AcpConnection, SessionLoadFailed, type AcpLaunchSpec } from "./acp/acpTransport.js";
+import type { AcpEnrichHook } from "./acp/normalize.js";
 import type {
   ProjectRecord,
   WorktreeRecord,
@@ -274,6 +276,21 @@ export class JsonAgentSession {
   private readonly livePids = new Set<number>();
 
   /**
+   * ACP migration (Decision 1): this session's ONE persistent AcpConnection,
+   * created lazily on first turn for a plugin with `supportsAcp()`, reused for
+   * every later turn, disposed on release()/toggle (Decision 9). `undefined`
+   * for a plugin not migrated to ACP.
+   */
+  private connection?: AcpConnection;
+  /**
+   * True until the connection's FIRST turn reaches `result` (Decision 6 Option
+   * B call-site gate) — `captureNativeChatId` must run exactly once, at that
+   * point, never earlier (the native side channel is a filesystem artifact
+   * written only once the CLI has actually produced a conversation).
+   */
+  private connectionFirstTurnPending = false;
+
+  /**
    * Set by `release()` — this instance is being torn down and must never write
    * again. Two late writers exist and both would corrupt state after release:
    *
@@ -458,6 +475,13 @@ export class JsonAgentSession {
       this.settled().catch(() => {}),
       new Promise<void>((resolve) => setTimeout(resolve, RELEASE_DRAIN_TIMEOUT_MS)),
     ]);
+    // Decision 9 — tear down the ACP connection (and its live terminals)
+    // BEFORE closing the SQLite handle. Bounded by the same drain timeout
+    // above having already elapsed; dispose() itself is internally capped.
+    if (this.connection) {
+      await this.connection.dispose().catch(() => {});
+      this.connection = undefined;
+    }
     this.dispose();
   }
 
@@ -469,10 +493,15 @@ export class JsonAgentSession {
    */
   stopActiveTurn(): boolean {
     if (!this.running || !this.activeAbort) return false;
-    // Kill the whole descendant tree (tool subprocesses in their own groups
-    // would otherwise survive the stop), then abort to unwind the iterator so
-    // the runner advances to the next queued turn (Decision 8/13).
-    this.killLivePids();
+    if (this.connection) {
+      // Decision 3 — an ACP connection (and its live terminals) must SURVIVE a
+      // Stop: cancel only the in-flight prompt, never kill the process group.
+      this.connection.cancelActivePrompt();
+    } else {
+      // Legacy per-turn spawn: kill the whole descendant tree (tool
+      // subprocesses in their own groups would otherwise survive the stop).
+      this.killLivePids();
+    }
     this.activeAbort.abort();
     return true;
   }
@@ -842,6 +871,9 @@ export class JsonAgentSession {
       systemPromptFile: this.systemPromptFile,
       daemonPort: this.daemonPort,
       onSpawn: (pid: number) => this.recordTurnPid(pid),
+      // ACP migration (Decision 1/2): only a plugin that calls this ever
+      // triggers connection creation — legacy plugins never invoke it.
+      getAcpConnection: (spec, enrich) => this.getOrCreateConnection(spec, enrich),
     };
 
     // Whether the turn reached its own terminal `result` before any abort. A stop
@@ -875,6 +907,9 @@ export class JsonAgentSession {
       // context) if a turn-1 is stopped early, but not data loss or a wrong
       // conversation.
       if (!abort.signal.aborted || sawResult) this.firstTurnDone = true;
+      // Decision 6 Option B call site — only meaningful once the plugin has
+      // actually reached a result on the (possibly brand-new) connection.
+      if (sawResult && this.plugin.supportsAcp?.()) await this.maybeCaptureNativeChatId();
     } catch (err) {
       // Plugins return cleanly on abort (they guard the non-zero-exit throw with
       // `!signal.aborted`), so this catch only fires on a real transport/exit
@@ -940,6 +975,122 @@ export class JsonAgentSession {
     }
     this.ensureDataDir();
     writeFileSync(pidFile, [...this.livePids].join("\n"), "utf8");
+  }
+
+  // --- ACP connection lifecycle (Decision 1/2/5/9) ---
+
+  /**
+   * Lazily create-or-return this session's ONE `AcpConnection`. First call:
+   * spawns + `initialize`s, then `session/load`s the existing `agentChatId`
+   * (iff `initialize` advertised `loadSession` AND an id already exists) or
+   * else `session/new`s (Decision 5) — a failed/unsupported load falls through
+   * to a fresh session with a `status` event naming the fallback, never a
+   * silent respawn. Subsequent calls return the cached connection untouched.
+   */
+  private async getOrCreateConnection(
+    spec: AcpLaunchSpec,
+    enrich?: AcpEnrichHook,
+  ): Promise<AcpConnection> {
+    if (this.connection) return this.connection;
+
+    const conn = new AcpConnection(spec, this.cli, enrich);
+    const { loadSession } = await conn.initialize();
+
+    // Decision 6 reconnect id: prefer `acpSessionId` (Option B — the id
+    // `session/load` actually understands) and fall back to `agentChatId`
+    // (Option A, where the two id spaces coincide so it's ALSO the right
+    // value). Never the other way around — using a native-only Option B id
+    // for `session/load` would ask the adapter to load an id it never minted.
+    const priorAcpId = this.session.acpSessionId ?? this.session.agentChatId;
+    let usedFreshSession = true;
+    if (loadSession && priorAcpId) {
+      try {
+        await conn.loadSession(this.cwd, priorAcpId);
+        usedFreshSession = false;
+      } catch (err) {
+        if (!(err instanceof SessionLoadFailed)) throw err;
+        const ev = this.newEvent("status", {
+          text: "resumed with a fresh agent session — prior context may not be visible to the CLI",
+        });
+        this.persist(ev);
+        this.stream.emitMessage(ev);
+      }
+    }
+    if (usedFreshSession) {
+      const acpSessionId = await conn.newSession(this.cwd);
+      // Decision 6 Option B: persist the ACP id separately so a LATER
+      // reconnect's `session/load` uses it (never `agentChatId`, which stays
+      // native-only for this plugin). Option A plugins persist their id via
+      // the synthetic `session_init` NormalizedEvent their `runTurn` yields
+      // instead (mirrors a legacy plugin's own session_init line) — that
+      // path writes `agentChatId` directly and never touches this column, so
+      // it is safe to ALSO opportunistically record it here: harmless for
+      // Option A (never read back, since `agentChatId` already equals it),
+      // necessary for Option B (the only place this id is captured at all).
+      await this.persistAcpSessionId(acpSessionId);
+    }
+    this.connection = conn;
+    this.connectionFirstTurnPending = true;
+    return conn;
+  }
+
+  /**
+   * Decision 6 Option B call site: called once per connection, at the
+   * `result` event of that connection's FIRST turn (never earlier — see the
+   * field doc comment). `null` is a normal outcome, not an error. Write-once:
+   * never overwrites an `agentChatId` already captured by the terminal path.
+   */
+  private async maybeCaptureNativeChatId(): Promise<void> {
+    if (!this.connectionFirstTurnPending) return;
+    this.connectionFirstTurnPending = false;
+    const acpSessionId = this.connection?.currentSessionId;
+    if (!acpSessionId || !this.plugin.captureNativeChatId) return;
+    if (this.session.agentChatId) return; // write-once — terminal path already set it
+    const captured = await this.plugin.captureNativeChatId({
+      session: this.session,
+      project: this.project,
+      cwd: this.cwd,
+      acpSessionId,
+    });
+    if (captured) {
+      this.session.agentChatId = captured;
+      await this.persistChatId(captured);
+    }
+  }
+
+  /**
+   * Decision 6 Option B storage — persist `sessions.acpSessionId` (twin of
+   * `persistChatId`, same mutateProject shape). Read back only by
+   * `getOrCreateConnection`'s reconnect `session/load` call — never by
+   * `getRestoreCommand`/importers/launch argv, which stay on `agentChatId`.
+   */
+  private async persistAcpSessionId(acpSessionId: string): Promise<void> {
+    if (this.session.acpSessionId === acpSessionId) return; // already current
+    this.session.acpSessionId = acpSessionId;
+    const worktreeId = this.worktree?.id;
+    await mutateProject(this.project.id, (p) => {
+      if (worktreeId) {
+        return {
+          ...p,
+          worktrees: p.worktrees.map((w) =>
+            w.id === worktreeId
+              ? {
+                  ...w,
+                  sessions: w.sessions.map((s) =>
+                    s.id === this.session.id ? { ...s, acpSessionId } : s,
+                  ),
+                }
+              : w,
+          ),
+        };
+      }
+      return {
+        ...p,
+        directSessions: p.directSessions.map((s) =>
+          s.id === this.session.id ? { ...s, acpSessionId } : s,
+        ),
+      };
+    });
   }
 
   private async handleEvent(ev: NormalizedEvent): Promise<void> {

--- a/daemon/src/services/recover.ts
+++ b/daemon/src/services/recover.ts
@@ -12,14 +12,41 @@ import { sessionDataDir, directSessionDataDir } from "./paths.js";
 import type { SessionLifecycle, SessionRecord } from "../types.js";
 
 /**
- * Binary names `runTurn` spawns per CLI (`spawn("claude", …)`,
- * `spawn("cursor-agent", …)`, `spawn("opencode", …)`, `spawn("agy", …)`) — the
- * allowlist `verifyPidIsTurnProcess` checks a recorded pidfile PID against
- * before killing it. Kept here (not re-derived from the plugin registry) to
- * avoid this recovery module depending on the whole plugin layer for one
- * string list; update this list if a plugin's spawned binary name changes.
+ * `comm` (`/proc/<pid>/stat`'s parenthesized field) names of every process
+ * this daemon may mirror into a session's `turn.pids` pidfile — the allowlist
+ * `verifyPidIsTurnProcess` checks a recorded PID against before killing it.
+ * Kept here (not re-derived from the plugin registry) to avoid this recovery
+ * module depending on the whole plugin layer for one string list; update this
+ * list if a plugin's spawned binary/adapter comm name changes.
+ *
+ * ACP migration (Decision 7): under ACP, `turn.pids` mirrors ONE connection
+ * PID per session (spawned once, alive across turns) instead of one PID per
+ * turn — the sweep's control flow is unchanged, only what it's allowed to
+ * kill grows to include the ACP adapter processes:
+ *   - claude: legacy one-shot spawn comm is `claude`; the ACP adapter
+ *     (`@agentclientprotocol/claude-agent-acp`, a Bun-bundled JS binary)
+ *     was empirically observed to report comm `MainThread` (Bun's default
+ *     main-thread name), NOT `claude-agent-acp`.
+ *   - cursor: legacy one-shot spawn comm is `cursor-agent`; `cursor-agent acp`
+ *     is the SAME Bun-bundled binary and was ALSO empirically observed to
+ *     report comm `MainThread`.
+ *   - opencode: both the legacy one-shot spawn and `opencode acp` report
+ *     comm `opencode` — no new entry needed.
+ *   - agy: unresolved — Phase 4.1's auth spike was not run this pass; add
+ *     agy's ACP adapter comm here once that spike determines it.
+ *
+ * Known precision gap (documented, not silently papered over): `MainThread`
+ * is a generic Bun runtime thread name, not a vibe-station-specific
+ * identifier — in principle ANY Bun-based process on the host could share it,
+ * which weakens the PID-reuse guard's specificity for exactly the two CLIs
+ * that happen to be Bun-bundled. This is the same trade-off the pre-ACP code
+ * already had for `cursor-agent`'s own one-shot spawns (its comm was already
+ * `MainThread` before this plan, not `cursor-agent`) — this plan does not
+ * introduce a NEW gap, it inherits and extends an existing one. A tighter fix
+ * (matching `/proc/<pid>/cmdline` against the known script path instead of
+ * `comm`) is a reasonable follow-up but out of scope here.
  */
-const KNOWN_TURN_BINARIES = new Set(["claude", "cursor-agent", "opencode", "agy"]);
+const KNOWN_TURN_BINARIES = new Set(["claude", "cursor-agent", "opencode", "agy", "MainThread"]);
 
 /**
  * Best-effort identity check before killing a pidfile-recorded PID on boot:

--- a/daemon/src/services/spawn.ts
+++ b/daemon/src/services/spawn.ts
@@ -21,6 +21,8 @@ import { DirectPtyBackend } from "./directPty.js";
 import type { ProjectRecord, WorktreeRecord, SessionRecord, NormalizedEvent } from "../types.js";
 import type { ResolvedContext } from "./context.js";
 import { resolvedContextOf, systemPromptPathFor, sessionDataDirFor } from "./context.js";
+import type { AcpConnection, AcpLaunchSpec } from "./acp/acpTransport.js";
+import type { AcpEnrichHook } from "./acp/normalize.js";
 
 /** Substring searched in pane output after paste (matches plugins' HTML tail marker). */
 export function promptVerificationNeedle(sessionId: string): string {
@@ -33,8 +35,15 @@ export function promptVerificationNeedle(sessionId: string): string {
  * The core asks the plugin to "run one turn" and consumes NormalizedEvents; it
  * NEVER sees raw CLI JSON, never `JSON.parse`es a CLI line, never branches on
  * `cli`. Each plugin owns spawn/transport AND normalization behind this
- * boundary. The async-iterator completing == the turn is done (a `result`
- * event was emitted). `signal` aborts/stops the turn.
+ * boundary. `signal` aborts/stops the turn.
+ *
+ * Turn-done signal (ACP migration, Decision 2): for a plugin with
+ * `supportsAcp() === true`, the iterator yields off a persistent
+ * `AcpConnection`'s `session/update` stream, and the turn is done when that
+ * connection's `session/prompt` RESULT resolves — not when a process exits.
+ * The connection itself is spawned once per session (Decision 1) and outlives
+ * any single turn; a legacy (non-ACP) plugin still spawns one process per
+ * turn and completes the iterator on process exit, exactly as before.
  */
 export interface AgentJsonTransport {
   /** Whether this plugin can run in the JSON channel. */
@@ -89,6 +98,15 @@ export interface TurnContext {
    * (Decision 13).
    */
   onSpawn?: (pid: number) => void;
+  /**
+   * ACP migration (Decision 1/2): lazily create-or-return this session's ONE
+   * persistent `AcpConnection`. The plugin builds the launch spec (argv/env —
+   * CLI-specific, AGENTS.md) and an optional per-CLI `enrich` hook; the core
+   * (`JsonAgentSession`) owns caching, `initialize`, `session/new`-or-`load`
+   * (Decision 5), and disposal. Only present for plugins that call it —
+   * legacy (non-ACP) plugins never receive it invoked.
+   */
+  getAcpConnection?(spec: AcpLaunchSpec, enrich?: AcpEnrichHook): Promise<AcpConnection>;
 }
 
 export interface AgentPlugin {
@@ -209,6 +227,108 @@ export interface AgentPlugin {
     ctx: TurnContext,
     signal: AbortSignal,
   ): AsyncIterable<NormalizedEvent>;
+  /**
+   * ACP migration (Decision 2/7): true once this plugin's `runTurn` drives a
+   * persistent `AcpConnection` (via `ctx.getAcpConnection`) instead of a
+   * per-turn one-shot spawn. Gates `runOneTurn`'s stop/release semantics
+   * (Decision 3/9) and the boot-sweep allowlist (Decision 7). A plugin not
+   * yet migrated (or permanently staying legacy, e.g. agy on spike failure)
+   * omits this or returns false.
+   */
+  supportsAcp?(): boolean;
+  // --- The two session identities (ACP migration, Decision 6) ---
+  //
+  // Once a session runs in Rich Chat over ACP it carries TWO distinct ids, and
+  // essentially every subtlety in the three methods below is about the gap
+  // between them:
+  //
+  //   1. The ACP session id (`SessionRecord.acpSessionId`) — protocol-level.
+  //      Minted by `session/new`, understood only by `session/load` /
+  //      `session/prompt` on that same ACP connection. Owned by the core
+  //      (`JsonAgentSession`), never by a plugin.
+  //   2. The NATIVE chat id (`SessionRecord.agentChatId`) — CLI-level. The
+  //      value this CLI's OWN `--resume`/`--session`/`--conversation` flag and
+  //      native transcript store understand. This is what the Terminal channel
+  //      resumes with (`getRestoreCommand`), and its meaning is invariant:
+  //      `agentChatId` is ALWAYS the native id, never the ACP one.
+  //
+  // Whether (1) and (2) are the same value is a per-CLI FACT, established
+  // empirically per plugin (Phase 1.8's spike procedure), not a design choice.
+  // Each plugin therefore declares one of four strategies, purely by which of
+  // the two optional methods below it implements:
+  //
+  //   | CLI      | Strategy    | captureNativeChatId | supportsJsonToTerminalResume |
+  //   |----------|-------------|---------------------|-----------------------|
+  //   | claude   | identical   | not implemented     | not implemented (true)|
+  //   | opencode | identical   | not implemented     | not implemented (true)|
+  //   | agy      | bridged     | implemented         | not implemented (true)|
+  //   | cursor   | unavailable | best-effort only    | returns FALSE         |
+  //
+  //   - identical   ("Option A" in the plan): the ACP id IS the native id, so
+  //                 `agentChatId` is already correct the moment the plugin's
+  //                 `runTurn` yields its `session_init`. Implementing
+  //                 `captureNativeChatId` here would only be a chance to
+  //                 overwrite a correct value with a wrong one — so don't.
+  //   - bridged     ("Option B", recoverable): the ids differ, but a reliable
+  //                 ACP-id-keyed mapping to the native id exists on disk, so
+  //                 `captureNativeChatId` converts one into the other.
+  //   - unavailable ("Option B", not recoverable): the ids differ and NO
+  //                 bridge exists. `captureNativeChatId` may still guess, but
+  //                 `supportsJsonToTerminalResume(): false` is the honest signal, and
+  //                 a degraded json→tty toggle is the expected outcome.
+  //
+  // Per-CLI resolution strategies live in `agent-plugins/native-chat-id/`
+  // (one file per CLI that needs one — opencode has none, because it needs
+  // none). `docs/AGENT-CHAT-ID-CAPTURE.md` carries the full matrix, including
+  // the separate terminal-channel capture story (`provideChatId` /
+  // `captureChatId` / `refreshChatIdOnToggle` above).
+  /**
+   * Bridged / unavailable strategies only (Decision 6 "Option B" — see the
+   * two-identities block above). Read the NATIVE chat id — the one this CLI's own
+   * `--resume`/`--session`/`--conversation` flag and native transcript store
+   * understand — out of band, after an ACP session has been established and the
+   * first turn has produced output. Return null when this plugin cannot recover it.
+   *
+   * Optional, and deliberately NOT implemented by plugins whose spike proved the ACP
+   * id IS the native id (the `identical` strategy) — for those, `agentChatId` is
+   * already correct and a second write would be a chance to make it wrong.
+   */
+  captureNativeChatId?(args: {
+    session: SessionRecord;
+    project: ProjectRecord;
+    /** Session working directory — same semantics as provideChatId/captureChatId. */
+    cwd: string;
+    /** The ACP session/new id, for plugins that can derive or verify from it. */
+    acpSessionId: string;
+  }): Promise<string | null>;
+  /**
+   * The `unavailable` strategy's declaration (see the two-identities block
+   * above): whether a Rich Chat (json) session for this CLI can actually resume
+   * its conversation when toggled to the Terminal channel.
+   *
+   * `false` means the CLI's ACP-side session state lives somewhere the raw
+   * binary's own resume flag cannot reach — `getRestoreCommand` returning null
+   * (or a native id that resumes the WRONG/no conversation) is then an
+   * expected, permanent outcome for this CLI, not a bug to keep chasing.
+   * `captureNativeChatId` may still populate `agentChatId` on a best-effort
+   * basis; it just isn't guaranteed to produce a working resume.
+   *
+   * Default when unimplemented: `true` (today's assumption — matches
+   * claude/opencode, whose ACP session id IS the native id, and agy, whose
+   * native id is now reliably derived from the ACP session via the adapter's
+   * own session store — see captureNativeChatId's per-plugin bodies).
+   *
+   * cursor returns `false`: `cursor-agent acp` persists each session in a
+   * dedicated SQLite store at `~/.cursor/acp-sessions/<sessionId>/store.db`,
+   * structurally separate from both interactive chat history and the
+   * print-mode `agent-transcripts/` directory `--resume` reads. There is no
+   * CLI-level bridge — confirmed by live spike (a completed ACP turn never
+   * appears in `agent-transcripts/`, ruling out a sync-timing explanation) and
+   * by checking that neither agent-orchestrator nor emdash bridge cursor's ACP
+   * session into a raw-terminal resume either. The toggle still works — it
+   * just starts a fresh terminal conversation instead of resuming.
+   */
+  supportsJsonToTerminalResume?(): boolean;
 }
 
 export interface LaunchConfig {

--- a/daemon/src/services/toolResultCap.ts
+++ b/daemon/src/services/toolResultCap.ts
@@ -18,9 +18,25 @@ export const TOOL_RESULT_MAX_BYTES = 20_000;
 
 /** Mutates `ev` in place, replacing oversized `tool_result.content` with a marker. */
 export function capToolResultContent(ev: NormalizedEvent): void {
-  if (ev.kind !== "tool_result" || !ev.toolResult?.content) return;
-  const size = Buffer.byteLength(ev.toolResult.content, "utf8");
-  if (size > TOOL_RESULT_MAX_BYTES) {
-    ev.toolResult = { ...ev.toolResult, content: `(tool result omitted — ${size} bytes)` };
+  if (ev.kind === "tool_result" && ev.toolResult?.content) {
+    const size = Buffer.byteLength(ev.toolResult.content, "utf8");
+    if (size > TOOL_RESULT_MAX_BYTES) {
+      ev.toolResult = { ...ev.toolResult, content: `(tool result omitted — ${size} bytes)` };
+    }
+  }
+  // Structured file-edit diffs (acp-normalize-superset) carry the full
+  // before/after file text — same unbounded-size risk as `toolResult.content`
+  // above (a large generated file rewrite), so the same cap applies per-diff.
+  if (ev.toolDiffs?.length) {
+    ev.toolDiffs = ev.toolDiffs.map((diff) => {
+      const oldSize = diff.oldText ? Buffer.byteLength(diff.oldText, "utf8") : 0;
+      const newSize = Buffer.byteLength(diff.newText, "utf8");
+      if (oldSize <= TOOL_RESULT_MAX_BYTES && newSize <= TOOL_RESULT_MAX_BYTES) return diff;
+      return {
+        path: diff.path,
+        oldText: oldSize > TOOL_RESULT_MAX_BYTES ? undefined : diff.oldText,
+        newText: newSize > TOOL_RESULT_MAX_BYTES ? `(diff omitted — ${newSize} bytes)` : diff.newText,
+      };
+    });
   }
 }

--- a/daemon/src/state/project-store.ts
+++ b/daemon/src/state/project-store.ts
@@ -258,8 +258,8 @@ function writeProjectFull(record: ProjectRecord): void {
        VALUES (@id, @projectId, @name, @branch, @baseBranch, @baseSha, @createdAt, @pinnedAt, @hiddenAt, @sortOrder, @terminalSeq, @agentSeq, @branchIsPlaceholder)`,
     );
     const insertSession = db.prepare(
-      `INSERT INTO sessions (id, worktreeId, projectId, isMain, sortOrder, type, modeId, name, nameSource, tmuxName, useTmux, channel, state, reason, lastTransitionAt, transcriptKind, transcriptPath, agentChatId, modelOverride, pinnedAt, initialPrompt, archivedAt, handoffSummary, spawnedFrom, supersededBy, prState, prNumber, prUrl, prCheckedAt, prBranch)
-       VALUES (@id, @worktreeId, @projectId, @isMain, @sortOrder, @type, @modeId, @name, @nameSource, @tmuxName, @useTmux, @channel, @state, @reason, @lastTransitionAt, @transcriptKind, @transcriptPath, @agentChatId, @modelOverride, @pinnedAt, @initialPrompt, @archivedAt, @handoffSummary, @spawnedFrom, @supersededBy, @prState, @prNumber, @prUrl, @prCheckedAt, @prBranch)`,
+      `INSERT INTO sessions (id, worktreeId, projectId, isMain, sortOrder, type, modeId, name, nameSource, tmuxName, useTmux, channel, state, reason, lastTransitionAt, transcriptKind, transcriptPath, agentChatId, acpSessionId, modelOverride, pinnedAt, initialPrompt, archivedAt, handoffSummary, spawnedFrom, supersededBy, prState, prNumber, prUrl, prCheckedAt, prBranch)
+       VALUES (@id, @worktreeId, @projectId, @isMain, @sortOrder, @type, @modeId, @name, @nameSource, @tmuxName, @useTmux, @channel, @state, @reason, @lastTransitionAt, @transcriptKind, @transcriptPath, @agentChatId, @acpSessionId, @modelOverride, @pinnedAt, @initialPrompt, @archivedAt, @handoffSummary, @spawnedFrom, @supersededBy, @prState, @prNumber, @prUrl, @prCheckedAt, @prBranch)`,
     );
 
     for (const w of p.worktrees) {

--- a/daemon/src/state/sqliteRowMappers.ts
+++ b/daemon/src/state/sqliteRowMappers.ts
@@ -34,6 +34,7 @@ export interface SessionRow {
   transcriptKind: string | null;
   transcriptPath: string | null;
   agentChatId: string | null;
+  acpSessionId: string | null;
   modelOverride: string | null;
   pinnedAt: string | null;
   initialPrompt: string | null;
@@ -93,6 +94,7 @@ export function rowToSession(row: SessionRow): SessionRecord {
     },
     ...(transcriptRef ? { transcriptRef } : {}),
     ...(row.agentChatId != null ? { agentChatId: row.agentChatId } : {}),
+    ...(row.acpSessionId != null ? { acpSessionId: row.acpSessionId } : {}),
     ...(row.modelOverride != null ? { modelOverride: row.modelOverride } : {}),
     ...(row.pinnedAt != null ? { pinnedAt: row.pinnedAt } : {}),
     ...(row.initialPrompt != null ? { initialPrompt: row.initialPrompt } : {}),
@@ -139,6 +141,7 @@ export function sessionToRow(session: SessionRecord, projectId: string, worktree
     transcriptKind: session.transcriptRef?.kind ?? null,
     transcriptPath: session.transcriptRef?.path ?? null,
     agentChatId: session.agentChatId ?? null,
+    acpSessionId: session.acpSessionId ?? null,
     modelOverride: session.modelOverride ?? null,
     pinnedAt: session.pinnedAt ?? null,
     initialPrompt: session.initialPrompt ?? null,

--- a/daemon/src/types.ts
+++ b/daemon/src/types.ts
@@ -235,7 +235,24 @@ export interface SessionRecord {
   channel?: Channel;
   lifecycle: SessionLifecycle;
   transcriptRef?: TranscriptRef;
+  /**
+   * Identity #1 of two (see the "two session identities" block above
+   * `AgentPlugin.captureNativeChatId` in `services/spawn.ts`): the **NATIVE**
+   * chat id — the value this CLI's OWN `--resume`/`--session`/`--conversation`
+   * flag and native transcript store understand. Invariant: this field is
+   * ALWAYS the native id, never an ACP-protocol one. It is what the Terminal
+   * channel resumes with, and for a CLI whose two ids coincide (claude,
+   * opencode) it doubles as the ACP id too.
+   */
   agentChatId?: string;
+  /**
+   * Identity #2 of two. ACP migration (Decision 6 Option B only). The ACP `session/new`/`load` id
+   * for a plugin whose spike proved this differs from the CLI's own native
+   * resume id — read ONLY by `session/load` reconnect (Decision 5). Plugins
+   * whose spike proved the two ids coincide (Option A) never set this; for
+   * them `agentChatId` alone is both the ACP id and the native id.
+   */
+  acpSessionId?: string;
   /**
    * Per-session model override (JSON channel), set live from the status-bar model
    * switcher. When present it wins over the mode's model for every subsequent

--- a/daemon/src/types.ts
+++ b/daemon/src/types.ts
@@ -81,7 +81,9 @@ export type NormalizedEventKind =
   | "usage"
   | "result"
   | "error"
-  | "status";
+  | "status"
+  | "mode_update"
+  | "commands_update";
 
 /** Token / cost usage numbers, normalized across harnesses. */
 export interface UsageInfo {
@@ -108,6 +110,48 @@ export interface Attachment {
   size: number;
   mime: string;
 }
+
+/**
+ * Normalized non-text (or text-in-a-mixed-array) content block, carried in
+ * `NormalizedEvent.blocks` (acp-normalize-superset, Gap 1). `type:"text"`
+ * blocks are a redundant copy of `NormalizedEvent.text` — kept for order,
+ * never the only place text lives.
+ */
+export interface NormalizedContentBlock {
+  type: "text" | "image" | "audio" | "resource" | "resource_link";
+  /** `type:"text"` only */
+  text?: string;
+  /** `type:"image"|"audio"|"resource_link"` */
+  mimeType?: string;
+  /** base64, `type:"image"|"audio"` only */
+  data?: string;
+  /** `type:"resource_link"`, or `type:"resource"`'s nested `resource.uri` */
+  uri?: string;
+  /** `type:"resource_link"` only */
+  name?: string;
+}
+
+/** A structured file-edit diff from a `ToolCallContent` entry (Gap 2). */
+export interface ToolDiff {
+  /** absolute file path */
+  path: string;
+  /** absent ⇒ new file */
+  oldText?: string;
+  newText: string;
+}
+
+/** ACP `ToolKind` union, verbatim (Gap 4). */
+export type AcpToolKind =
+  | "read"
+  | "edit"
+  | "delete"
+  | "move"
+  | "search"
+  | "execute"
+  | "think"
+  | "fetch"
+  | "switch_mode"
+  | "other";
 
 /**
  * One normalized chat event. This is the single shape the UI renders and the
@@ -168,6 +212,20 @@ export interface NormalizedEvent {
    * core can capture + persist it (Decision 10) without parsing raw CLI JSON.
    */
   agentChatId?: string;
+  /** Non-text (or mixed) content blocks from `agent_message_chunk`/`agent_thought_chunk` (Gap 1). */
+  blocks?: NormalizedContentBlock[];
+  /** Structured file-edit diffs from `tool_call`/`tool_call_update.content` (Gap 2). */
+  toolDiffs?: ToolDiff[];
+  /** `tool_call`/`tool_call_update.locations` (Gap 3). */
+  toolLocations?: { path: string; line?: number }[];
+  /** `tool_call`/`tool_call_update.kind`, structural (Gap 4). */
+  toolKind?: AcpToolKind;
+  /** ACP `ToolCallStatus`, mirrored on `tool_use`/`tool_result` events (Gap 5). */
+  toolStatus?: "pending" | "in_progress" | "completed" | "failed";
+  /** `mode_update` only — the new `currentModeId` (Gap 6). */
+  modeId?: string;
+  /** `commands_update` only — the available slash commands (Gap 7). */
+  commands?: { name: string; description: string }[];
 }
 
 /** Derived turn state driving the composer status indicator. */

--- a/daemon/src/ws/protocol.ts
+++ b/daemon/src/ws/protocol.ts
@@ -165,6 +165,8 @@ export const NormalizedEventSchema = z.object({
     "result",
     "error",
     "status",
+    "mode_update",
+    "commands_update",
   ]),
   role: z.enum(["user", "assistant"]).optional(),
   text: z.string().optional(),
@@ -182,6 +184,34 @@ export const NormalizedEventSchema = z.object({
   agentChatId: z.string().optional(),
   /** Durable monotonic pagination cursor assigned at persist (R0.3/R2.x). */
   logSeq: z.number().optional(),
+  blocks: z
+    .array(
+      z.object({
+        type: z.enum(["text", "image", "audio", "resource", "resource_link"]),
+        text: z.string().optional(),
+        mimeType: z.string().optional(),
+        data: z.string().optional(),
+        uri: z.string().optional(),
+        name: z.string().optional(),
+      }),
+    )
+    .optional(),
+  toolDiffs: z
+    .array(
+      z.object({
+        path: z.string(),
+        oldText: z.string().optional(),
+        newText: z.string(),
+      }),
+    )
+    .optional(),
+  toolLocations: z.array(z.object({ path: z.string(), line: z.number().optional() })).optional(),
+  toolKind: z
+    .enum(["read", "edit", "delete", "move", "search", "execute", "think", "fetch", "switch_mode", "other"])
+    .optional(),
+  toolStatus: z.enum(["pending", "in_progress", "completed", "failed"]).optional(),
+  modeId: z.string().optional(),
+  commands: z.array(z.object({ name: z.string(), description: z.string() })).optional(),
 });
 
 export const SessionMetaSchema = z.object({

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -19,7 +19,7 @@
 FROM node:24-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    tmux git procps curl ripgrep ca-certificates \
+    tmux git procps curl ripgrep ca-certificates unzip \
     python3 make g++ \
   && update-ca-certificates \
   && rm -rf /var/lib/apt/lists/*
@@ -63,6 +63,15 @@ RUN chmod +x /app/scripts/dev-entrypoint.sh
 USER vst
 RUN pnpm install --frozen-lockfile
 RUN pnpm --filter @vibestation/cli build
+
+# agy's ACP path (`daemon/src/agent-plugins/agy.ts`) spawns the third-party
+# `antigravity-acp` adapter via `bunx` — Bun is a hard runtime dependency of
+# that one plugin, not otherwise needed by this project. Installed as `vst`
+# (not root) so it lands under $HOME/.bun, matching how the daemon itself
+# runs `bunx` at spawn time.
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/home/vst/.bun/bin:${PATH}"
+
 USER root
 
 EXPOSE 5173

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -27,7 +27,16 @@
 # CLI binaries are bind-mounted read-only from the host so that
 # GET /cli-models works inside the container. gemini is installed directly in the image;
 # ~/.gemini is bind-mounted so OAuth credentials are available inside the container.
-# Override paths with OPENCODE_BIN, CURSOR_BIN, CLAUDE_BIN, AGY_BIN if yours differ.
+# Override paths with OPENCODE_BIN, CURSOR_AGENT_VERSIONS, CLAUDE_BIN, AGY_BIN if yours differ.
+#
+# Real credentials for claude/cursor/opencode/agy are piped in too (read-only
+# "seed" mounts under /seed/*, copied by scripts/dev-entrypoint.sh into a
+# writable location inside the container — see that script's
+# `seed_writable_home` calls for exactly what's copied vs. excluded per CLI,
+# and why: each CLI's credential lives in a different, specific file/dir,
+# usually alongside gigabytes of unrelated local history/db state that a
+# throwaway sandbox has no use for). `VST_NO_AUTH` above is the DAEMON's own
+# login, unrelated to these — these are the underlying agent CLIs' auth.
 #
 # To inspect a running sandbox interactively, use
 # `docker compose exec -u vst vst-dev bash` (or `docker exec -u vst
@@ -66,11 +75,26 @@ services:
       VST_SEED_MODE: "${VST_SEED_MODE:-demo}"
     volumes:
       # Mount CLI binaries read-only so the daemon can shell out to them.
-      # Paths use $HOME — override with OPENCODE_BIN, CURSOR_BIN, CLAUDE_BIN if yours differ.
+      # Paths use $HOME — override with OPENCODE_BIN, CURSOR_AGENT_VERSIONS, CLAUDE_BIN, AGY_BIN if yours differ.
       - ${OPENCODE_BIN:-${HOME}/.opencode/bin/opencode}:/usr/local/bin/opencode:ro
-      - ${CURSOR_BIN:-${HOME}/.local/bin/cursor-agent}:/usr/local/bin/cursor-agent:ro
       - ${CLAUDE_BIN:-${HOME}/.local/bin/claude}:/usr/local/bin/claude:ro
       - ${AGY_BIN:-${HOME}/.local/bin/agy}:/usr/local/bin/agy:ro
+      # cursor-agent is NOT a single-file mount like the others — its own
+      # launcher script does `realpath "$0"` and expects a bundled `node`
+      # binary + numbered chunk `.js` files to sit in the SAME directory as
+      # itself. Docker resolves a host symlink to its target's CONTENTS at
+      # single-file-mount time (verified: `docker run -v host-symlink:...`
+      # produces a plain regular file in the container, not a working
+      # symlink pointing anywhere), so a single-file mount of just the
+      # launcher silently loses those sibling files — the container-side
+      # symptom is `Error: Cannot find module '.../index.js'`. Mount the
+      # WHOLE `versions/` directory (every installed version, not just the
+      # current one — cheap for a read-only bind mount, and avoids needing
+      # this compose file to know which version is "current") and let
+      # scripts/dev-entrypoint.sh symlink the newest one into
+      # /usr/local/bin/cursor-agent from inside the container, where the
+      # sibling files are actually reachable.
+      - ${CURSOR_AGENT_VERSIONS:-${HOME}/.local/share/cursor-agent/versions}:/opt/cursor-agent-versions:ro
       # Gemini/agy creds: mount host ~/.gemini READ-ONLY as a seed. The container
       # entrypoint (see `command:` below) copies it into a WRITABLE /home/vst/.gemini
       # on startup — agy (antigravity-cli) writes logs/cache/conversations under
@@ -80,6 +104,29 @@ services:
       # neither. Refreshed host OAuth tokens re-propagate only on container
       # recreate (the copy is guarded by a `.seeded` marker), not on restart.
       - ${HOME}/.gemini:/seed/gemini:ro
+      # claude creds: `.credentials.json` (the OAuth token) lives directly
+      # under `~/.claude`, alongside gigabytes of past-conversation
+      # transcripts (`projects/`) the entrypoint excludes from the copy (see
+      # `seed_writable_home` there). `~/.claude.json` is a SEPARATE sibling
+      # file (onboarding/telemetry state claude checks on startup), seeded
+      # independently since it isn't inside `~/.claude` itself.
+      - ${CLAUDE_HOME:-${HOME}/.claude}:/seed/claude:ro
+      - ${CLAUDE_JSON:-${HOME}/.claude.json}:/seed/claude.json:ro
+      # cursor creds: verified empirically that the real OAuth access/refresh
+      # tokens live under `~/.config/cursor/auth.json`, NOT `~/.cursor`
+      # (which holds CLI session/workspace state — chats, per-project
+      # transcripts, extensions — excluded by the entrypoint as bulk/
+      # non-auth). Both are mounted since cursor-agent also reads small
+      # preference files (`cli-config.json` etc) out of `~/.cursor`.
+      - ${CURSOR_CONFIG_HOME:-${HOME}/.config/cursor}:/seed/cursor-config:ro
+      - ${CURSOR_HOME:-${HOME}/.cursor}:/seed/cursor-home:ro
+      # opencode creds: `~/.local/share/opencode/auth.json` is the actual
+      # credential; that same directory also holds `opencode.db` (the CLI's
+      # global session/transcript store, routinely 500MB-1GB+) which the
+      # entrypoint excludes. `~/.config/opencode` (small) carries opencode's
+      # own config/skills and is mounted in full.
+      - ${OPENCODE_DATA_HOME:-${HOME}/.local/share/opencode}:/seed/opencode-data:ro
+      - ${OPENCODE_CONFIG_HOME:-${HOME}/.config/opencode}:/seed/opencode-config:ro
 
       # Hot-reload: mount web source so Vite picks up changes instantly
       # (daemon changes still require a rebuild — see below)

--- a/docs/ACP-TRANSPORT-OVERVIEW.md
+++ b/docs/ACP-TRANSPORT-OVERVIEW.md
@@ -1,0 +1,124 @@
+# ACP Transport — How It Works
+
+Rich Chat's `json` channel talks to every coding-agent CLI over the same
+protocol: the **Agent Client Protocol (ACP)**, a JSON-RPC 2.0 wire format
+sent over stdio. This doc explains that layer specifically — the shared
+transport, not the channel/toggle mechanics (see `JSON-CHAT-ARCHITECTURE.md`
+for those) or per-CLI chat-id capture (see `AGENT-CHAT-ID-CAPTURE.md`).
+
+## The key idea
+
+ACP is a **protocol**, not a per-CLI library the daemon writes. The daemon
+implements the client side of that protocol exactly once and reuses it for
+every CLI. What differs per CLI is only:
+
+1. Whether the CLI's own binary speaks ACP directly, or a separate
+   **adapter process** sits in front of it and translates ACP calls into
+   that CLI's native mechanism.
+2. A small per-plugin file supplying (a) the launch command/args/env for
+   that CLI's process, and (b) an `enrich()` hook for any CLI-specific
+   event nuances.
+
+Everything else — spawning, the JSON-RPC handshake, streaming updates,
+cancellation, idle teardown, background-terminal handling — lives in one
+shared module set and is never duplicated per plugin.
+
+## Diagram
+
+```mermaid
+flowchart TB
+  subgraph Daemon["vibe-station daemon (shared, CLI-agnostic)"]
+    JAS["JsonAgentSession\nowns 1 connection per sessionId"]
+    ACM["AcpConnection\nONE implementation of the ACP\nJSON-RPC client, reused by all CLIs"]
+    NORM["normalize.ts\nsession/update -> NormalizedEvent\n(shared mapping + per-plugin enrich)"]
+    ATM["AcpTerminalManager\nserves terminal/* (background work\nsurvives past turn end)"]
+  end
+
+  subgraph Plugins["Per-CLI plugin files (thin)"]
+    P1["plugin A: launch argv + enrich"]
+    P2["plugin B: launch argv + enrich"]
+    P3["plugin C: launch argv + enrich"]
+  end
+
+  JAS -->|"session/prompt"| ACM
+  ACM -->|"session/update stream"| NORM --> JAS
+  P1 -. supplies spawn spec .-> ACM
+  P2 -. supplies spawn spec .-> ACM
+  P3 -. supplies spawn spec .-> ACM
+  ACM -.->|"terminal/*"| ATM
+
+  subgraph Native["CLI speaks ACP natively"]
+    NATIVEBIN["CLI's own binary,\nspawned directly"]
+  end
+
+  subgraph Adapted["CLI does not speak ACP itself"]
+    ADAPTER["a separate adapter process\ntranslates ACP <-> the CLI's own mechanism"] --> REALBIN["the wrapped CLI binary"]
+  end
+
+  ACM <-->|"stdio JSON-RPC"| NATIVEBIN
+  ACM <-->|"stdio JSON-RPC"| ADAPTER
+
+  WEBUI["web-ui chat/* — unchanged\nconsumes the existing NormalizedEvent stream"]
+  JAS -->|"WS broadcast"| WEBUI
+```
+
+## What each layer owns
+
+| Layer | Owns | Shared or per-CLI? |
+|---|---|---|
+| `JsonAgentSession` | FIFO turn queue, transcript persistence, "first turn on this connection" bookkeeping | Shared |
+| `AcpConnection` | Process spawn/liveness, `initialize`, `session/new`/`load`/`prompt`/`cancel`, idle-TTL disposal | Shared — one implementation for every CLI |
+| `normalize.ts` | Base `session/update -> NormalizedEvent` mapping | Shared, with a per-plugin `enrich()` hook for nuance only |
+| `AcpTerminalManager` | Host-managed OS child processes started as ACP `terminal/*` calls, so background work (e.g. a dev server) survives past the turn that started it | Shared |
+| Plugin file (per CLI) | Launch command/args/env for that CLI's process; its `enrich()` hook; nothing about the protocol itself | Per-CLI, intentionally thin |
+| `agent-plugins/native-chat-id/` | Converting/recovering the CLI's OWN resume id, for the CLIs where it isn't just the ACP session id — see below | Per-CLI; one file only for a CLI that needs one |
+
+The last row is the one place the protocol layer and the per-CLI adaptation
+layer genuinely meet: `services/acp/` never knows which CLI it is driving,
+while `agent-plugins/native-chat-id/` is *entirely* CLI-specific knowledge
+about where that CLI keeps its own conversation state on disk.
+
+## One process per session, not one per turn
+
+Before ACP, each turn spawned a fresh one-shot CLI process that exited when
+its own final response line landed — which meant any background work
+started mid-turn (a backgrounded shell command, a dev server) died with it.
+
+Under ACP, the daemon spawns **one** agent process per session, once, and
+keeps it alive across every turn:
+
+```mermaid
+stateDiagram-v2
+    [*] --> NoConnection: session created, no turn yet
+    NoConnection --> Connecting: first turn — spawn + initialize
+    Connecting --> Idle: session established, no active turn
+    Idle --> Prompting: user sends a message (session/prompt)
+    Prompting --> Idle: turn ends — CONNECTION SURVIVES
+    Idle --> Idle: a background terminal keeps running across turns
+    Idle --> Disposed: idle timeout AND zero live background terminals
+    Idle --> Disposed: explicit teardown (delete / done / channel toggle / shutdown)
+    Disposed --> [*]
+```
+
+A turn's "done" signal is the `session/prompt` JSON-RPC call resolving —
+not a process exiting. Stopping a turn sends `session/cancel` over the same
+connection rather than killing the process tree, so the connection and any
+live background terminal survive a Stop click.
+
+## Why the plugin interface didn't need to change shape
+
+`AgentPlugin` is still the seam between the daemon's turn engine and every
+CLI. `runTurn(input, ctx, signal)` keeps its exact signature and its
+`AsyncIterable<NormalizedEvent>` return type — internally it now gets the
+session's connection (`ctx.getAcpConnection()`) and yields off its update
+stream instead of spawning a process itself. Everything CLI-specific still
+lives entirely inside that CLI's own plugin file; no shared daemon code
+branches on which CLI is running.
+
+## Related docs
+
+- `JSON-CHAT-ARCHITECTURE.md` — the two channels (`json` / terminal), the
+  toggle between them, and where per-CLI chat-id handling fits in.
+- `AGENT-CHAT-ID-CAPTURE.md` — why the id a CLI's own resume flag expects
+  isn't always the same as the id ACP hands back, and how each plugin
+  reconciles that.

--- a/docs/AGENT-CHAT-ID-CAPTURE.md
+++ b/docs/AGENT-CHAT-ID-CAPTURE.md
@@ -4,9 +4,11 @@ How the daemon learns each CLI's own conversation/session identifier
 (`SessionRecord.agentChatId`) — the value that lets a session resume the
 **same** underlying CLI conversation across a daemon restart, a terminal
 `/resume`, or a JSON↔terminal channel toggle. Read this before touching
-`provideChatId` / `captureChatId` / `refreshChatIdOnToggle` on any plugin
-(`daemon/src/agent-plugins/*.ts`) or the spawn/toggle call sites
-(`daemon/src/services/spawn.ts`, `daemon/src/routes/sessions.ts`).
+`provideChatId` / `captureChatId` / `refreshChatIdOnToggle` /
+`captureNativeChatId` / `supportsChannelResume` on any plugin
+(`daemon/src/agent-plugins/*.ts`, `daemon/src/agent-plugins/native-chat-id/*.ts`)
+or the spawn/toggle call sites (`daemon/src/services/spawn.ts`,
+`daemon/src/services/jsonAgent.ts`, `daemon/src/routes/sessions.ts`).
 
 `agentChatId` is the one piece of state that has to survive every transition
 a session can go through — fresh spawn, resume, and a live channel toggle in
@@ -15,7 +17,62 @@ either direction — because it's the only thing that tells the CLI "continue
 failure is silent: the CLI happily resumes *some* conversation, just not the
 right one (see [Historical note](#historical-note--the-agy-investigation)).
 
-## Summary
+## Two identities, not one (ACP migration)
+
+Since Rich Chat moved to the Agent Client Protocol, a session that has run a
+JSON turn carries **two** distinct ids. Nearly every subtlety below is about
+the gap between them:
+
+| # | Field | Layer | Minted by | Understood by |
+|---|---|---|---|---|
+| 1 | `SessionRecord.acpSessionId` | Protocol | ACP `session/new` | `session/load` / `session/prompt` on the same ACP connection — and nothing else |
+| 2 | `SessionRecord.agentChatId` | CLI | the CLI itself (hook, pre-mint, log, or adapter store) | the CLI's own `--resume`/`--session`/`--conversation` flag and its native transcript store |
+
+**The invariant: `agentChatId` is ALWAYS the native id, never the protocol
+one.** That is what makes the Terminal channel's `getRestoreCommand` and the
+native-history importers safe to write against a single field. `acpSessionId`
+exists only because, for some CLIs, the ACP id is *not* the same value and
+still has to be remembered somewhere for a `session/load` reconnect.
+
+Whether the two ids coincide is a per-CLI **fact**, established by a live spike
+per plugin — not a design choice. Each plugin declares its answer purely by
+which optional `AgentPlugin` methods it implements (`daemon/src/services/spawn.ts`,
+see the "two session identities" block above `captureNativeChatId`):
+
+| CLI | Strategy | ACP id == native id? | `captureNativeChatId` | `supportsChannelResume` | Resolver file |
+|---|---|---|---|---|---|
+| **claude** | `identical` | Yes, byte-identical | not implemented (deliberately) | not implemented → `true` | `native-chat-id/claude.ts` (terminal restore only) |
+| **opencode** | `identical` | Yes, byte-identical | not implemented (deliberately) | not implemented → `true` | none needed |
+| **agy** | `bridged` | No — but a reliable, ACP-id-keyed mapping exists on disk | implemented: reads the `antigravity-acp` adapter's own `~/.agy-acp/sessions.json` | not implemented → `true` | `native-chat-id/agy.ts` |
+| **cursor** | `unavailable` | No, and no bridge exists at all | implemented best-effort only (a cwd-keyed guess) | returns **`false`** | `native-chat-id/cursor.ts` |
+
+- `identical` — implementing `captureNativeChatId` would be pure downside: the
+  id is already right, so a second write is only a chance to make it wrong.
+- `bridged` — the ids differ, but the ACP adapter persists its own
+  session→conversation binding keyed by the exact ACP session id, so the
+  native id is recoverable with no cross-session ambiguity.
+- `unavailable` — the ids differ and nothing bridges them. `cursor-agent acp`
+  keeps its sessions in `~/.cursor/acp-sessions/<id>/store.db`, structurally
+  separate from the store `cursor-agent --resume` reads, and no CLI flag spans
+  the two. `supportsChannelResume(): false` is the honest declaration of that;
+  a json→tty toggle then starts a *fresh* terminal conversation rather than
+  crashing or passing a bogus `--resume`. It is surfaced to the UI via
+  `GET /supported-clis` so the user gets a warning before toggling. See
+  `JSON-CHAT-ARCHITECTURE.md`'s Decision-6 table for the full evidence trail.
+
+**Where the code lives:** all per-CLI native-id resolution is in
+`daemon/src/agent-plugins/native-chat-id/` — one file per CLI that needs one.
+opencode's *absence* from that directory is meaningful, not an omission: its
+native id never has to be discovered out of band. Those files are shared by
+both consumers of a native id — the terminal restore path
+(`getRestoreCommand`) and, for `bridged`/`unavailable` plugins, the ACP-side
+`captureNativeChatId`.
+
+## Summary — terminal-channel capture
+
+The rest of this document covers the *other* half of the story: how the native
+id (identity #2) is first learned for a session started in the **terminal**
+channel, which predates ACP and is unchanged by it.
 
 | CLI | Pre-mint before spawn? | Terminal-start capture | JSON-turn self-report | Toggle self-heal (tty→json) | Resume/restore self-heal (→tty) |
 |---|---|---|---|---|---|

--- a/docs/JSON-CHAT-ARCHITECTURE.md
+++ b/docs/JSON-CHAT-ARCHITECTURE.md
@@ -32,15 +32,20 @@ flowchart TB
   TOGGLE{{"Channel toggle\n(idle-gated)"}}
   PROC --> TOGGLE
 
-  subgraph JSONCH["JSON channel"]
-    JAS["JsonAgentSession\nFIFO turn queue"]
-    RUNTURN["runTurn()\nfresh process per turn"]
+  subgraph JSONCH["JSON channel (acp-migration, PR-following-#29)"]
+    JAS["JsonAgentSession\nFIFO turn queue\nowns ONE AcpConnection"]
+    ACM["AcpConnection\nspawned ONCE per session,\nalive across ALL turns"]
+    ATM["AcpTerminalManager\nhost-managed background\nterminals (survive turn end)"]
+    RUNTURN["runTurn()\nsession/prompt per turn —\nturn ends when the RESPONSE\nresolves, not on process exit"]
     STORE[("SqliteTranscriptStore\nappend/tail/pageBefore/since\nfork-supersede · tool_result cap")]
+    JAS --> ACM
     JAS --> RUNTURN --> STORE
+    ACM -.->|"terminal/*"| ATM
   end
   PLUGINS --> JAS
-  TOGGLE -->|"json→tty:\ngetRestoreCommand,\nresume same agentChatId"| SPAWNSVC
+  TOGGLE -->|"json→tty:\ngetRestoreCommand,\nresume the NATIVE id\n(agentChatId — see below)"| SPAWNSVC
   TOGGLE -->|"tty→json:\nbackfill via native-history\nimporter (claude/opencode only)"| JAS
+  TOGGLE -.->|"disposes the AcpConnection\n(Decision 9)"| ACM
 
   PROC -.->|"terminal I/O"| WEBUI
   STORE -.->|"WS + replay"| WEBUI
@@ -55,9 +60,17 @@ flowchart TB
   it's genuinely bidirectional (that's what a toggle is), so it's the only
   node with an edge pointing back up into the terminal branch.
 - **Two channels, one session record.** A session is always on exactly one
-  of `tmux`/`pty` (a live, persistent process) or `json` (no persistent
-  process — the daemon spawns the CLI fresh for every single turn). The
-  toggle switches a session between them without losing the conversation.
+  of `tmux`/`pty` (a live, persistent process) or `json`. **Both channels are
+  now persistent-process models** (acp-migration, superseding the original
+  "fresh process per turn" design): the JSON channel spawns ONE Agent Client
+  Protocol (ACP) connection per session, alive across every turn, and each
+  turn is one `session/prompt` over that same connection — the turn ends when
+  that call's response resolves, not when a process exits. This is why
+  background work started mid-turn (a backgrounded shell command, a dev
+  server) now survives past the turn that started it: it runs as a
+  host-managed ACP terminal (`AcpTerminalManager`) that the connection, not
+  any single turn, owns. The toggle switches a session between the two
+  channels without losing the conversation.
 - **Dashed arrows are live loopbacks to the UI**, not the main request
   flow — the terminal's raw I/O stream and the transcript store's WS
   broadcast both feed back into the same `WEBUI` box that started the
@@ -77,6 +90,37 @@ flowchart TB
   turns (via the P2 importer) when toggling tty→json. This is also where
   the fork/edit feature (P4) and the `tool_result` size cap live, since both
   are really "what gets written to this store" concerns.
+
+## Per-plugin ACP id vs. native id (acp-migration Decision 6)
+
+`sessions.agentChatId` always means "the id the CLI's OWN `--resume`/
+`--session`/`--conversation` flag and native transcript store understand" —
+this invariant never changes. The open question the ACP migration had to
+answer PER PLUGIN, empirically (Phase 1.8's spike procedure, run once per
+CLI), was whether the ACP `session/new` id IS that same value:
+
+| Plugin | ACP id == native id? | Storage | Toggle (json→tty) behavior |
+|---|---|---|---|
+| claude | **Yes** (byte-identical; verified `claude --resume <ACP id>` recalls the conversation) | `agentChatId` only — no `acpSessionId` column used | Normal: `getRestoreCommand` resumes correctly |
+| opencode | **Yes** (byte-identical; verified via a direct `opencode.db` query AND `opencode --session <ACP id>`) | `agentChatId` only | Normal |
+| cursor | **No, and no fix exists** (re-investigated live 2026-08-30). `cursor-agent`'s ACP mode persists each session at `~/.cursor/acp-sessions/<sessionId>/store.db` — a dedicated SQLite store keyed by the ACP session id, structurally separate from BOTH the interactive `~/.cursor/chats/` store and the print-mode `~/.cursor/projects/<slug>/agent-transcripts/` store that the raw CLI's `--resume` flag and `findLatestCursorChatId` read. `cursor-agent acp` takes no flags to bridge into an existing ACP session — the only way to resume one is the ACP `session/load` RPC, which a plain terminal invocation cannot call. Live-tested and refuted: this is NOT a timing/async-sync issue (polled >90s, no `agent-transcripts/` entry ever appears for an ACP-only session in a fresh cwd) | `sessions.acpSessionId` (new nullable column, `session/load` only) + `agentChatId` populated out-of-band by `findLatestCursorChatId(cwd)` (may legitimately stay NULL) | **Degraded, documented, confirmed final**: when the native id can't be recovered, `getRestoreCommand` returns `null` and the toggle falls through to a FRESH terminal launch — no crash, no bogus `--resume`. The Rich Chat transcript itself is unaffected (it lives in SQLite, not in cursor's own state) |
+| agy | **No, but a real fix exists** (found and live-verified 2026-08-30). The ACP `session/new` id is a different uuid than agy's own native conversation id, BUT the third-party `antigravity-acp` npm adapter (which drives agy under ACP) persists its own session↔conversation binding to `~/.agy-acp/sessions.json`, keyed by the exact ACP session id — verified live end-to-end: spawned a real ACP session, read the adapter's own file, and confirmed `agy --conversation <that id>` correctly resumed the conversation | `sessions.acpSessionId` (session/load only) + `agentChatId` populated out-of-band by `readAgyAcpSessionConversationId(acpSessionId)` (reads the adapter's own `~/.agy-acp/sessions.json`; falls back to the old cwd-keyed `readLatestAgyConversationId(cwd)` only if that file/entry is missing) | **Normal — NOT degraded**: `getRestoreCommand` resumes correctly via the adapter-provided id in the common case; falls to the old cwd-keyed best-effort path (and, from there, possibly the documented degrade) only for sessions from an adapter version predating this store |
+
+**Queryable, not just documented:** the "Toggle (json→tty) behavior" column above is exposed as a named capability, `AgentPlugin.supportsChannelResume?(): boolean` (`spawn.ts`) — `false` only for cursor, defaulting to `true` for the other three. It's surfaced through `GET /supported-clis` (`supportsChannelResume` field) and consumed by `web-ui`'s `StatusBar.tsx` to show an honest pre-toggle warning for cursor rather than a silent degrade discovered only after switching. The toggle is never disabled by this flag — it only changes the copy.
+
+**Important caveat on the agy plugin (flag for human review before shipping):**
+unlike claude (an npm-installable, Anthropic-affiliated adapter) and
+cursor/opencode (first-party native ACP subcommands on binaries this plugin
+already required), agy's only available ACP adapter is a **third-party,
+single-maintainer npm package** (`antigravity-acp`, not published by
+Google/Zed/agentclientprotocol), built on **Bun** — it introduces a brand-new
+system-level runtime dependency (`bun`/`bunx`) that nothing else in this
+stack needs, and it carries the supply-chain trust profile of an individual
+maintainer's package rather than a vendor-backed one. The live spike
+(`initialize` + `session/new` + `session/prompt`, no auth hang) succeeded on
+the machine this was implemented on, but this trade-off was not something the
+original plan anticipated and deserves an explicit go/no-go from a human
+before agy's ACP path ships to real users.
 
 ## Commit map (PR #29 → diagram)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,12 @@ importers:
 
   cli:
     dependencies:
+      '@agentclientprotocol/claude-agent-acp':
+        specifier: 0.70.0
+        version: 0.70.0(@anthropic-ai/sdk@0.122.0(zod@4.4.2))(@modelcontextprotocol/sdk@1.30.0(zod@4.4.2))
+      '@agentclientprotocol/sdk':
+        specifier: 1.4.0
+        version: 1.4.0(zod@4.4.2)
       '@fastify/cookie':
         specifier: ^11.0.2
         version: 11.0.2
@@ -217,8 +223,80 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
+  '@agentclientprotocol/claude-agent-acp@0.70.0':
+    resolution: {integrity: sha512-Psqj6fhV4pQ8IM480zpJ+xGiMMIqNLxlsTj5Mzn+T8KSURCVNJdl0ktcqLMjgHJC/QnOvDdDkFf3xTW9VIV9aQ==}
+    engines: {node: '>=22'}
+    hasBin: true
+
+  '@agentclientprotocol/sdk@1.3.0':
+    resolution: {integrity: sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ==}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+
+  '@agentclientprotocol/sdk@1.4.0':
+    resolution: {integrity: sha512-/eufudw+aFY1LKLolT6yFE6UMmYRl7fMJ/DEONSIyR6wI3slHWITBsANRGqXEY8FRzqUxwh7QEaGiZHcJPVThg==}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.232':
+    resolution: {integrity: sha512-+/4PX+dwmQAjlOlooocwa3kClulZfMo133xQH3LYDlK7D5bzze16lwlDGPVAYGEarpvXg7G5JK8QjfWAJ2HYbg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.232':
+    resolution: {integrity: sha512-EHZ1Y3aGyZ2mFZ6QLR1bM3/HiIn2cLrPjU+k3/oCIW6omJFodfzf410aWjDPSnMj7CE4d6t7MSjBWekMUbcv0g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.232':
+    resolution: {integrity: sha512-XkLcb9UT/l42Rtw7KBApzgxUe/kwoWJ9KCPcVEnYojzIvVR+AwBCl/QReNU5+6c72w48dYBMmLebI64gQbN0tg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.232':
+    resolution: {integrity: sha512-wW2opwA5s7gLghjU6B2ADMAtoc7bAZMevUzi4g+1PXMJ8MGcPvbnx92EDYJrVDcZmAl1+fz19XyPsaShlisTzw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.232':
+    resolution: {integrity: sha512-L1x2ge9NpXMLTczmT44TKPQ88PHE+gsCakQMVEOa8rXFvfBoqvcpxM0DT8wrqYWUHhQEYR8NXxQTP9a1NVRj8Q==}
+    cpu: [x64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.232':
+    resolution: {integrity: sha512-6Px1xDiwQyLkSxwRQ34/kPA8WMXQ2rHYGkwockND7+9yMw+ShI3AfLkyi9G7JtJHObWFT6B82eSHjDS/Fy+9hQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.232':
+    resolution: {integrity: sha512-fDiuwL5dm1elOy7fNp4Qmdor8so4R8npj2pUGQA1G/xKfJhaK236aTWezvZid3L/O7cRdFeN9IVofOAlWLQcsw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.232':
+    resolution: {integrity: sha512-Hc/9uy1BI9mqKVyB1b/zoUnm3MFgtVNzQY6p5zgaq9DaIjCKDpR4a4L1aDZM4lMqUcWFMZM+u7juOhh+m39NBQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk@0.3.232':
+    resolution: {integrity: sha512-8od7hJk9fZnF1/oYYiR9PvroGbZRQrpmNgKirjHNGoj5ur5YcAZLohI70XVUAUe3KvjB1msLxtkvmlAT9sqFAg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@anthropic-ai/sdk': '>=0.93.0'
+      '@modelcontextprotocol/sdk': ^1.29.0
+      zod: ^4.0.0
+
+  '@anthropic-ai/sdk@0.122.0':
+    resolution: {integrity: sha512-GGPNftt0caaz9MDlmNQGHX8855Ojaduyy5pm9Sm1h7HalCn0cWNb5/bweadJF+4yzbal+QL6ztBa09WAAOzLmQ==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -601,6 +679,12 @@ packages:
   '@fastify/websocket@11.2.0':
     resolution: {integrity: sha512-3HrDPbAG1CzUCqnslgJxppvzaAZffieOVbLp1DAy1huCSynUWPifSvfdEDUR8HlJLp3sp1A36uOM2tJogADS8w==}
 
+  '@hono/node-server@2.1.1':
+    resolution: {integrity: sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -645,6 +729,16 @@ packages:
 
   '@mermaid-js/parser@1.1.0':
     resolution: {integrity: sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==}
+
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
@@ -809,6 +903,9 @@ packages:
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -1120,6 +1217,10 @@ packages:
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1220,6 +1321,10 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
@@ -1235,12 +1340,20 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
@@ -1337,12 +1450,36 @@ packages:
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.1.0:
+    resolution: {integrity: sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cose-base@1.0.3:
     resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
@@ -1564,6 +1701,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -1591,11 +1732,18 @@ packages:
   duplexify@4.1.3:
     resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   electron-to-chromium@1.5.348:
     resolution: {integrity: sha512-QC2X59nRlycQQMc4ZXjSVBX+tSgJfgRtcrYHbIZLgOV2dCvefoQGegLR7lLXKgpPpSuVmJU19LMzGrSa2C7k3Q==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -1631,6 +1779,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1698,6 +1849,18 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
@@ -1705,6 +1868,16 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.7.0:
+    resolution: {integrity: sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -1726,6 +1899,9 @@ packages:
 
   fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
@@ -1758,6 +1934,10 @@ packages:
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-my-way@9.5.0:
     resolution: {integrity: sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==}
     engines: {node: '>=20'}
@@ -1777,6 +1957,10 @@ packages:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
   framer-motion@12.38.0:
     resolution: {integrity: sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==}
     peerDependencies:
@@ -1790,6 +1974,10 @@ packages:
         optional: true
       react-dom:
         optional: true
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -1876,6 +2064,10 @@ packages:
     resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
     engines: {node: '>=12.0.0'}
 
+  hono@4.13.5:
+    resolution: {integrity: sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==}
+    engines: {node: '>=16.9.0'}
+
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
@@ -1885,6 +2077,10 @@ packages:
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -1896,6 +2092,10 @@ packages:
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
@@ -1937,6 +2137,14 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
+  ip-address@10.7.0:
+    resolution: {integrity: sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   ipaddr.js@2.3.0:
     resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
     engines: {node: '>= 10'}
@@ -1972,6 +2180,9 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-unicode-supported@1.3.0:
     resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
     engines: {node: '>=12'}
@@ -1982,6 +2193,9 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jose@6.2.10:
+    resolution: {integrity: sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2014,11 +2228,18 @@ packages:
     resolution: {integrity: sha512-HqMnbz0tz2DaEJ3ntsqtx3ezzZyDE7G56A/pPY/NGmrPu76UzsWquOpHFRAf5beTNXoH2LU5cQePVvRli1nchA==}
     engines: {node: '>=20'}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -2165,6 +2386,14 @@ packages:
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
+  media-typer@1.1.1:
+    resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   mermaid@11.14.0:
     resolution: {integrity: sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==}
 
@@ -2256,9 +2485,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
@@ -2312,6 +2549,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@1.1.0:
+    resolution: {integrity: sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==}
+    engines: {node: '>=18'}
+
   nock@13.5.6:
     resolution: {integrity: sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==}
     engines: {node: '>= 10.13'}
@@ -2332,9 +2573,21 @@ packages:
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -2381,6 +2634,10 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-data-parser@0.1.0:
     resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
@@ -2391,6 +2648,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -2418,6 +2678,10 @@ packages:
   pino@10.3.1:
     resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
     hasBin: true
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -2473,6 +2737,10 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -2480,8 +2748,20 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
+    engines: {node: '>=0.6'}
+
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -2605,6 +2885,10 @@ packages:
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   rrweb-cssom@0.7.1:
     resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
 
@@ -2647,8 +2931,19 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -2660,6 +2955,22 @@ packages:
 
   shiki@3.23.0:
     resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -2697,6 +3008,13 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standardwebhooks@1.1.1:
+    resolution: {integrity: sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -2798,6 +3116,10 @@ packages:
     resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
     engines: {node: '>=12'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
@@ -2815,6 +3137,9 @@ packages:
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -2835,6 +3160,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typescript-eslint@8.59.1:
     resolution: {integrity: sha512-xqDcFVBmlrltH64lklOVp1wYxgJr6LVdg3NamBgH2OOQDLFdTKfIZXF5PfghrnXQKXZGTQs8tr1vL7fJvq8CTQ==}
@@ -2875,6 +3204,10 @@ packages:
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -2890,6 +3223,10 @@ packages:
   uuid@11.1.1:
     resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -3047,6 +3384,11 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
   zod@4.4.2:
     resolution: {integrity: sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==}
 
@@ -3075,10 +3417,73 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
+  '@agentclientprotocol/claude-agent-acp@0.70.0(@anthropic-ai/sdk@0.122.0(zod@4.4.2))(@modelcontextprotocol/sdk@1.30.0(zod@4.4.2))':
+    dependencies:
+      '@agentclientprotocol/sdk': 1.3.0(zod@4.4.2)
+      '@anthropic-ai/claude-agent-sdk': 0.3.232(@anthropic-ai/sdk@0.122.0(zod@4.4.2))(@modelcontextprotocol/sdk@1.30.0(zod@4.4.2))(zod@4.4.2)
+      zod: 4.4.2
+    transitivePeerDependencies:
+      - '@anthropic-ai/sdk'
+      - '@modelcontextprotocol/sdk'
+
+  '@agentclientprotocol/sdk@1.3.0(zod@4.4.2)':
+    dependencies:
+      zod: 4.4.2
+
+  '@agentclientprotocol/sdk@1.4.0(zod@4.4.2)':
+    dependencies:
+      zod: 4.4.2
+
   '@antfu/install-pkg@1.1.0':
     dependencies:
       package-manager-detector: 1.6.0
       tinyexec: 1.1.2
+
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.232':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.232':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.232':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.232':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.232':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.232':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.232':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.232':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk@0.3.232(@anthropic-ai/sdk@0.122.0(zod@4.4.2))(@modelcontextprotocol/sdk@1.30.0(zod@4.4.2))(zod@4.4.2)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.122.0(zod@4.4.2)
+      '@modelcontextprotocol/sdk': 1.30.0(zod@4.4.2)
+      zod: 4.4.2
+    optionalDependencies:
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.232
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.232
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.232
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.232
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.232
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.232
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.232
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.232
+
+  '@anthropic-ai/sdk@0.122.0(zod@4.4.2)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.1.1
+    optionalDependencies:
+      zod: 4.4.2
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -3451,6 +3856,10 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  '@hono/node-server@2.1.1(hono@4.13.5)':
+    dependencies:
+      hono: 4.13.5
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -3497,6 +3906,28 @@ snapshots:
   '@mermaid-js/parser@1.1.0':
     dependencies:
       langium: 4.2.3
+
+  '@modelcontextprotocol/sdk@1.30.0(zod@4.4.2)':
+    dependencies:
+      '@hono/node-server': 2.1.1(hono@4.13.5)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.1
+      express: 5.2.1
+      express-rate-limit: 8.7.0(express@5.2.1)
+      hono: 4.13.5
+      jose: 6.2.10
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.2
+      zod-to-json-schema: 3.25.2(zod@4.4.2)
+    transitivePeerDependencies:
+      - supports-color
 
   '@pinojs/redact@0.4.0': {}
 
@@ -3617,6 +4048,8 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@stablelib/base64@1.0.1': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -4013,7 +4446,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 1.2.0
-      vitest: 2.1.9(@types/node@22.19.17)(@vitest/ui@2.1.9)(jsdom@25.0.1)
+      vitest: 2.1.9(@types/node@20.19.39)(@vitest/ui@2.1.9)(jsdom@25.0.1)
 
   '@vitest/utils@2.1.9':
     dependencies:
@@ -4028,6 +4461,11 @@ snapshots:
   '@xterm/xterm@6.0.0': {}
 
   abstract-logging@2.0.1: {}
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.1.0
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -4111,6 +4549,20 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.1.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.16.0
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
@@ -4133,12 +4585,19 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  bytes@3.1.2: {}
+
   cac@6.7.14: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
 
@@ -4218,9 +4677,24 @@ snapshots:
 
   confbox@0.1.8: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.1.0: {}
+
   convert-source-map@2.0.0: {}
 
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
   cookie@1.1.1: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cose-base@1.0.3:
     dependencies:
@@ -4462,6 +4936,8 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
@@ -4491,9 +4967,13 @@ snapshots:
       readable-stream: 3.6.2
       stream-shift: 1.0.3
 
+  ee-first@1.1.1: {}
+
   electron-to-chromium@1.5.348: {}
 
   emoji-regex@10.6.0: {}
+
+  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -4545,6 +5025,8 @@ snapshots:
       '@esbuild/win32-x64': 0.21.5
 
   escalade@3.2.0: {}
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -4628,9 +5110,58 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
+  eventsource-parser@3.1.1: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.1
+
   expand-template@2.0.3: {}
 
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.7.0(express@5.2.1):
+    dependencies:
+      debug: 4.4.3
+      express: 5.2.1
+      ip-address: 10.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.16.0
+      range-parser: 1.3.0
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   extend@3.0.2: {}
 
@@ -4654,6 +5185,8 @@ snapshots:
   fast-querystring@1.1.2:
     dependencies:
       fast-decode-uri-component: 1.0.1
+
+  fast-sha256@1.3.0: {}
 
   fast-uri@3.1.0: {}
 
@@ -4693,6 +5226,17 @@ snapshots:
 
   file-uri-to-path@1.0.0: {}
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-my-way@9.5.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -4719,6 +5263,8 @@ snapshots:
       hasown: 2.0.3
       mime-types: 2.1.35
 
+  forwarded@0.2.0: {}
+
   framer-motion@12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       motion-dom: 12.38.0
@@ -4727,6 +5273,8 @@ snapshots:
     optionalDependencies:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
+
+  fresh@2.0.0: {}
 
   fs-constants@1.0.0: {}
 
@@ -4835,6 +5383,8 @@ snapshots:
 
   highlight.js@11.11.1: {}
 
+  hono@4.13.5: {}
+
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
@@ -4842,6 +5392,14 @@ snapshots:
   html-url-attributes@3.0.1: {}
 
   html-void-elements@3.0.0: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -4858,6 +5416,10 @@ snapshots:
       - supports-color
 
   iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.7.3:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -4886,6 +5448,10 @@ snapshots:
 
   internmap@2.0.3: {}
 
+  ip-address@10.7.0: {}
+
+  ipaddr.js@1.9.1: {}
+
   ipaddr.js@2.3.0: {}
 
   is-alphabetical@2.0.1: {}
@@ -4911,11 +5477,15 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
+  is-promise@4.0.0: {}
+
   is-unicode-supported@1.3.0: {}
 
   is-unicode-supported@2.1.0: {}
 
   isexe@2.0.0: {}
+
+  jose@6.2.10: {}
 
   js-tokens@4.0.0: {}
 
@@ -4967,9 +5537,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -5213,6 +5790,10 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
 
+  media-typer@1.1.1: {}
+
+  merge-descriptors@2.0.0: {}
+
   mermaid@11.14.0:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
@@ -5430,9 +6011,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mimic-function@5.0.1: {}
 
@@ -5475,6 +6062,10 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@1.1.0:
+    dependencies:
+      content-type: 2.1.0
+
   nock@13.5.6:
     dependencies:
       debug: 4.4.3
@@ -5497,7 +6088,15 @@ snapshots:
 
   nwsapi@2.2.23: {}
 
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
   on-exit-leak-free@2.1.2: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -5566,11 +6165,15 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parseurl@1.3.3: {}
+
   path-data-parser@0.1.0: {}
 
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-to-regexp@8.4.2: {}
 
   pathe@1.1.2: {}
 
@@ -5601,6 +6204,8 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
       thread-stream: 4.0.0
+
+  pkce-challenge@5.0.1: {}
 
   pkg-types@1.3.1:
     dependencies:
@@ -5665,6 +6270,11 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -5672,7 +6282,21 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  qs@6.16.0:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
   quick-format-unescaped@4.0.4: {}
+
+  range-parser@1.3.0: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
 
   rc@1.2.8:
     dependencies:
@@ -5851,6 +6475,16 @@ snapshots:
       points-on-curve: 0.2.0
       points-on-path: 0.2.1
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   rrweb-cssom@0.7.1: {}
 
   rrweb-cssom@0.8.0: {}
@@ -5879,7 +6513,34 @@ snapshots:
 
   semver@7.7.4: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
   set-cookie-parser@2.7.2: {}
+
+  setprototypeof@1.2.0: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -5897,6 +6558,34 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -5929,6 +6618,13 @@ snapshots:
   split2@4.2.0: {}
 
   stackback@0.0.2: {}
+
+  standardwebhooks@1.1.1:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
+  statuses@2.0.2: {}
 
   std-env@3.10.0: {}
 
@@ -6023,6 +6719,8 @@ snapshots:
 
   toad-cache@3.7.0: {}
 
+  toidentifier@1.0.1: {}
+
   totalist@3.0.1: {}
 
   tough-cookie@5.1.2:
@@ -6036,6 +6734,8 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
@@ -6052,6 +6752,12 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.1.0
+      media-typer: 1.1.1
+      mime-types: 3.0.2
 
   typescript-eslint@8.59.1(eslint@9.39.4)(typescript@5.9.3):
     dependencies:
@@ -6108,6 +6814,8 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
+  unpipe@1.0.0: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
@@ -6121,6 +6829,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@11.1.1: {}
+
+  vary@1.1.2: {}
 
   vfile-message@4.0.3:
     dependencies:
@@ -6318,6 +7028,10 @@ snapshots:
   yaml@2.8.3: {}
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.2):
+    dependencies:
+      zod: 4.4.2
 
   zod@4.4.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       '@xterm/xterm':
         specifier: ^6.0.0
         version: 6.0.0
+      diff:
+        specifier: ^9.0.0
+        version: 9.0.0
       dompurify:
         specifier: ^3.2.0
         version: 3.4.2
@@ -1715,6 +1718,10 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
+    engines: {node: '>=0.3.1'}
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -4446,7 +4453,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 1.2.0
-      vitest: 2.1.9(@types/node@20.19.39)(@vitest/ui@2.1.9)(jsdom@25.0.1)
+      vitest: 2.1.9(@types/node@22.19.17)(@vitest/ui@2.1.9)(jsdom@25.0.1)
 
   '@vitest/utils@2.1.9':
     dependencies:
@@ -4945,6 +4952,8 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  diff@9.0.0: {}
 
   dom-accessibility-api@0.5.16: {}
 

--- a/scripts/demo-seed.sh
+++ b/scripts/demo-seed.sh
@@ -96,6 +96,7 @@ JSON
   "prefix": "napi",
   "defaultBranch": "main",
   "createdAt": "2025-05-01T09:00:00.000Z",
+  "nextWorktreeNum": 5,
   "worktrees": [
     {
       "id": "napi-1",
@@ -152,6 +153,7 @@ JSON
   "prefix": "atls",
   "defaultBranch": "main",
   "createdAt": "2025-05-01T09:10:00.000Z",
+  "nextWorktreeNum": 4,
   "worktrees": [
     {
       "id": "atls-1",
@@ -196,6 +198,7 @@ JSON
   "prefix": "frge",
   "defaultBranch": "main",
   "createdAt": "2025-05-01T09:15:00.000Z",
+  "nextWorktreeNum": 3,
   "worktrees": [
     {
       "id": "frge-1",

--- a/scripts/dev-entrypoint.sh
+++ b/scripts/dev-entrypoint.sh
@@ -19,27 +19,104 @@ set -e
 mkdir -p /home/vst/.vibe-station /home/vst/projects
 chown -R vst:vst /home/vst/.vibe-station /home/vst/projects
 
-# Seed a writable ~/.gemini from a read-only /seed/gemini mount, if one is
-# present. Plain `docker run` off this image's own CMD (no compose file)
-# won't have that mount, so skip cleanly rather than failing.
-if [ -d /seed/gemini ] && [ ! -f /home/vst/.gemini/.seeded ]; then
-  echo 'Seeding writable ~/.gemini from /seed/gemini (excluding browser profile)...'
-  mkdir -p /home/vst/.gemini
-  for item in /seed/gemini/*; do
-    case "$(basename "$item")" in
-      antigravity|antigravity-browser-profile) continue ;;
-    esac
-    cp -a "$item" /home/vst/.gemini/ 2>/dev/null || true
-  done
-  # chown BEFORE the .seeded marker is touched: if the container is killed
-  # mid-seed, the marker must stay unset so the next start retries the
-  # whole seed cleanly, instead of leaving .gemini permanently root-owned
-  # with a marker that claims the seed already succeeded.
-  chown -R vst:vst /home/vst/.gemini
-  touch /home/vst/.gemini/.seeded
-  chown vst:vst /home/vst/.gemini/.seeded
-  echo 'Seed complete.'
+# Symlink cursor-agent's REAL wrapper script into place from the mounted
+# `versions/` directory (see docker-compose.dev.yml's CURSOR_AGENT_VERSIONS
+# comment for the full root-cause writeup). cursor-agent's own launcher does
+# `realpath "$0"` and expects its bundled `node` binary + numbered chunk
+# `.js` files to sit in the SAME directory as itself — a single-file bind
+# mount of just the launcher script (the old approach) breaks that: Docker
+# resolves a host symlink to its target's CONTENTS at mount time, so the
+# container never sees a real path back to those sibling files, and the
+# launcher fails with `Cannot find module '.../index.js'`. Mounting the
+# whole `versions/` tree read-only and symlinking from INSIDE the container
+# preserves the sibling-file relationship the launcher relies on.
+if [ -d /opt/cursor-agent-versions ]; then
+  # Version dirs are date-prefixed (e.g. `2026.08.25-<sha>`) and sort
+  # lexicographically in chronological order — no need to know which one
+  # the host's own `~/.local/bin/cursor-agent` symlink currently points at.
+  cursor_agent_version_dir="$(find /opt/cursor-agent-versions -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort | tail -1)"
+  if [ -n "$cursor_agent_version_dir" ] && [ -f "$cursor_agent_version_dir/cursor-agent" ]; then
+    ln -sf "$cursor_agent_version_dir/cursor-agent" /usr/local/bin/cursor-agent
+    echo "cursor-agent: symlinked to $cursor_agent_version_dir/cursor-agent"
+  else
+    echo 'cursor-agent: WARNING — /opt/cursor-agent-versions is mounted but no version dir with a `cursor-agent` launcher was found; cursor-agent will not run' >&2
+  fi
 fi
+
+# Seed a writable ~/<name> dir from a read-only /seed/<name> mount, if one is
+# present, skipping any basenames listed in $3 (space-separated) — bulk,
+# non-auth-relevant data (old conversation transcripts, multi-hundred-MB
+# local databases) that would make every container start slow for no benefit
+# inside a throwaway sandbox; only the small config/credential files matter
+# here. Plain `docker run` off this image's own CMD (no compose file) won't
+# have the /seed mount, so skip cleanly rather than failing. The `.seeded`
+# marker is written only AFTER chown, so a kill mid-seed self-heals into a
+# full retry next boot rather than leaving a permanently-root-owned dir with
+# a marker that falsely claims the seed already succeeded.
+seed_writable_home() {
+  seed_src="$1"; target="$2"; excludes="$3"
+  if [ -d "$seed_src" ] && [ ! -f "$target/.seeded" ]; then
+    echo "Seeding writable $target from $seed_src..."
+    mkdir -p "$target"
+    # `*` alone does NOT match dotfiles in POSIX sh (no dotglob) — claude's
+    # actual credential file is `.credentials.json`, a dotfile, so a plain
+    # `"$seed_src"/*` glob would silently skip the one file that matters
+    # most. `.[!.]*` + `..?*` are the standard POSIX trick to also match
+    # dotfiles without matching the literal `.`/`..` entries; any pattern
+    # that matches nothing stays as a literal, unexpanded string, which the
+    # `[ -e "$item" ]` guard below skips harmlessly.
+    for item in "$seed_src"/* "$seed_src"/.[!.]* "$seed_src"/..?*; do
+      [ -e "$item" ] || continue
+      base="$(basename "$item")"
+      skip=0
+      for ex in $excludes; do
+        if [ "$base" = "$ex" ]; then skip=1; break; fi
+      done
+      [ "$skip" = 1 ] && continue
+      cp -a "$item" "$target/" 2>/dev/null || true
+    done
+    chown -R vst:vst "$target"
+    touch "$target/.seeded"
+    chown vst:vst "$target/.seeded"
+    echo "Seed complete: $target"
+  fi
+}
+
+# gemini/agy — writes logs/cache/conversations under
+# ~/.gemini/antigravity-cli and fails hard on a read-only mount; the bulky
+# `antigravity`/`antigravity-browser-profile` dirs (~1.9G, the desktop IDE +
+# its browser profile) are excluded — agy-cli needs neither.
+seed_writable_home /seed/gemini /home/vst/.gemini "antigravity antigravity-browser-profile"
+
+# claude — `.credentials.json` (OAuth token) lives directly under `~/.claude`
+# alongside gigabytes of past-conversation transcripts (`projects/`) and file
+# snapshots (`file-history/`) neither needed for auth nor for a fresh
+# sandbox's own conversations, which claude writes to on its own once
+# authenticated. `~/.claude.json` (a SIBLING FILE, not inside `~/.claude`)
+# carries onboarding/telemetry state claude checks on startup — seeded
+# separately since `seed_writable_home` only handles directories.
+seed_writable_home /seed/claude /home/vst/.claude "projects file-history"
+if [ -f /seed/claude.json ] && [ ! -f /home/vst/.claude.json ]; then
+  cp /seed/claude.json /home/vst/.claude.json 2>/dev/null || true
+  chown vst:vst /home/vst/.claude.json 2>/dev/null || true
+fi
+
+# cursor — the actual OAuth access/refresh tokens live under
+# `~/.config/cursor/auth.json`, NOT `~/.cursor` (verified empirically —
+# `~/.cursor` holds CLI session/workspace state: `chats/`, `projects/`,
+# `extensions/`, `acp-sessions/`, all excluded here as bulk/non-auth). Small
+# CLI preference files (`cli-config.json`, `argv.json`, `mcp.json`) are kept
+# since cursor-agent reads them for permission/editor/display settings.
+seed_writable_home /seed/cursor-config /home/vst/.config/cursor ""
+seed_writable_home /seed/cursor-home /home/vst/.cursor "chats projects extensions acp-sessions sandbox-policies"
+
+# opencode — the credential is `~/.local/share/opencode/auth.json`; that same
+# directory also holds `opencode.db` (the CLI's own global session/transcript
+# store, routinely 500MB-1GB+) and `snapshot/`/`repos/` working-copy caches,
+# none of which a fresh sandbox needs. `~/.config/opencode` (small) carries
+# opencode's own config/skills and is kept in full.
+seed_writable_home /seed/opencode-data /home/vst/.local/share/opencode "opencode.db opencode.db-shm opencode.db-wal snapshot repos"
+seed_writable_home /seed/opencode-config /home/vst/.config/opencode ""
 
 # VST_SEED_MODE selects what gets seeded into this sandbox:
 #   demo                  (default) — 3 projects / 9 worktrees / 14 sessions,

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -22,6 +22,7 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
+    "diff": "^9.0.0",
     "dompurify": "^3.2.0",
     "framer-motion": "^12.0.0",
     "highlight.js": "*",

--- a/web-ui/src/api/mock.ts
+++ b/web-ui/src/api/mock.ts
@@ -969,10 +969,10 @@ export function createMockApi() {
 
     async getSupportedClis(): Promise<SupportedCli[]> {
       return [
-        { id: "claude", defaultModel: "sonnet", supportsJson: true, importsNativeHistory: true },
-        { id: "cursor", defaultModel: "auto", supportsJson: true, importsNativeHistory: false },
-        { id: "opencode", defaultModel: "opencode/big-pickle", supportsJson: true, importsNativeHistory: true },
-        { id: "agy", defaultModel: "Gemini 3.1 Pro (High)", supportsJson: true, importsNativeHistory: false },
+        { id: "claude", defaultModel: "sonnet", supportsJson: true, importsNativeHistory: true, supportsJsonToTerminalResume: true },
+        { id: "cursor", defaultModel: "auto", supportsJson: true, importsNativeHistory: false, supportsJsonToTerminalResume: false },
+        { id: "opencode", defaultModel: "opencode/big-pickle", supportsJson: true, importsNativeHistory: true, supportsJsonToTerminalResume: true },
+        { id: "agy", defaultModel: "Gemini 3.1 Pro (High)", supportsJson: true, importsNativeHistory: false, supportsJsonToTerminalResume: true },
       ];
     },
 

--- a/web-ui/src/api/types.ts
+++ b/web-ui/src/api/types.ts
@@ -188,7 +188,39 @@ export type NormalizedEventKind =
   | "usage"
   | "result"
   | "error"
-  | "status";
+  | "status"
+  | "mode_update"
+  | "commands_update";
+
+/** Normalized non-text (or text-in-a-mixed-array) content block (mirror of daemon `NormalizedContentBlock`). */
+export interface NormalizedContentBlock {
+  type: "text" | "image" | "audio" | "resource" | "resource_link";
+  text?: string;
+  mimeType?: string;
+  data?: string;
+  uri?: string;
+  name?: string;
+}
+
+/** A structured file-edit diff (mirror of daemon `ToolDiff`). */
+export interface ToolDiff {
+  path: string;
+  oldText?: string;
+  newText: string;
+}
+
+/** ACP `ToolKind` union, verbatim (mirror of daemon `AcpToolKind`). */
+export type AcpToolKind =
+  | "read"
+  | "edit"
+  | "delete"
+  | "move"
+  | "search"
+  | "execute"
+  | "think"
+  | "fetch"
+  | "switch_mode"
+  | "other";
 
 /** One normalized chat event (mirror of daemon `NormalizedEvent`). */
 export interface NormalizedEvent {
@@ -218,6 +250,20 @@ export interface NormalizedEvent {
   agentChatId?: string;
   /** Durable monotonic pagination cursor assigned by the daemon at persist. */
   logSeq?: number;
+  /** Non-text (or mixed) content blocks from `agent_message_chunk`/`agent_thought_chunk`. */
+  blocks?: NormalizedContentBlock[];
+  /** Structured file-edit diffs from `tool_call`/`tool_call_update.content`. */
+  toolDiffs?: ToolDiff[];
+  /** `tool_call`/`tool_call_update.locations`. */
+  toolLocations?: { path: string; line?: number }[];
+  /** `tool_call`/`tool_call_update.kind`, structural. */
+  toolKind?: AcpToolKind;
+  /** ACP `ToolCallStatus`, mirrored on `tool_use`/`tool_result` events. */
+  toolStatus?: "pending" | "in_progress" | "completed" | "failed";
+  /** `mode_update` only — the new `currentModeId`. */
+  modeId?: string;
+  /** `commands_update` only — the available slash commands. */
+  commands?: { name: string; description: string }[];
 }
 
 export type TurnState = "idle" | "queued" | "thinking" | "responding" | "tool" | "error";

--- a/web-ui/src/api/types.ts
+++ b/web-ui/src/api/types.ts
@@ -292,6 +292,13 @@ export interface SupportedCli {
    * won't appear in JSON chat, though the agent still has them via --resume.
    */
   importsNativeHistory: boolean;
+  /**
+   * Whether a Rich Chat session for this CLI can actually resume its
+   * conversation when toggled to the Terminal channel. `false` (cursor) means
+   * the toggle still works but always starts a fresh terminal conversation —
+   * the CLI's ACP session state lives somewhere its own `--resume` can't reach.
+   */
+  supportsJsonToTerminalResume: boolean;
 }
 
 export interface Mode {

--- a/web-ui/src/components/chat/MessageList.test.tsx
+++ b/web-ui/src/components/chat/MessageList.test.tsx
@@ -197,6 +197,64 @@ describe("groupEvents thinking merge/close (1.T1 / 1.T2)", () => {
   });
 });
 
+describe("groupEvents acp-normalize-superset (Phase 3)", () => {
+  it("3.T1 — a tool_result with toolStatus in_progress and no toolResult does not erase a previously-set diffs", () => {
+    const items = groupEvents([
+      toolUseEvent("tc1", "t1"),
+      {
+        id: "r1",
+        sessionId: "s1",
+        ts: "",
+        provider: "claude",
+        kind: "tool_result",
+        toolId: "tc1",
+        toolDiffs: [{ path: "/a.ts", oldText: "old", newText: "new" }],
+        toolStatus: "in_progress",
+      },
+      {
+        id: "r2",
+        sessionId: "s1",
+        ts: "",
+        provider: "claude",
+        kind: "tool_result",
+        toolId: "tc1",
+        toolStatus: "in_progress",
+      },
+    ]);
+    const tool = items.find((i) => i.type === "tool") as { diffs?: unknown[]; status?: string };
+    expect(tool.diffs).toEqual([{ path: "/a.ts", oldText: "old", newText: "new" }]);
+    expect(tool.status).toBe("in_progress");
+  });
+
+  it("3.T2 — a mode_update event produces a status-type RenderItem", () => {
+    const items = groupEvents([
+      { id: "m1", sessionId: "s1", ts: "", provider: "claude", kind: "mode_update", modeId: "build" },
+    ]);
+    const status = items.find((i) => i.type === "status") as { text: string };
+    expect(status).toBeTruthy();
+    expect(status.text).toContain("build");
+  });
+
+  it("3.T4 — a text event with no text but a non-empty blocks array renders a non-empty placeholder bubble", () => {
+    const items = groupEvents([
+      {
+        id: "b1",
+        sessionId: "s1",
+        ts: "",
+        provider: "claude",
+        kind: "text",
+        role: "assistant",
+        turnId: "t1",
+        blocks: [{ type: "image", mimeType: "image/png", data: "abc" }],
+      },
+    ]);
+    const assistant = items.find((i) => i.type === "assistant") as { text: string };
+    expect(assistant).toBeTruthy();
+    expect(assistant.text.length).toBeGreaterThan(0);
+    expect(assistant.text).not.toBe("");
+  });
+});
+
 describe("MessageList queued-turn filtering (tray relocation)", () => {
   it("hides user turns listed in hiddenTurnIds from the inline log", () => {
     render(

--- a/web-ui/src/components/chat/MessageList.tsx
+++ b/web-ui/src/components/chat/MessageList.tsx
@@ -8,7 +8,7 @@ import { ThinkingBlock } from "./ThinkingBlock";
 import { ToolRunSummary } from "./ToolRunSummary";
 import { ErrorCard } from "./ErrorCard";
 import { WorkingDots } from "./WorkingDots";
-import type { ToolCallEntry } from "./toolFormat";
+import { blocksToPlaceholder, type ToolCallEntry } from "./toolFormat";
 
 type RenderItem =
   | { type: "user"; id: string; text: string; attachments?: Attachment[]; turnId?: string; cancelled?: boolean }
@@ -176,10 +176,11 @@ export function groupEvents(events: NormalizedEvent[]): RenderItem[] {
         // Merge streaming deltas WITHIN a turn, but a new turn always starts a
         // fresh bubble — otherwise back-to-back replies (e.g. answers to several
         // queued messages, with only meta events between them) run together.
+        const incomingText = ev.text ?? (ev.blocks && ev.blocks.length > 0 ? blocksToPlaceholder(ev.blocks) : "");
         if (last && last.type === "assistant" && last.turnId === ev.turnId) {
-          last.text += ev.text ?? "";
+          last.text += incomingText;
         } else {
-          items.push({ type: "assistant", id: ev.id, text: ev.text ?? "", turnId: ev.turnId });
+          items.push({ type: "assistant", id: ev.id, text: incomingText, turnId: ev.turnId });
         }
         break;
       }
@@ -193,7 +194,7 @@ export function groupEvents(events: NormalizedEvent[]): RenderItem[] {
         // downstream by `mergeToolRuns`' drop-rule above.
         const openIdx = ev.turnId ? thinkingOpenByTurnId.get(ev.turnId) : undefined;
         const open = openIdx != null ? items[openIdx] : undefined;
-        const incoming = ev.text ?? "";
+        const incoming = ev.text ?? (ev.blocks && ev.blocks.length > 0 ? blocksToPlaceholder(ev.blocks) : "");
         // Real text arriving into a group that opened EMPTY and no longer sits
         // at the end of the feed (a tool call has rendered since) must NOT be
         // appended: that group's position is stale, so the reasoning would show
@@ -228,19 +229,38 @@ export function groupEvents(events: NormalizedEvent[]): RenderItem[] {
       }
       case "tool_use": {
         markToolCallDuringThinking(ev.turnId);
-        items.push({ type: "tool", id: ev.id, toolName: ev.toolName ?? "tool", toolInput: ev.toolInput, turnId: ev.turnId });
+        items.push({
+          type: "tool",
+          id: ev.id,
+          toolName: ev.toolName ?? "tool",
+          toolInput: ev.toolInput,
+          turnId: ev.turnId,
+          status: ev.toolStatus,
+          diffs: ev.toolDiffs,
+          locations: ev.toolLocations,
+          toolKind: ev.toolKind,
+        });
         if (ev.toolId) toolIndexById.set(ev.toolId, items.length - 1);
         break;
       }
       case "tool_result": {
         markToolCallDuringThinking(ev.turnId);
-        const result = { content: ev.toolResult?.content, isError: ev.toolResult?.isError };
         const idx = ev.toolId ? toolIndexById.get(ev.toolId) : undefined;
         const target = idx != null ? items[idx] : undefined;
         if (target && target.type === "tool") {
-          target.result = result;
+          if (ev.toolResult !== undefined) {
+            target.result = { content: ev.toolResult.content, isError: ev.toolResult.isError };
+          }
+          if (ev.toolStatus !== undefined) target.status = ev.toolStatus;
+          if (ev.toolDiffs !== undefined) target.diffs = ev.toolDiffs;
+          if (ev.toolLocations !== undefined) target.locations = ev.toolLocations;
+          if (ev.toolKind !== undefined) target.toolKind = ev.toolKind;
         } else {
-          items.push({ type: "tool", id: ev.id, toolName: ev.toolName ?? "tool", result, turnId: ev.turnId });
+          items.push({
+            type: "tool", id: ev.id, toolName: ev.toolName ?? "tool", turnId: ev.turnId,
+            result: ev.toolResult !== undefined ? { content: ev.toolResult.content, isError: ev.toolResult.isError } : undefined,
+            status: ev.toolStatus, diffs: ev.toolDiffs, locations: ev.toolLocations, toolKind: ev.toolKind,
+          });
         }
         break;
       }
@@ -265,6 +285,23 @@ export function groupEvents(events: NormalizedEvent[]): RenderItem[] {
           items.push({ type: "status", id: ev.id, text: ev.text });
         }
         break;
+      case "mode_update":
+        closeOpenThinking(ev.turnId, ev.ts);
+        items.push({ type: "status", id: ev.id, text: `Mode changed${ev.modeId ? ` to ${ev.modeId}` : ""}` });
+        break;
+      case "commands_update": {
+        closeOpenThinking(ev.turnId, ev.ts);
+        const names = (ev.commands ?? []).map((c) => c.name);
+        const CAP = 8;
+        const shown = names.slice(0, CAP).join(", ");
+        const more = names.length > CAP ? ` (+${names.length - CAP} more)` : "";
+        items.push({
+          type: "status",
+          id: ev.id,
+          text: `${names.length} command${names.length === 1 ? "" : "s"} available${shown ? `: ${shown}${more}` : ""}`,
+        });
+        break;
+      }
       default:
         // session_init / usage / result — not rendered as bubbles, but a
         // `result` event marks the turn as over, so close any open group.

--- a/web-ui/src/components/chat/StatusBar.tsx
+++ b/web-ui/src/components/chat/StatusBar.tsx
@@ -82,13 +82,22 @@ export function StatusBar({ meta, queueDepth = 0, onStop, api, sessionId, atBott
   // we default to NOT warning until it resolves. cursor/agy → false.
   const cli = meta?.cli;
   const [importsHistory, setImportsHistory] = useState<boolean | null>(null);
+  // Same resolve-once-from-GET/supported-clis pattern as importsHistory above,
+  // for a second, independent caveat: can the terminal side actually RESUME
+  // this CLI's conversation at all (vs. just missing its terminal-phase
+  // backfill). false only for cursor today — its ACP session state lives in a
+  // store `--resume` can't read (Decision 6 follow-up, spawn.ts).
+  const [supportsResume, setSupportsResume] = useState<boolean | null>(null);
   useEffect(() => {
     if (!api || !cli) return undefined;
     setImportsHistory(null);
+    setSupportsResume(null);
     let live = true;
     void api.getSupportedClis().then((clis) => {
       if (!live) return;
-      setImportsHistory(clis.find((c) => c.id === cli)?.importsNativeHistory ?? true);
+      const entry = clis.find((c) => c.id === cli);
+      setImportsHistory(entry?.importsNativeHistory ?? true);
+      setSupportsResume(entry?.supportsJsonToTerminalResume ?? true);
     });
     return () => {
       live = false;
@@ -166,11 +175,17 @@ export function StatusBar({ meta, queueDepth = 0, onStop, api, sessionId, atBott
           triggerDisabled={!idle}
           confirmBlocked={!idle}
           blockedMessage="The session just went busy — wait for it to finish (or clear the queue) before switching."
-          {...(importsHistory === false
-            ? {
-                warning: `⚠ ${cli} can't read its terminal history yet — anything you do in the terminal won't appear back in Rich Chat, though the agent still remembers it.`,
-              }
-            : {})}
+          {...(() => {
+            const warnings = [
+              supportsResume === false
+                ? `⚠ ${cli} can't resume in the terminal — this switch starts a FRESH terminal conversation instead of continuing this one. Your Rich Chat history stays intact and untouched.`
+                : null,
+              importsHistory === false
+                ? `⚠ ${cli} can't read its terminal history yet — anything you do in the terminal won't appear back in Rich Chat, though the agent still remembers it.`
+                : null,
+            ].filter((w): w is string => w !== null);
+            return warnings.length > 0 ? { warning: warnings.join("\n\n") } : {};
+          })()}
         />
       ) : null}
     </div>

--- a/web-ui/src/components/chat/ToolRunSummary.test.tsx
+++ b/web-ui/src/components/chat/ToolRunSummary.test.tsx
@@ -25,6 +25,30 @@ describe("ToolRunSummary status-aware spinner/checkmark (Decision 4b, 3.T3)", ()
   });
 });
 
+describe("ToolRunSummary shows a file name for a location-only tool call", () => {
+  it("falls back to `locations` for the inline summary when toolInput carries nothing usable", () => {
+    const tools = [
+      tool({
+        toolName: "Edit",
+        toolInput: {},
+        toolKind: "edit",
+        locations: [{ path: "/app/README.md" }],
+      }),
+    ];
+    render(<ToolRunSummary tools={tools} live={false} />);
+    expect(screen.getByText("/app/README.md")).toBeTruthy();
+  });
+
+  it("does not expand into a useless empty {} body when toolInput is {} and locations cover it", () => {
+    const tools = [
+      tool({ toolName: "Edit", toolInput: {}, locations: [{ path: "/app/README.md" }] }),
+    ];
+    render(<ToolRunSummary tools={tools} live={false} />);
+    const header = document.querySelector(".chat-tool-entry__header") as HTMLElement;
+    expect(header.hasAttribute("disabled")).toBe(true);
+  });
+});
+
 describe("ToolRunSummary structured diffs (Decision 3/4, 4.T2)", () => {
   it("renders DiffView via the structured diffs path, not the looksLikeUnifiedDiff heuristic", () => {
     const tools = [

--- a/web-ui/src/components/chat/ToolRunSummary.test.tsx
+++ b/web-ui/src/components/chat/ToolRunSummary.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ToolRunSummary } from "./ToolRunSummary";
+import type { ToolCallEntry } from "./toolFormat";
+
+function tool(overrides: Partial<ToolCallEntry> = {}): ToolCallEntry {
+  return { id: "t1", toolName: "Bash", ...overrides };
+}
+
+describe("ToolRunSummary status-aware spinner/checkmark (Decision 4b, 3.T3)", () => {
+  it("renders the spinner for a status:in_progress tool ONLY when live", () => {
+    const { rerender } = render(
+      <ToolRunSummary tools={[tool({ status: "in_progress" })]} live />,
+    );
+    expect(document.querySelector(".chat-spinner")).toBeTruthy();
+
+    rerender(<ToolRunSummary tools={[tool({ status: "in_progress" })]} live={false} />);
+    expect(document.querySelector(".chat-spinner")).toBeNull();
+  });
+
+  it("renders the checkmark, not the spinner, for a status:completed tool", () => {
+    render(<ToolRunSummary tools={[tool({ status: "completed" })]} live />);
+    expect(document.querySelector(".chat-spinner")).toBeNull();
+    expect(document.querySelector(".chat-tool-entry__done")).toBeTruthy();
+  });
+});
+
+describe("ToolRunSummary structured diffs (Decision 3/4, 4.T2)", () => {
+  it("renders DiffView via the structured diffs path, not the looksLikeUnifiedDiff heuristic", () => {
+    const tools = [
+      tool({
+        status: "completed",
+        diffs: [{ path: "/a.ts", oldText: "a\nb", newText: "a\nc" }],
+        result: { content: "not a unified diff at all" },
+      }),
+    ];
+    render(<ToolRunSummary tools={tools} live={false} />);
+    // A lone tool run starts expanded (see ToolRunSummary), but the per-tool
+    // entry row itself starts collapsed — open it to reveal the diff body.
+    const entryHeader = document.querySelector(".chat-tool-entry__header") as HTMLElement;
+    fireEvent.click(entryHeader);
+    expect(document.querySelector(".diff-line")).toBeTruthy();
+    // The heuristic text-diff path (a plain <pre> of resultText) is skipped
+    // once structured diffs are present.
+    expect(screen.queryByText("not a unified diff at all")).toBeTruthy();
+  });
+});

--- a/web-ui/src/components/chat/ToolRunSummary.tsx
+++ b/web-ui/src/components/chat/ToolRunSummary.tsx
@@ -76,9 +76,12 @@ function summarizeGroup(tools: ToolCallEntry[]): string {
  */
 function ToolRunEntryRow({ tool, running }: { tool: ToolCallEntry; running: boolean }) {
   const [open, setOpen] = useState(false);
-  const inline = summarizeToolInput(tool.toolInput);
+  const inline = summarizeToolInput(tool.toolInput, tool.locations);
   const pretty = prettyToolInput(tool.toolInput);
-  const hasInputBody = tool.toolInput != null && pretty !== "undefined";
+  // `toolInput` is often `{}` for an ACP adapter that reports the target via
+  // `locations` instead (see summarizeToolInput) — an empty-object body adds
+  // nothing over the inline location text above, so don't expand into one.
+  const hasInputBody = tool.toolInput != null && pretty !== "undefined" && pretty !== "{}";
   const result = tool.result;
   const resultText = result?.content ? capForDisplay(result.content) : "";
   const hasResultBody = resultText.length > 0;

--- a/web-ui/src/components/chat/ToolRunSummary.tsx
+++ b/web-ui/src/components/chat/ToolRunSummary.tsx
@@ -82,9 +82,12 @@ function ToolRunEntryRow({ tool, running }: { tool: ToolCallEntry; running: bool
   const result = tool.result;
   const resultText = result?.content ? capForDisplay(result.content) : "";
   const hasResultBody = resultText.length > 0;
-  const isError = !!result?.isError;
-  const isDiff = !isError && hasResultBody && looksLikeUnifiedDiff(resultText);
-  const hasBody = hasInputBody || hasResultBody;
+  const isError = !!result?.isError || tool.status === "failed";
+  const hasDiffs = !!tool.diffs && tool.diffs.length > 0;
+  // Structured diffs win over the heuristic text-sniffing path (Decision 3).
+  const isDiff = !hasDiffs && !isError && hasResultBody && looksLikeUnifiedDiff(resultText);
+  const hasBody = hasInputBody || hasResultBody || hasDiffs;
+  const done = tool.status ? tool.status === "completed" : (!hasBody && !!result);
 
   return (
     <div className={`chat-tool-entry${isError ? " chat-tool-entry--error" : ""}`}>
@@ -110,7 +113,7 @@ function ToolRunEntryRow({ tool, running }: { tool: ToolCallEntry; running: bool
         <span className="chat-tool-entry__status">
           {running ? (
             <span className="chat-spinner" aria-label="running" />
-          ) : !hasBody && result ? (
+          ) : done ? (
             <span className="chat-tool-entry__done" aria-hidden>
               ✓
             </span>
@@ -124,6 +127,11 @@ function ToolRunEntryRow({ tool, running }: { tool: ToolCallEntry; running: bool
               <code>{pretty}</code>
             </pre>
           ) : null}
+          {hasDiffs
+            ? tool.diffs!.map((diff, i) => (
+                <DiffView key={`${diff.path}-${i}`} oldText={diff.oldText ?? ""} newText={diff.newText} filePath={diff.path} />
+              ))
+            : null}
           {hasResultBody ? (
             isDiff ? (
               <DiffView diffText={resultText} />
@@ -156,8 +164,14 @@ export function ToolRunSummary({ tools, live }: ToolRunSummaryProps) {
   // (in the entry row below) are visible without a click, matching what a
   // lone tool call used to show directly.
   const [open, setOpen] = useState(() => !!live || tools.length === 1);
-  const hasError = tools.some((t) => t.result?.isError);
-  const hasPending = live && tools.some((t) => !t.result);
+  const hasError = tools.some((t) => t.result?.isError || t.status === "failed");
+  // A result already arrived, or a terminal status was set — never spin, even
+  // if an adapter's terminal update omitted a fresh `status` field (per ACP's
+  // "only changed fields need to be included", a stale `status:"pending"`
+  // could otherwise outlive an already-arrived result).
+  const isPending = (t: ToolCallEntry) =>
+    t.result ? false : t.status ? t.status === "pending" || t.status === "in_progress" : true;
+  const hasPending = live && tools.some(isPending);
 
   return (
     <div className="chat-tool-run">
@@ -178,7 +192,7 @@ export function ToolRunSummary({ tools, live }: ToolRunSummaryProps) {
       {open ? (
         <div className="chat-tool-run__body">
           {tools.map((t) => (
-            <ToolRunEntryRow key={t.id} tool={t} running={!!live && !t.result} />
+            <ToolRunEntryRow key={t.id} tool={t} running={!!live && isPending(t)} />
           ))}
         </div>
       ) : null}

--- a/web-ui/src/components/chat/toolFormat.ts
+++ b/web-ui/src/components/chat/toolFormat.ts
@@ -51,15 +51,24 @@ export function blocksToPlaceholder(blocks: NormalizedContentBlock[]): string {
     .join(" ");
 }
 
-/** Common single-value tool inputs render inline (command / path / pattern). */
-export function summarizeToolInput(input: unknown): string {
-  if (input == null) return "";
-  if (typeof input === "string") return input;
-  if (typeof input === "object") {
-    const obj = input as Record<string, unknown>;
-    for (const key of ["command", "cmd", "path", "file_path", "filePath", "pattern", "query"]) {
-      if (typeof obj[key] === "string") return obj[key] as string;
+/** Common single-value tool inputs render inline (command / path / pattern).
+ *  `locations` (ACP `tool_call.locations`, acp-normalize-superset Gap 3) is a
+ *  fallback for adapters that report a structural edit/read via `locations`
+ *  instead of an inspectable `toolInput` — e.g. claude's ACP adapter sends
+ *  `toolInput: {}` for Edit/Read, with the actual file path arriving only via
+ *  `locations`, so without this fallback those calls show no file name at all. */
+export function summarizeToolInput(input: unknown, locations?: { path: string; line?: number }[]): string {
+  if (input != null) {
+    if (typeof input === "string") return input;
+    if (typeof input === "object") {
+      const obj = input as Record<string, unknown>;
+      for (const key of ["command", "cmd", "path", "file_path", "filePath", "pattern", "query"]) {
+        if (typeof obj[key] === "string") return obj[key] as string;
+      }
     }
+  }
+  if (locations && locations.length > 0) {
+    return locations.map((l) => (l.line != null ? `${l.path}:${l.line}` : l.path)).join(", ");
   }
   return "";
 }

--- a/web-ui/src/components/chat/toolFormat.ts
+++ b/web-ui/src/components/chat/toolFormat.ts
@@ -4,6 +4,7 @@
  * call) and by ToolRunSummary's merged per-tool rows (a run of consecutive
  * tool calls) — kept in one place so both stay in sync.
  */
+import type { AcpToolKind, NormalizedContentBlock, ToolDiff } from "@/api/types";
 
 /** One tool_use (+ its tool_result, once it arrives) as rendered in chat —
  *  shared shape between MessageList's `RenderItem` and ToolRunSummary's
@@ -17,6 +18,37 @@ export interface ToolCallEntry {
   /** The turn this tool call belongs to — used to stop a run of consecutive
    *  tool calls from merging across a turn boundary. */
   turnId?: string;
+  /** ACP `ToolCallStatus` — when present, drives the spinner/checkmark instead
+   *  of `result` truthiness (acp-normalize-superset Decision 4b). */
+  status?: "pending" | "in_progress" | "completed" | "failed";
+  /** Structured file-edit diffs (acp-normalize-superset Decision 2/3). */
+  diffs?: ToolDiff[];
+  /** `tool_call`/`tool_call_update.locations` (acp-normalize-superset Gap 3). */
+  locations?: { path: string; line?: number }[];
+  /** `tool_call`/`tool_call_update.kind`, structural (acp-normalize-superset Gap 4). */
+  toolKind?: AcpToolKind;
+}
+
+/** One-line placeholder for a non-text content block, joined into a bubble's
+ *  text when an assistant/thinking event carries `blocks` but no `text`
+ *  (acp-normalize-superset Decision 4c) — never a silently blank bubble. */
+export function blocksToPlaceholder(blocks: NormalizedContentBlock[]): string {
+  return blocks
+    .map((b) => {
+      switch (b.type) {
+        case "image":
+          return "🖼 image";
+        case "audio":
+          return "🔊 audio";
+        case "resource":
+        case "resource_link":
+          return `📎 ${b.name ?? b.uri ?? "resource"}`;
+        default:
+          return b.text ?? "";
+      }
+    })
+    .filter((s) => s.length > 0)
+    .join(" ");
 }
 
 /** Common single-value tool inputs render inline (command / path / pattern). */

--- a/web-ui/src/components/dialogs/NewTabDialog.channel.test.tsx
+++ b/web-ui/src/components/dialogs/NewTabDialog.channel.test.tsx
@@ -29,7 +29,7 @@ describe("NewTabDialog channel toggle (5.T3 / 5.T4)", () => {
       { id: "n", name: "No-JSON", cli: "nojson", context: "x" },
     ]);
     vi.spyOn(api, "getSupportedClis").mockResolvedValue([
-      { id: "nojson", defaultModel: "auto", supportsJson: false, importsNativeHistory: false },
+      { id: "nojson", defaultModel: "auto", supportsJson: false, importsNativeHistory: false, supportsJsonToTerminalResume: true },
     ]);
     render(<NewTabDialog open api={api} worktreeId="wt-1" onClose={() => {}} />);
 

--- a/web-ui/src/components/preview/DiffView.test.tsx
+++ b/web-ui/src/components/preview/DiffView.test.tsx
@@ -1,0 +1,38 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { DiffView } from "./DiffView";
+
+describe("DiffView oldText/newText prop path (4.T1)", () => {
+  it("renders one removed line and one added line for a single-line change", () => {
+    const { container } = render(<DiffView oldText={"a\nb"} newText={"a\nc"} />);
+    const removed = container.querySelectorAll(".diff-line--removed");
+    const added = container.querySelectorAll(".diff-line--added");
+    expect(removed).toHaveLength(1);
+    expect(added).toHaveLength(1);
+    expect(removed[0]!.textContent).toContain("b");
+    expect(added[0]!.textContent).toContain("c");
+  });
+
+  it("treats an absent oldText as a brand-new file (all-added)", () => {
+    const { container } = render(<DiffView newText={"line1\nline2"} />);
+    const added = container.querySelectorAll(".diff-line--added");
+    const removed = container.querySelectorAll(".diff-line--removed");
+    expect(added).toHaveLength(2);
+    expect(removed).toHaveLength(0);
+  });
+});
+
+describe("DiffView regression — existing diffText/heuristic path (4.T4)", () => {
+  it("still renders identically for unified-diff text with no structured diff props", () => {
+    const diffText = [
+      "@@ -1,2 +1,2 @@",
+      " context line",
+      "-old line",
+      "+new line",
+    ].join("\n");
+    const { container } = render(<DiffView diffText={diffText} />);
+    expect(container.querySelectorAll(".diff-line--removed")).toHaveLength(1);
+    expect(container.querySelectorAll(".diff-line--added")).toHaveLength(1);
+    expect(container.querySelectorAll(".diff-line--context")).toHaveLength(1);
+  });
+});

--- a/web-ui/src/components/preview/DiffView.tsx
+++ b/web-ui/src/components/preview/DiffView.tsx
@@ -1,15 +1,22 @@
 import { useEffect, useMemo, useState } from "react";
 import type { DiffLine } from "@/preview/diffParser";
 import { parseUnifiedDiff, syntheticUntrackedHunks } from "@/preview/diffParser";
+import { diffLinesToHunks } from "@/preview/diffFromTexts";
 import { useTheme } from "@/hooks/useTheme";
 import { languageForFilePath } from "./codeHighlight";
 import { pickShikiLang } from "./previewLang";
 import { escapeHtml, highlightLineHtml } from "./shikiHighlighter";
 
 interface DiffViewProps {
-  diffText: string;
+  /** Unified-diff text. Optional when `oldText`/`newText` are supplied instead
+   *  (acp-normalize-superset Decision 3). */
+  diffText?: string;
   /** Raw file text when diff empty / untracked */
   fileContentFallback?: string;
+  /** Structured before/after text — takes precedence over `diffText` when
+   *  either is defined (a new file has `oldText` absent, `newText` required). */
+  oldText?: string;
+  newText?: string;
   /** Used for syntax highlighting (extension → language) */
   filePath?: string;
   themeMode?: "dark" | "light";
@@ -38,6 +45,8 @@ function flattenHunks(hunks: ReturnType<typeof parseUnifiedDiff>): FlatDiffRow[]
 export function DiffView({
   diffText,
   fileContentFallback,
+  oldText,
+  newText,
   filePath,
   themeMode,
 }: DiffViewProps) {
@@ -49,11 +58,14 @@ export function DiffView({
   const shikiLang = pickShikiLang(filePath, hljsLang);
 
   const hunks = useMemo(() => {
-    const trimmed = diffText.trim();
-    if (trimmed.length > 0) return parseUnifiedDiff(diffText);
+    if (oldText !== undefined || newText !== undefined) {
+      return diffLinesToHunks(oldText ?? "", newText ?? "");
+    }
+    const trimmed = (diffText ?? "").trim();
+    if (trimmed.length > 0) return parseUnifiedDiff(diffText ?? "");
     if (fileContentFallback) return syntheticUntrackedHunks(fileContentFallback);
     return [];
-  }, [diffText, fileContentFallback]);
+  }, [diffText, fileContentFallback, oldText, newText]);
 
   const flatRows = useMemo(() => flattenHunks(hunks), [hunks]);
 

--- a/web-ui/src/preview/diffFromTexts.ts
+++ b/web-ui/src/preview/diffFromTexts.ts
@@ -1,0 +1,30 @@
+// diffFromTexts.ts — Decision 3. Maps jsdiff's Change[] (added/removed/neither,
+// each covering 1+ lines via `.value`) onto the SAME DiffHunk/DiffLine shape
+// DiffView already renders, as ONE synthetic hunk (no @@ header math needed —
+// jsdiff diffs the whole file, there's no "hunk" boundary concept to preserve).
+import { diffLines } from "diff";
+import type { DiffHunk, DiffLine } from "./diffParser";
+
+export function diffLinesToHunks(oldText: string, newText: string): DiffHunk[] {
+  const changes = diffLines(oldText, newText);
+  const lines: DiffLine[] = [];
+  let oldNum = 1, newNum = 1;
+  for (const part of changes) {
+    const type = part.added ? "added" : part.removed ? "removed" : "context";
+    // jsdiff keeps trailing "\n" inside `.value`, so split() always leaves a
+    // final "" entry EXCEPT for a part with no trailing newline (the file's
+    // very last line) — only drop it when it's actually empty, never
+    // unconditionally, or the last real line silently disappears.
+    const rawLines = part.value.split("\n");
+    if (rawLines[rawLines.length - 1] === "") rawLines.pop();
+    for (const content of rawLines) {
+      lines.push({
+        type,
+        content,
+        oldLineNumber: type === "added" ? null : oldNum++,
+        newLineNumber: type === "removed" ? null : newNum++,
+      });
+    }
+  }
+  return [{ header: `@@ -1,${oldNum - 1} +1,${newNum - 1} @@`, lines }];
+}


### PR DESCRIPTION
## Summary

- **`67a3736`** — migrates Rich Chat's `json` channel transport from a per-turn one-shot CLI spawn to the Agent Client Protocol (ACP): one persistent agent process per session, a shared JSON-RPC client (`AcpConnection`/`acpTransport.ts`) reused by every CLI (claude/cursor/opencode/agy), and a lossy `session/update` → `NormalizedEvent` mapping that deliberately introduced no new event kinds so the migration wouldn't require UI changes.
- **`217b02c`** — closes the gap that migration left: extends `NormalizedEvent`/`NormalizedEventKind` additively (2 new kinds, 7 new optional fields, mirrored across `daemon/src/types.ts`, the WS Zod schema, and the web-ui client type) so `normalize.ts` stops silently dropping non-text content blocks, structured file-edit diffs, tool locations/kind, in-progress tool status, and mode/command updates. File-edit diffs now render as real green/red diffs in chat via `DiffView`. Old persisted rows are unaffected — every new field/kind is optional.
- **`0068032`** — fixes a live-blocking bug found while testing the above in a dev sandbox: `session/request_permission` was never handled anywhere in the shared ACP client, so every file-modifying tool call (Edit, or a write-capable Bash command) across every ACP-migrated CLI failed with `unhandled method: session/request_permission`. Now auto-approved, matching the `--dangerously-skip-permissions` trust model used everywhere else. Also fixes tool calls showing no file name in chat (claude's ACP adapter reports Edit/Read with an empty `toolInput`; the path only arrives via `tool_call.locations`, which the UI now falls back to).
- **`49130d0`** — code-review follow-up: caps the new `toolDiffs` field's size the same way `tool_result.content` was already capped (an uncapped large-file diff could bloat the transcript DB and freeze the browser tab), and hardens the permission auto-approve so it can never mistakenly "select" a reject-kind option as an approval.

## Process

`217b02c` went through a full plan → review → implement → verify → review cycle (sonnet planner/implementer, opus reviewer, 2 review rounds on the plan + a final review of the implemented diff). `0068032` and `49130d0` were found and fixed by hand while manually verifying the feature against a real claude ACP session in an isolated Docker dev sandbox, then confirmed by a high-effort `/code-review` pass across the full branch diff.

## Test plan

- [x] `pnpm --filter @vibestation/cli test` — 856 passed, 8 skipped (1 pre-existing unrelated flake in `sessions.test.ts`, confirmed against the unmodified base)
- [x] `pnpm --filter @vibestation/cli build` (tsc) — clean
- [x] `pnpm --filter @vibestation/web test` — 587 passed
- [x] `pnpm --filter @vibestation/web typecheck` — clean
- [x] Manually verified live against a real `claude` ACP session in a Docker dev sandbox (`scripts/dev-sandbox.sh`): permission auto-approval, an actual Edit tool call producing a green/red diff in chat with the file path visible, `toolKind`/`toolStatus` populated correctly end-to-end

https://claude.ai/code/session_01SnG7hLie2YQTDz9pWg9vq4