### PR TITLE
feat(acp): forward 1M context-window beta to claude-agent-acp sessions

### DIFF
--- a/daemon/src/__tests__/acpTransport.test.ts
+++ b/daemon/src/__tests__/acpTransport.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { AcpConnection, ConnectionSpawnFailed, InitializeFailed } from "../services/acp/acpTransport.js";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { AcpConnection, ConnectionSpawnFailed, InitializeFailed, type AcpSessionMeta } from "../services/acp/acpTransport.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FAKE_AGENT = join(__dirname, "fixtures", "fakeAcpAgent.mjs");
@@ -213,5 +215,48 @@ describe("AcpConnection self-healing (idle-dispose / crash respawn regression)",
     await expect(result).rejects.toThrow(/timed out/i);
     expect(Date.now() - start).toBeLessThan(2000);
     await conn.dispose();
+  });
+});
+
+describe("AcpConnection _meta forwarding", () => {
+  const BETA_META: AcpSessionMeta = { claudeCode: { options: { betas: ["context-1m-2025-08-07"] } } };
+
+  /**
+   * Runs `body` against an `echo_meta` fake agent and returns what that agent
+   * saw on the wire: `{ hasMeta, meta }`, written on EVERY session/new|load so
+   * absence is observed rather than inferred from a missing file.
+   */
+  async function captureWireMeta(
+    body: (conn: AcpConnection) => Promise<void>,
+  ): Promise<{ hasMeta: boolean; meta: unknown }> {
+    const dir = mkdtempSync(join(tmpdir(), "acp-meta-"));
+    const outFile = join(dir, "meta.json");
+    const conn = new AcpConnection(
+      { command: process.execPath, args: [FAKE_AGENT], cwd: __dirname, env: { FAKE_ACP_MODE: "echo_meta", META_OUT_FILE: outFile } },
+      "claude",
+    );
+    try {
+      await conn.initialize();
+      await body(conn);
+      return JSON.parse(readFileSync(outFile, "utf8"));
+    } finally {
+      await conn.dispose();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("newSession forwards _meta to the wire (betas reach the adapter)", async () => {
+    const seen = await captureWireMeta((conn) => conn.newSession("/tmp", BETA_META).then(() => {}));
+    expect(seen).toEqual({ hasMeta: true, meta: BETA_META });
+  });
+
+  it("loadSession forwards _meta to the wire", async () => {
+    const seen = await captureWireMeta((conn) => conn.loadSession("/tmp", "fake-session-1", BETA_META));
+    expect(seen).toEqual({ hasMeta: true, meta: BETA_META });
+  });
+
+  it("newSession omits _meta from the wire when no meta is passed", async () => {
+    const seen = await captureWireMeta((conn) => conn.newSession("/tmp").then(() => {}));
+    expect(seen).toEqual({ hasMeta: false, meta: null });
   });
 });

--- a/daemon/src/__tests__/fixtures/fakeAcpAgent.mjs
+++ b/daemon/src/__tests__/fixtures/fakeAcpAgent.mjs
@@ -30,7 +30,13 @@
 //     session/prompt behaves like normal mode.
 //   FAKE_ACP_MODE=steering_method_not_found — _session/steering returns a
 //     JSON-RPC method-not-found error (-32601); everything else behaves normally.
+//   FAKE_ACP_MODE=echo_meta — on every session/new and session/load, write the
+//     `_meta` field exactly as it arrived on the wire to the file named by
+//     META_OUT_FILE, as `{ hasMeta, meta }`. The file is ALWAYS written (with
+//     hasMeta:false when `_meta` was omitted) so tests can assert absence
+//     positively rather than relying on a missing file.
 import { createInterface } from "node:readline";
+import { writeFileSync } from "node:fs";
 
 const mode = process.env.FAKE_ACP_MODE ?? "normal";
 
@@ -55,6 +61,14 @@ let nextClientReqId = 1000;
 
 function write(obj) {
   process.stdout.write(JSON.stringify(obj) + "\n");
+}
+
+// echo_meta mode: record the `_meta` of a session/new|load request exactly as
+// it arrived, so a test can assert both its contents and its absence.
+function recordMeta(params) {
+  if (mode !== "echo_meta" || !process.env.META_OUT_FILE) return;
+  const meta = params?._meta;
+  writeFileSync(process.env.META_OUT_FILE, JSON.stringify({ hasMeta: meta !== undefined, meta: meta ?? null }));
 }
 
 // Maps a client-request id we sent to a callback for its eventual response —
@@ -88,6 +102,7 @@ rl.on("line", (line) => {
     return;
   }
   if (msg.method === "session/new") {
+    recordMeta(msg.params);
     write({ jsonrpc: "2.0", id: msg.id, result: { sessionId } });
     return;
   }
@@ -95,6 +110,7 @@ rl.on("line", (line) => {
     if (msg.params.sessionId === "fail-me") {
       write({ jsonrpc: "2.0", id: msg.id, error: { code: -1, message: "no such session" } });
     } else {
+      recordMeta(msg.params);
       write({ jsonrpc: "2.0", id: msg.id, result: {} });
     }
     return;

--- a/daemon/src/services/acp/acpTransport.ts
+++ b/daemon/src/services/acp/acpTransport.ts
@@ -23,6 +23,18 @@ export class ConnectionSpawnFailed extends Error {}
 export class InitializeFailed extends Error {}
 export class SessionLoadFailed extends Error {}
 
+/** Typed extension bag for `session/new` and `session/load` params. */
+export interface AcpSessionMeta {
+  claudeCode?: {
+    options?: {
+      betas?: string[];
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
 export type PromptBlock =
   | { type: "text"; text: string }
   | { type: "resource_link"; uri: string; name: string };
@@ -216,8 +228,8 @@ export class AcpConnection {
   }
 
   /** `session/new` — mint a fresh ACP session for `cwd`. */
-  async newSession(cwd: string): Promise<string> {
-    const result = (await this.request("session/new", { cwd, mcpServers: [] })) as { sessionId: string };
+  async newSession(cwd: string, meta?: AcpSessionMeta): Promise<string> {
+    const result = (await this.request("session/new", { cwd, mcpServers: [], ...(meta ? { _meta: meta } : {}) })) as { sessionId: string };
     this.sessionId = result.sessionId;
     this.resetIdleTimer();
     return result.sessionId;
@@ -229,9 +241,9 @@ export class AcpConnection {
    * `newSession` and emits a `status` event naming the fallback. Never call
    * this unless `initialize()` reported `loadSession: true`.
    */
-  async loadSession(cwd: string, priorAcpSessionId: string): Promise<void> {
+  async loadSession(cwd: string, priorAcpSessionId: string, meta?: AcpSessionMeta): Promise<void> {
     try {
-      await this.request("session/load", { sessionId: priorAcpSessionId, cwd, mcpServers: [] });
+      await this.request("session/load", { sessionId: priorAcpSessionId, cwd, mcpServers: [], ...(meta ? { _meta: meta } : {}) });
       this.sessionId = priorAcpSessionId;
       this.resetIdleTimer();
     } catch (err) {

--- a/daemon/src/services/jsonAgent.ts
+++ b/daemon/src/services/jsonAgent.ts
@@ -1083,10 +1083,21 @@ export class JsonAgentSession {
     // value). Never the other way around — using a native-only Option B id
     // for `session/load` would ask the adapter to load an id it never minted.
     const priorAcpId = this.session.acpSessionId ?? this.session.agentChatId;
+    // The 1M-token context-window beta is forwarded to the claude-agent-acp
+    // adapter via _meta.claudeCode.options. The adapter spreads these into the
+    // SDK options, which serialises `betas` into an `--betas` CLI flag that
+    // reaches the API as an `anthropic-beta` header. The API enforces
+    // eligibility per-account; passing the beta for an ineligible model/
+    // account is a no-op rather than an error.
+    // Only sent for the claude adapter — the _meta.claudeCode namespace is
+    // claude-agent-acp-specific; other adapters don't read it.
+    const acpMeta = this.cli === "claude"
+      ? { claudeCode: { options: { betas: ["context-1m-2025-08-07"] } } }
+      : undefined;
     let usedFreshSession = true;
     if (loadSession && priorAcpId) {
       try {
-        await conn.loadSession(this.cwd, priorAcpId);
+        await conn.loadSession(this.cwd, priorAcpId, acpMeta);
         usedFreshSession = false;
       } catch (err) {
         if (!(err instanceof SessionLoadFailed)) throw err;
@@ -1098,7 +1109,7 @@ export class JsonAgentSession {
       }
     }
     if (usedFreshSession) {
-      const acpSessionId = await conn.newSession(this.cwd);
+      const acpSessionId = await conn.newSession(this.cwd, acpMeta);
       // Decision 6 Option B: persist the ACP id separately so a LATER
       // reconnect's `session/load` uses it (never `agentChatId`, which stays
       // native-only for this plugin). Option A plugins persist their id via

--- a/scripts/test-1m-context-beta.mjs
+++ b/scripts/test-1m-context-beta.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+/**
+ * test-1m-context-beta.mjs — verify that the 1M context-window beta flows
+ * end-to-end from vibe-station's ACP session/new call to the claude CLI.
+ *
+ * Strategy (two complementary checks):
+ *
+ * 1. ARGS CHECK (primary) — wraps the claude binary with a spy script that
+ *    logs its argv to a temp file. Verifies that `--betas context-1m-2025-08-07`
+ *    appears in the args for the WITH-beta run but NOT for the WITHOUT-beta run.
+ *    This works even if the API key lacks the beta entitlement.
+ *
+ * 2. CONTEXT WINDOW CHECK (secondary) — watches usage_update notifications from
+ *    the adapter for the `size` field. Useful when the account IS entitled to
+ *    the beta; the expected change is 200K → 1M for claude-sonnet-4-5.
+ *
+ * Spawns the claude-agent-acp adapter directly (same way the daemon does),
+ * runs one minimal prompt with and without the beta, and reports both checks.
+ *
+ * Usage:
+ *   node scripts/test-1m-context-beta.mjs [--model <model>] [--skip-real-run]
+ *
+ * Requires: claude binary on PATH (or CLAUDE_BIN env), and the
+ * @agentclientprotocol/claude-agent-acp adapter installed under cli/node_modules
+ * (or VS_REPO_ROOT pointing at a checkout where it is).
+ *
+ * This is a manual/dev tool: it is deliberately NOT under any vitest `include`
+ * glob and is not referenced by any package.json script, because it talks to
+ * the real claude CLI and the real API.
+ *
+ * Exit code 0 = beta flag confirmed to reach the claude CLI.
+ * Exit code 1 = beta flag not detected in CLI args.
+ */
+
+import { spawn, execFileSync } from "node:child_process";
+import { createInterface } from "node:readline";
+import { createRequire } from "node:module";
+import { accessSync, constants, mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+
+const args = process.argv.slice(2);
+const modelIdx = args.indexOf("--model");
+const MODEL = modelIdx >= 0 ? args[modelIdx + 1] : "claude-sonnet-4-5";
+
+// Resolve claude binary: CLAUDE_BIN env → ~/.local/bin → PATH
+function resolveClaude() {
+  if (process.env.CLAUDE_BIN) return process.env.CLAUDE_BIN;
+  const candidate = join(homedir(), ".local", "bin", "claude");
+  try { accessSync(candidate, constants.X_OK); return candidate; } catch {}
+  try { return execFileSync("which", ["claude"], { encoding: "utf8" }).trim(); } catch {}
+  throw new Error("claude binary not found — set CLAUDE_BIN or install Claude Code");
+}
+const REAL_CLAUDE_BIN = resolveClaude();
+
+// Resolve the adapter entry. The daemon sources it from cli/node_modules; in a
+// git worktree that directory may not exist, so VS_REPO_ROOT can point at the
+// main checkout whose node_modules is actually installed.
+function resolveAdapterEntry() {
+  const bases = [import.meta.url, new URL("../cli/package.json", import.meta.url).href];
+  if (process.env.VS_REPO_ROOT) bases.push(new URL("file://" + join(process.env.VS_REPO_ROOT, "cli", "package.json")).href);
+  for (const base of bases) {
+    try {
+      return createRequire(base).resolve("@agentclientprotocol/claude-agent-acp/dist/index.js");
+    } catch {}
+  }
+  throw new Error(
+    "Cannot find @agentclientprotocol/claude-agent-acp — run pnpm install, or set VS_REPO_ROOT to a checkout that has it",
+  );
+}
+const ADAPTER_ENTRY = resolveAdapterEntry();
+
+// ---------------------------------------------------------------------------
+// Spy wrapper: logs claude CLI args to a file, then delegates to real binary.
+// ---------------------------------------------------------------------------
+
+// One wrapper (and one log) per run, so a run that spawns claude more than once
+// can never be confused with the other run's args. Everything lives inside the
+// returned dir, which the caller removes.
+function createSpyWrapper(realBin) {
+  const dir = mkdtempSync(join(tmpdir(), "claude-spy-"));
+  const logFile = join(dir, "args.log");
+  const wrapperPath = join(dir, "claude");
+  writeFileSync(wrapperPath, `#!/usr/bin/env bash\necho "ARGS: $*" >> "${logFile}"\nexec "${realBin}" "$@"\n`, { mode: 0o755 });
+  return { wrapperPath, logFile, dir };
+}
+
+// ---------------------------------------------------------------------------
+// Minimal ACP client
+// ---------------------------------------------------------------------------
+
+async function runSession({ useBeta, claudeBin }) {
+  const label = useBeta ? "WITH beta" : "WITHOUT beta";
+  const child = spawn(process.execPath, [ADAPTER_ENTRY], {
+    cwd: "/tmp",
+    env: {
+      ...process.env,
+      CLAUDE_CODE_EXECUTABLE: claudeBin,
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  let stderr = "";
+  child.stderr?.on("data", (d) => { stderr += d.toString(); });
+
+  const rl = createInterface({ input: child.stdout, crlfDelay: Infinity });
+  let nextId = 1;
+  const pending = new Map();
+  let contextWindowSeen = null;
+
+  function writeLine(obj) {
+    child.stdin.write(JSON.stringify(obj) + "\n");
+  }
+
+  function request(method, params) {
+    const id = nextId++;
+    return new Promise((resolve, reject) => {
+      pending.set(id, { resolve, reject });
+      writeLine({ jsonrpc: "2.0", id, method, params });
+    });
+  }
+
+  rl.on("line", (line) => {
+    let msg;
+    try { msg = JSON.parse(line.trim()); } catch { return; }
+    if (!msg) return;
+
+    if ("id" in msg && !("method" in msg)) {
+      const p = pending.get(msg.id);
+      if (!p) return;
+      pending.delete(msg.id);
+      if (msg.error) p.reject(new Error(`${msg.error.message} [code=${msg.error.code}, data=${JSON.stringify(msg.error.data ?? null).slice(0, 200)}]`));
+      else p.resolve(msg.result);
+      return;
+    }
+
+    if (msg.method === "session/update") {
+      const update = msg.params?.update;
+      if (update?.sessionUpdate === "usage_update" && typeof update.size === "number") {
+        contextWindowSeen = update.size;
+      }
+      return;
+    }
+
+    if (msg.method === "session/request_permission" && msg.id !== undefined) {
+      const options = msg.params?.options ?? [];
+      const chosen =
+        options.find((o) => o.kind === "allow_always") ??
+        options.find((o) => o.kind === "allow_once") ??
+        options.find((o) => o.kind?.startsWith("allow_"));
+      writeLine({
+        jsonrpc: "2.0", id: msg.id,
+        result: chosen
+          ? { outcome: { outcome: "selected", optionId: chosen.optionId } }
+          : { outcome: { outcome: "cancelled" } },
+      });
+    }
+  });
+
+  try {
+    await Promise.race([
+      request("initialize", {
+        protocolVersion: 1,
+        clientCapabilities: { fs: { readTextFile: true, writeTextFile: true }, terminal: false },
+      }),
+      new Promise((_, reject) => setTimeout(() => reject(new Error("initialize timed out")), 30_000)),
+    ]);
+    console.log(`  [${label}] initialize OK`);
+
+    // Same shape the daemon sends (jsonAgent.getOrCreateConnection). `model` is
+    // included in BOTH runs so --model actually selects a model; only `betas`
+    // differs between the two runs, which is what the args check compares.
+    const meta = {
+      claudeCode: { options: { model: MODEL, ...(useBeta ? { betas: ["context-1m-2025-08-07"] } : {}) } },
+    };
+
+    const newSessionResult = await Promise.race([
+      request("session/new", { cwd: "/tmp", mcpServers: [], _meta: meta }),
+      new Promise((_, reject) => setTimeout(() => reject(new Error("session/new timed out")), 30_000)),
+    ]);
+    const sessionId = newSessionResult.sessionId;
+    console.log(`  [${label}] session/new → sessionId=${sessionId}`);
+
+    const promptResult = await Promise.race([
+      request("session/prompt", {
+        sessionId,
+        prompt: [{ type: "text", text: "Reply with exactly one word: ok" }],
+      }),
+      new Promise((_, reject) => setTimeout(() => reject(new Error("session/prompt timed out")), 120_000)),
+    ]);
+    console.log(`  [${label}] session/prompt → stopReason=${promptResult.stopReason}`);
+  } catch (err) {
+    const tail = stderr.trim().split("\n").slice(-5).join("\n    ");
+    if (tail) console.error(`  [${label}] adapter stderr (tail):\n    ${tail}`);
+    throw err;
+  } finally {
+    // Reject anything still in flight so no timer/promise keeps the loop alive.
+    for (const [, p] of pending) p.reject(new Error("session torn down"));
+    pending.clear();
+    rl.close();
+    try { child.kill(); } catch {}
+  }
+
+  return contextWindowSeen;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+console.log(`\nTesting 1M context-window beta (model: ${MODEL})`);
+console.log("──────────────────────────────────────────────────────────────\n");
+
+const spyDirs = [];
+
+/** One run: fresh spy wrapper, one session, then read back that run's args. */
+async function run(label, useBeta) {
+  const spy = createSpyWrapper(REAL_CLAUDE_BIN);
+  spyDirs.push(spy.dir);
+  console.log(`${label}\n  spy wrapper: ${spy.wrapperPath}`);
+  const window = await runSession({ useBeta, claudeBin: spy.wrapperPath }).catch((err) => {
+    console.error(`  FAILED: ${err.message}`);
+    return null;
+  });
+  console.log(`  → contextWindowSize: ${window ?? "(no usage_update received)"}\n`);
+  let log = "";
+  try { log = readFileSync(spy.logFile, "utf8"); } catch {}
+  return { window, log, hasBeta: log.includes("context-1m-2025-08-07") };
+}
+
+let exitCode = 1;
+try {
+  const without = await run("Run 1: WITHOUT beta flag", false);
+  await new Promise((r) => setTimeout(r, 1000));
+  const with_ = await run("Run 2: WITH beta flag", true);
+
+  const { window: windowWithout } = without;
+  const { window: windowWith } = with_;
+
+  console.log("──────────────────────────────────────────────────────────────");
+  console.log("Args check:");
+  console.log(`  Run 1 (no betas): ${without.hasBeta ? "⚠ --betas PRESENT (unexpected)" : "✓ --betas absent"}`);
+  console.log(`  Run 2 (with betas): ${with_.hasBeta ? "✓ --betas context-1m-2025-08-07 PRESENT" : "✗ --betas MISSING"}`);
+  console.log(`\nRaw CLI args (run 1):\n  ${without.log.trim() || "(claude was never invoked)"}`);
+  console.log(`Raw CLI args (run 2):\n  ${with_.log.trim() || "(claude was never invoked)"}`);
+
+  console.log("\nContext window check:");
+  console.log(`  Without beta: ${windowWithout?.toLocaleString() ?? "n/a"}`);
+  console.log(`  With beta:    ${windowWith?.toLocaleString() ?? "n/a"}`);
+  if (windowWith !== null && windowWith >= 1_000_000) {
+    console.log("  ✓ Context window confirmed ≥1M with beta");
+  } else if (windowWithout !== null && windowWith !== null && windowWith > windowWithout) {
+    console.log("  ✓ Context window increased with beta");
+  } else {
+    console.log("  ⚠ Context window unchanged (account may not have beta entitlement — args check is authoritative)");
+  }
+
+  const PASS = !without.hasBeta && with_.hasBeta;
+  console.log(`\n${PASS ? "✓ PASS" : "✗ FAIL"} — ${PASS
+    ? "--betas context-1m-2025-08-07 is forwarded to the claude CLI when the beta is configured"
+    : "beta flag was not detected in claude CLI args"}`);
+  exitCode = PASS ? 0 : 1;
+} finally {
+  // NB: cleanup must happen before process.exit — a finally block does not run
+  // once process.exit has been called, so the exit is deliberately last.
+  for (const dir of spyDirs) {
+    try { rmSync(dir, { recursive: true, force: true }); } catch {}
+  }
+}
+
+process.exit(exitCode);


### PR DESCRIPTION
## What

Forwards the Claude **1M-token context-window beta** (`context-1m-2025-08-07`) through vibe-station's ACP transport, so Rich Chat sessions running on the `claude-agent-acp` adapter can use it.

Single commit: `feat(daemon): forward the 1M context-window beta to the claude ACP adapter`.

## How

- **`daemon/src/services/acp/acpTransport.ts`** — `newSession()` / `loadSession()` take an optional, typed `AcpSessionMeta` (new exported interface) sent as the JSON-RPC `_meta` field. When no meta is passed, `_meta` is omitted entirely, so every other adapter's wire payload is byte-identical to before.
- **`daemon/src/services/jsonAgent.ts`** — `getOrCreateConnection()` builds `_meta.claudeCode.options.betas = ["context-1m-2025-08-07"]` and passes it on **both** the `session/load` and the fresh `session/new` path. Gated on `this.cli === "claude"`, since the `claudeCode` key is that adapter's own namespace.

The adapter spreads `_meta.claudeCode.options` into the Claude Agent SDK options, which the SDK serialises into a `--betas <csv>` CLI flag → `anthropic-beta` request header.

The beta is sent unconditionally for the claude adapter rather than gated on the model string: model aliases (`sonnet`, …) are user-supplied and unreliable, and the API enforces entitlement itself. Verified empirically that this is safe:

| Model | Behaviour |
|---|---|
| `sonnet` → `claude-sonnet-5` | Already 1M natively; beta is a no-op |
| `claude-sonnet-4-5` | 200K baseline, expands to 1M on an entitled account |
| `claude-haiku-4-5` | Unrecognised beta silently ignored with a CLI warning — no error, no broken session |

## Tests

`daemon/src/__tests__/acpTransport.test.ts` gains three wire-level tests: `_meta` reaches the wire on `session/new` and `session/load`, and is **absent** when not supplied.

The fake ACP agent gains an `echo_meta` mode that records the `_meta` of every `session/new`/`session/load` exactly as it arrived, as `{ hasMeta, meta }`. The file is written on *every* such request — including when `_meta` was omitted — so the negative test asserts `{ hasMeta: false }` positively instead of inferring absence from a missing file (which would have passed vacuously had the fixture stopped writing at all).

## Manual verification

`scripts/test-1m-context-beta.mjs` is a **manual dev tool** — deliberately outside every vitest `include` glob and not referenced by any `package.json` script, since it drives the real `claude` CLI and the real API. It spawns the real adapter, wraps the claude binary with a spy that logs argv, and diffs a with-beta run against a without-beta run.

Run manually and confirmed passing: `--betas context-1m-2025-08-07` reaches the CLI args only when `_meta.claudeCode.options.betas` is set. (The API key used lacked the beta entitlement, so the reported context window stayed at 200K — the CLI-args check is what proves the plumbing.)

## Known gap (accepted, not fixed here)

The legacy per-turn spawn fork path (`ctx.forkFromChatId`, still alive for edit-a-sent-message forks) does **not** pass `--betas`. ACP has no fork primitive today, so that path stays on the old spawn mechanism.

## Verification

- `vitest run daemon/src/__tests__/acpTransport.test.ts` — 14/14 pass.
- `tsc -b --noEmit` (cli project) — clean. Note the project's tsconfig `include` is `src`, so the daemon *test* files are type-checked only via vitest's esbuild transpile, not by `tsc`; that is the pre-existing repo baseline, not something this PR changes.
