### PR TITLE
fix(daemon): self-heal stale ACP connections instead of hanging forever

### DIFF
--- a/daemon/src/__tests__/acpTransport.test.ts
+++ b/daemon/src/__tests__/acpTransport.test.ts
@@ -105,3 +105,86 @@ describe("AcpConnection happy path", () => {
     await conn.dispose();
   });
 });
+
+describe("AcpConnection self-healing (idle-dispose / crash respawn regression)", () => {
+  it("isAlive() flips to false and onDispose fires exactly once when dispose() is called", async () => {
+    let disposeCalls = 0;
+    const conn = new AcpConnection(
+      { command: process.execPath, args: [FAKE_AGENT], cwd: __dirname, env: { FAKE_ACP_MODE: "normal" } },
+      "claude",
+      undefined,
+      () => {
+        disposeCalls += 1;
+      },
+    );
+    await conn.initialize();
+    expect(conn.isAlive()).toBe(true);
+
+    await conn.dispose();
+    await conn.dispose(); // idempotent — must not double-fire onDispose
+    expect(conn.isAlive()).toBe(false);
+    expect(disposeCalls).toBe(1);
+  });
+
+  it("onDispose fires when the child process exits on its own (crash), not just on explicit dispose()", async () => {
+    let disposed = false;
+    const conn = new AcpConnection(
+      { command: process.execPath, args: [FAKE_AGENT], cwd: __dirname, env: { FAKE_ACP_MODE: "normal" } },
+      "claude",
+      undefined,
+      () => {
+        disposed = true;
+      },
+    );
+    await conn.initialize();
+    const sessionId = await conn.newSession("/tmp");
+
+    // Kill the child out from under the connection — mirrors a crash, not a
+    // clean dispose() call.
+    const pid = (conn as unknown as { child: { pid?: number } }).child?.pid;
+    expect(pid).toBeTruthy();
+    process.kill(pid!, "SIGKILL");
+
+    const deadline = Date.now() + 2000;
+    while (!disposed && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    expect(disposed).toBe(true);
+    expect(conn.isAlive()).toBe(false);
+
+    // A prompt against the now-dead connection must reject immediately with
+    // a clear error, never hang or silently drop the write.
+    await expect(
+      conn.sendPrompt(sessionId, [{ type: "text", text: "hi" }], new AbortController().signal).result,
+    ).rejects.toThrow(/disposed/i);
+  });
+
+  it("a request against an already-disposed connection rejects immediately instead of hanging", async () => {
+    const conn = makeConnection("normal");
+    await conn.initialize();
+    await conn.dispose();
+
+    await expect(conn.newSession("/tmp")).rejects.toThrow(/disposed/i);
+  });
+
+  it("session/prompt times out with a clear error instead of hanging forever when the agent stops responding", async () => {
+    const conn = new AcpConnection(
+      {
+        command: process.execPath,
+        args: [FAKE_AGENT],
+        cwd: __dirname,
+        env: { FAKE_ACP_MODE: "prompt_hang" },
+        promptTimeoutMs: 200,
+      },
+      "claude",
+    );
+    await conn.initialize();
+    const sessionId = await conn.newSession("/tmp");
+
+    const start = Date.now();
+    const { result } = conn.sendPrompt(sessionId, [{ type: "text", text: "hi" }], new AbortController().signal);
+    await expect(result).rejects.toThrow(/timed out/i);
+    expect(Date.now() - start).toBeLessThan(2000);
+    await conn.dispose();
+  });
+});

--- a/daemon/src/__tests__/fixtures/fakeAcpAgent.mjs
+++ b/daemon/src/__tests__/fixtures/fakeAcpAgent.mjs
@@ -21,6 +21,11 @@
 //   FAKE_ACP_MODE=permission_request_reject_only — same, but every offered
 //     option is reject-kind (no allow_once/allow_always at all) — asserts the
 //     daemon cancels rather than ever "selecting" a rejection as an approval.
+//   FAKE_ACP_MODE=prompt_hang — initialize/session/new succeed normally, but
+//     session/prompt NEVER responds and ignores session/cancel too (unlike
+//     "cancel" mode) — simulates a connection that looks alive (child process
+//     still running) but has stopped answering, so the per-request timeout
+//     (not process death) must be what eventually rejects the turn.
 import { createInterface } from "node:readline";
 
 const mode = process.env.FAKE_ACP_MODE ?? "normal";
@@ -155,6 +160,10 @@ rl.on("line", (line) => {
         method: "session/request_permission",
         params: { sessionId: sid, toolCall: { toolCallId: "tc-1" }, options },
       });
+      return;
+    }
+    if (mode === "prompt_hang") {
+      // Deliberately never write a response and never observe cancelRequested.
       return;
     }
     if (mode === "cancel") {

--- a/daemon/src/__tests__/jsonAgent.test.ts
+++ b/daemon/src/__tests__/jsonAgent.test.ts
@@ -928,4 +928,54 @@ describe("JsonAgentSession — 1.T4 stopActiveTurn cancels an ACP connection, ne
       await agent.release();
     }
   });
+
+  // Regression test for the "stuck thinking… forever after 30+ min idle" bug:
+  // AcpConnection.dispose() (idle TTL, or the child process dying on its own)
+  // must notify the owning JsonAgentSession so it drops the dead connection,
+  // and the NEXT getOrCreateConnection() call must transparently respawn
+  // instead of silently reusing (and hanging on) the dead one.
+  it("a connection disposed while idle is transparently respawned on the next turn, no stuck 'thinking…'", async () => {
+    const { JsonAgentSession } = await import("../services/jsonAgent.js");
+    const { getProject } = await import("../state/project-store.js");
+    const session = getProject(PROJECT_ID)!.directSessions[0]!;
+
+    const conns: Array<{ dispose(): Promise<void>; isAlive(): boolean }> = [];
+    const agent = new JsonAgentSession({
+      project,
+      worktree: null,
+      session,
+      plugin: acpPlugin("normal", (c) => {
+        conns.push(c as unknown as { dispose(): Promise<void>; isAlive(): boolean });
+      }),
+      daemonPort: 0,
+      cli: "claude",
+    });
+
+    try {
+      agent.enqueue({ message: "first turn" });
+      await agent.settled();
+      expect(conns).toHaveLength(1);
+      expect(conns[0]!.isAlive()).toBe(true);
+
+      // Simulate exactly what the idle TTL (or a crashed child) does: dispose
+      // the connection out from under the session, with no explicit teardown
+      // or "restart" action from the caller.
+      await conns[0]!.dispose();
+      expect(conns[0]!.isAlive()).toBe(false);
+
+      // The next turn must NOT hang forever reusing the dead connection — it
+      // should silently spin up a fresh one and complete normally.
+      agent.enqueue({ message: "second turn, after idle-dispose" });
+      await agent.settled();
+
+      expect(conns).toHaveLength(2);
+      expect(conns[1]).not.toBe(conns[0]);
+      expect(conns[1]!.isAlive()).toBe(true);
+
+      const results = agent.readTranscript().filter((e) => e.kind === "result");
+      expect(results.filter((e) => e.text === "end_turn")).toHaveLength(2);
+    } finally {
+      await agent.release();
+    }
+  });
 });

--- a/daemon/src/services/acp/acpTransport.ts
+++ b/daemon/src/services/acp/acpTransport.ts
@@ -38,11 +38,22 @@ export interface AcpLaunchSpec {
   onSpawn?: (pid: number) => void;
   /** ms to wait for `initialize` to resolve before ConnectionSpawnFailed/InitializeFailed. */
   initializeTimeoutMs?: number;
+  /** ms to wait for a `session/prompt` response before it is rejected with a timeout error. */
+  promptTimeoutMs?: number;
 }
 
 /** 30 minutes (Decision 4) — a connection with zero live terminals idles out after this. */
 const IDLE_TTL_MS = 30 * 60 * 1000;
 const DEFAULT_INITIALIZE_TIMEOUT_MS = 30_000;
+/**
+ * Ceiling on how long a single `session/prompt` turn may run before the
+ * transport gives up on it. Generous — real agentic turns can legitimately
+ * run for many minutes — this exists purely as a last-resort guard against a
+ * connection that looks alive (child process still running) but has stopped
+ * responding for some other reason, so the turn eventually surfaces a clear
+ * error instead of hanging "thinking..." forever.
+ */
+const DEFAULT_PROMPT_TIMEOUT_MS = 20 * 60 * 1000;
 
 interface JsonRpcRequest {
   jsonrpc: "2.0";
@@ -67,6 +78,7 @@ export class AcpConnection {
   private agentCapabilities: Record<string, unknown> = {};
   private idleTimer: ReturnType<typeof setTimeout> | null = null;
   private disposed = false;
+  private disposeNotified = false;
   private disposePromise: Promise<void> | null = null;
   private activeUpdateSink: ((u: AcpSessionUpdate) => void) | null = null;
   readonly terminals = new AcpTerminalManager();
@@ -75,7 +87,32 @@ export class AcpConnection {
     private readonly spec: AcpLaunchSpec,
     private readonly provider: NormalizedEventProvider,
     private readonly enrich?: AcpEnrichHook,
+    /**
+     * Called exactly once, the first time this connection transitions to
+     * disposed — whether via idle TTL, explicit `dispose()`, or the child
+     * process exiting/crashing on its own. Lets the owning `JsonAgentSession`
+     * drop its cached reference so the NEXT `getOrCreateConnection()` call
+     * transparently respawns instead of reusing a dead connection.
+     */
+    private readonly onDispose?: () => void,
   ) {}
+
+  /** False once this connection has been (or is being) torn down for any reason. */
+  isAlive(): boolean {
+    return !this.disposed;
+  }
+
+  /** Idempotent — fires `onDispose` at most once regardless of how disposal was triggered. */
+  private notifyDisposed(): void {
+    this.disposed = true;
+    if (this.disposeNotified) return;
+    this.disposeNotified = true;
+    try {
+      this.onDispose?.();
+    } catch {
+      /* owner's callback must never break teardown */
+    }
+  }
 
   /** Spawn the agent process and complete the ACP `initialize` handshake. */
   async initialize(): Promise<{ loadSession: boolean }> {
@@ -103,6 +140,10 @@ export class AcpConnection {
         p.reject(new Error(`agent process closed${stderr ? `: ${stderr.trim()}` : ""}`));
         this.pending.delete(id);
       }
+      // The process died on its own (crash, kill from outside, etc.) rather
+      // than via our own dispose() — still a disposal from the owning
+      // session's point of view, so it must notify the same way.
+      this.notifyDisposed();
     });
 
     // Fail-closed-before-ready race (mirrors emdash `acp-agent-connection.ts:118-119`):
@@ -180,6 +221,13 @@ export class AcpConnection {
     prompt: PromptBlock[],
     signal: AbortSignal,
   ): { updates: AsyncIterable<NormalizedEvent>; result: Promise<{ stopReason: StopReason }> } {
+    if (this.disposed) {
+      const err = new Error("ACP connection is disposed; cannot send prompt");
+      return {
+        updates: (async function* (): AsyncGenerator<NormalizedEvent> {})(),
+        result: Promise.reject(err),
+      };
+    }
     this.resetIdleTimer();
     const queue: NormalizedEvent[] = [];
     const waiters: Array<() => void> = [];
@@ -201,10 +249,11 @@ export class AcpConnection {
     };
     signal.addEventListener("abort", onAbort, { once: true });
 
-    const resultPromise = this.request("session/prompt", {
-      sessionId,
-      prompt,
-    })
+    const resultPromise = this.request(
+      "session/prompt",
+      { sessionId, prompt },
+      this.spec.promptTimeoutMs ?? DEFAULT_PROMPT_TIMEOUT_MS,
+    )
       .then((r) => r as { stopReason: StopReason })
       .finally(() => {
         done = true;
@@ -245,7 +294,7 @@ export class AcpConnection {
   async dispose(): Promise<void> {
     if (this.disposePromise) return this.disposePromise;
     this.disposePromise = (async () => {
-      this.disposed = true;
+      this.notifyDisposed();
       if (this.idleTimer) clearTimeout(this.idleTimer);
       this.terminals.killAll();
       for (const [id, p] of this.pending) {
@@ -326,13 +375,24 @@ export class AcpConnection {
   }
 
   private async handleAgentMessage(req: JsonRpcRequest): Promise<void> {
+    // Best-effort — if the connection has died, there is no one left to
+    // write back to; the outer notifyDisposed()/dispose() path already
+    // handles surfacing that, so these must never throw.
     const respond = (result: unknown): void => {
       if (req.id === undefined) return; // notification — no response
-      this.writeLine({ jsonrpc: "2.0", id: req.id, result });
+      try {
+        this.writeLine({ jsonrpc: "2.0", id: req.id, result });
+      } catch {
+        /* connection is gone — nothing more to do */
+      }
     };
     const respondError = (message: string): void => {
       if (req.id === undefined) return;
-      this.writeLine({ jsonrpc: "2.0", id: req.id, error: { code: -32000, message } });
+      try {
+        this.writeLine({ jsonrpc: "2.0", id: req.id, error: { code: -32000, message } });
+      } catch {
+        /* connection is gone — nothing more to do */
+      }
     };
 
     try {
@@ -415,20 +475,60 @@ export class AcpConnection {
     }
   }
 
-  private request(method: string, params?: unknown): Promise<unknown> {
+  /**
+   * `timeoutMs`, when given, rejects the request after that many ms with a
+   * clear timeout error if no response has arrived yet — a last-resort guard
+   * so a connection that never answers (rather than cleanly erroring or
+   * dying) can't hang a caller forever. Always guards against a disposed
+   * connection up front: never registers a pending promise that a dead
+   * connection could never fulfill.
+   */
+  private request(method: string, params?: unknown, timeoutMs?: number): Promise<unknown> {
+    if (this.disposed) {
+      return Promise.reject(new Error(`ACP connection is disposed; cannot send "${method}"`));
+    }
     const id = this.nextId++;
     return new Promise((resolve, reject) => {
-      this.pending.set(id, { resolve, reject });
-      this.writeLine({ jsonrpc: "2.0", id, method, params });
+      let timer: ReturnType<typeof setTimeout> | null = null;
+      const settle = (fn: (v: unknown) => void, value: unknown): void => {
+        if (timer) clearTimeout(timer);
+        this.pending.delete(id);
+        fn(value);
+      };
+      this.pending.set(id, {
+        resolve: (v) => settle(resolve, v),
+        reject: (e) => settle(reject, e),
+      });
+      if (timeoutMs !== undefined) {
+        timer = setTimeout(() => {
+          this.pending.delete(id);
+          reject(new Error(`ACP request "${method}" timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+        timer.unref?.();
+      }
+      try {
+        this.writeLine({ jsonrpc: "2.0", id, method, params });
+      } catch (err) {
+        this.pending.delete(id);
+        if (timer) clearTimeout(timer);
+        reject(err);
+      }
     });
   }
 
   private notify(method: string, params?: unknown): void {
-    this.writeLine({ jsonrpc: "2.0", method, params });
+    try {
+      this.writeLine({ jsonrpc: "2.0", method, params });
+    } catch {
+      /* best-effort notification (e.g. session/cancel) — nothing to reject */
+    }
   }
 
+  /** Throws (never silently no-ops) if the child process/stdin is gone or destroyed. */
   private writeLine(obj: unknown): void {
-    if (!this.child?.stdin || this.child.stdin.destroyed) return;
+    if (!this.child?.stdin || this.child.stdin.destroyed) {
+      throw new Error("ACP connection: agent process is not available (stdin closed)");
+    }
     this.child.stdin.write(JSON.stringify(obj) + "\n");
   }
 }

--- a/daemon/src/services/jsonAgent.ts
+++ b/daemon/src/services/jsonAgent.ts
@@ -991,9 +991,23 @@ export class JsonAgentSession {
     spec: AcpLaunchSpec,
     enrich?: AcpEnrichHook,
   ): Promise<AcpConnection> {
-    if (this.connection) return this.connection;
+    // Defensive liveness check, not just truthiness: a cached connection can
+    // have died on its own (idle TTL dispose, crashed child process) without
+    // this session ever being told directly. `isAlive()` catches that so the
+    // next turn transparently respawns instead of reusing a dead connection
+    // and hanging forever (see AcpConnection's `onDispose` callback below,
+    // which is the primary way `this.connection` gets cleared — this check
+    // is a belt-and-suspenders backstop for any path that missed it).
+    if (this.connection?.isAlive()) return this.connection;
+    this.connection = undefined;
 
-    const conn = new AcpConnection(spec, this.cli, enrich);
+    const conn: AcpConnection = new AcpConnection(spec, this.cli, enrich, () => {
+      // Self-healing lazy respawn: notified whenever THIS connection disposes
+      // (idle TTL, explicit teardown, or the child process exiting/crashing
+      // on its own) so the next getOrCreateConnection() call spawns fresh
+      // instead of returning a connection nothing will ever answer on.
+      if (this.connection === conn) this.connection = undefined;
+    });
     const { loadSession } = await conn.initialize();
 
     // Decision 6 reconnect id: prefer `acpSessionId` (Option B — the id


### PR DESCRIPTION
## Root cause

Regression from #d97f3a6 (ACP migration) and its follow-ups (#4e8d1b0, #c31ab2d), confirmed via live investigation of a stuck production session.

`AcpConnection`'s idle-TTL `dispose()` (`daemon/src/services/acp/acpTransport.ts`) — and any other disposal path: explicit teardown, or the child process crashing/exiting on its own — never told the owning `JsonAgentSession`. `getOrCreateConnection()` (`daemon/src/services/jsonAgent.ts`) started with `if (this.connection) return this.connection;`, a plain truthiness check, so the next turn after an idle-dispose reused a dead connection object.

`writeLine()` then silently no-op'd (`if (!child?.stdin || destroyed) return;`) when writing to the dead child's stdin. `request()`/`sendPrompt()` had already registered the `session/prompt` call as a pending promise before that silent no-op, and there was no per-request timeout (only `initialize()` had one). Net effect: the turn's promise never settled, no error/result event was ever emitted, and the UI showed "thinking..." forever with zero diagnostic trail — for any `channel:"json"` ACP session left idle past the 30-minute TTL, not just direct sessions.

## Fix

All changes live in the shared ACP transport/session-lifecycle layer (`acpTransport.ts`, `jsonAgent.ts`) — no CLI-specific branching, per this repo's "Agent plugin" architecture rule in `AGENTS.md`.

1. **Self-healing lazy respawn.** `AcpConnection` now takes an `onDispose` callback fired exactly once whenever it transitions to disposed (idle TTL, explicit `dispose()`, or the child process closing on its own via the `close` event handler). `JsonAgentSession` uses it to drop its cached `this.connection` reference. `getOrCreateConnection()` also defensively checks a new `isAlive()` getter before reusing a cached connection, as a backstop for any path that might miss the callback. Either way, the very next chat message after an idle-dispose transparently respawns the ACP process — no user-facing "restart" action.
2. **No silent dropped writes.** `writeLine()` now throws instead of silently returning when `child`/`stdin` is gone or destroyed; `request()`/`notify()` catch that and reject/no-op the caller instead of leaving a promise to hang.
3. **Guard against disposed connections.** `request()` and `sendPrompt()` check `this.disposed` up front and reject immediately with a clear error, rather than registering a pending promise nothing will ever fulfill.
4. **Timeout on `session/prompt`.** Added a configurable, generous (20min default) timeout mirroring the existing `initialize()` timeout pattern, so a connection that looks alive but stops responding for any other reason still eventually surfaces a clear error — which propagates through `runTurn` to the existing error-event path (`daemon/src/services/jsonAgent.ts`'s catch around the `runTurn` loop), not just an unhandled rejection.

## Testing

- New regression tests in `daemon/src/__tests__/acpTransport.test.ts`: dispose()/onDispose/isAlive semantics (idempotent, fires once), disposal triggered by the child process dying on its own (not just explicit dispose), a disposed connection rejecting immediately instead of hanging, and a `session/prompt` timeout firing with a clear error.
- New end-to-end regression test in `daemon/src/__tests__/jsonAgent.test.ts`: a connection disposed mid-session (simulating idle-TTL dispose) is transparently respawned by the next `getOrCreateConnection()` call, and the following turn completes normally — exercised against a real child process over stdio via the existing `fakeAcpAgent.mjs` fixture (new `prompt_hang` mode added for the timeout test).
- Full daemon test suite: 861 passed. `pnpm typecheck` passes. One pre-existing unrelated unhandled-rejection warning (`sessions.test.ts`) and one pre-existing unrelated lint failure (`cli/src/__tests__/daemon-client.test.ts`) both reproduce identically on `main` — unaffected by this change.
- Did not additionally exercise this via the Docker dev sandbox (`scripts/dev-sandbox.sh`) — the automated tests above already exercise the exact idle-dispose → respawn → successful-turn path end-to-end against a real spawned process, which is the scenario the docker sandbox would otherwise be used to reproduce.

https://claude.ai/code/session_016HuaSfedom3Peuia6wqPPK