### PR TITLE
fix(chat): send button shows correct styling when canSteer is true

### DIFF
--- a/web-ui/src/components/chat/Composer.test.tsx
+++ b/web-ui/src/components/chat/Composer.test.tsx
@@ -162,6 +162,13 @@ describe("5.T7 — Composer canSteer aria-label", () => {
     const btn = screen.getByLabelText("Interrupts and steers the running turn");
     expect(btn).toBeTruthy();
   });
+
+  it("busy && canSteer → no queue class (button looks like normal send, not dashed)", () => {
+    const api = createMockApi();
+    render(<Composer api={api} sessionId="s-steer-class" onSend={vi.fn()} busy canSteer initialText="text" />);
+    const btn = screen.getByLabelText("Interrupts and steers the running turn");
+    expect(btn.className).not.toContain("chat-composer__send--queue");
+  });
 });
 
 describe("Composer textarea auto-grow", () => {

--- a/web-ui/src/components/chat/Composer.tsx
+++ b/web-ui/src/components/chat/Composer.tsx
@@ -265,7 +265,7 @@ export function Composer({
           ) : (
             <button
               type="button"
-              className={`chat-composer__send${busy ? " chat-composer__send--queue" : ""}`}
+              className={`chat-composer__send${busy && !canSteer ? " chat-composer__send--queue" : ""}`}
               aria-label={
                 busy && canSteer
                   ? "Interrupts and steers the running turn"


### PR DESCRIPTION
## Summary

- When a JSON agent turn is running and ACP steering is supported (`canSteer=true`), the send button was showing dashed/muted queue styling (`chat-composer__send--queue`) even though clicking it would steer the running turn, not enqueue
- Fix: only apply `--queue` class when `busy && !canSteer` — matches the aria-label logic that was already correct
- Added a test: `busy && canSteer → no queue class`

## Root cause

`Composer.tsx` line 268 used `busy` alone as the guard:
```tsx
className={`chat-composer__send${busy ? " chat-composer__send--queue" : ""}`}
```

The fix:
```tsx
className={`chat-composer__send${busy && !canSteer ? " chat-composer__send--queue" : ""}`}
```

The aria-label/title logic already correctly differentiated the two states; only the CSS class was wrong.

## Test plan
- [ ] All 16 Composer tests pass (`vitest run src/components/chat/Composer.test.tsx`)
- [ ] With a running JSON agent turn and ACP steering enabled: send button looks solid/accent (steer), not dashed (queue)
- [ ] With a running turn and no steering support: send button still shows dashed queue styling