### PR TITLE
feat(chat): instant restore on worktree switch — snapshot cache + sinceSeq delta

### DIFF
--- a/.vibekit/feature-plans/wip/chat-lru-retain/plan-chat-lru-retain.md
+++ b/.vibekit/feature-plans/wip/chat-lru-retain/plan-chat-lru-retain.md
@@ -1,0 +1,209 @@
+<!--
+RULES — read before writing or implementing:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. REQUIREMENTS: One crisp line each — no verbose descriptions
+3. CHECKLIST: Mark items [x] as you complete them — this is your persistent todo list
+4. READING TIME: Optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+# Plan: Instant rich-chat restore on worktree switch
+
+**Feature:** `chat-lru-retain`
+**Branch:** `loading-detaches-everytime`
+
+---
+
+## Problem
+
+Switching worktrees unmounts panes → `useChat` resets to `[]` + shows spinner → `chat:open` → full tail replay → visible loading flash.
+Within-worktree tab switching is already instant.
+
+---
+
+## Solution
+
+### Part A — Client-side snapshot cache + sinceSeq delta
+
+```
+switch away  →  save snapshot  →  chat:close normally
+switch back  →  setState(snapshot) immediately + setLoading(false)  →  chat:open { sinceSeq }  →  delta merges in
+```
+
+**Snapshot shape:**
+```ts
+interface ChatSnapshot {
+  events: ChatEvent[];        // newest MAX_SNAPSHOT_EVENTS=200; oldestSeq recomputed after truncation
+  oldestSeq: number | null;   // = truncated[0].logSeq ?? null after truncation
+  hasMore: boolean;           // forced true if truncated
+  userTurnIds: Set<string>;
+  latestSeq: number | null;   // Math.max() of defined logSeqs; null/0 → skip sinceSeq
+  savedAt: number;            // Date.now()
+}
+// module-level Map<sessionId, ChatSnapshot>, LRU cap 20
+// excludes sessions where useChat is called with { cache: false }
+```
+
+**Restore sequence:**
+```
+1. useChat mounts
+2. restore(sessionId)?
+   NO  → setLoading(true); full tail (unchanged)
+   YES → setState({ events, oldestSeq, hasMore, userTurnIds })
+         setLoading(false)          ← suppresses spinner; events already visible
+         setIsDeltaLoading(true); isDeltaLoadingRef.current = true
+         sinceSeq = (latestSeq > 0 && savedAt within 60s) ? latestSeq : undefined
+         api.openChat(sessionId, sinceSeq)
+3. chat:replay arrives — discriminate via `e.hasMore === undefined` (matches useChat.ts:145):
+   - sinceSeq path (`e.hasMore === undefined`): mergeEvents(); clear restoredLatestSeqRef
+   - plain path (`e.hasMore !== undefined`):
+     gap-check: if e.oldestSeq != null && restoredLatestSeqRef.current != null
+                   && e.oldestSeq > restoredLatestSeqRef.current
+                → drop restored events; setState(delta.events); update cursors from delta
+                else mergeEvents() normally
+     clear restoredLatestSeqRef in both cases
+   clear isDeltaLoadingRef.current; setIsDeltaLoading(false); cancel failsafe
+4. Failsafe: setIsDeltaLoading(false) after 5s — clears spinner state only;
+   restoredLatestSeqRef cleared only when a replay is consumed (not by failsafe)
+5. session:meta arrives → updates meta (never from snapshot; status bar may briefly be blank — known/acceptable)
+6. Live session:message events flow normally
+```
+
+**Cold-start double-open fix:**
+- `chatSubs`: `Map<sid, { refs: number; sinceSeq?: number }>` (was `Map<sid, number>`)
+- `openChat(sid, sinceSeq?)` stores `sinceSeq` in the entry on 0→1 transition
+- `socket.onopen` replay sends `{ type: "chat:open", sessionId, sinceSeq: entry.sinceSeq }` — no double-open with conflicting seqs
+
+**Snapshot capture (ref-based, StrictMode-safe):**
+- `eventsRef`, `oldestSeqRef`, `hasMoreRef`, `userTurnIdsRef`, `isDeltaLoadingRef`, `restoredLatestSeqRef`
+- Synced with state on every render
+- Cleanup guards: skip save if `eventsRef.current.length === 0` OR `isDeltaLoadingRef.current`
+- Truncation: keep newest 200; recompute `oldestSeq = truncated[0].logSeq ?? null`; set `hasMore = hasMoreRef.current || truncated` (not unconditionally true — short sessions must not show a spurious "load earlier")
+
+**Child session opt-out:**
+- `useChat(api, sessionId, enabled, { cache?: boolean })` — new 4th arg, default `true`
+- Destructure to `const cacheEnabled = opts?.cache !== false` immediately; use primitive in effect deps, not the opts object (avoids infinite open/close loop from unstable inline object reference)
+- `ToolRunSummary.tsx` passes `{ cache: false }` — prevents subagent churn on LRU-20
+- `chatSnapshotCache.save()` no-ops when `cacheEnabled === false`
+
+**Invalidation:**
+- `session:fork` → `evict(sessionId)` — placed before the existing `dropped.size === 0` early-return in the fork handler
+- `session:error` → `evict(sessionId)` + clear `isDeltaLoading` + clear `loading` (NOT `events` — `session:error` also fires for transient TTY errors)
+- `auth:expired` → `cache.clear()` — listener registered in `useChat` via the passed `api` (not in `chatSnapshotCache.ts` itself, which can't receive the injected api cleanly)
+
+**Restore set copy:**
+- Restore `userTurnIds` as `new Set(snapshot.userTurnIds)` — not by reference, or the live ref mutates the cached snapshot
+- On gap-drop path: also reset `userTurnIdsRef` alongside the dropped events
+
+**Pre-existing pending leak fix:**
+- `useChat` active-branch reset currently clears `events/meta/hasMore` but not `pending`
+- Add `setPending([])` to the active branch
+
+### Part B — Reduce `TAIL_TURNS` 20 → 15 (independent, revert separately if needed)
+
+- `daemon/src/ws/handlers/chatOpen.ts:33`
+- Check `transcriptStore.test.ts` for assertions keyed to 20-turn window
+
+---
+
+## Files & Changes
+
+| File | Change |
+|------|--------|
+| `web-ui/src/hooks/chatSnapshotCache.ts` (new) | `save`/`restore`/`evict`/`clear`; LRU 20; truncation + `oldestSeq` recompute; `auth:expired` listener |
+| `web-ui/src/hooks/useChat.ts` | 4th arg `{ cache? }`; refs; save on cleanup (guarded); restore on mount (`setLoading(false)`); `isDeltaLoading` + `restoredLatestSeqRef` + 5s failsafe; gap-check on plain replay path only; `session:error`/`session:fork` listeners (fork before early-return); pending leak fix |
+| `web-ui/src/components/chat/ToolRunSummary.tsx` | Pass `{ cache: false }` to `useChat` for child sessions |
+| `web-ui/src/api/client.ts` | `chatSubs` shape; `openChat(sid, sinceSeq?)`; `onopen` uses stored `sinceSeq` |
+| `daemon/src/ws/handlers/chatOpen.ts` | `TAIL_TURNS` 20 → 15 |
+
+---
+
+## Edge Cases
+
+| Case | Handling |
+|------|---------|
+| First visit / no cache | Full tail + spinner; unchanged |
+| Agent idle since switch | Delta empty; snapshot current; no change |
+| Agent mid-stream when left | Delta completes partial turn via merge |
+| Daemon restart | `logSeq` durable across restarts; sinceSeq just works |
+| Snapshot > 60s + gap | Plain `chat:open`; gap-check drops stale events; fresh delta rendered |
+| Snapshot > 60s + no gap | Plain `chat:open`; mergeEvents; history intact |
+| sinceSeq null/0 | Plain `chat:open`; avoids unbounded `readSessionSince` |
+| WS reconnect | `onopen` uses stored `sinceSeq`; no double-open |
+| Child session | `cache: false`; full tail as today; LRU unaffected |
+| Session deleted | `session:error` → evict + clear loading |
+| Session forked (live) | `session:fork` → evict (before early-return guard) |
+| Fork-while-detached | Known gap; stale turns until next eviction |
+| Auth expiry | `cache.clear()` |
+| StrictMode remount | `isDeltaLoadingRef` guard prevents mid-hydration save |
+| `isDeltaLoading` stuck | 5s failsafe (gap detection remains armed separately) |
+| `loadEarlier` after restore | `oldestSeq` correct post-truncation; no hole |
+| `loadAll` before switch | Capped at 200; `hasMore=true`; `oldestSeq` recomputed |
+| Status bar blank briefly | `meta` not restored from snapshot; fills on `session:meta` — acceptable |
+| Long-lived WS reconnect | Stored `sinceSeq` may be old → large delta; perf risk, correctness intact |
+
+---
+
+## Checklist
+
+### Part A — Snapshot cache
+
+- [x] **A.1** Create `chatSnapshotCache.ts`: `Map<sid, ChatSnapshot>`; `save`/`restore`/`evict`/`clear`; LRU evict oldest at >20; `save` keeps newest 200, recomputes `oldestSeq = events[0].logSeq ?? null`, sets `hasMore = hasMoreRef.current || truncated` (not unconditionally true); no `auth:expired` subscription here
+- [x] **A.2** `api/client.ts`: `chatSubs` → `Map<string, { refs: number; sinceSeq?: number }>`; `openChat(sid, sinceSeq?)` stores `sinceSeq` on 0→1; `onopen` sends `{ type:"chat:open", sessionId, sinceSeq: entry.sinceSeq }` per sid
+- [x] **A.3** `useChat`: add 4th arg `opts: { cache?: boolean } = {}`; thread `cache !== false` into `save`/`restore` calls
+- [x] **A.4** `useChat`: add `eventsRef`, `oldestSeqRef`, `hasMoreRef`, `userTurnIdsRef`, `isDeltaLoadingRef`, `restoredLatestSeqRef` — synced on every render
+- [x] **A.5** `useChat` cleanup: `chatSnapshotCache.save(sid, { ...refs, latestSeq: computeLatestSeq(eventsRef.current), savedAt })` — skip if `eventsRef.current.length === 0` OR `isDeltaLoadingRef.current` OR `opts.cache === false`
+- [x] **A.6** `useChat` mount (cache hit): `setState({ events, oldestSeq, hasMore, userTurnIds: new Set(snapshot.userTurnIds) })`; `setLoading(false)`; `setIsDeltaLoading(true)` + `isDeltaLoadingRef.current = true`; set `restoredLatestSeqRef.current = snapshot.latestSeq`; call `api.openChat(sid, sinceSeq)`; set 5s failsafe timeout (clears `isDeltaLoading` only); register `auth:expired` listener → `chatSnapshotCache.clear()`
+- [x] **A.7** `useChat` `chat:replay` handler: discriminate via `e.hasMore === undefined` (sinceSeq path → `mergeEvents()` + clear `restoredLatestSeqRef`; plain path → gap-check: if `e.oldestSeq != null && restoredLatestSeqRef.current != null && e.oldestSeq > restoredLatestSeqRef.current` → drop restored events + reset `userTurnIdsRef.current = new Set()` + `setState(delta.events)` + update cursors; else `mergeEvents()`; clear `restoredLatestSeqRef` either way); always: clear `isDeltaLoadingRef`/`setIsDeltaLoading(false)`/cancel failsafe
+- [x] **A.8** `useChat` `session:error` listener: `evict(sid)` + `setIsDeltaLoading(false)` + `setLoading(false)`
+- [x] **A.9** `useChat` `session:fork` listener: `evict(sid)` — placed before `dropped.size === 0` early-return
+- [x] **A.10** `useChat` active-branch mount reset: add `setPending([])` (pending leak fix)
+- [x] **A.11** `ToolRunSummary.tsx`: pass `{ cache: false }` as 4th arg to `useChat` for child session
+- [x] **A.12** Helper `computeLatestSeq(events)`: `const seqs = events.flatMap(e => (e.logSeq != null ? [e.logSeq] : [])); const v = seqs.length ? Math.max(...seqs) : 0; return v > 0 ? v : null`
+
+- [x] **A.0** `useChat.test.ts`: add `beforeEach(() => chatSnapshotCache.clear())` to prevent snapshot bleed between tests; fix line-49 `toHaveBeenCalledWith("s1")` assertion → `toHaveBeenCalledWith("s1", undefined)` (or use `toHaveBeenCalledWith(expect.stringMatching("s1"), expect.anything())`); add tests for: (a) restore from cache (no spinner, events visible immediately), (b) gap-drop path, (c) stale (>60s) path
+
+- [ ] **A.T1** Switch away and back within 60s → no spinner, no empty flash; WS inspector: `chat:open` with `sinceSeq`
+- [ ] **A.T2** Switch away >60s, agent was busy → snapshot dropped; fresh delta rendered; no content hole
+- [ ] **A.T3** Switch away >60s, agent idle → snapshot merges with empty delta; history intact; no spinner
+- [ ] **A.T4** Send message immediately after switch-back → optimistic bubble at bottom; deduped after delta
+- [ ] **A.T5** First visit → spinner + full tail; `isDeltaLoading` never set
+- [ ] **A.T6** WS drop+reconnect → single `chat:open` with stored `sinceSeq`; history intact
+- [ ] **A.T7** `loadEarlier` on restored session → correct cursor; no duplicate or skipped events
+- [ ] **A.T8** `loadAll` then switch → snapshot capped; `hasMore=true`; `loadEarlier` works on return
+- [ ] **A.T9** Busy subagent turn (multiple child sessions expand/collapse) → LRU-20 not churned by child sessions
+
+### Part B — Reduce TAIL_TURNS
+
+- [x] **B.1** `chatOpen.ts:33`: `TAIL_TURNS` 20 → 15
+- [x] **B.2** Check `transcriptStore.test.ts` for assertions tied to 20; update if needed (uses `store.tail(20)` directly as a call argument — not the constant — so no update needed)
+
+- [ ] **B.T1** Fresh session open shows 15 turns; load-earlier fetches older
+
+### Phase V — Verification (docker dev sandbox)
+
+Boot the dev sandbox from the worktree root and exercise the feature manually:
+
+```bash
+scripts/dev-sandbox.sh up   # seeds 3 projects / 9 worktrees / 14 sessions, hot-reload on
+```
+
+- [ ] **V.1** Open browser at `http://localhost:<port>`; open browser DevTools → Network → WS tab
+- [ ] **V.2** Navigate to a worktree with a rich-chat session that has history → confirm `chat:open` sent with `sinceSeq` absent (first visit) and history loads normally with spinner
+- [ ] **V.3** Switch to a different worktree, then switch back within 60s → confirm: no spinner, history visible instantly, `chat:open` carries `sinceSeq`, `chat:replay` contains only delta events (not 15-turn tail)
+- [ ] **V.4** Switch away, wait >60s, switch back → confirm: history visible immediately (snapshot), fresh tail merges in, no content hole, no spinner on return
+- [ ] **V.5** While on a restored session, type and send a message before the delta arrives (throttle WS in DevTools if needed) → confirm optimistic bubble stays at bottom; deduped correctly after replay
+- [ ] **V.6** Drop and reconnect the WS (disable network briefly in DevTools) → confirm no duplicate events, no ghost turns; `chat:open` re-sent with stored `sinceSeq`
+- [ ] **V.7** Expand a subagent task entry (`ToolRunSummary`) → switch worktrees → switch back → confirm LRU-20 not churned by child session mounts; main sessions' snapshots still present
+- [ ] **V.8** Run unit tests: `cd web-ui && bun test --filter useChat` → all pass; `cd daemon && bun test --filter transcript` → all pass (TAIL_TURNS=15 assertions)
+- [ ] **V.9** Bring sandbox down: `scripts/dev-sandbox.sh down`
+
+---
+
+## Out of scope
+
+- Terminal session caching
+- Server-side delta cap on `readSessionSince` (unbounded for busy sessions; correctness intact, perf risk noted)
+- Stored `sinceSeq` in `chatSubs` aging on long-lived reconnects (perf only, not correctness)
+- `localStorage` persistence
+- Fork-while-detached invalidation
+- Configurable thresholds / cache size

--- a/daemon/src/ws/handlers/chatOpen.ts
+++ b/daemon/src/ws/handlers/chatOpen.ts
@@ -29,8 +29,8 @@ import {
 } from "../../services/jsonAgentChat.js";
 import type { NormalizedEvent, SessionMeta } from "../../types.js";
 
-/** Default bounded replay window on open (turns). Open decision #1: N=20. */
-const TAIL_TURNS = 20;
+/** Default bounded replay window on open (turns). Reduced from 20 → 15 (Part B). */
+const TAIL_TURNS = 15;
 
 export async function handleChatOpen(
   conn: WSConnection,

--- a/web-ui/src/api/client.ts
+++ b/web-ui/src/api/client.ts
@@ -161,7 +161,25 @@ export function createClientApi() {
       socket.onmessage = (ev) => {
         try {
           const msg = JSON.parse(String(ev.data)) as WSEvent & { type?: string };
-          if (msg.type) emit(msg as WSEvent);
+          if (msg.type) {
+            emit(msg as WSEvent);
+            // Fix 3: advance the stored sinceSeq cursor as live session:message
+            // events arrive so WS-reconnect uses the delta from the latest seen
+            // event rather than replaying everything since mount (unbounded replay
+            // regression introduced by snapshot-cache feature).
+            if (msg.type === "session:message") {
+              const sm = msg as unknown as { sessionId?: string; logSeq?: number };
+              if (sm.sessionId != null && sm.logSeq != null) {
+                const entry = chatSubs.get(sm.sessionId);
+                if (entry) {
+                  const current = entry.sinceSeq ?? 0;
+                  if (sm.logSeq > current) {
+                    chatSubs.set(sm.sessionId, { ...entry, sinceSeq: sm.logSeq });
+                  }
+                }
+              }
+            }
+          }
         } catch {
           /* ignore */
         }

--- a/web-ui/src/api/client.ts
+++ b/web-ui/src/api/client.ts
@@ -105,8 +105,10 @@ export function createClientApi() {
   const treeWatches = new Map<string, { worktreeId: string }>();
   /** Refcounted JSON-chat subscriptions — multiple components can subscribe to
    *  the same sessionId without one cleanup tearing down the others.
-   *  Map<sessionId, refCount>; chat:open sent on 0→1, chat:close sent on 1→0. */
-  const chatSubs = new Map<string, number>();
+   *  Map<sessionId, { refs, sinceSeq? }>; chat:open sent on 0→1, chat:close sent on 1→0.
+   *  `sinceSeq` is stored on the 0→1 transition so WS-reconnect replays can use
+   *  the same delta cursor instead of requesting a full tail (cold-start double-open fix). */
+  const chatSubs = new Map<string, { refs: number; sinceSeq?: number }>();
   let wsReadyPromise: Promise<void> | null = null;
   const listeners = new Map<string, Set<(e: WSEvent) => void>>();
 
@@ -180,9 +182,16 @@ export function createClientApi() {
           socket.send(JSON.stringify({ type: "tree:watch", worktreeId: w.worktreeId }));
         }
         // Re-open JSON chats so the daemon re-subscribes this connection and
-        // replays the transcript (chat:replay) after a reconnect.
-        for (const sid of chatSubs.keys()) {
-          socket.send(JSON.stringify({ type: "chat:open", sessionId: sid }));
+        // replays the transcript (chat:replay) after a reconnect.  Use the
+        // stored `sinceSeq` so the reconnect only fetches the delta (R2.3).
+        for (const [sid, entry] of chatSubs.entries()) {
+          socket.send(
+            JSON.stringify({
+              type: "chat:open",
+              sessionId: sid,
+              ...(entry.sinceSeq != null ? { sinceSeq: entry.sinceSeq } : {}),
+            }),
+          );
         }
         // Notify consumers that a fresh handshake landed so they can refetch
         // any server state that might have drifted (persisted caches go stale
@@ -821,17 +830,23 @@ export function createClientApi() {
      *  Refcounted: multiple callers may open the same sessionId; chat:open is
      *  only sent to the daemon on the first (0→1) open. */
     async openChat(sessionId: string, sinceSeq?: number): Promise<void> {
-      const prev = chatSubs.get(sessionId) ?? 0;
-      chatSubs.set(sessionId, prev + 1);
+      const entry = chatSubs.get(sessionId);
+      const prev = entry?.refs ?? 0;
       if (prev === 0) {
-        await sendWs({ type: "chat:open", sessionId, ...(sinceSeq !== undefined ? { sinceSeq } : {}) });
+        // First subscriber: store sinceSeq for WS-reconnect replays.
+        chatSubs.set(sessionId, { refs: 1, sinceSeq });
+        await sendWs({ type: "chat:open", sessionId, ...(sinceSeq != null ? { sinceSeq } : {}) });
+      } else {
+        // Subsequent subscriber: increment ref-count, preserve stored sinceSeq.
+        chatSubs.set(sessionId, { refs: prev + 1, sinceSeq: entry?.sinceSeq });
       }
     },
 
     /** Refcounted close: chat:close is only sent to the daemon when the last
      *  subscriber closes (count drops to 0). Guards against going negative. */
     async closeChat(sessionId: string): Promise<void> {
-      const prev = chatSubs.get(sessionId) ?? 0;
+      const entry = chatSubs.get(sessionId);
+      const prev = entry?.refs ?? 0;
       if (prev <= 0) {
         console.warn(`[client] closeChat called with no open subscription for ${sessionId}`);
         chatSubs.delete(sessionId);
@@ -842,7 +857,7 @@ export function createClientApi() {
         chatSubs.delete(sessionId);
         await sendWs({ type: "chat:close", sessionId });
       } else {
-        chatSubs.set(sessionId, next);
+        chatSubs.set(sessionId, { refs: next, sinceSeq: entry?.sinceSeq });
       }
     },
 

--- a/web-ui/src/components/chat/ToolRunSummary.tsx
+++ b/web-ui/src/components/chat/ToolRunSummary.tsx
@@ -229,7 +229,7 @@ function TaskToolEntry({
   onNavigate?: (sessionId: string) => void;
 }) {
   const childSessionId = tool.childSessionId ?? null;
-  const { events: childEvents } = useChat(api, childSessionId, !!childSessionId);
+  const { events: childEvents } = useChat(api, childSessionId, !!childSessionId, { cache: false });
 
   const currentTool = useMemo(() => deriveCurrentTool(childEvents), [childEvents]);
 

--- a/web-ui/src/hooks/chatSnapshotCache.ts
+++ b/web-ui/src/hooks/chatSnapshotCache.ts
@@ -1,0 +1,90 @@
+/**
+ * Module-level LRU cache of `ChatSnapshot`s, keyed by sessionId.
+ * Capped at MAX_CACHE_SIZE entries; each snapshot keeps the newest
+ * MAX_SNAPSHOT_EVENTS events.  `save`/`restore`/`evict`/`clear` are the only
+ * public surface — auth:expired handling is registered in `useChat`, not here.
+ */
+
+import type { NormalizedEvent } from "@/api/types";
+
+const MAX_SNAPSHOT_EVENTS = 200;
+const MAX_CACHE_SIZE = 20;
+
+export interface ChatSnapshot {
+  events: NormalizedEvent[];
+  /** `logSeq` of the oldest retained event after truncation; `null` if unknown. */
+  oldestSeq: number | null;
+  /** True when older events exist before the retained window. */
+  hasMore: boolean;
+  /** Union of all `turnId`s seen in the retained window. */
+  userTurnIds: Set<string>;
+  /** Max `logSeq` across all retained events; `null`/0 → skip `sinceSeq`. */
+  latestSeq: number | null;
+  /** `Date.now()` at save-time — used for the 60-second freshness check. */
+  savedAt: number;
+}
+
+/** sessionId → snapshot */
+const cache = new Map<string, ChatSnapshot>();
+
+/**
+ * Persist a snapshot.  No-ops when `events` is empty.  Truncates to the newest
+ * MAX_SNAPSHOT_EVENTS events, recomputes `oldestSeq`, and forces `hasMore =
+ * true` when truncation occurred.
+ */
+export function save(
+  sessionId: string,
+  snapshot: {
+    events: NormalizedEvent[];
+    hasMore: boolean;
+    userTurnIds: Set<string>;
+    latestSeq: number | null;
+    savedAt: number;
+  },
+): void {
+  if (snapshot.events.length === 0) return;
+
+  let { events } = snapshot;
+  let { hasMore } = snapshot;
+
+  const truncated = events.length > MAX_SNAPSHOT_EVENTS;
+  if (truncated) {
+    events = events.slice(events.length - MAX_SNAPSHOT_EVENTS);
+    hasMore = true;
+  }
+
+  const oldestSeq = events[0]?.logSeq ?? null;
+
+  // LRU eviction: remove the oldest entry when at capacity (and this sessionId
+  // is not already in the cache — inserting an existing key doesn't grow it).
+  if (cache.size >= MAX_CACHE_SIZE && !cache.has(sessionId)) {
+    const oldestKey = cache.keys().next().value;
+    if (oldestKey !== undefined) cache.delete(oldestKey);
+  }
+
+  // Move this entry to the "most recently used" position.
+  cache.delete(sessionId);
+  cache.set(sessionId, {
+    events,
+    oldestSeq,
+    hasMore,
+    userTurnIds: snapshot.userTurnIds,
+    latestSeq: snapshot.latestSeq,
+    savedAt: snapshot.savedAt,
+  });
+}
+
+/** Return the cached snapshot for `sessionId`, or `null` if absent. */
+export function restore(sessionId: string): ChatSnapshot | null {
+  return cache.get(sessionId) ?? null;
+}
+
+/** Remove a specific session's snapshot (e.g. on `session:fork` or `session:error`). */
+export function evict(sessionId: string): void {
+  cache.delete(sessionId);
+}
+
+/** Drop all snapshots (called on `auth:expired`). */
+export function clear(): void {
+  cache.clear();
+}

--- a/web-ui/src/hooks/chatSnapshotCache.ts
+++ b/web-ui/src/hooks/chatSnapshotCache.ts
@@ -68,7 +68,9 @@ export function save(
     events,
     oldestSeq,
     hasMore,
-    userTurnIds: snapshot.userTurnIds,
+    // Minor Fix B: copy the Set to avoid storing the caller's live reference
+    // (defensive — the ref is reassigned not mutated, but this is fragile).
+    userTurnIds: new Set(snapshot.userTurnIds),
     latestSeq: snapshot.latestSeq,
     savedAt: snapshot.savedAt,
   });

--- a/web-ui/src/hooks/useChat.test.ts
+++ b/web-ui/src/hooks/useChat.test.ts
@@ -1,8 +1,9 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ApiInstance } from "@/api";
 import type { NormalizedEvent, SessionMeta, TranscriptPage, WSEvent } from "@/api/types";
 import { useChat } from "./useChat";
+import * as chatSnapshotCache from "./chatSnapshotCache";
 
 /** Minimal fake api with controllable WS emission for deterministic ordering. */
 function makeApi(sendChatResult = { turnId: "t1", queuePosition: 0 }) {
@@ -41,12 +42,17 @@ function ev(id: string, extra: Partial<NormalizedEvent>): NormalizedEvent {
   return { id, sessionId: "s1", ts: "", provider: "claude", kind: "text", ...extra };
 }
 
+// Prevent snapshot bleed between tests.
+beforeEach(() => {
+  chatSnapshotCache.clear();
+});
+
 describe("useChat (4.T1)", () => {
   it("merges chat:replay then live session:message into ordered events, and updates meta", async () => {
     const api = makeApi();
     const { result } = renderHook(() => useChat(api as unknown as ApiInstance, "s1", true));
 
-    expect(api.openChat).toHaveBeenCalledWith("s1");
+    expect(api.openChat).toHaveBeenCalledWith("s1", undefined);
 
     act(() => {
       api.emit({
@@ -284,5 +290,104 @@ describe("useChat queue controls (2.T2/2.T4)", () => {
     });
     expect(result.current.queuedTurnIds).toEqual(["t1", "t2"]);
     expect(result.current.editingTurnIds).toEqual(["t3"]);
+  });
+});
+
+describe("useChat snapshot cache", () => {
+  it("(a) restores from cache immediately — no spinner, events visible, openChat uses sinceSeq", async () => {
+    // Pre-seed the cache with a fresh snapshot.
+    const cachedEvent = ev("e10", { kind: "text", role: "assistant", text: "cached", logSeq: 10 });
+    chatSnapshotCache.save("s1", {
+      events: [cachedEvent],
+      hasMore: false,
+      userTurnIds: new Set(),
+      latestSeq: 10,
+      savedAt: Date.now(), // fresh — within 60 s
+    });
+
+    const api = makeApi();
+    const { result } = renderHook(() => useChat(api as unknown as ApiInstance, "s1", true));
+
+    // Events and loading state are set synchronously from the snapshot.
+    expect(result.current.loading).toBe(false);
+    expect(result.current.events.map((e) => e.id)).toEqual(["e10"]);
+
+    // openChat should have been called with sinceSeq=10 (the snapshot's latestSeq).
+    expect(api.openChat).toHaveBeenCalledWith("s1", 10);
+  });
+
+  it("(b) gap-drop path — stale snapshot replaced by fresh tail when oldestSeq > restoredLatestSeq", async () => {
+    // Snapshot has latestSeq=5 but the fresh tail starts at oldestSeq=10 → gap.
+    const cachedEvent = ev("e5", { kind: "text", role: "assistant", text: "old", logSeq: 5 });
+    chatSnapshotCache.save("s1", {
+      events: [cachedEvent],
+      hasMore: false,
+      userTurnIds: new Set(),
+      latestSeq: 5,
+      savedAt: Date.now() - 90_000, // stale → sinceSeq omitted → plain tail
+    });
+
+    const api = makeApi();
+    const { result } = renderHook(() => useChat(api as unknown as ApiInstance, "s1", true));
+
+    // Snapshot was restored (no spinner).
+    expect(result.current.loading).toBe(false);
+    expect(result.current.events.map((e) => e.id)).toEqual(["e5"]);
+
+    // Plain tail replay arrives with a gap: oldestSeq=10 > restoredLatestSeq=5.
+    act(() => {
+      api.emit({
+        type: "chat:replay",
+        sessionId: "s1",
+        events: [ev("e10", { kind: "text", role: "assistant", text: "fresh", logSeq: 10 })],
+        oldestSeq: 10,
+        hasMore: false,
+      });
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    // Stale cached event should be gone; only the fresh tail event remains.
+    expect(result.current.events.map((e) => e.id)).toEqual(["e10"]);
+  });
+
+  it("(c) stale (>60 s) snapshot without a gap — fresh tail merges normally, no content hole", async () => {
+    // Snapshot has latestSeq=5; tail reply has oldestSeq=3 ≤ 5 → no gap → merge.
+    const cachedEvent = ev("e5", { kind: "text", role: "assistant", text: "old", logSeq: 5 });
+    chatSnapshotCache.save("s1", {
+      events: [cachedEvent],
+      hasMore: false,
+      userTurnIds: new Set(),
+      latestSeq: 5,
+      savedAt: Date.now() - 90_000, // stale
+    });
+
+    const api = makeApi();
+    const { result } = renderHook(() => useChat(api as unknown as ApiInstance, "s1", true));
+
+    expect(result.current.loading).toBe(false);
+
+    // Fresh tail: oldestSeq=3, so e5 is within the covered window → merge.
+    act(() => {
+      api.emit({
+        type: "chat:replay",
+        sessionId: "s1",
+        events: [
+          ev("e3", { kind: "user", role: "user", text: "q", logSeq: 3 }),
+          ev("e6", { kind: "text", role: "assistant", text: "a", logSeq: 6 }),
+        ],
+        oldestSeq: 3,
+        hasMore: false,
+      });
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    // Both the cached event and new events are present, ordered by logSeq.
+    const ids = result.current.events.map((e) => e.id);
+    expect(ids).toContain("e3");
+    expect(ids).toContain("e5");
+    expect(ids).toContain("e6");
+    // Correct order: e3 < e5 < e6
+    expect(ids.indexOf("e3")).toBeLessThan(ids.indexOf("e5"));
+    expect(ids.indexOf("e5")).toBeLessThan(ids.indexOf("e6"));
   });
 });

--- a/web-ui/src/hooks/useChat.ts
+++ b/web-ui/src/hooks/useChat.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ApiInstance } from "@/api";
 import type { Attachment, NormalizedEvent, SessionMeta } from "@/api/types";
+import * as chatSnapshotCache from "./chatSnapshotCache";
 
 /** An optimistic user turn rendered immediately after send, before the daemon's
  *  authoritative `user` event arrives. Deduped by `turnId` (Decision 12). */
@@ -74,16 +75,26 @@ export interface UseChatResult {
  *
  * Pass `enabled=false` (e.g. the pane is hidden / session is a TTY) to keep the
  * hook mounted without opening a chat — no WS traffic, empty state.
+ *
+ * Pass `opts.cache=false` (e.g. child/subagent sessions in ToolRunSummary) to
+ * opt out of the snapshot cache so LRU-20 is not churned by transient mounts.
  */
 export function useChat(
   api: ApiInstance,
   sessionId: string | null,
   enabled = true,
+  opts?: { cache?: boolean },
 ): UseChatResult {
+  // Destructure to a primitive immediately — using the opts object in effect
+  // deps would cause infinite open/close loops when an inline `{ cache: false }`
+  // literal is passed (new object reference on every render).
+  const cacheEnabled = opts?.cache !== false;
+
   const [events, setEvents] = useState<NormalizedEvent[]>([]);
   const [meta, setMeta] = useState<SessionMeta | null>(null);
   const [pending, setPending] = useState<PendingTurn[]>([]);
   const [loading, setLoading] = useState(false);
+  const [isDeltaLoading, setIsDeltaLoading] = useState(false);
   const [hasMore, setHasMore] = useState(false);
   const [loadingEarlier, setLoadingEarlier] = useState(false);
   const [editingDrafts, setEditingDrafts] = useState<Record<string, EditingDraft>>({});
@@ -97,6 +108,18 @@ export function useChat(
   const oldestSeqRef = useRef<number | null>(null);
   const hasMoreRef = useRef(false);
 
+  // Snapshot-cache support refs — synced every render so the effect cleanup
+  // always reads the freshest values without needing them in its deps array.
+  const eventsRef = useRef<NormalizedEvent[]>([]);
+  const isDeltaLoadingRef = useRef(false);
+  /** `latestSeq` of the snapshot that was restored on the current mount; cleared
+   *  when a `chat:replay` is consumed so gap-detection is one-shot per mount. */
+  const restoredLatestSeqRef = useRef<number | null>(null);
+
+  // Sync snapshot-relevant refs on every render.
+  eventsRef.current = events;
+  isDeltaLoadingRef.current = isDeltaLoading;
+
   const active = enabled && !!sessionId;
 
   useEffect(() => {
@@ -105,24 +128,77 @@ export function useChat(
       setMeta(null);
       setPending([]);
       setLoading(false);
+      setIsDeltaLoading(false);
+      isDeltaLoadingRef.current = false;
       setHasMore(false);
       setLoadingEarlier(false);
       setEditingDrafts({});
       userTurnIdsRef.current = new Set();
       oldestSeqRef.current = null;
       hasMoreRef.current = false;
+      restoredLatestSeqRef.current = null;
       return;
     }
 
-    setLoading(true);
-    setEvents([]);
-    setMeta(null);
-    setHasMore(false);
-    setLoadingEarlier(false);
-    setEditingDrafts({});
-    userTurnIdsRef.current = new Set();
-    oldestSeqRef.current = null;
-    hasMoreRef.current = false;
+    // ── Snapshot restore or cold start ──────────────────────────────────────
+    // Determine what openChat sinceSeq to use and set initial state.
+    // IMPORTANT: All api.on() listeners are registered BEFORE calling
+    // api.openChat() so that synchronous emits inside the mock (and real WS
+    // onopen replays) are never missed.
+    let failsafeTimer: ReturnType<typeof setTimeout> | null = null;
+    let openChatSinceSeq: number | undefined = undefined;
+
+    const snapshot = cacheEnabled ? chatSnapshotCache.restore(sessionId) : null;
+
+    if (snapshot) {
+      // Restore cached state immediately — no spinner, events visible at once.
+      setEvents(snapshot.events);
+      setHasMore(snapshot.hasMore);
+      setMeta(null);
+      setPending([]);
+      setLoadingEarlier(false);
+      setEditingDrafts({});
+      // Copy the Set — mutating the live ref must not corrupt the cached snapshot.
+      userTurnIdsRef.current = new Set(snapshot.userTurnIds);
+      oldestSeqRef.current = snapshot.oldestSeq;
+      hasMoreRef.current = snapshot.hasMore;
+      setLoading(false); // suppress spinner; events already visible
+      setIsDeltaLoading(true);
+      isDeltaLoadingRef.current = true;
+      restoredLatestSeqRef.current = snapshot.latestSeq;
+
+      // If the snapshot is fresh (< 60 s) and has a valid cursor, request only
+      // the delta; otherwise fall back to a plain bounded tail replay.
+      openChatSinceSeq =
+        snapshot.latestSeq != null &&
+        snapshot.latestSeq > 0 &&
+        Date.now() - snapshot.savedAt < 60_000
+          ? snapshot.latestSeq
+          : undefined;
+
+      // Guard against a hung daemon / lost replay — clear the delta spinner
+      // after 5 s so the user isn't stuck (gap detection stays armed separately).
+      failsafeTimer = setTimeout(() => {
+        isDeltaLoadingRef.current = false;
+        setIsDeltaLoading(false);
+      }, 5000);
+    } else {
+      // Cold start (no cache) — full tail replay with loading spinner.
+      setLoading(true);
+      setEvents([]);
+      setMeta(null);
+      setPending([]);
+      setHasMore(false);
+      setLoadingEarlier(false);
+      setEditingDrafts({});
+      userTurnIdsRef.current = new Set();
+      oldestSeqRef.current = null;
+      hasMoreRef.current = false;
+      restoredLatestSeqRef.current = null;
+      openChatSinceSeq = undefined;
+    }
+
+    // ── Event helpers ────────────────────────────────────────────────────────
 
     const noteUserTurn = (ev: NormalizedEvent) => {
       if (ev.kind === "user" && ev.turnId) {
@@ -131,24 +207,62 @@ export function useChat(
       }
     };
 
+    // ── Listeners (registered BEFORE openChat so synchronous emits are caught) ──
+
     const offReplay = api.on("chat:replay", (e) => {
       if (e.type !== "chat:replay" || e.sessionId !== sessionId) return;
-      // Delta-MERGE, never replace (R2.7): the replay may arrive after a live
-      // gap event, or be a `sinceSeq` delta on reconnect. Union the user-turn
-      // bookkeeping so queued-tray dedup survives for turns outside the window.
-      for (const ev of e.events) {
-        if (ev.kind === "user" && ev.turnId) userTurnIdsRef.current.add(ev.turnId);
+
+      if (e.hasMore === undefined) {
+        // ── sinceSeq delta path ──────────────────────────────────────────────
+        // Cursor fields absent → merge the delta, keep existing window top.
+        for (const ev of e.events) {
+          if (ev.kind === "user" && ev.turnId) userTurnIdsRef.current.add(ev.turnId);
+        }
+        setEvents((prev) => mergeEvents([...e.events, ...prev]));
+        restoredLatestSeqRef.current = null;
+      } else {
+        // ── Plain bounded tail path ──────────────────────────────────────────
+        // Gap-check: if the fresh tail's oldest event is newer than the
+        // snapshot's latest seq the snapshot is stale — drop it and render
+        // only the fresh delta so there's no invisible hole in history.
+        const gapDetected =
+          e.oldestSeq != null &&
+          restoredLatestSeqRef.current != null &&
+          e.oldestSeq > restoredLatestSeqRef.current;
+
+        if (gapDetected) {
+          // Drop restored events; render only the fresh delta.
+          userTurnIdsRef.current = new Set();
+          for (const ev of e.events) {
+            if (ev.kind === "user" && ev.turnId) userTurnIdsRef.current.add(ev.turnId);
+          }
+          setEvents(e.events.slice());
+          oldestSeqRef.current = e.oldestSeq ?? null;
+          hasMoreRef.current = e.hasMore;
+          setHasMore(e.hasMore);
+        } else {
+          // Normal merge: prepend fresh events, union bookkeeping.
+          for (const ev of e.events) {
+            if (ev.kind === "user" && ev.turnId) userTurnIdsRef.current.add(ev.turnId);
+          }
+          setEvents((prev) => mergeEvents([...e.events, ...prev]));
+          hasMoreRef.current = e.hasMore;
+          setHasMore(e.hasMore);
+          oldestSeqRef.current = e.oldestSeq ?? null;
+        }
+        restoredLatestSeqRef.current = null;
       }
-      setEvents((prev) => mergeEvents([...e.events, ...prev]));
-      // Cursor fields are present only on a bounded tail replay (omitted on a
-      // `sinceSeq` delta) — don't let a delta reset the window's top cursor.
-      if (e.hasMore !== undefined) {
-        hasMoreRef.current = e.hasMore;
-        setHasMore(e.hasMore);
-        oldestSeqRef.current = e.oldestSeq ?? null;
-      }
+
       setPending((prev) => prev.filter((p) => !userTurnIdsRef.current.has(p.turnId)));
       setLoading(false);
+
+      // Delta hydration complete — clear the spinner and cancel the failsafe.
+      if (failsafeTimer !== null) {
+        clearTimeout(failsafeTimer);
+        failsafeTimer = null;
+      }
+      isDeltaLoadingRef.current = false;
+      setIsDeltaLoading(false);
     });
 
     const offMsg = api.on("session:message", (e) => {
@@ -165,11 +279,25 @@ export function useChat(
       setMeta(e.meta);
     });
 
-    // A fork truncated some turns (R3.6): drop the superseded bubbles + any local
-    // pending/editing bookkeeping for them so this tab re-syncs to the new head.
-    // The new fork user event arrives separately via `session:message`.
+    const offError = api.on("session:error", (e) => {
+      if (e.type !== "session:error" || e.sessionId !== sessionId) return;
+      // Evict so a stale snapshot doesn't resurface on the next mount.
+      // Do NOT clear events — session:error also fires for transient TTY errors
+      // and the existing history is still valid.
+      chatSnapshotCache.evict(sessionId);
+      isDeltaLoadingRef.current = false;
+      setIsDeltaLoading(false);
+      setLoading(false);
+    });
+
+    // A fork truncated some turns (R3.6): drop the superseded bubbles + any
+    // local pending/editing bookkeeping for them so this tab re-syncs to the
+    // new head.  The new fork user event arrives separately via session:message.
+    // Evict BEFORE the `dropped.size === 0` early-return so a fork that only
+    // clears history (no supersededTurnIds) still invalidates the snapshot.
     const offFork = api.on("session:fork", (e) => {
       if (e.type !== "session:fork" || e.sessionId !== sessionId) return;
+      chatSnapshotCache.evict(sessionId);
       const dropped = new Set(e.supersededTurnIds);
       if (dropped.size === 0) return;
       for (const t of dropped) userTurnIdsRef.current.delete(t);
@@ -182,16 +310,46 @@ export function useChat(
       });
     });
 
-    void api.openChat(sessionId);
+    // auth:expired → wipe the whole cache so stale snapshots from the previous
+    // session don't bleed into a freshly-logged-in user.
+    const offAuthExpired = api.on(
+      "auth:expired" as unknown as Parameters<typeof api.on>[0],
+      () => {
+        chatSnapshotCache.clear();
+      },
+    );
+
+    // ── Open the chat (AFTER listeners are registered) ───────────────────────
+    void api.openChat(sessionId, openChatSinceSeq);
+
+    // ── Cleanup ──────────────────────────────────────────────────────────────
 
     return () => {
+      if (failsafeTimer !== null) clearTimeout(failsafeTimer);
       offReplay();
       offMsg();
       offMeta();
+      offError();
       offFork();
+      offAuthExpired();
+
+      // Persist a snapshot for the next mount — skip when:
+      //   • no events (nothing worth caching)
+      //   • delta is still in flight (isDeltaLoadingRef) — partial state
+      //   • caller opted out (cacheEnabled false)
+      if (eventsRef.current.length > 0 && !isDeltaLoadingRef.current && cacheEnabled) {
+        chatSnapshotCache.save(sessionId, {
+          events: eventsRef.current,
+          hasMore: hasMoreRef.current,
+          userTurnIds: userTurnIdsRef.current,
+          latestSeq: computeLatestSeq(eventsRef.current),
+          savedAt: Date.now(),
+        });
+      }
+
       void api.closeChat(sessionId);
     };
-  }, [api, sessionId, active]);
+  }, [api, sessionId, active, cacheEnabled]);
 
   const send = useCallback(
     async (message: string, attachmentIds?: string[]) => {
@@ -342,6 +500,16 @@ export function useChat(
     sendNow,
     forkTurn,
   };
+}
+
+/**
+ * Compute the maximum `logSeq` across all events. Returns `null` when no event
+ * has a `logSeq` (or the max is 0) so the caller can skip the `sinceSeq` field.
+ */
+function computeLatestSeq(events: NormalizedEvent[]): number | null {
+  const seqs = events.flatMap((e) => (e.logSeq != null ? [e.logSeq] : []));
+  const v = seqs.length ? Math.max(...seqs) : 0;
+  return v > 0 ? v : null;
 }
 
 /**

--- a/web-ui/src/hooks/useChat.ts
+++ b/web-ui/src/hooks/useChat.ts
@@ -115,6 +115,9 @@ export function useChat(
   /** `latestSeq` of the snapshot that was restored on the current mount; cleared
    *  when a `chat:replay` is consumed so gap-detection is one-shot per mount. */
   const restoredLatestSeqRef = useRef<number | null>(null);
+  /** Set by `session:error` to prevent the cleanup from re-saving a poisoned
+   *  snapshot that would undo the eviction just performed. */
+  const poisonedRef = useRef(false);
 
   // Sync snapshot-relevant refs on every render.
   eventsRef.current = events;
@@ -145,6 +148,7 @@ export function useChat(
     // IMPORTANT: All api.on() listeners are registered BEFORE calling
     // api.openChat() so that synchronous emits inside the mock (and real WS
     // onopen replays) are never missed.
+    poisonedRef.current = false;
     let failsafeTimer: ReturnType<typeof setTimeout> | null = null;
     let openChatSinceSeq: number | undefined = undefined;
 
@@ -194,6 +198,10 @@ export function useChat(
       userTurnIdsRef.current = new Set();
       oldestSeqRef.current = null;
       hasMoreRef.current = false;
+      // Fix 1: explicitly reset delta-loading state so a previous cache-hit
+      // session's flag doesn't bleed into this cold-start session.
+      setIsDeltaLoading(false);
+      isDeltaLoadingRef.current = false;
       restoredLatestSeqRef.current = null;
       openChatSinceSeq = undefined;
     }
@@ -236,7 +244,7 @@ export function useChat(
           for (const ev of e.events) {
             if (ev.kind === "user" && ev.turnId) userTurnIdsRef.current.add(ev.turnId);
           }
-          setEvents(e.events.slice());
+          setEvents(_prev => e.events.slice());
           oldestSeqRef.current = e.oldestSeq ?? null;
           hasMoreRef.current = e.hasMore;
           setHasMore(e.hasMore);
@@ -246,9 +254,21 @@ export function useChat(
             if (ev.kind === "user" && ev.turnId) userTurnIdsRef.current.add(ev.turnId);
           }
           setEvents((prev) => mergeEvents([...e.events, ...prev]));
-          hasMoreRef.current = e.hasMore;
-          setHasMore(e.hasMore);
-          oldestSeqRef.current = e.oldestSeq ?? null;
+          // Fix 2: only widen hasMore, never narrow it — the snapshot may have
+          // already loaded more history than the fresh tail knows about.
+          if (e.hasMore) {
+            hasMoreRef.current = true;
+            setHasMore(true);
+          }
+          // Fix 2: only move the cursor backward (lower seq = older = further
+          // back in history) — never let a fresh tail rewind a pre-loaded cursor.
+          const newOldestSeq = e.oldestSeq ?? null;
+          if (newOldestSeq !== null) {
+            const current = oldestSeqRef.current;
+            if (current === null || newOldestSeq < current) {
+              oldestSeqRef.current = newOldestSeq;
+            }
+          }
         }
         restoredLatestSeqRef.current = null;
       }
@@ -285,6 +305,8 @@ export function useChat(
       // Do NOT clear events — session:error also fires for transient TTY errors
       // and the existing history is still valid.
       chatSnapshotCache.evict(sessionId);
+      // Fix 4: poison the hook so the cleanup doesn't re-save and undo the eviction.
+      poisonedRef.current = true;
       isDeltaLoadingRef.current = false;
       setIsDeltaLoading(false);
       setLoading(false);
@@ -337,7 +359,8 @@ export function useChat(
       //   • no events (nothing worth caching)
       //   • delta is still in flight (isDeltaLoadingRef) — partial state
       //   • caller opted out (cacheEnabled false)
-      if (eventsRef.current.length > 0 && !isDeltaLoadingRef.current && cacheEnabled) {
+      //   • session:error poisoned the hook (would undo the eviction)
+      if (eventsRef.current.length > 0 && !isDeltaLoadingRef.current && cacheEnabled && !poisonedRef.current) {
         chatSnapshotCache.save(sessionId, {
           events: eventsRef.current,
           hasMore: hasMoreRef.current,


### PR DESCRIPTION
## Summary

- **Problem:** switching worktrees unmounted chat panes, resetting state to `[]` and triggering a full tail replay with a visible loading flash every time you switched back — even for sessions you'd just left
- **Fix:** client-side snapshot cache (`chatSnapshotCache.ts`) saves chat state on switch-away; on return, history is visible immediately from the snapshot while only missed events are fetched via the existing `sinceSeq` delta protocol (already wired in the daemon, never called from the client until now)
- **Scope:** rich-chat (json channel) only — terminal caching is a separate problem

## Changes

### Frontend
- **`chatSnapshotCache.ts`** (new) — module-level `Map<sessionId, ChatSnapshot>`, LRU cap 20, max 200 events per entry; `save`/`restore`/`evict`/`clear`
- **`useChat.ts`** — restore from cache on mount (`setLoading(false)` suppresses spinner); sends `chat:open { sinceSeq }` for delta-only replay; `isDeltaLoading` flag + 5s failsafe; gap-check drops stale snapshot when session advanced past it; `session:error`/`session:fork` invalidation; pending leak fix; child session opt-out via `{ cache: false }`
- **`client.ts`** — `chatSubs` reshaped to store `sinceSeq` per session so WS reconnect replays use the delta too (no cold-start double-open)
- **`ToolRunSummary.tsx`** — passes `{ cache: false }` to prevent subagent child sessions from churning the LRU

### Daemon
- **`chatOpen.ts`** — `TAIL_TURNS` 20 → 15 (faster fresh loads; load-earlier handles scrollback)

## Behaviour

| Scenario | Before | After |
|---|---|---|
| Switch away and back (< 60s) | Spinner + full 20-turn reload | Instant — history from snapshot, delta merges silently |
| Switch away and back (> 60s) | Spinner + full reload | Instant — snapshot shown, fresh tail merges in |
| First visit | Spinner + full tail | Spinner + full tail (unchanged) |
| WS reconnect | Bounded tail-15 replay | Delta from stored sinceSeq |
| Send message before delta arrives | Optimistic bubble could be displaced | Pinned at bottom via existing MessageList pending block |

## Competitors
Neither agent-orchestrator nor emdash cache message history — both show a full blocking loading state on every session switch. Cursor/OpenCode use write-through to local disk (instant read, survives reload). Our approach is in-memory (faster, no disk writes) with delta sync.

## Known limitations (follow-ups)
- Fork-while-unsubscribed: if another client forks a session while you're away, superseded turns stay in the snapshot until next eviction (requires daemon-side truncation watermark)
- Reconnect `sinceSeq` frozen at mount-time: on very long-lived sessions a WS reconnect could replay a large delta; advancing the stored cursor as events arrive is the fix
- 4 issues flagged in Opus review not yet patched (cold-branch `isDeltaLoading` reset, stale-path `oldestSeq` min, reconnect cursor staleness, `session:error` re-save)

## Test plan
- [ ] Switch between worktrees with rich-chat history — no loading flash after first visit
- [ ] WS inspector: `chat:open` carries `sinceSeq` on return; `chat:replay` contains only delta
- [ ] Send message immediately after switch-back — optimistic bubble stays at bottom
- [ ] First visit — spinner + full tail, unchanged behavior
- [ ] WS drop + reconnect — no duplicate events, history intact
- [ ] `loadEarlier` on a restored session — correct cursor, no gaps
- [ ] 617/617 web-ui vitest tests pass