### PR TITLE
Rich-chat UX fixes: keyboard shortcuts, overflow, tool display, imported diffs, out-of-band events

### DIFF
--- a/.vibekit/feature-plans/pending/rich-chat-issues-5-7-8/plan-rich-chat-issues-5-7-8.md
+++ b/.vibekit/feature-plans/pending/rich-chat-issues-5-7-8/plan-rich-chat-issues-5-7-8.md
@@ -1,0 +1,201 @@
+# Plan: Rich-chat issues 5, 7, 8
+
+> Fix three bugs: task-notification replies invisible, Edit diff lost after channel toggle, diff blocks over-indented.
+
+**Issue:** rich-chat-issues-5-7-8
+**Branch:** `rich-typing-message`
+**Status:** WIP
+
+**Reference files:**
+- ACP transport: `daemon/src/services/acp/acpTransport.ts`
+- JSON agent: `daemon/src/services/jsonAgent.ts`
+- Native import: `daemon/src/agent-plugins/claudeImport.ts`
+- Types: `daemon/src/types.ts:135-141` (`ToolDiff` shape)
+- Chat CSS: `web-ui/src/styles/chat.css`
+- Workspace CSS: `web-ui/src/styles/workspace.css`
+- Diff view: `web-ui/src/components/preview/DiffView.tsx`
+- Tool run summary: `web-ui/src/components/chat/ToolRunSummary.tsx:98` (`hasDiffs`)
+- Message list: `web-ui/src/components/chat/MessageList.tsx:239` (`toolDiffs→diffs`)
+
+---
+
+## Problem
+
+- **Issue 5:** Background-agent task-notification replies are silently dropped — `activeUpdateSink` is null between turns, so `session/update` events arriving after a turn ends never reach the transcript store or WS broadcast
+- **Issue 7:** After switching terminal→rich-chat, Edit/MultiEdit tool calls lose their colored diff view — `toolDiffs` is never computed on re-import, confirmed by DB: re-imported rows have `toolInput: {old_string, new_string}` but `toolDiffs: null`
+- **Issue 8:** Diff blocks in chat are excessively indented (~144px total) and have loose line spacing — no chat-scoped overrides exist for the shared diff CSS
+
+## Out of Scope
+
+- Issue 6 (▾/▸ misparsed) — needs concrete repro before a fix target is known
+- Write tool diff reconstruction (low priority, no `oldText`)
+- Whole-file diff for imported entries (fragment-level is sufficient)
+
+## Concept
+
+- **Issue 5:** Add a permanent `outOfBandSink` callback on `AcpConnection`; events arriving between turns route there instead of being dropped; `JsonAgentSession` subscribes and feeds them through the same persist+broadcast pipeline with a synthetic turnId
+- **Issue 7:** During native-history import, compute `ToolDiff` from `old_string`/`new_string` and attach to the `tool_result` emit — matching where live ACP entries store diffs
+- **Issue 8:** Add `.chat-tool-entry__body`-scoped CSS overrides that tighten gutter widths, padding, and line-height without touching the full preview pane
+
+## Requirements
+
+| # | Requirement |
+|---|-------------|
+| 1 | Out-of-band assistant replies appear in rich-chat without a channel toggle or refresh |
+| 2 | Out-of-band events must NOT flip session lifecycle to `working`/`thinking` |
+| 3 | Re-imported Edit/MultiEdit tool calls render with a colored diff view |
+| 4 | Diff blocks in chat have ≤40px total left offset and line-height ≤1.25 |
+| 5 | Full preview-pane diff rendering is unchanged |
+
+---
+
+## Research
+
+### Issue 5 — ACP out-of-band drop
+
+- **File:** `daemon/src/services/acp/acpTransport.ts:402` — `activeUpdateSink?.()` optional-chains to null between turns; events dropped silently
+- **File:** `acpTransport.ts:242,258-264` — sink set at `sendPrompt`, nulled in `.finally()`
+- **File:** `daemon/src/services/jsonAgent.ts:889,1131-1135` — persist + WS fan-out only inside `runOneTurn`'s event loop; `updateTurnState` and `emitMeta` also called here
+- **Risk:** MEDIUM — must not trigger spurious lifecycle transitions; `emitMeta()` must still be called so WS subscribers get a metadata refresh
+
+### Issue 7 — Import missing diffs
+
+- **File:** `daemon/src/agent-plugins/claudeImport.ts:190-199` — `tool_result` events emitted with no `toolDiffs`
+- **DB evidence:** live `tool_result` rows (e.g. rowid 54, 71) carry `toolDiffs`; re-imported rows (113, 123 `tool_use` have `old_string`/`new_string`; 115, 125 `tool_result` have `toolDiffs: null`)
+- **File:** `daemon/src/types.ts:135-141` — `ToolDiff: { path, oldText?, newText }`
+- **Risk:** LOW — pure data enrichment; no UI change; no ACP protocol change
+
+### Issue 8 — Diff indentation
+
+- **File:** `web-ui/src/styles/workspace.css:2639-2646` — `.diff-line` uses `grid-template-columns: 48px 48px 16px 1fr` + `padding: 0 16px` → 96px gutters + 16px marker
+- **File:** `workspace.css:2163-2172` — `.preview-diff-root` has `padding: 12px 0; line-height: 1.45; min-height: 100%`
+- **File:** `web-ui/src/styles/chat.css:507-513` — `.chat-tool-run__body` adds `margin-left: var(--space-3)` (12px) + gap
+- **File:** `chat.css:570-574` — `.chat-tool-entry__body` adds `margin-left: calc(1em + var(--space-2))` (~20px)
+- **Risk:** LOW — all overrides scoped under `.chat-tool-entry__body`
+
+## Root Cause
+
+- **Issue 5:** `AcpConnection` has no permanent event channel — only a per-prompt sink that is cleared after each turn
+- **Issue 7:** `claudeImport.ts` reconstructs tool events from raw JSONL but never computes diffs; live ACP supplies diffs as `{type:"diff"}` content blocks which importers never see
+- **Issue 8:** Diff CSS has no context-aware variant; chat nests inside multiple indenting wrappers that compound with full-pane sizing
+
+---
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    subgraph Issue5["Issue 5 — OOB sink"]
+        A[task-notification fires] --> B[session/update arrives]
+        B --> C{activeUpdateSink null?}
+        C -->|yes, currently| D[DROPPED]
+        C -->|yes, after fix| E[outOfBandSink]
+        E --> F[handleOutOfBandEvent]
+        F --> G[persist + emitMessage + emitMeta]
+    end
+```
+
+---
+
+## Design Details
+
+### Key Decisions
+
+#### Decision 1: `outOfBandSink` as public field, not private
+
+- **Decision:** `outOfBandSink` is a public field so `JsonAgentSession` can assign it after `new AcpConnection(...)` without a setter
+- **Rationale:** `activeUpdateSink` is private because only `AcpConnection.prompt()` sets it; the OOB sink is set externally once at construction — public is the correct visibility
+- **Where:** `acpTransport.ts:83`
+
+#### Decision 2: Burst-stable `notif-<uuid>` turnId
+
+- **Decision:** All OOB events in a burst share one synthetic turnId; reset on `result`/`error` kind
+- **Rationale:** Per-event turnIds fragment `groupEvents`'s thinking/tool-run grouping in `MessageList.tsx:180,195`; a burst-stable id preserves grouping while keeping OOB turns visually separate from user-initiated turns
+- **Where:** `jsonAgent.ts` new `handleOutOfBandEvent` method
+
+```ts
+// Burst-stable: all events in one OOB reply share a turnId; reset when the reply ends
+private outOfBandTurnId: string | null = null;
+private handleOutOfBandEvent(ev: NormalizedEvent): void {
+  if (ev.kind === "result" || ev.kind === "error") {
+    this.outOfBandTurnId = null;
+    return;
+  }
+  const turnId = (this.outOfBandTurnId ??= `notif-${crypto.randomUUID()}`);
+  ev = { ...ev, turnId };
+  this.persist(ev);
+  this.stream.emitMessage(ev);
+  this.emitMeta();
+  // NOT calling this.updateTurnState — prevents spurious working/thinking lifecycle flip
+}
+```
+
+#### Decision 3: Attach `toolDiffs` on `tool_result` emit, not `tool_use`
+
+- **Decision:** Compute diffs and attach to the `tool_result` import event
+- **Rationale:** Matches where live ACP entries store diffs (confirmed in DB); `groupEvents` reads `toolDiffs` from whichever event has it; `tool_use` already has the input so we compute at `tool_result` emit time using a tracked map
+- **Where:** `claudeImport.ts:190-199`
+
+---
+
+## Risks / Open Questions
+
+| # | Question | Notes |
+|---|----------|-------|
+| 1 | Should OOB events update `session.usage`/`model`? | No — `normalizeSessionUpdate` never emits those fields; non-issue |
+| 2 | Imported diffs are fragment-level; live diffs are whole-file — visual inconsistency? | Acceptable; comment in code. Could read file at import time for whole-file but adds I/O complexity |
+
+---
+
+## Implementation Phases
+
+### Phase 1 — CSS fix (Issue 8)
+
+- [ ] **1.1** Reduce `.chat-tool-run__body` gap and margin-left — `web-ui/src/styles/chat.css:507-513`
+- [ ] **1.2** Reduce `.chat-tool-entry__body` margin-left — `chat.css:570-574`
+- [ ] **1.3** Add `.chat-tool-entry__body`-scoped overrides for `.preview-diff-root`, `.preview-diff-hunk-header`, `.diff-line`, `.diff-gutter` — `web-ui/src/styles/workspace.css` (end of file)
+
+**Verify phase 1:**
+- [ ] **1.T1** Visual — diff block in rich-chat has ≤40px left offset and lines are visually tight
+- [ ] **1.T2** Regression — full preview-pane diff (outside `.chat-tool-entry__body`) is visually unchanged
+
+---
+
+### Phase 2 — Import diff reconstruction (Issue 7)
+
+- [ ] **2.1** In `claudeImport.ts`, add `Map<toolId, {toolName, toolInput}>` to track `tool_use` events as they're emitted
+- [ ] **2.2** When emitting a `tool_result`, look up the corresponding `tool_use`; if `toolName === "Edit"` and `toolInput.old_string` exists, attach `toolDiffs: [{path, oldText, newText}]`
+- [ ] **2.3** For `MultiEdit`: one `ToolDiff` per `toolInput.edits[]` entry
+- [ ] **2.4** Mirror changes to `cli/src/daemon/agent-plugins/claudeImport.ts` if it exists
+
+**Verify phase 2:**
+- [ ] **2.T1** Manual — switch napi-5 session to terminal then back to rich-chat; Edit tool calls show colored diff view
+- [ ] **2.T2** Unit — import a JSONL fixture with Edit tool calls; assert `toolDiffs` populated on `tool_result` events
+
+---
+
+### Phase 3 — Out-of-band ACP sink (Issue 5)
+
+- [ ] **3.1** Add `public outOfBandSink: ((ev: NormalizedEvent) => void) | null = null` to `AcpConnection` — `acpTransport.ts:83`
+- [ ] **3.2** In `session/update` handler, when `activeUpdateSink` is null: null-guard `this.sessionId`, normalize, call `this.outOfBandSink?.()` — `acpTransport.ts:400-404`
+- [ ] **3.3** After `AcpConnection` construction/retrieval in `jsonAgent.ts:1005-1011`, assign `conn.outOfBandSink = this.handleOutOfBandEvent.bind(this)`
+- [ ] **3.4** Add `private outOfBandTurnId: string | null = null` field to `JsonAgentSession`
+- [ ] **3.5** Add `private handleOutOfBandEvent(ev: NormalizedEvent): void` — see Decision 2 snippet above
+
+**Verify phase 3:**
+- [ ] **3.T1** Manual — send a message that spawns a background agent; when agent completes, task-notification reply appears in rich-chat without toggling channels
+- [ ] **3.T2** Regression — `session.lifecycle.state` does NOT flip to `working` or `thinking` during OOB event delivery
+- [ ] **3.T3** Unit — `acpTransport.test.ts`: `session/update` with no active prompt calls `outOfBandSink` and does NOT throw
+
+---
+
+## Files & Phase Impact
+
+| File | Status | Phase | Description |
+|------|--------|-------|-------------|
+| `web-ui/src/styles/chat.css` | **Modified** | 1.1, 1.2 | Tighten tool run wrapper margins and gap |
+| `web-ui/src/styles/workspace.css` | **Modified** | 1.3 | Add chat-scoped diff overrides |
+| `daemon/src/agent-plugins/claudeImport.ts` | **Modified** | 2.1–2.3 | Attach computed `toolDiffs` to imported `tool_result` events |
+| `cli/src/daemon/agent-plugins/claudeImport.ts` | **Modified** | 2.4 | Mirror of daemon import fix |
+| `daemon/src/services/acp/acpTransport.ts` | **Modified** | 3.1–3.2 | Add `outOfBandSink` field; route dropped events to it |
+| `daemon/src/services/jsonAgent.ts` | **Modified** | 3.3–3.5 | Wire `outOfBandSink`; add `handleOutOfBandEvent` |

--- a/.vibekit/feature-plans/pending/skill-invocation-in-chat/research-skill-invocation-in-chat.md
+++ b/.vibekit/feature-plans/pending/skill-invocation-in-chat/research-skill-invocation-in-chat.md
@@ -1,0 +1,38 @@
+# Research: Reliable skill invocation from rich-chat
+
+> Not yet planned for implementation — captured for later. No code changes in this doc's scope.
+
+**Issue:** skill-invocation-in-chat
+**Status:** Pending (research only)
+
+---
+
+## Problem
+
+- Typing `/skill-name args` in the TTY (terminal channel) is intercepted by Claude Code's own harness dispatcher **before** it reaches the model — deterministic, zero token cost.
+- Typing the same `/skill-name args` text in rich-chat (ACP `session/prompt`) has no such interception layer — it arrives as plain prompt text, and the model must *recognize* the slash syntax and choose to invoke the Skill tool itself.
+- Observed in practice: recognition is not reliable — the model sometimes treats `/skill-name` as a topic rather than a command, requiring the user to explicitly say "that's a skill, invoke it."
+- This affects every CLI vibe-station drives (claude, cursor, opencode) that goes through the daemon's chat path, not just Claude specifically.
+
+## Findings
+
+- **ACP has no dispatch mechanism for this.** The Agent Client Protocol spec (`session/prompt`) is a generic request-response; there is no distinct message type or flag for "invoke this skill by name," unlike the TTY's local interception.
+- **`session/init` advertises `slash_commands`**, but this is informational only (what commands exist) — dispatch still relies on the model parsing prompt text.
+- **Per-CLI skill/command formats likely differ** (Claude skills vs Cursor rules vs opencode commands) — a daemon-side solution needs to be CLI-agnostic or route through [`AgentPlugin`](../../../CLAUDE.md) per the "all CLI-specific logic lives in the plugin" invariant already established in this codebase.
+
+## Inclination (not yet decided)
+
+- A **daemon-driven rewrite** is preferred over relying on model recognition: before the daemon forwards a chat message as a `session/prompt`, detect a leading `/skill-name` in the outgoing text and rewrite that portion inline — replacing it with the skill's full resolved path/instructions (or an unambiguous directive) rather than leaving it as bare text for the model to interpret.
+- This should live in `daemon/src/agent-plugins/` per the existing plugin-boundary rule — each CLI's plugin resolves its own skill/command lookup and rewrite format, since "Terminal" (`Bash`) vs `Edit` naming differences and skill/command formats already diverge per-CLI in this codebase.
+- **Open problem — arguments:** the composer is a single free-text field. `/skill-name arg1 arg2` mixes the skill selector and its arguments in one string with no structured separation. Any rewrite logic needs a clear boundary between "this is the skill name" and "this is the args payload" — e.g. first whitespace-delimited token after `/` is the skill, remainder is `args` verbatim (matches the existing `Skill` tool's `{skill, args}` shape) — but this needs validation against real skill usage patterns (do any skill names contain spaces or special chars? do args ever need to reference the skill name again?).
+- Deferred: exact detection regex, where in the daemon pipeline the rewrite happens (before persist? before ACP send only?), how failure/no-match cases degrade (fall through to plain text vs error), and whether cursor/opencode need this at all given their own command surfaces may already work differently.
+
+## Alternative considered
+
+- Contributing to the upstream [`claude-agent-acp`](https://github.com/agentclientprotocol/claude-agent-acp) adapter to add a proper `session/command`-style dispatch message. Rejected as the primary path for now: it only fixes Claude, not cursor/opencode, and vibe-station doesn't control that repo's release cadence — but worth revisiting if the daemon-side rewrite proves too fragile per-CLI.
+
+## Next steps (when this is picked up)
+
+1. Confirm argument-boundary convention against real skill catalogs across all three CLIs.
+2. Decide rewrite injection point in the daemon chat pipeline.
+3. Prototype for Claude only first (highest-value CLI), validate reliability improvement, then generalize to the `AgentPlugin` interface.

--- a/daemon/src/__tests__/nativeHistoryImport.test.ts
+++ b/daemon/src/__tests__/nativeHistoryImport.test.ts
@@ -154,6 +154,83 @@ describe("P2.T1 — claude native-history adapter", () => {
     const r = await importer.import({ sessionId: SESSION_ID, agentChatId: "nope", cwd: CWD });
     expect(r.events).toEqual([]);
   });
+
+  it("keeps real prompts (origin.kind human, any promptSource) and drops harness injections", async () => {
+    const slug = CWD.replaceAll("/", "-").replaceAll(".", "-");
+    const dir = join(tmp, "projects", slug);
+    await mkdir(dir, { recursive: true });
+    const lines = [
+      // Real prompts: every genuine prompt carries `origin.kind === "human"`,
+      // whatever `promptSource` says — "typed", "sdk" and "queued" are all real.
+      { type: "user", uuid: "u1", promptSource: "typed", origin: { kind: "human" }, message: { role: "user", content: "typed prompt" } },
+      { type: "user", uuid: "u2", promptSource: "sdk", origin: { kind: "human" }, message: { role: "user", content: "sdk prompt" } },
+      { type: "user", uuid: "u3", promptSource: "queued", origin: { kind: "human" }, message: { role: "user", content: "queued prompt" } },
+      // Harness injections — never real user messages.
+      { type: "user", uuid: "x1", promptSource: "system", origin: { kind: "task-notification" }, message: { role: "user", content: "<task-notification>…" } },
+      { type: "user", uuid: "x2", promptSource: "sdk", origin: { kind: "task-notification" }, message: { role: "user", content: "<task-notification>…" } },
+      // Turn 1's multi-block prompt: system-prompt prefix block + the real message.
+      {
+        type: "user",
+        uuid: "u4",
+        promptSource: "sdk",
+        origin: { kind: "human" },
+        message: { role: "user", content: [{ type: "text", text: "# Injected system prompt" }, { type: "text", text: "the real message" }] },
+      },
+    ];
+    await writeFile(join(dir, `${CHAT_ID}.jsonl`), lines.map((l) => JSON.stringify(l)).join("\n") + "\n", "utf8");
+
+    const importer = createClaudeHistoryImporter({ projectsDir: join(tmp, "projects") });
+    const { events } = await importer.import({ sessionId: SESSION_ID, agentChatId: CHAT_ID, cwd: CWD });
+    expect(events.filter((e) => e.kind === "user").map((e) => e.text)).toEqual([
+      "typed prompt",
+      "sdk prompt",
+      "queued prompt",
+      "the real message",
+    ]);
+  });
+
+  it("reconstructs fragment diffs for imported Edit / MultiEdit calls", async () => {
+    const slug = CWD.replaceAll("/", "-").replaceAll(".", "-");
+    const dir = join(tmp, "projects", slug);
+    await mkdir(dir, { recursive: true });
+    const lines = [
+      { type: "user", uuid: "u1", origin: { kind: "human" }, message: { role: "user", content: "edit things" } },
+      {
+        type: "assistant",
+        message: {
+          content: [
+            { type: "tool_use", id: "e1", name: "Edit", input: { file_path: "/p/a.ts", old_string: "a", new_string: "b" } },
+            { type: "tool_use", id: "e2", name: "MultiEdit", input: { file_path: "/p/b.ts", edits: [{ old_string: "1", new_string: "2" }, { old_string: "3", new_string: "4" }] } },
+            { type: "tool_use", id: "e3", name: "Read", input: { file_path: "/p/c.ts" } },
+          ],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "e1", content: "ok" },
+            { type: "tool_result", tool_use_id: "e2", content: "ok" },
+            { type: "tool_result", tool_use_id: "e3", content: "ok" },
+          ],
+        },
+      },
+    ];
+    await writeFile(join(dir, `${CHAT_ID}.jsonl`), lines.map((l) => JSON.stringify(l)).join("\n") + "\n", "utf8");
+
+    const importer = createClaudeHistoryImporter({ projectsDir: join(tmp, "projects") });
+    const { events } = await importer.import({ sessionId: SESSION_ID, agentChatId: CHAT_ID, cwd: CWD });
+    const byId = new Map(events.filter((e) => e.kind === "tool_result").map((e) => [e.toolId, e]));
+    expect(byId.get("e1")!.toolDiffs).toEqual([{ path: "/p/a.ts", oldText: "a", newText: "b" }]);
+    // MultiEdit: EVERY edit in the array, each inheriting the call-level file_path.
+    expect(byId.get("e2")!.toolDiffs).toEqual([
+      { path: "/p/b.ts", oldText: "1", newText: "2" },
+      { path: "/p/b.ts", oldText: "3", newText: "4" },
+    ]);
+    // A non-edit tool never grows a diff.
+    expect(byId.get("e3")!.toolDiffs).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/daemon/src/agent-plugins/claudeImport.ts
+++ b/daemon/src/agent-plugins/claudeImport.ts
@@ -44,6 +44,9 @@ const SKIP_TYPES = new Set([
   "attachment",
 ]);
 
+/** Tool names whose `tool_use` input can be replayed into a rendered diff. */
+const DIFF_TOOL_NAMES = new Set(["Edit", "MultiEdit"]);
+
 const num = (v: unknown): number => (typeof v === "number" ? v : 0);
 
 /**
@@ -103,6 +106,11 @@ export function parseClaudeNativeHistory(
   // Turn grouping: a `user` TEXT prompt opens a turn; every following event
   // (assistant blocks, tool results) inherits its `turnId` until the next prompt.
   let currentTurnId: string | undefined;
+  // Track tool_use name+input keyed by toolId so tool_result can compute toolDiffs.
+  // Imported diffs are fragment-level (the old_string/new_string pair), not whole-file;
+  // line numbers restart at 1 within each fragment. Entries are dropped as soon as
+  // their tool_result consumes them, so the map stays bounded on a large import.
+  const editToolCallById = new Map<string, { name: string; input: Record<string, unknown> }>();
 
   const mk = (kind: NormalizedEventKind, extra: Partial<NormalizedEvent> & { ts: string }): NormalizedEvent => ({
     id: randomUUID(),
@@ -136,9 +144,21 @@ export function parseClaudeNativeHistory(
     const content = msg.content;
 
     if (type === "user") {
+      // Is this a real prompt, or a harness-injected one? claude tags every
+      // genuine prompt with `origin.kind === "human"` (whatever `promptSource`
+      // says — "typed" / "sdk" / "queued" are all real), and tags its own
+      // injections (`<task-notification>` replies, etc.) with
+      // `promptSource: "system"` and/or a non-human `origin.kind`.
+      // NOTE: this gates the PROMPT TEXT only — `tool_result` lines carry no
+      // `origin` at all and must still be imported below.
+      const originKind = (d.origin as Record<string, unknown> | null | undefined)?.kind;
+      const harnessInjected =
+        d.promptSource === "system" || (originKind != null && originKind !== "human");
+
       // A `user` line is EITHER a real prompt (string / text blocks) OR tool
       // RESULTS (tool_result blocks) delivered back to the model.
       if (typeof content === "string") {
+        if (harnessInjected) continue;
         currentTurnId = typeof d.uuid === "string" ? d.uuid : randomUUID();
         events.push(mk("user", { role: "user", text: content, ts }));
         continue;
@@ -151,18 +171,45 @@ export function parseClaudeNativeHistory(
           if (block.type === "text" && typeof block.text === "string") textParts.push(block.text);
           else if (block.type === "tool_result") toolResults.push(block);
         }
-        if (textParts.length) {
+        if (textParts.length && !harnessInjected) {
           currentTurnId = typeof d.uuid === "string" ? d.uuid : randomUUID();
-          events.push(mk("user", { role: "user", text: textParts.join("\n"), ts }));
+          // Use only the last text block: multi-block user turns start with a
+          // harness-injected system-prompt prefix (turn 1 carries the skill /
+          // system prompt as its own block); the real user message is the last.
+          events.push(mk("user", { role: "user", text: textParts[textParts.length - 1]!, ts }));
         }
         for (const block of toolResults) {
           const stripped = stripInlineBase64(block.content);
           const contentStr =
             typeof stripped === "string" ? stripped : stripped != null ? JSON.stringify(stripped) : undefined;
+          const toolId = typeof block.tool_use_id === "string" ? block.tool_use_id : undefined;
+          // Restore toolDiffs for Edit/MultiEdit calls by looking up the corresponding
+          // tool_use input. Imported diffs are fragment-level (old_string/new_string pair),
+          // not whole-file; line numbers restart at 1 within each fragment.
+          let toolDiffs: NormalizedEvent["toolDiffs"] | undefined;
+          const call = toolId ? editToolCallById.get(toolId) : undefined;
+          if (toolId && call) {
+            editToolCallById.delete(toolId); // one result per call — keep the map bounded
+            const { name, input } = call;
+            if (name === "Edit" && typeof input.old_string === "string" && typeof input.new_string === "string") {
+              toolDiffs = [{ path: String(input.file_path ?? ""), oldText: input.old_string, newText: input.new_string }];
+            } else if (name === "MultiEdit" && Array.isArray(input.edits)) {
+              const diffs = (input.edits as unknown[])
+                .filter((e): e is Record<string, unknown> => !!e && typeof e === "object")
+                .filter((e) => typeof e.old_string === "string" && typeof e.new_string === "string")
+                .map((e) => ({
+                  path: String(e.file_path ?? input.file_path ?? ""),
+                  oldText: e.old_string as string,
+                  newText: e.new_string as string,
+                }));
+              if (diffs.length > 0) toolDiffs = diffs;
+            }
+          }
           events.push(
             mk("tool_result", {
-              toolId: typeof block.tool_use_id === "string" ? block.tool_use_id : undefined,
+              toolId,
               toolResult: { content: contentStr, isError: block.is_error === true },
+              ...(toolDiffs ? { toolDiffs } : {}),
               ts,
             }),
           );
@@ -180,12 +227,20 @@ export function parseClaudeNativeHistory(
         } else if (block.type === "thinking" && typeof block.thinking === "string") {
           events.push(mk("thinking", { role: "assistant", text: block.thinking, ts }));
         } else if (block.type === "tool_use") {
+          const toolId = typeof block.id === "string" ? block.id : undefined;
+          const toolInput = stripInlineBase64(block.input);
+          const toolName = typeof block.name === "string" ? block.name : undefined;
+          // Only edit tools can yield a reconstructed diff — don't retain every
+          // other tool's input for the whole import.
+          if (toolId && toolName && DIFF_TOOL_NAMES.has(toolName) && toolInput && typeof toolInput === "object") {
+            editToolCallById.set(toolId, { name: toolName, input: toolInput as Record<string, unknown> });
+          }
           events.push(
             mk("tool_use", {
               role: "assistant",
-              toolName: typeof block.name === "string" ? block.name : undefined,
-              toolId: typeof block.id === "string" ? block.id : undefined,
-              toolInput: stripInlineBase64(block.input),
+              toolName,
+              toolId,
+              toolInput,
               ts,
             }),
           );

--- a/daemon/src/services/acp/acpTransport.ts
+++ b/daemon/src/services/acp/acpTransport.ts
@@ -81,6 +81,8 @@ export class AcpConnection {
   private disposeNotified = false;
   private disposePromise: Promise<void> | null = null;
   private activeUpdateSink: ((u: AcpSessionUpdate) => void) | null = null;
+  /** Receives session/update notifications that arrive outside an active session/prompt turn. */
+  outOfBandSink: ((ev: NormalizedEvent) => void) | null = null;
   readonly terminals = new AcpTerminalManager();
 
   constructor(
@@ -399,7 +401,13 @@ export class AcpConnection {
       switch (req.method) {
         case "session/update": {
           const params = req.params as { sessionId: string; update: AcpSessionUpdate };
-          this.activeUpdateSink?.(params.update);
+          if (this.activeUpdateSink) {
+            this.activeUpdateSink(params.update);
+          } else if (this.outOfBandSink) {
+            if (!this.sessionId) return;
+            const ev = normalizeSessionUpdate(params.update, this.sessionId, this.provider, this.enrich);
+            if (ev) this.outOfBandSink(ev);
+          }
           return; // notification, no response
         }
         case "session/request_permission": {

--- a/daemon/src/services/jsonAgent.ts
+++ b/daemon/src/services/jsonAgent.ts
@@ -57,6 +57,13 @@ import type {
 const RELEASE_DRAIN_TIMEOUT_MS = 2000;
 
 /**
+ * Quiet gap after which the next out-of-band ACP event (a task notification
+ * arriving between turns) starts a NEW pseudo-turn instead of appending to the
+ * previous one — see `handleOutOfBandEvent`.
+ */
+const OUT_OF_BAND_BURST_GAP_MS = 30_000;
+
+/**
  * Inject absolute attachment paths into a user message (Decision 5). The agent
  * reads the files by absolute path (they live under `sessionDataDir`, not the
  * checkout). Applied at RUN time (not enqueue) so the queued turn retains the
@@ -289,6 +296,10 @@ export class JsonAgentSession {
    * written only once the CLI has actually produced a conversation).
    */
   private connectionFirstTurnPending = false;
+  /** Stable turnId for the current burst of out-of-band ACP events (task notifications). */
+  private outOfBandTurnId: string | null = null;
+  /** `Date.now()` of the last out-of-band event — a long quiet gap opens a new burst. */
+  private outOfBandLastAt = 0;
 
   /**
    * Set by `release()` — this instance is being torn down and must never write
@@ -730,6 +741,7 @@ export class JsonAgentSession {
       queuedTurnIds: this.queue.map((t) => t.turnId),
       editingTurnIds: [...this.holds.keys()],
       ...(this.usage ? { usage: this.usage } : {}),
+      cwd: this.cwd,
     };
   }
 
@@ -843,6 +855,9 @@ export class JsonAgentSession {
 
     const abort = new AbortController();
     this.activeAbort = abort;
+    // A real turn closes any open out-of-band notification burst — notifications
+    // that arrive after it must not be folded back into the pre-turn pseudo-turn.
+    this.outOfBandTurnId = null;
     this.setTurnState("thinking");
     this.emitMeta();
 
@@ -1045,6 +1060,7 @@ export class JsonAgentSession {
     }
     this.connection = conn;
     this.connectionFirstTurnPending = true;
+    conn.outOfBandSink = this.handleOutOfBandEvent.bind(this);
     return conn;
   }
 
@@ -1105,6 +1121,32 @@ export class JsonAgentSession {
         ),
       };
     });
+  }
+
+  /**
+   * Routes out-of-band ACP events (task notifications sent by the agent outside
+   * of an active session/prompt turn) through the same persist+broadcast pipeline
+   * as normal turn events. Does NOT call updateTurnState to avoid spurious
+   * lifecycle transitions.
+   */
+  private handleOutOfBandEvent(ev: NormalizedEvent): void {
+    if (this.released) return;
+    // Mint a burst-stable turnId shared by every event of one notification
+    // burst. There is no end-of-burst marker to key off: `session/update`
+    // never normalizes to a `result`/`error` event (see normalizeSessionUpdate
+    // — only text/thinking/tool_*/status/mode/commands kinds exist), so a
+    // burst is closed by a long quiet gap, or by a real turn starting
+    // (`runOneTurn` clears the id). Without that, every notification for the
+    // whole life of the session would collapse into one endless turn.
+    const now = Date.now();
+    if (!this.outOfBandTurnId || now - this.outOfBandLastAt > OUT_OF_BAND_BURST_GAP_MS) {
+      this.outOfBandTurnId = `notif-${randomUUID()}`;
+    }
+    this.outOfBandLastAt = now;
+    ev.turnId = this.outOfBandTurnId;
+    capToolResultContent(ev);
+    this.persist(ev);
+    this.stream.emitMessage(ev);
   }
 
   private async handleEvent(ev: NormalizedEvent): Promise<void> {
@@ -1359,6 +1401,7 @@ export function buildMetaFromStoreMeta(opts: {
   modeId?: string;
   modeName?: string;
   modelOverride?: string;
+  cwd?: string;
   meta: TranscriptMeta;
 }): SessionMeta {
   return assembleMeta(opts, opts.meta);
@@ -1366,7 +1409,7 @@ export function buildMetaFromStoreMeta(opts: {
 
 /** Shared idle-meta assembly: apply the model override, then build the record. */
 function assembleMeta(
-  opts: { sessionId: string; cli: string; modeId?: string; modeName?: string; modelOverride?: string },
+  opts: { sessionId: string; cli: string; modeId?: string; modeName?: string; modelOverride?: string; cwd?: string },
   found: TranscriptMeta,
 ): SessionMeta {
   const model = opts.modelOverride ?? found.model;
@@ -1382,5 +1425,6 @@ function assembleMeta(
     queuedTurnIds: [],
     editingTurnIds: [],
     ...(found.usage ? { usage: found.usage } : {}),
+    ...(opts.cwd ? { cwd: opts.cwd } : {}),
   };
 }

--- a/daemon/src/services/jsonAgentChat.ts
+++ b/daemon/src/services/jsonAgentChat.ts
@@ -26,7 +26,7 @@ import {
   type JsonAgentSession,
 } from "./jsonAgent.js";
 import { sessionChannel } from "./channel.js";
-import { sessionDataDir, directSessionDataDir } from "./paths.js";
+import { sessionDataDir, directSessionDataDir, worktreePath } from "./paths.js";
 import type { TranscriptPage } from "./transcriptStore.js";
 import type {
   ProjectRecord,
@@ -319,12 +319,16 @@ export async function readSessionMeta(
   void daemonPort;
   // Bounded meta rebuild (R2.6): resolve the last model + last real usage via the
   // store's bounded reverse scan, never a whole-transcript read.
+  const cwd = ctx.worktree
+    ? worktreePath(ctx.project.id, ctx.worktree.id)
+    : ctx.project.absolutePath;
   return buildMetaFromStoreMeta({
     sessionId: ctx.session.id,
     cli,
     ...(modeId ? { modeId } : {}),
     ...(modeName ? { modeName } : {}),
     ...(ctx.session.modelOverride ? { modelOverride: ctx.session.modelOverride } : {}),
+    cwd,
     meta: readMetaFromDataDir(sessionDataDirFor(ctx), ctx.session.id),
   });
 }

--- a/daemon/src/types.ts
+++ b/daemon/src/types.ts
@@ -253,6 +253,8 @@ export interface SessionMeta {
   /** turnIds withdrawn into the editing hold (drives the "editing" bubble state). */
   editingTurnIds: string[];
   usage?: UsageInfo;
+  /** Absolute working directory for the session (worktree or project root). */
+  cwd?: string;
 }
 
 export interface SessionRecord {

--- a/daemon/src/ws/protocol.ts
+++ b/daemon/src/ws/protocol.ts
@@ -226,6 +226,7 @@ export const SessionMetaSchema = z.object({
   queuedTurnIds: z.array(z.string()),
   editingTurnIds: z.array(z.string()),
   usage: UsageInfoSchema.optional(),
+  cwd: z.string().optional(),
 });
 
 /**

--- a/web-ui/src/api/types.ts
+++ b/web-ui/src/api/types.ts
@@ -321,6 +321,8 @@ export interface SessionMeta {
   /** turnIds withdrawn into the editing hold (drives the "editing" bubble). */
   editingTurnIds: string[];
   usage?: UsageInfo;
+  /** Absolute working directory for the session (worktree or project root). */
+  cwd?: string;
 }
 
 /** Dynamic CLI id strings — canonical list from GET /supported-clis */

--- a/web-ui/src/components/chat/Composer.tsx
+++ b/web-ui/src/components/chat/Composer.tsx
@@ -12,6 +12,12 @@ const COMPOSER_MAX_GROW_LINES = 10;
  *  send emptied the box while a turn is still running — see `justSent`. */
 const SEND_SETTLE_MS = 700;
 
+/** Shift+Enter and Alt+Enter insert a newline. The OS/browser sometimes drops the
+ *  modifier from the very next keydown when keys are released quickly, so a bare
+ *  Enter arriving within this window after either combo is treated as another
+ *  newline — a fast double-tap must never accidentally send the message. */
+const NEWLINE_KEY_GUARD_MS = 500;
+
 /** Resize `el` to fit its content, capped at `COMPOSER_MAX_GROW_LINES` worth
  *  of height (derived from the element's own resolved line-height/padding/
  *  border, not a guessed pixel constant, so it tracks the user's chat font
@@ -122,6 +128,9 @@ export function Composer({
     return () => window.clearTimeout(id);
   }, [justSent]);
 
+  // Timestamp of the last Shift/Alt+Enter — see NEWLINE_KEY_GUARD_MS.
+  const lastNewlineKeyRef = useRef<number>(0);
+
   async function handleSend() {
     if (!canSend) return;
     const message = text.trim();
@@ -139,7 +148,32 @@ export function Composer({
   }
 
   function onKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
-    if (e.key === "Enter" && !e.shiftKey) {
+    const isNewlineCombo = e.key === "Enter" && (e.shiftKey || e.altKey);
+    if (isNewlineCombo) {
+      lastNewlineKeyRef.current = Date.now();
+      // Alt+Enter: browser doesn't insert a newline by default, do it manually.
+      if (e.altKey && !e.shiftKey) {
+        e.preventDefault();
+        const ta = e.currentTarget;
+        const start = ta.selectionStart ?? text.length;
+        const end = ta.selectionEnd ?? text.length;
+        const next = text.slice(0, start) + "\n" + text.slice(end);
+        setText(next);
+        draft.save(next);
+        // Restore caret after React re-renders the controlled value.
+        requestAnimationFrame(() => {
+          ta.selectionStart = ta.selectionEnd = start + 1;
+        });
+      }
+      return;
+    }
+    if (e.key === "Enter" && e.ctrlKey) {
+      e.preventDefault();
+      void handleSend();
+      return;
+    }
+    if (e.key === "Enter" && !e.shiftKey && !e.altKey && !e.ctrlKey) {
+      if (Date.now() - lastNewlineKeyRef.current < NEWLINE_KEY_GUARD_MS) return;
       e.preventDefault();
       void handleSend();
     }
@@ -240,7 +274,7 @@ export function Composer({
         </div>
       </div>
       <div className="chat-composer__hint">
-        <span aria-hidden>⤓</span> Drop files here · Enter to send · Shift+Enter for newline
+        <span aria-hidden>⤓</span> Drop files here · Enter / Ctrl+Enter to send · Shift+Enter or Alt+Enter for newline
       </div>
     </div>
   );

--- a/web-ui/src/components/chat/MessageList.test.tsx
+++ b/web-ui/src/components/chat/MessageList.test.tsx
@@ -355,7 +355,8 @@ describe("MessageList live thinking block suppression", () => {
     expect(container.querySelector(".chat-thinking")).toBeNull();
     expect(screen.queryByText("let me reason")).toBeNull();
     // The tool card around it is unaffected — no gap, no placeholder.
-    expect(screen.getByText("Bash")).toBeTruthy();
+    // Bash/Terminal rows render under the "Ran" label, not the raw tool name.
+    expect(screen.getByText("Ran")).toBeTruthy();
   });
 
   it("renders the completed block in its original position once the group closes", () => {
@@ -370,7 +371,7 @@ describe("MessageList live thinking block suppression", () => {
     // open (see `liveEvents`), so the completed label takes the tool variant.
     expect(block!.textContent).toContain("Worked for 3s");
     // Position preserved: thinking block precedes the tool card in DOM order.
-    const tool = screen.getByText("Bash");
+    const tool = screen.getByText("Ran");
     expect(block!.compareDocumentPosition(tool) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 

--- a/web-ui/src/components/chat/MessageList.tsx
+++ b/web-ui/src/components/chat/MessageList.tsx
@@ -382,6 +382,8 @@ interface MessageListProps {
    *  footer `StatusBar` can show busy dots exactly when the in-feed
    *  `WorkingIndicator` is scrolled out of view. */
   onAtBottomChange?: (atBottom: boolean) => void;
+  /** Absolute working directory — tool-call paths are shown relative to it. */
+  cwd?: string;
 }
 
 export function MessageList({
@@ -400,6 +402,7 @@ export function MessageList({
   sessionId,
   onForkTurn,
   onAtBottomChange,
+  cwd,
 }: MessageListProps) {
   // Which answered user turn (if any) this tab is editing → fork. Local to the
   // list; a fork closes the editor and the daemon truncates + re-runs (R3.1).
@@ -800,7 +803,7 @@ export function MessageList({
             // any tool inside it still missing a result is genuinely running
             // (turns can fire several tool calls before results land), not
             // just the last one in the run.
-            node = <ToolRunSummary key={key} tools={item.tools} live={!!turnActive && i === items.length - 1} />;
+            node = <ToolRunSummary key={key} tools={item.tools} live={!!turnActive && i === items.length - 1} cwd={cwd} />;
             break;
           case "error":
             node = <ErrorCard key={key} text={item.text} onRetry={onRetry} />;

--- a/web-ui/src/components/chat/ToolRunSummary.tsx
+++ b/web-ui/src/components/chat/ToolRunSummary.tsx
@@ -1,12 +1,17 @@
 import { useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import { DiffView } from "@/components/preview/DiffView";
 import {
   capForDisplay,
   looksLikeUnifiedDiff,
   prettyToolInput,
+  relativize,
   summarizeToolInput,
   type ToolCallEntry,
 } from "./toolFormat";
+
+const BASH_TOOL_NAMES = new Set(["bash", "terminal"]);
 
 interface ToolRunSummaryProps {
   tools: ToolCallEntry[];
@@ -14,6 +19,8 @@ interface ToolRunSummaryProps {
    *  inside it still missing a result is genuinely in flight (a turn can fire
    *  several tool calls before results land, not just the last one). */
   live?: boolean;
+  /** Absolute working directory — paths are shown relative to it. */
+  cwd?: string;
 }
 
 // Tool names that describe the same kind of action fold into one bucket so
@@ -74,9 +81,12 @@ function summarizeGroup(tools: ToolCallEntry[]): string {
  * done, a quiet checkmark marks completion when there's no detail to expand
  * into (an empty-output Bash call, say) so it doesn't read as still pending.
  */
-function ToolRunEntryRow({ tool, running }: { tool: ToolCallEntry; running: boolean }) {
-  const [open, setOpen] = useState(false);
-  const inline = summarizeToolInput(tool.toolInput, tool.locations);
+function ToolRunEntryRow({ tool, running, cwd }: { tool: ToolCallEntry; running: boolean; cwd?: string }) {
+  const isBash = BASH_TOOL_NAMES.has(tool.toolName.toLowerCase());
+  // Bash/Terminal output is often verbose — start collapsed so it doesn't
+  // dominate the chat view; all other tool rows start expanded.
+  const [open, setOpen] = useState(!isBash);
+  const inline = summarizeToolInput(tool.toolInput, tool.locations, cwd);
   const pretty = prettyToolInput(tool.toolInput);
   // `toolInput` is often `{}` for an ACP adapter that reports the target via
   // `locations` instead (see summarizeToolInput) — an empty-object body adds
@@ -111,7 +121,7 @@ function ToolRunEntryRow({ tool, running }: { tool: ToolCallEntry; running: bool
         <span className="chat-tool-entry__icon" aria-hidden>
           {isError ? "⚠" : "🔧"}
         </span>
-        <span className="chat-tool-entry__name">{tool.toolName}</span>
+        <span className="chat-tool-entry__name">{isBash ? "Ran" : tool.toolName}</span>
         {inline ? <code className="chat-tool-entry__inline">{inline}</code> : null}
         <span className="chat-tool-entry__status">
           {running ? (
@@ -132,12 +142,21 @@ function ToolRunEntryRow({ tool, running }: { tool: ToolCallEntry; running: bool
           ) : null}
           {hasDiffs
             ? tool.diffs!.map((diff, i) => (
-                <DiffView key={`${diff.path}-${i}`} oldText={diff.oldText ?? ""} newText={diff.newText} filePath={diff.path} />
+                <DiffView
+                  key={`${diff.path}-${i}`}
+                  oldText={diff.oldText ?? ""}
+                  newText={diff.newText}
+                  filePath={relativize(diff.path, cwd)}
+                />
               ))
             : null}
           {hasResultBody ? (
             isDiff ? (
               <DiffView diffText={resultText} />
+            ) : isBash ? (
+              <div className="chat-tool-entry__md workspace-markdown-preview">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{resultText}</ReactMarkdown>
+              </div>
             ) : (
               <pre className="chat-tool-entry__pre">
                 <code>{resultText}</code>
@@ -161,12 +180,12 @@ function ToolRunEntryRow({ tool, running }: { tool: ToolCallEntry; running: bool
  * under the summary line; each tool's call and result render as ONE
  * element, not a separate card pair.
  */
-export function ToolRunSummary({ tools, live }: ToolRunSummaryProps) {
+export function ToolRunSummary({ tools, live, cwd }: ToolRunSummaryProps) {
   // A singleton run's summary line is a generic phrase ("Ran 1 shell
   // command") — start it expanded so the actual tool name + inline args
   // (in the entry row below) are visible without a click, matching what a
   // lone tool call used to show directly.
-  const [open, setOpen] = useState(() => !!live || tools.length === 1);
+  const [open, setOpen] = useState(true);
   const hasError = tools.some((t) => t.result?.isError || t.status === "failed");
   // A result already arrived, or a terminal status was set — never spin, even
   // if an adapter's terminal update omitted a fresh `status` field (per ACP's
@@ -195,7 +214,7 @@ export function ToolRunSummary({ tools, live }: ToolRunSummaryProps) {
       {open ? (
         <div className="chat-tool-run__body">
           {tools.map((t) => (
-            <ToolRunEntryRow key={t.id} tool={t} running={!!live && isPending(t)} />
+            <ToolRunEntryRow key={t.id} tool={t} running={!!live && isPending(t)} cwd={cwd} />
           ))}
         </div>
       ) : null}

--- a/web-ui/src/components/chat/toolFormat.ts
+++ b/web-ui/src/components/chat/toolFormat.ts
@@ -51,24 +51,29 @@ export function blocksToPlaceholder(blocks: NormalizedContentBlock[]): string {
     .join(" ");
 }
 
+/** Strip the `cwd` prefix from an absolute path to produce a relative one. */
+export function relativize(p: string, cwd?: string): string {
+  return cwd && p.startsWith(cwd + "/") ? p.slice(cwd.length + 1) : p;
+}
+
 /** Common single-value tool inputs render inline (command / path / pattern).
  *  `locations` (ACP `tool_call.locations`, acp-normalize-superset Gap 3) is a
  *  fallback for adapters that report a structural edit/read via `locations`
  *  instead of an inspectable `toolInput` — e.g. claude's ACP adapter sends
  *  `toolInput: {}` for Edit/Read, with the actual file path arriving only via
  *  `locations`, so without this fallback those calls show no file name at all. */
-export function summarizeToolInput(input: unknown, locations?: { path: string; line?: number }[]): string {
+export function summarizeToolInput(input: unknown, locations?: { path: string; line?: number }[], cwd?: string): string {
   if (input != null) {
-    if (typeof input === "string") return input;
+    if (typeof input === "string") return relativize(input, cwd);
     if (typeof input === "object") {
       const obj = input as Record<string, unknown>;
       for (const key of ["command", "cmd", "path", "file_path", "filePath", "pattern", "query"]) {
-        if (typeof obj[key] === "string") return obj[key] as string;
+        if (typeof obj[key] === "string") return relativize(obj[key] as string, cwd);
       }
     }
   }
   if (locations && locations.length > 0) {
-    return locations.map((l) => (l.line != null ? `${l.path}:${l.line}` : l.path)).join(", ");
+    return locations.map((l) => (l.line != null ? `${relativize(l.path, cwd)}:${l.line}` : relativize(l.path, cwd))).join(", ");
   }
   return "";
 }

--- a/web-ui/src/components/layout/ChatPane.test.tsx
+++ b/web-ui/src/components/layout/ChatPane.test.tsx
@@ -65,8 +65,9 @@ describe("ChatPane (4.T2)", () => {
 
     // Assistant markdown text.
     expect(await screen.findByText("Here is the fix")).toBeTruthy();
-    // Tool card (name).
-    expect(screen.getByText("Bash")).toBeTruthy();
+    // Tool card: a Bash call renders as "Ran <command>", not the raw tool name.
+    expect(screen.getByText("Ran")).toBeTruthy();
+    expect(screen.getByText("ls -la")).toBeTruthy();
 
     // Thinking block collapsed by default; expands on click.
     const toggle = screen.getByRole("button", { name: /thinking/i });

--- a/web-ui/src/components/layout/ChatPane.tsx
+++ b/web-ui/src/components/layout/ChatPane.tsx
@@ -263,6 +263,7 @@ export function ChatPane({ api, session, visible }: ChatPaneProps) {
               {...(sessionId ? { sessionId } : {})}
               onForkTurn={(turnId, message, attachmentIds) => forkTurn(turnId, message, attachmentIds)}
               onAtBottomChange={setAtBottom}
+              {...(meta?.cwd ? { cwd: meta.cwd } : {})}
             />
           )}
         </div>

--- a/web-ui/src/styles/chat.css
+++ b/web-ui/src/styles/chat.css
@@ -189,6 +189,7 @@
   flex: 1;
   min-height: 0;
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .chat-pane__state {
@@ -223,6 +224,7 @@
   flex-direction: column;
   gap: var(--space-3);
   padding: var(--space-4);
+  min-width: 0;
 }
 
 /* Floating jump-to-bottom button (Decision 5). `position: absolute` here
@@ -505,8 +507,8 @@
 .chat-tool-run__body {
   display: flex;
   flex-direction: column;
-  gap: var(--space-1);
-  margin-left: var(--space-3);
+  gap: 2px;
+  margin-left: var(--space-1);
   padding-top: var(--space-1);
 }
 
@@ -566,7 +568,7 @@
   color: var(--fg-muted);
 }
 .chat-tool-entry__body {
-  margin-left: calc(1em + var(--space-2));
+  margin-left: var(--space-1);
   display: flex;
   flex-direction: column;
   gap: var(--space-1);

--- a/web-ui/src/styles/workspace.css
+++ b/web-ui/src/styles/workspace.css
@@ -4778,3 +4778,32 @@ a.dashboard-card.dashboard-card--session {
 .pane-holder--offscreen {
   display: none;
 }
+
+/* ── Chat pane overflow fixes ─────────────────────────────────────────────── */
+
+.chat-pane .chat-tool-entry__body {
+  overflow-x: auto;
+  min-width: 0;
+}
+
+.chat-pane .workspace-markdown-preview {
+  overflow-wrap: anywhere;
+}
+
+/* Chat-scoped diff overrides — tighter than the full preview pane */
+.chat-tool-entry__body .preview-diff-root {
+  padding: 2px 0;
+  line-height: 1.25;
+  min-height: 0;
+}
+.chat-tool-entry__body .preview-diff-hunk-header {
+  padding: 2px 4px;
+}
+.chat-tool-entry__body .diff-line {
+  grid-template-columns: 32px 32px 10px 1fr;
+  padding: 0 4px;
+  line-height: 1.25;
+}
+.chat-tool-entry__body .diff-gutter {
+  padding-right: var(--space-1);
+}


### PR DESCRIPTION
## Summary

- Keyboard: Alt+Enter/Ctrl+Enter shortcuts, 500ms guard against accidental send on fast Shift+Enter double-tap
- Chat pane never shows a horizontal scrollbar; diffs get a local scroller; long unbroken text wraps
- Tool calls expanded by default; bash/terminal entries relabeled "Ran `<command>`", collapsed by default, output rendered as markdown
- File paths in tool messages shown relative to project/worktree root instead of absolute
- Native history import (terminal → rich-chat channel switch) no longer re-imports harness-injected system lines as user messages, and reconstructs diffs for imported Edit/MultiEdit calls so they render with a colored diff view
- Diff blocks in chat get tighter left indentation and line spacing (full preview pane unaffected)
- ACP out-of-band events (e.g. background-agent task-notification replies arriving between turns) now persist and broadcast instead of being silently dropped

Reviewed by an independent pass that found and fixed two blocking bugs before this PR was opened:
- The harness-injection filter for native history import was keying off `origin != null`, which is set on **every** genuine user message too (`origin.kind: "human"`) — it would have dropped all real user messages from imported history. Fixed to only exclude non-human origins.
- `outOfBandTurnId` reset condition checked for `result`/`error` event kinds that `normalizeSessionUpdate` can never emit, so it was structurally dead code — every out-of-band notification for a session's lifetime collapsed into one endless turn. Replaced with a real 30s quiet-gap burst boundary, and turn-start now closes any open burst.

Also fixed: 3 tests broken by the bash relabel, O(n²) toolName lookup in the import path, a duplicated `relativize` helper, and a redundant `emitMeta()` call.

Plan doc: `.vibekit/feature-plans/pending/rich-chat-issues-5-7-8/plan-rich-chat-issues-5-7-8.md`
Research doc (not yet implemented — reliable skill invocation from rich-chat): `.vibekit/feature-plans/pending/skill-invocation-in-chat/research-skill-invocation-in-chat.md`

## Test plan

- [x] `pnpm -r typecheck` passes (web-ui + cli/daemon)
- [x] Lint: 0 errors
- [x] web-ui tests: 587/587 passing
- [x] cli tests: 863 passing / 8 skipped
- [ ] Manual verification in dev sandbox: Shift+Enter/Alt+Enter/Ctrl+Enter behavior, long-path overflow, tool call display, Edit diff view after terminal→rich-chat toggle, background-agent task-notification reply visibility

https://claude.ai/code/session_01FJVWF879fHezDTo8gtdbaT