### PR TITLE
feat(settings): storage management UI — worktree disk usage + section-switcher

### DIFF
--- a/.vibekit/feature-plans/wip/storage-management/.sdlc-state.yaml
+++ b/.vibekit/feature-plans/wip/storage-management/.sdlc-state.yaml
@@ -1,0 +1,14 @@
+feature: storage-management
+worktree: /home/gb/.vibe-station/projects/vibe-station/worktrees/vs-72
+master:
+  prd: skipped   # PRD authored manually in docs/STORAGE-MANAGEMENT-PRD.md
+  plan: in_progress
+current_subfeature: root
+subfeatures:
+  - id: root
+    origin: planned
+    mode: planning
+    last_completed: null
+    awaiting_phase: null
+    awaiting_artifact: null
+    phase_chain: "plan+implement"

--- a/.vibekit/feature-plans/wip/storage-management/plan-storage-management.md
+++ b/.vibekit/feature-plans/wip/storage-management/plan-storage-management.md
@@ -1,7 +1,7 @@
 ---
 Issue: N/A
 Branch: management-ui-option
-Status: planning
+Status: planning (post-review rev 2)
 PRD: docs/STORAGE-MANAGEMENT-PRD.md
 ---
 
@@ -15,15 +15,15 @@ RULES — read before writing or implementing:
 
 ## Problem & Concept
 
-- Settings panel (desktop) renders ALL sections stacked in one scrollable column — adding Storage would produce an unusably tall dump
+- Settings panel (desktop) renders ALL sections stacked in one scrollable column — adding Storage produces an unusably tall dump
 - No way to see how much disk each worktree uses or delete stale ones from the UI
 - "Dismiss (keep files)" leaves orphaned git checkouts with no re-import path — a confusing half-deleted state
-- DELETE /worktrees/:id has no guard: any worktree can be deleted regardless of session lifecycle state
+- `DELETE /worktrees/:id` has no guard: any worktree can be deleted regardless of session lifecycle state
 
 Success state:
 - Desktop settings nav is a true section-switcher (one section at a time, active pill highlight)
 - Settings → Storage shows device disk bar + filterable/sortable worktree list with per-row disk usage + multi-select delete
-- Dismiss is removed from all surfaces; DELETE always purges and rejects non-done worktrees with 409
+- Dismiss is removed from all surfaces; DELETE always purges and rejects worktrees that aren't fully done with 409
 
 ---
 
@@ -32,15 +32,17 @@ Success state:
 | # | Requirement |
 |---|-------------|
 | R1 | Desktop SettingsPanel nav switches sections (one at a time); active item gets filled pill |
-| R2 | Mobile SettingsPanel is unchanged (already tab-based) |
-| R3 | DELETE /worktrees/:id always purges (no `?purge` param); rejects with 409 if any session ≠ `done` |
-| R4 | `dismissWorktree()` removed from client, mock, and all UI call sites |
-| R5 | GET /api/worktrees/disk-usage returns per-worktree diskBytes + device used/total/available |
-| R6 | StorageSetting shows device disk bar, worktree list defaulting to filter=done, sort=creation-date-desc |
-| R7 | Checkboxes and delete icons enabled only for worktrees where ALL sessions are lifecycle=done |
+| R2 | Mobile SettingsPanel unchanged (already tab-based) |
+| R3 | `DELETE /worktrees/:id` always purges; rejects 409 if any **agent** session ≠ `done` or any **terminal** session ∉ {`done`, `exited`} |
+| R4 | `dismissWorktree()` removed from client.ts, mock.ts, and all UI call sites atomically |
+| R5 | `GET /api/worktrees/disk-usage` returns per-worktree diskBytes + device used/total/available |
+| R6 | StorageSetting shows device disk bar, worktree list defaulting to filter=`done`, sort=creation-date-desc |
+| R7 | Checkboxes and delete icons enabled only for worktrees where ALL agent sessions are `done` and all terminal sessions ∈ {`done`, `exited`} |
 | R8 | Multi-select bulk delete with confirmation dialog listing names + sizes + total freed |
 | R9 | Filter dropdown: Done (default) / All; Sort dropdown: Creation date ↓ / Disk usage ↓ |
 | R10 | Confirmation dialog shows inline error banner on mid-flight 409 from daemon guard |
+| R11 | Controls bar shows summary: `N done worktrees · X GB` (filter=Done) or `N worktrees · X GB` (filter=All) |
+| R12 | Hint line when filter=Done with N>0 hidden worktrees: `N others hidden by filter` |
 
 ---
 
@@ -48,43 +50,56 @@ Success state:
 
 ```
 daemon/src/routes/
-  worktrees.ts              ~ remove purge branch; add done guard; add disk-usage route
+  worktrees.ts                  ~ remove purge branch; add done guard; add disk-usage route
 web-ui/src/api/
-  client.ts                 ~ remove dismissWorktree; add getDiskUsage
-  mock.ts                   ~ remove dismissWorktree mock; add getDiskUsage mock
+  client.ts                     ~ remove dismissWorktree; add getDiskUsage
+  mock.ts                       ~ remove dismissWorktree mock; add getDiskUsage mock
+  types.ts                      ~ add DiskUsageResponse, WorktreeDiskUsage, DeviceDiskInfo
 web-ui/src/components/
   settings/
-    SettingsPanel.tsx        ~ desktop: section-switcher (no scroll refs)
-    StorageSetting.tsx       + new Storage section component
+    SettingsPanel.tsx            ~ desktop: section-switcher (no scroll refs)
+    StorageSetting.tsx           + new Storage section component
   layout/
-    DashboardPanel.tsx       ~ remove dismiss button, pendingDismiss state, dismiss ConfirmDialog
-    LeftSidebar.tsx          ~ remove dismiss context menu item, pendingDismiss, confirmDismissWorktree
+    DashboardPanel.tsx           ~ remove dismiss button, pendingDismiss state, dismiss ConfirmDialog
+    LeftSidebar.tsx              ~ remove dismiss context menu item, pendingDismiss, confirmDismissWorktree
+web-ui/src/styles/
+  workspace.css                  ~ remove two dismiss CSS blocks
 ```
 
 | Today | After this plan |
 |-------|-----------------|
 | Desktop settings nav scrolls to anchored section cards | Desktop nav switches sections; only active section renders |
-| DELETE /worktrees/:id?purge=true deletes, no purge = dismiss (keep files) | DELETE always purges; 409 if any session not done |
+| `DELETE /worktrees/:id?purge=true` deletes; no purge = dismiss | DELETE always purges; 409 if sessions not fully done |
 | Dismiss (keep files) affordance on dashboard card and sidebar context menu | Dismiss removed from all surfaces |
-| No disk usage data exposed by daemon | GET /api/worktrees/disk-usage returns per-worktree bytes + device stats |
+| No disk usage data exposed by daemon | `GET /api/worktrees/disk-usage` returns per-worktree bytes + device stats |
 | No Storage settings section | Settings → Storage shows disk bar + filterable/deletable worktree list |
 
 ---
 
 ## Research
 
-- `SettingsPanel.tsx:58-60` — `scrollTo` calls `ref.current?.scrollIntoView` on desktop; `activeTab` state already exists but only drives the mobile branch (line 63). The desktop branch never reads `activeTab`.
-- `SettingsPanel.tsx:179-201` — desktop nav buttons call `scrollTo(section.ref)`, not `setActiveTab`. The fix is wiring these buttons to `setActiveTab` and collapsing the dual-branch into one render path.
-- `client.ts:328-343` — `deleteWorktree` appends `?purge=true`; `dismissWorktree` omits it. Delete both; keep only `deleteWorktree`.
-- `mock.ts:416-423` — `dismissWorktree` mock removes from in-memory arrays.
-- `DashboardPanel.tsx:83,218,244,262-273,441-466` — `pendingDismiss` state, `showDismiss` flag, EyeOff icon button, ConfirmDialog for dismiss.
-- `LeftSidebar.tsx:609,765-776,1859-1870,1990-1997` — `pendingDismiss` state, `confirmDismissWorktree()`, two ConfirmDialogs, context-menu item "Dismiss (keep files)".
-- `worktrees.ts:859-909` — DELETE handler: `shouldPurge = purge === "true" || purge === "1"`; guard to add: check all `worktree.sessions` have `lifecycle.state === "done"`.
-- `paths.ts:63-65` — `worktreePath(projectId, worktreeId)` → `~/.vibe-station/projects/<pid>/worktrees/<wid>` (git checkout).
-- `paths.ts:88` — `sessionDataDir(projectId, worktreeId, sessionId)` → `~/.vibe-station/projects/<pid>/session-data/<wid>/<sid>`.
-- `WorktreeRecord` (`types.ts:384`) has `createdAt: string` (ISO8601) — available for sort.
-- `LifecycleState` (`types.ts:8-14`): `"not_started" | "working" | "idle" | "waiting_for_human" | "done" | "exited"` — guard checks ALL sessions have `"done"`.
-- Device disk: `df -B1 <path>` gives bytes; `du -sb <path>` gives apparent size per directory.
+- `web-ui/src/components/settings/SettingsPanel.tsx:58-60` — `scrollTo` calls `ref.current?.scrollIntoView` on desktop; `activeTab` state (line 26) already exists but only drives the mobile branch
+- `web-ui/src/components/settings/SettingsPanel.tsx:179-201` — desktop nav buttons call `scrollTo(section.ref)`, not `setActiveTab`; fix: wire buttons to `setActiveTab`, collapse dual-branch
+- `web-ui/src/api/client.ts:328-343` — `deleteWorktree` appends `?purge=true`; `dismissWorktree` (lines 337-343) omits it; remove `dismissWorktree` only
+- `web-ui/src/api/mock.ts:416-423` — `dismissWorktree` mock; remove
+- `web-ui/src/components/layout/DashboardPanel.tsx:83,218,244,262-273,441-466` — `pendingDismiss` state, `showDismiss` flag, EyeOff icon button, ConfirmDialog for dismiss
+- `web-ui/src/components/layout/LeftSidebar.tsx:609,765-776,1859-1870,1990-1997` — `pendingDismiss` state, `confirmDismissWorktree()`, two ConfirmDialogs, context-menu item "Dismiss (keep files)"
+- `web-ui/src/styles/workspace.css:3407-3418` — two dismiss CSS blocks: `.dashboard-card-shell--dismissable:hover .dashboard-card__dismiss` (3407-3409) and `.dashboard-card__dismiss` (3411-3418); both must be removed
+- `daemon/src/routes/worktrees.ts:824-856` — `POST /worktrees/:id/done` marks agent sessions `done` and terminal sessions `exited` (comment at line 818-819 explains why terminals have no `done` state); the delete guard must mirror this: agents need `done`, terminals accept `done` OR `exited`
+- `daemon/src/routes/worktrees.ts:859-909` — DELETE handler; `shouldPurge` variable at line 863; `releaseSessionRuntime` loop at lines 872-878; guard goes BEFORE the loop
+- `daemon/src/routes/worktrees.ts:24` — existing import: `import { worktreePath as getWorktreePath, cleanupSessionDataDir, sessionDataDir } from "../services/paths.js"`; add `vstHome, projectDir` to this import for disk-usage route
+- `daemon/src/services/paths.ts:43` — `vstHome(): string` returns `~/.vibe-station`; use as `df` target (the partition vst data lives on); **`$VST_DATA_DIR` is a child-process env var, not in the daemon's own process.env**
+- `daemon/src/services/paths.ts:48,63,88` — `projectDir(pid)`, `worktreePath(pid, wid)` (git checkout path), `sessionDataDir(pid, wid, sid)` (per-session data dir)
+- `daemon/src/types.ts:8-14` — `LifecycleState` (daemon): `"not_started" | "working" | "idle" | "waiting_for_human" | "done" | "exited"`
+- `daemon/src/types.ts:384-430` — `WorktreeRecord`: fields `id, branch, baseBranch, createdAt, sessions: SessionRecord[]`; no `absolutePath` on the worktree — git checkout path = `worktreePath(project.id, wt.id)`
+- `web-ui/src/api/types.ts:24-53` — UI `Worktree` type: **no `sessions` array**; StorageSetting must call `api.listSessions()` separately and group by `session.worktreeId`
+- `web-ui/src/api/client.ts:301` — `listWorktrees(projectId?: string): Promise<Worktree[]>`
+- `web-ui/src/api/client.ts:444` — `listSessions(worktreeId?: string): Promise<Session[]>`
+- `web-ui/src/api/types.ts:103` — `Session.state: SessionState` is the right field; `Session.lifecycleState` (line 104) is a legacy alias populated only from the initial REST fetch — use `state`
+- `web-ui/src/api/types.ts:74-84` — `SessionState`: `"not_started" | "working" | "idle" | "waiting_for_human" | "done" | "exited"`
+- `web-ui/src/api/index.ts:8` — `ApiInstance` is `ReturnType<typeof createMockApi> | ReturnType<typeof createClientApi>`; removing `dismissWorktree` from **both** `client.ts` and `mock.ts` must happen in a single edit pass — removing from only one breaks the union type
+- Node 24.14.0 is available; `statfs` from `node:fs/promises` is supported (Node 19.6+) — cleaner than parsing `df` output; use it for device stats
+- `du -sb` is GNU/Linux only; macOS `du` requires `-sk` (kilobytes) → multiply by 1024; branch on `process.platform`
 
 ---
 
@@ -93,19 +108,21 @@ web-ui/src/components/
 ```mermaid
 flowchart LR
     subgraph Browser
-        StorageSetting --> ClientAPI[api.getDiskUsage]
+        StorageSetting --> ClientDisk[api.getDiskUsage]
+        StorageSetting --> ClientSessions[api.listSessions]
+        StorageSetting --> ClientWorktrees[api.listWorktrees]
         StorageSetting --> ClientDelete[api.deleteWorktree]
         SettingsPanel --> StorageSetting
     end
     subgraph Daemon
-        DiskUsageRoute["GET /worktrees/disk-usage"]
+        DiskRoute["GET /worktrees/disk-usage"]
         DeleteRoute["DELETE /worktrees/:id (guard + always-purge)"]
     end
-    ClientAPI --"GET /worktrees/disk-usage"--> DiskUsageRoute
+    ClientDisk --"GET /worktrees/disk-usage"--> DiskRoute
     ClientDelete --"DELETE /worktrees/:id"--> DeleteRoute
-    DiskUsageRoute --> du["du -sb (per worktree + session-data)"]
-    DiskUsageRoute --> df["df -B1 (device stats)"]
-    DeleteRoute --> Guard{all sessions done?}
+    DiskRoute --> statfs["statfs(vstHome()) — device stats"]
+    DiskRoute --> du["du per worktree (platform-branched)"]
+    DeleteRoute --> Guard{agents=done, terminals=done|exited?}
     Guard --"no"--> 409
     Guard --"yes"--> Purge[worktreeRemove + manifest]
 ```
@@ -116,35 +133,41 @@ flowchart LR
 
 ### Critical User Journeys
 
-**Happy path — delete a done worktree from Storage settings:**
+**Happy path — delete done worktrees from Storage settings:**
 ```
 User opens Settings → clicks Storage in nav
-  → StorageSetting renders with filter=Done, sort=creation-date-desc
-  → Device disk bar shows used/total/available
-  → Worktree list shows only done worktrees with per-row disk bar
-  → User checks one or more rows → "Delete selected" button activates
-  → Confirmation dialog lists worktrees + sizes + total freed
-  → User confirms → DELETE /worktrees/:id per selected worktree
-  → Daemon checks all sessions done → purges checkout + manifest
-  → UI removes rows, disk bar refreshes
+  → StorageSetting mounts; fetches listWorktrees() + listSessions() + getDiskUsage() in parallel
+  → Device disk bar renders with used/total/available
+  → Worktree list shows only done worktrees (filter=Done default)
+  → Summary: "2 done worktrees · 4.0 GB"
+  → User checks two rows → "Delete selected" footer activates
+  → Confirmation dialog: "Delete 2 worktrees?" listing branch + size + total freed
+  → User confirms → sequential DELETE /worktrees/:id calls
+  → Both 200 → rows removed, getDiskUsage() re-fetched, disk bar updates
 ```
 
 **Error path — worktree no longer done at confirm time:**
 ```
 User selects done worktree → opens confirm dialog
-  → Meanwhile a sibling session starts (lifecycle → working)
+  → Sibling session starts (lifecycle → working)
   → User clicks Delete
-  → Daemon returns 409 { error: "worktree_not_done", sessions: [...] }
-  → Confirm dialog replaces button row with:
+  → Daemon returns 409 { error: "worktree_not_done", sessions: ["<id>"] }
+  → Dialog button row replaced with:
       "! <branch> is no longer done — deletion cancelled."
       [Close]
 ```
 
-**Error path — filter=Done with no done worktrees:**
+**Error path — filter=Done, no done worktrees exist:**
 ```
-User opens Storage
-  → All worktrees are active
-  → List empty, hint: "No done worktrees. Switch to All to see active ones."
+User opens Storage → all worktrees are active
+  → Worktree list empty
+  → Shows: "No done worktrees. Switch to All to see active ones."
+```
+
+**Error path — no worktrees at all:**
+```
+User opens Storage → project has no worktrees
+  → Shows: "No worktrees yet. Worktrees appear here once you spawn an agent."
 ```
 
 ---
@@ -153,22 +176,22 @@ User opens Storage
 
 #### GET /api/worktrees/disk-usage
 
-New endpoint. No auth change (same session-cookie auth as other routes).
+New route. No new auth — same session-cookie middleware as all other routes. Test via dev sandbox (`scripts/dev-sandbox.sh up`) which sets `VST_NO_AUTH=1`.
 
 ```
 GET /api/worktrees/disk-usage
 
 200 {
   device: {
-    usedBytes: number,      // df: Used column
-    totalBytes: number,     // df: 1K-blocks * 1024
-    availableBytes: number, // df: Avail column
-    mountPoint: string      // df: Mounted on
+    usedBytes: number,        // totalBytes - bfree*bsize
+    totalBytes: number,       // blocks * bsize  (from statfs)
+    availableBytes: number,   // bavail * bsize  (non-root free)
+    mountPoint: string        // resolved via statfs on vstHome()
   },
   worktrees: [
     {
-      id: string,           // WorktreeRecord.id
-      diskBytes: number     // du -sb checkout + du -sb session-data/<id>, summed
+      id: string,             // WorktreeRecord.id
+      diskBytes: number       // du on checkout + du on session-data/<wid>; 0 on individual failure
     }
   ]
 }
@@ -176,51 +199,91 @@ GET /api/worktrees/disk-usage
 500 { error: "disk_usage_failed", details: string }
 ```
 
-- `diskBytes` is apparent size (du -sb), not actual — matches user expectation
-- Runs du/df in parallel per worktree via `Promise.all`; individual failures return 0 for that worktree
-- Device stats from `df -B1` on `$VST_DATA_DIR` (the partition vst data lives on)
+- Device stats: `statfs(vstHome())` → `bsize * blocks` (total), `bsize * bavail` (available), `totalBytes - bsize * bfree` (used)
+- Mount point: not directly in Node `statfs` result; omit or hard-code as `vstHome()` string
+- Per-worktree: `diskUsageBytes(worktreePath(pid, wid)) + diskUsageBytes(join(projectDir(pid), "session-data", wid))` via `Promise.all`
+
+```ts
+// platform-branched du helper — include verbatim in the route file
+async function diskUsageBytes(path: string): Promise<number> {
+  try {
+    const args = process.platform === "darwin" ? ["-sk", path] : ["-sb", path];
+    const { stdout } = await execFileAsync("du", args);
+    const n = parseInt(stdout.split("\t")[0], 10);
+    return process.platform === "darwin" ? n * 1024 : n;
+  } catch {
+    return 0;
+  }
+}
+```
+
+- Route sits before the `GET /worktrees/:id/...` family; Fastify's radix router prefers the static segment `disk-usage` over the param `:id`, so no shadowing issue.
 
 #### DELETE /worktrees/:id (modified)
 
 ```
 DELETE /worktrees/:id
-  (no longer reads ?purge — always purges)
+  (?purge param accepted but ignored — always purges for backward compat)
 
 200 { ok: true }
-409 { error: "worktree_not_done", sessions: ["<id>", ...] }
+409 { error: "worktree_not_done", sessions: ["<sessionId>", ...] }
+      — lists IDs of sessions that are not in an acceptable terminal state
 404 { error: "Worktree '<id>' not found" }
 ```
 
-- `?purge` query param is ignored (never read); backward-compat: existing callers that sent `?purge=true` still get a 200
+Guard predicate (must pass before entering the `releaseSessionRuntime` loop):
+```ts
+const notDone = worktree.sessions.filter(s =>
+  s.type === "agent"
+    ? s.lifecycle.state !== "done"
+    : s.lifecycle.state !== "done" && s.lifecycle.state !== "exited"
+);
+if (notDone.length > 0) {
+  return reply.status(409).send({
+    error: "worktree_not_done",
+    sessions: notDone.map(s => s.id),
+  });
+}
+```
 
 ---
 
 ### Key Decisions
 
 #### Decision 1: Always-purge on DELETE
-- **Decision:** remove the `shouldPurge` branch; `worktreeRemove()` is called unconditionally
-- **Rationale:** dismiss (keep files) is removed; the only remaining caller (`client.ts:deleteWorktree`) always sent `?purge=true` anyway; backward compat: param still accepted but ignored
+- **Decision:** remove `shouldPurge` branch; `worktreeRemove()` called unconditionally
+- **Rationale:** dismiss is removed; `client.ts:deleteWorktree` already always sent `?purge=true`; backward compat: param ignored, not rejected
 - **Where:** `daemon/src/routes/worktrees.ts:862-890`
 
-#### Decision 2: done guard checks ALL sessions
-- **Decision:** `worktree.sessions.every(s => s.lifecycle.state === "done")` must be true; exited does NOT satisfy the guard
-- **Rationale:** `exited` means the agent crashed or was killed, not that the user marked work done — PRD is explicit that only `done` is deletable
-- **Where:** `daemon/src/routes/worktrees.ts` (new check before releaseSessionRuntime loop)
+#### Decision 2: Done guard — agents need `done`; terminals accept `done` OR `exited`
+- **Decision:** guard predicate matches the `/done` route's own semantics — see API Contracts above for exact code
+- **Rationale:** `POST /worktrees/:id/done` (`worktrees.ts:824-856`) marks terminals `exited` by design (comment lines 818-819); a guard requiring `done` on terminals would make every worktree that ever had a terminal permanently undeletable
+- **Where:** `daemon/src/routes/worktrees.ts` — new check before `releaseSessionRuntime` loop (line 872)
 
-#### Decision 3: Disk usage computed server-side per request
-- **Decision:** no caching; fresh `du`/`df` on each GET /worktrees/disk-usage call
-- **Rationale:** worktrees rarely change size between opens; complexity of cache invalidation outweighs benefit; `du` on typical worktree dirs completes in <200 ms
-- **Where:** `daemon/src/routes/worktrees.ts` (new route)
+#### Decision 3: Device disk stats via Node `statfs`, per-worktree via `du`
+- **Decision:** `statfs(vstHome())` from `node:fs/promises` for device totals; `du` (platform-branched) for per-directory apparent size
+- **Rationale:** `statfs` is cross-platform, no subprocess, no output parsing; `du` apparent size matches user mental model of "how big is this folder"
+- **Where:** `daemon/src/routes/worktrees.ts` — new `GET /worktrees/disk-usage` handler
 
-#### Decision 4: Settings desktop → single `activeSection` state, no refs
-- **Decision:** remove all `useRef` / `scrollIntoView` from desktop path; reuse existing `activeTab` state for both mobile and desktop; render only `sections.find(s => s.id === activeSection).content`
-- **Rationale:** PRD §0 — mobile already works this way; unifying removes the dual-branch entirely; Storage needs full panel height, not a card in a scroll
+#### Decision 4: Settings desktop → single `activeTab` state, no refs
+- **Decision:** remove all `useRef` / `scrollIntoView` from desktop path; reuse existing `activeTab` state (already present at `SettingsPanel.tsx:26`) for both breakpoints; render only the active section
+- **Rationale:** PRD §0 — mobile already works this way; Storage needs full panel height, not a card in a scroll
 - **Where:** `web-ui/src/components/settings/SettingsPanel.tsx:22-241`
 
-#### Decision 5: Disk usage fetched once on StorageSetting mount; refresh after delete
-- **Decision:** single `useEffect` on mount; after a successful delete, re-fetch disk-usage
-- **Rationale:** avoids stale disk bar after deletion; no need for polling
-- **Where:** `web-ui/src/components/settings/StorageSetting.tsx`
+#### Decision 5: StorageSetting fetches worktrees + sessions + disk-usage in parallel on mount
+- **Decision:** `Promise.all([listWorktrees(), listSessions(), getDiskUsage()])` on mount; `listSessions()` called without `worktreeId` to get all sessions, then grouped by `session.worktreeId` client-side
+- **Rationale:** UI `Worktree` type has no `sessions` array — sessions must be fetched separately; parallel fetch minimises load time
+- **Where:** `web-ui/src/components/settings/StorageSetting.tsx` — mount effect
+
+#### Decision 6: Partial bulk delete — keep-and-report
+- **Decision:** on bulk delete, call DELETE sequentially per worktree; if one returns 409, set `deleteError` for that worktree's branch name, abort remaining deletes, show error banner; successfully deleted rows are removed from the list
+- **Rationale:** rolling back already-successful deletes is impossible; user sees exactly what was deleted and what failed
+- **Where:** `web-ui/src/components/settings/StorageSetting.tsx` — delete handler
+
+#### Decision 7: `session.state` is the right field on the UI Session type
+- **Decision:** use `session.state` (not `session.lifecycleState`) when checking done-ness in StorageSetting
+- **Rationale:** `Session.lifecycleState` (`types.ts:104`) is a legacy alias populated only from the initial REST fetch; `session.state` is updated by `session:state` WS events and is the canonical live value — see comment at `web-ui/src/api/types.ts:74-84`
+- **Where:** `web-ui/src/components/settings/StorageSetting.tsx:4.4`
 
 ---
 
@@ -228,9 +291,9 @@ DELETE /worktrees/:id
 
 | # | Question | Notes |
 |---|----------|-------|
-| 1 | `du -sb` on a large worktree with git history could take >200 ms | Mitigation: run all worktrees in parallel via Promise.all; acceptable for a settings screen |
-| 2 | Which partition for device disk bar? | Use `$VST_DATA_DIR` partition — that's where the checkouts live |
-| 3 | `exited` sessions — should they block deletion? | Decision 2: yes, only `done` passes. A crashed agent should be retried or manually marked done |
+| 1 | `du` on a large worktree with git history could take >200 ms | Mitigation: run all worktrees in parallel via `Promise.all`; zero returned on individual failure |
+| 2 | macOS `du` uses `-sk` (KB), not `-sb` (bytes) | Handled in `diskUsageBytes()` helper in Decision 3 — branch on `process.platform` |
+| 3 | Node `statfs` doesn't expose `mountPoint` | Omit from response or return `vstHome()` string; frontend doesn't render it |
 
 ---
 
@@ -238,96 +301,130 @@ DELETE /worktrees/:id
 
 ### Phase 1 — Remove dismiss + add done guard (daemon + UI cleanup)
 
-- [ ] **1.1** `daemon/src/routes/worktrees.ts` — add done guard before `releaseSessionRuntime` loop: if any session `lifecycle.state !== "done"`, return `reply.status(409).send({ error: "worktree_not_done", sessions: [...non-done ids] })`
-- [ ] **1.2** `daemon/src/routes/worktrees.ts` — remove `const { purge } = req.query` and `shouldPurge` variable; call `worktreeRemove()` unconditionally (inside existing try/catch)
-- [ ] **1.3** `web-ui/src/api/client.ts` — delete `dismissWorktree()` method (lines 337-343)
-- [ ] **1.4** `web-ui/src/api/mock.ts` — delete `dismissWorktree()` mock (lines 416-423)
+- [ ] **1.1** `daemon/src/routes/worktrees.ts` — add `vstHome, projectDir` to the existing `paths.js` import (line 24); add done guard before `releaseSessionRuntime` loop using the exact predicate from API Contracts above; return 409 with non-done session IDs
+- [ ] **1.2** `daemon/src/routes/worktrees.ts` — remove `const { purge } = req.query` and `shouldPurge` variable; call `worktreeRemove()` unconditionally inside the existing try/catch
+- [ ] **1.3** `web-ui/src/api/client.ts` — delete `dismissWorktree()` method (lines 337-343); **do this in the same edit as 1.4** — `ApiInstance` is a union of both return types; removing from only one side breaks the type
+- [ ] **1.4** `web-ui/src/api/mock.ts` — delete `dismissWorktree()` mock (lines 416-423); same edit pass as 1.3
 - [ ] **1.5** `web-ui/src/components/layout/DashboardPanel.tsx` — remove `pendingDismiss` state (line 83), `showDismiss` (line 218), `dashboard-card-shell--dismissable` class (line 244), EyeOff button (lines 262-273), dismiss ConfirmDialog (lines 441-466)
 - [ ] **1.6** `web-ui/src/components/layout/LeftSidebar.tsx` — remove `pendingDismiss` state (line 609), `confirmDismissWorktree()` (lines 765-776), dismiss ConfirmDialogs (lines 1859-1870), context-menu item "Dismiss (keep files)" (lines 1990-1997)
-- [ ] **1.7** Remove any CSS classes introduced solely for dismiss affordance (e.g. `dashboard-card-shell--dismissable` in the stylesheet)
+- [ ] **1.7** `web-ui/src/styles/workspace.css` — remove both dismiss CSS blocks: `.dashboard-card-shell--dismissable:hover .dashboard-card__dismiss` (lines 3407-3409) and `.dashboard-card__dismiss` (lines 3411-3418)
 
 **Verify phase 1:**
 - [ ] **1.T1** Manual — open Dashboard: no EyeOff / dismiss button on any done card
 - [ ] **1.T2** Manual — open LeftSidebar worktree context menu: no "Dismiss (keep files)" item
-- [ ] **1.T3** Integration — `DELETE /worktrees/:id` (no purge param) on a done worktree: returns 200 and removes the worktree from the list
-- [ ] **1.T4** Integration — `DELETE /worktrees/:id` on a working worktree: returns 409 `{ error: "worktree_not_done" }`
-- [ ] **1.T5** Regression — `DELETE /worktrees/:id?purge=true` on a done worktree: still returns 200 (param ignored, not rejected)
-- [ ] **1.T6** Regression — TypeScript build: `npm run build` (or `tsc --noEmit`) in `web-ui/` passes with no errors referencing `dismissWorktree`
+- [ ] **1.T3** Integration — via dev sandbox (`scripts/dev-sandbox.sh up`); mark a worktree done via `POST /worktrees/:id/done`; then `DELETE /worktrees/:id` → 200, worktree removed from list
+- [ ] **1.T4** Integration — `DELETE /worktrees/:id` on a working worktree → 409 `{ error: "worktree_not_done", sessions: [...] }`
+- [ ] **1.T5** Regression — `DELETE /worktrees/:id?purge=true` on a done worktree → 200 (param ignored, not rejected)
+- [ ] **1.T6** Regression — `pnpm --filter @vibestation/web typecheck` passes with no `dismissWorktree` errors
+- [ ] **1.T7** Regression — `pnpm --filter @vibestation/cli typecheck` passes
 
 ### Phase 2 — Settings desktop section-switcher
 
-- [ ] **2.1** `SettingsPanel.tsx` — remove the three worktree `useRef` hooks (`modesRef`, `appearanceRef`, `projectsRef`, `hiddenProjectsRef`) and the `scrollTo` callback (lines 23-26, 29, 58-60)
-- [ ] **2.2** `SettingsPanel.tsx` — remove `ref` field from the `Section` interface (line 13) and from every `sections` array entry (lines 31-56)
-- [ ] **2.3** `SettingsPanel.tsx` — unify mobile and desktop behind a single `activeTab` state: both branches read `sections.find(s => s.id === activeTab)`; remove the `if (isMobile)` hard split
-- [ ] **2.4** `SettingsPanel.tsx` desktop nav — wire each nav button to `setActiveTab(section.id)` instead of `scrollTo(section.ref)`; add active-state styling: when `activeTab === section.id`, apply background pill (e.g. `background: "var(--bg-hover)"`, `borderRadius: "var(--radius-sm)"`, `fontWeight: "var(--font-weight-medium)"`)
-- [ ] **2.5** `SettingsPanel.tsx` desktop content area — render only `sections.find(s => s.id === activeTab)?.content`; remove the `sections.map(...)` scroll loop (lines 207-238); remove `id`, `ref`, and `scrollMarginTop` from the content wrapper; remove the section-label caption (lines 212-222) — the section title is now in the nav
-- [ ] **2.6** Add `Storage` to the `sections` array (placeholder content `<div>Storage coming soon</div>` — replaced in Phase 4)
+- [ ] **2.1** `SettingsPanel.tsx` — remove `modesRef`, `appearanceRef`, `projectsRef`, `hiddenProjectsRef` useRef hooks (lines 23-26, 29) and the `scrollTo` callback (lines 58-60)
+- [ ] **2.2** `SettingsPanel.tsx` — remove `ref: React.RefObject<HTMLElement | null>` field from the `Section` interface (line 13) and from every `sections` array entry (lines 31-56)
+- [ ] **2.3** `SettingsPanel.tsx` — collapse the `if (isMobile)` split: both breakpoints now read `sections.find(s => s.id === activeTab)`; render only that section's `.content` in the right column; the mobile underline tab bar and the desktop sidebar nav both call `setActiveTab(section.id)` on click
+- [ ] **2.4** `SettingsPanel.tsx` desktop nav — add active-state pill: when `activeTab === section.id`, apply `background: "var(--bg-hover)"`, `borderRadius: "var(--radius-sm)"`, `fontWeight: "var(--font-weight-medium)"` to the nav button's inline style
+- [ ] **2.5** `SettingsPanel.tsx` desktop content — remove the `sections.map(...)` scroll loop (lines 207-238); remove `id`, `ref`, `scrollMarginTop` from the wrapper; remove the section-label caption (lines 212-222); replace with single `{activeSectionContent}` render
+- [ ] **2.6** Add `{ id: "storage", label: "Storage", content: <div>Storage coming soon</div> }` to the `sections` array — placeholder replaced in Phase 4.8; note this placeholder is visible in dev but **must not ship to users without Phase 4 complete**
 
 **Verify phase 2:**
-- [ ] **2.T1** Manual — open Settings desktop: clicking each nav item shows only that section's content
-- [ ] **2.T2** Manual — active nav item has a filled pill; inactive items have no highlight
-- [ ] **2.T3** Manual — open Settings mobile: tab bar still works, one section at a time (regression)
-- [ ] **2.T4** Regression — all four existing sections (Modes, Appearance, Projects, Hidden projects) render their content correctly when selected
+- [ ] **2.T1** Manual — open Settings desktop: clicking each nav item shows only that section's content; no scroll
+- [ ] **2.T2** Manual — active nav item has filled pill background; inactive items are plain
+- [ ] **2.T3** Manual — open Settings mobile: underline tab bar still works, one section at a time (regression)
+- [ ] **2.T4** Regression — Modes, Appearance, Projects, Hidden projects all render correctly when selected
 
 ### Phase 3 — Disk usage daemon endpoint
 
-- [ ] **3.1** `daemon/src/routes/worktrees.ts` — add `GET /worktrees/disk-usage` handler:
-  - Import `execFile` from `node:child_process` and `promisify` if not already present
-  - Device stats: `df -B1 <vstDataDir>` — parse `Used`, `1K-blocks`, `Avail`, `Mounted on` columns
-  - Per-worktree diskBytes: for each worktree across all projects, `du -sb <checkoutPath>` + `du -sb <sessionDataParentDir>` (parent = `~/.vibe-station/projects/<pid>/session-data/<wid>`) — sum both; run via `Promise.all`; individual failures → 0
-  - `checkoutPath` = `getWorktreePath(project.id, wt.id)`; `sessionDataParentDir` = `join(projectDir(project.id), "session-data", wt.id)`
-  - Response shape: `{ device: { usedBytes, totalBytes, availableBytes, mountPoint }, worktrees: [{ id, diskBytes }] }`
-- [ ] **3.2** `web-ui/src/api/client.ts` — add `getDiskUsage(): Promise<DiskUsageResponse>` hitting `GET /api/worktrees/disk-usage`
-- [ ] **3.3** `web-ui/src/api/mock.ts` — add `getDiskUsage()` mock returning plausible static data
-- [ ] **3.4** `web-ui/src/api/types.ts` — add `DiskUsageResponse`, `WorktreeDiskUsage`, `DeviceDiskInfo` interfaces
+- [ ] **3.1** `daemon/src/routes/worktrees.ts` — add `execFile` (from `node:child_process`) and `promisify` (from `node:util`) and `statfs` (from `node:fs/promises`) to imports; add `vstHome, projectDir` to the `paths.js` import (already listed in 1.1 — ensure both phases share the same import line); add `diskUsageBytes()` helper (exact code from API Contracts section above); add `GET /worktrees/disk-usage` handler before the `GET /worktrees/:id/tree` route using `statfs(vstHome())` for device stats and `Promise.all` for per-worktree `diskUsageBytes`
+- [ ] **3.2** `web-ui/src/api/client.ts` — add `getDiskUsage(): Promise<DiskUsageResponse>` calling `GET ${root}/worktrees/disk-usage`
+- [ ] **3.3** `web-ui/src/api/mock.ts` — add `getDiskUsage()` returning static plausible data (e.g. device 50 GB total, 30 GB used; two mock worktree entries)
+- [ ] **3.4** `web-ui/src/api/types.ts` — add:
+  ```ts
+  export interface DeviceDiskInfo {
+    usedBytes: number;
+    totalBytes: number;
+    availableBytes: number;
+    mountPoint: string;
+  }
+  export interface WorktreeDiskUsage {
+    id: string;
+    diskBytes: number;
+  }
+  export interface DiskUsageResponse {
+    device: DeviceDiskInfo;
+    worktrees: WorktreeDiskUsage[];
+  }
+  ```
 
 **Verify phase 3:**
-- [ ] **3.T1** Integration — `curl http://localhost:<port>/api/worktrees/disk-usage` returns 200 JSON with `device` and `worktrees` array
-- [ ] **3.T2** Integration — each worktree entry in the response has a non-negative `diskBytes`
-- [ ] **3.T3** Integration — `device.availableBytes + device.usedBytes ≈ device.totalBytes` (within 5%)
-- [ ] **3.T4** Regression — TypeScript build in `daemon/` passes with no errors
+- [ ] **3.T1** Integration — in dev sandbox (auth disabled): `curl http://localhost:<port>/api/worktrees/disk-usage` → 200 JSON with `device` object and non-empty `worktrees` array; replace `<port>` with the port printed by `scripts/dev-sandbox.sh up`
+- [ ] **3.T2** Integration — each `worktrees[i].diskBytes` is a non-negative integer
+- [ ] **3.T3** Integration — `device.availableBytes + device.usedBytes` is within 5% of `device.totalBytes`
+- [ ] **3.T4** Regression — `pnpm --filter @vibestation/cli typecheck` passes
 
 ### Phase 4 — StorageSetting component
 
-- [ ] **4.1** Create `web-ui/src/components/settings/StorageSetting.tsx`:
-  - Props: `{ api: ApiInstance }`
-  - State: `diskUsage: DiskUsageResponse | null`, `loading: boolean`, `error: string | null`, `filter: "done" | "all"` (default `"done"`), `sort: "created" | "disk"` (default `"created"`), `selected: Set<string>`, `pendingDelete: Worktree[] | null`, `deleteError: string | null`
-  - On mount: fetch `api.getDiskUsage()` + `api.listWorktrees()` (or equivalent) in parallel
-  - After successful delete: re-fetch `getDiskUsage()`
-- [ ] **4.2** Device disk bar sub-component (inline in StorageSetting):
-  - Show `usedBytes / totalBytes` as a filled bar (CSS width %)
-  - Labels: `<usedHuman> / <totalHuman>` and `<availHuman> free` below
-  - Use `formatBytes(n)` helper (KB/MB/GB, 1 decimal place)
-- [ ] **4.3** Controls bar:
-  - "Select all" checkbox — checks all visible (post-filter) done worktrees
+- [ ] **4.1** Create `web-ui/src/components/settings/StorageSetting.tsx` with props `{ api: ApiInstance }` and state:
+  ```ts
+  diskUsage: DiskUsageResponse | null
+  worktrees: Worktree[]
+  sessionsByWorktree: Record<string, Session[]>   // keyed by worktree.id
+  loading: boolean
+  error: string | null
+  filter: "done" | "all"          // default "done"
+  sort: "created" | "disk"        // default "created"
+  selected: Set<string>           // worktree ids
+  pendingDelete: Worktree[] | null
+  deleteError: string | null
+  ```
+  Mount effect: `Promise.all([api.listWorktrees(), api.listSessions(), api.getDiskUsage()])` → populate state; group sessions by `session.worktreeId`
+
+- [ ] **4.2** `isWorktreeDone(wt: Worktree, sessions: Session[]): boolean` pure helper:
+  - agent sessions (`session.type === "agent"`): `session.state === "done"`
+  - terminal sessions: `session.state === "done" || session.state === "exited"`
+  - empty sessions array → treat as done (no sessions to block deletion)
+
+- [ ] **4.3** Device disk bar: `usedBytes / totalBytes` as CSS width %; labels `<usedHuman> / <totalHuman>` and `<availHuman> free`; `formatBytes(n: number): string` helper (auto KB/MB/GB, 1 decimal)
+
+- [ ] **4.4** Controls bar (three controls left to right):
+  - "Select all" checkbox — checks all visible post-filter done worktrees
   - Sort dropdown: `Creation date ↓` / `Disk usage ↓`
   - Filter dropdown: `Done` / `All`
-- [ ] **4.4** Worktree list rows:
-  - Checkbox: enabled only when all sessions of that worktree are `done`
-  - Display: worktree id · branch, status dot (`● done` / `● idle` / etc.), creation date, mini disk bar (relative to max in list), human-readable size, delete icon (active if done, disabled with tooltip otherwise)
-  - Status dot: reuse `StatusDot` component (from `web-ui/src/components/layout/StatusDot.tsx`)
-  - Determine "all done" by checking `worktree.sessions` array — all `session.state === "done"`
-- [ ] **4.5** Per-row delete icon (`XIcon` or trash): calls `handleDelete([worktree])` which sets `pendingDelete`
-- [ ] **4.6** Bulk delete footer bar (visible when `selected.size > 0`): shows `N selected (X GB)` + `Delete selected` button
-- [ ] **4.7** Confirmation dialog (`pendingDelete !== null`):
-  - List each worktree: `• <branch> (<size>)`
-  - Total freed
-  - "This cannot be undone"
-  - Cancel / Delete buttons
-  - On confirm: call `api.deleteWorktree(id)` sequentially per selected; catch 409 → set `deleteError`; on `deleteError`, replace button row with inline error banner; on all success, close dialog + refresh
-- [ ] **4.8** Replace placeholder in Phase 2.6 with `<StorageSetting api={api} />`; pass `api` prop down from `SettingsPanel`
-- [ ] **4.9** Empty state: when filter=done and no done worktrees, show "No done worktrees. Switch to All to see active ones."
-- [ ] **4.10** Loading state: show spinner while initial fetch is in-flight
+  - Summary line below controls: `N done worktrees · X GB` (filter=Done) or `N worktrees · X GB` (filter=All)
+  - Hint when filter=Done and some are hidden: `M others hidden by filter`
+
+- [ ] **4.5** Worktree list rows (using `session.state`, not `session.lifecycleState` — see Decision 7):
+  - Checkbox: enabled iff `isWorktreeDone(wt, sessions)` (use `sessionsByWorktree[wt.id] ?? []`)
+  - Display: `<wt.id> · <wt.branch>`, status dot (reuse `StatusDot` from `web-ui/src/components/layout/StatusDot.tsx`), `Created <date> · <N> sessions`, mini disk bar (`diskBytes / maxDiskBytes` in list), human-readable size, delete icon
+  - Delete icon: enabled iff `isWorktreeDone`; disabled with `title="Only done worktrees can be deleted"`
+  - Session count: `sessionsByWorktree[wt.id]?.length ?? 0`
+
+- [ ] **4.6** Per-row delete icon click → `setPendingDelete([wt])`
+
+- [ ] **4.7** Bulk delete footer (visible when `selected.size > 0`): `N selected (X GB)` + `Delete selected` button → `setPendingDelete(selectedWorktrees)`
+
+- [ ] **4.8** Confirmation dialog (`pendingDelete !== null`):
+  - Title: `Delete N worktrees?` (or `Delete worktree?` for N=1)
+  - Body: `This will permanently remove:` then bulleted list `• <branch> (<size>)`; `Total freed: X GB`; `This cannot be undone.`
+  - On confirm: call `api.deleteWorktree(id)` sequentially; on 409 → set `deleteError` to `"! <branch> is no longer done — deletion cancelled."`, abort remaining; on all success → close dialog, clear selection, re-fetch `getDiskUsage()`
+
+- [ ] **4.9** Three empty states:
+  - Loading: spinner while mount fetch in-flight
+  - Filter=Done, no done worktrees: `"No done worktrees. Switch to All to see active ones."`
+  - No worktrees at all: `"No worktrees yet. Worktrees appear here once you spawn an agent."`
+
+- [ ] **4.10** Replace Phase 2.6 placeholder with `<StorageSetting api={api} />`; add `api` prop to `SettingsPanel` if not already threaded through
 
 **Verify phase 4:**
-- [ ] **4.T1** Manual — open Settings → Storage: device disk bar shows reasonable used/free values
-- [ ] **4.T2** Manual — filter=Done (default): only done worktrees shown; hint visible if none
-- [ ] **4.T3** Manual — filter=All: all worktrees shown; active worktrees have disabled checkbox + greyed delete icon
-- [ ] **4.T4** Manual — select 2 done worktrees → Delete selected → confirm → worktrees removed, disk bar updates
+- [ ] **4.T1** Manual — Settings → Storage: device disk bar shows reasonable used/free values
+- [ ] **4.T2** Manual — filter=Done (default): only done worktrees shown; summary count correct; hint visible when some are hidden
+- [ ] **4.T3** Manual — filter=All: all worktrees shown; non-done rows have disabled checkbox + greyed delete icon with tooltip
+- [ ] **4.T4** Manual — select 2 done worktrees → Delete selected → confirm → rows removed, disk bar updates
 - [ ] **4.T5** Manual — per-row delete on a done worktree → confirm → removed
-- [ ] **4.T6** Manual — sort by Disk usage: list reorders largest first
-- [ ] **4.T7** Regression — other settings sections (Modes, Appearance, Projects, Hidden projects) unaffected
-- [ ] **4.T8** Regression — TypeScript build in `web-ui/` passes with no errors
+- [ ] **4.T6** Manual — sort=Disk usage: list reorders largest first
+- [ ] **4.T7** Manual — "No done worktrees" empty state appears correctly when all worktrees are active
+- [ ] **4.T8** Regression — other settings sections unaffected by section-switcher change
+- [ ] **4.T9** Regression — `pnpm --filter @vibestation/web typecheck` passes
 
 ---
 
@@ -335,12 +432,13 @@ DELETE /worktrees/:id
 
 | File | Status | Phase | Description / Contract Change |
 |------|--------|-------|-------------------------------|
-| `daemon/src/routes/worktrees.ts` | Modified | 1.1–1.2 | Done guard (409) + always-purge; Contract: `DELETE /worktrees/:id` — see API Contracts |
+| `daemon/src/routes/worktrees.ts` | Modified | 1.1–1.2 | Done guard (409) + always-purge; add `vstHome, projectDir` to import — see API Contracts |
 | `daemon/src/routes/worktrees.ts` | Modified | 3.1 | New `GET /worktrees/disk-usage` route — see API Contracts |
 | `web-ui/src/api/client.ts` | Modified | 1.3, 3.2 | Remove `dismissWorktree`; add `getDiskUsage(): Promise<DiskUsageResponse>` |
 | `web-ui/src/api/mock.ts` | Modified | 1.4, 3.3 | Remove `dismissWorktree` mock; add `getDiskUsage()` mock |
-| `web-ui/src/api/types.ts` | Modified | 3.4 | Add `DiskUsageResponse`, `WorktreeDiskUsage`, `DeviceDiskInfo` interfaces |
+| `web-ui/src/api/types.ts` | Modified | 3.4 | Add `DiskUsageResponse`, `WorktreeDiskUsage`, `DeviceDiskInfo` |
 | `web-ui/src/components/layout/DashboardPanel.tsx` | Modified | 1.5 | Remove `pendingDismiss`, `showDismiss`, EyeOff button, dismiss ConfirmDialog |
 | `web-ui/src/components/layout/LeftSidebar.tsx` | Modified | 1.6 | Remove `pendingDismiss`, `confirmDismissWorktree`, dismiss ConfirmDialogs, context-menu item |
+| `web-ui/src/styles/workspace.css` | Modified | 1.7 | Remove `.dashboard-card-shell--dismissable:hover .dashboard-card__dismiss` (3407-3409) and `.dashboard-card__dismiss` (3411-3418) |
 | `web-ui/src/components/settings/SettingsPanel.tsx` | Modified | 2.1–2.6 | Section-switcher: remove refs + scrollTo; unify behind `activeTab`; add Storage entry |
-| `web-ui/src/components/settings/StorageSetting.tsx` | New | 4.1–4.10 | Storage management section — device disk bar, filtered/sorted worktree list, multi-select delete |
+| `web-ui/src/components/settings/StorageSetting.tsx` | New | 4.1–4.10 | Storage section — device disk bar, filtered/sorted worktree list, multi-select delete |

--- a/.vibekit/feature-plans/wip/storage-management/plan-storage-management.md
+++ b/.vibekit/feature-plans/wip/storage-management/plan-storage-management.md
@@ -1,0 +1,346 @@
+---
+Issue: N/A
+Branch: management-ui-option
+Status: planning
+PRD: docs/STORAGE-MANAGEMENT-PRD.md
+---
+
+<!--
+RULES — read before writing or implementing:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. REQUIREMENTS: One crisp line each — no verbose descriptions
+3. CHECKLIST: Mark items [x] as you complete them — this is your persistent todo list
+4. READING TIME: Optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+## Problem & Concept
+
+- Settings panel (desktop) renders ALL sections stacked in one scrollable column — adding Storage would produce an unusably tall dump
+- No way to see how much disk each worktree uses or delete stale ones from the UI
+- "Dismiss (keep files)" leaves orphaned git checkouts with no re-import path — a confusing half-deleted state
+- DELETE /worktrees/:id has no guard: any worktree can be deleted regardless of session lifecycle state
+
+Success state:
+- Desktop settings nav is a true section-switcher (one section at a time, active pill highlight)
+- Settings → Storage shows device disk bar + filterable/sortable worktree list with per-row disk usage + multi-select delete
+- Dismiss is removed from all surfaces; DELETE always purges and rejects non-done worktrees with 409
+
+---
+
+## Requirements
+
+| # | Requirement |
+|---|-------------|
+| R1 | Desktop SettingsPanel nav switches sections (one at a time); active item gets filled pill |
+| R2 | Mobile SettingsPanel is unchanged (already tab-based) |
+| R3 | DELETE /worktrees/:id always purges (no `?purge` param); rejects with 409 if any session ≠ `done` |
+| R4 | `dismissWorktree()` removed from client, mock, and all UI call sites |
+| R5 | GET /api/worktrees/disk-usage returns per-worktree diskBytes + device used/total/available |
+| R6 | StorageSetting shows device disk bar, worktree list defaulting to filter=done, sort=creation-date-desc |
+| R7 | Checkboxes and delete icons enabled only for worktrees where ALL sessions are lifecycle=done |
+| R8 | Multi-select bulk delete with confirmation dialog listing names + sizes + total freed |
+| R9 | Filter dropdown: Done (default) / All; Sort dropdown: Creation date ↓ / Disk usage ↓ |
+| R10 | Confirmation dialog shows inline error banner on mid-flight 409 from daemon guard |
+
+---
+
+## Change Map
+
+```
+daemon/src/routes/
+  worktrees.ts              ~ remove purge branch; add done guard; add disk-usage route
+web-ui/src/api/
+  client.ts                 ~ remove dismissWorktree; add getDiskUsage
+  mock.ts                   ~ remove dismissWorktree mock; add getDiskUsage mock
+web-ui/src/components/
+  settings/
+    SettingsPanel.tsx        ~ desktop: section-switcher (no scroll refs)
+    StorageSetting.tsx       + new Storage section component
+  layout/
+    DashboardPanel.tsx       ~ remove dismiss button, pendingDismiss state, dismiss ConfirmDialog
+    LeftSidebar.tsx          ~ remove dismiss context menu item, pendingDismiss, confirmDismissWorktree
+```
+
+| Today | After this plan |
+|-------|-----------------|
+| Desktop settings nav scrolls to anchored section cards | Desktop nav switches sections; only active section renders |
+| DELETE /worktrees/:id?purge=true deletes, no purge = dismiss (keep files) | DELETE always purges; 409 if any session not done |
+| Dismiss (keep files) affordance on dashboard card and sidebar context menu | Dismiss removed from all surfaces |
+| No disk usage data exposed by daemon | GET /api/worktrees/disk-usage returns per-worktree bytes + device stats |
+| No Storage settings section | Settings → Storage shows disk bar + filterable/deletable worktree list |
+
+---
+
+## Research
+
+- `SettingsPanel.tsx:58-60` — `scrollTo` calls `ref.current?.scrollIntoView` on desktop; `activeTab` state already exists but only drives the mobile branch (line 63). The desktop branch never reads `activeTab`.
+- `SettingsPanel.tsx:179-201` — desktop nav buttons call `scrollTo(section.ref)`, not `setActiveTab`. The fix is wiring these buttons to `setActiveTab` and collapsing the dual-branch into one render path.
+- `client.ts:328-343` — `deleteWorktree` appends `?purge=true`; `dismissWorktree` omits it. Delete both; keep only `deleteWorktree`.
+- `mock.ts:416-423` — `dismissWorktree` mock removes from in-memory arrays.
+- `DashboardPanel.tsx:83,218,244,262-273,441-466` — `pendingDismiss` state, `showDismiss` flag, EyeOff icon button, ConfirmDialog for dismiss.
+- `LeftSidebar.tsx:609,765-776,1859-1870,1990-1997` — `pendingDismiss` state, `confirmDismissWorktree()`, two ConfirmDialogs, context-menu item "Dismiss (keep files)".
+- `worktrees.ts:859-909` — DELETE handler: `shouldPurge = purge === "true" || purge === "1"`; guard to add: check all `worktree.sessions` have `lifecycle.state === "done"`.
+- `paths.ts:63-65` — `worktreePath(projectId, worktreeId)` → `~/.vibe-station/projects/<pid>/worktrees/<wid>` (git checkout).
+- `paths.ts:88` — `sessionDataDir(projectId, worktreeId, sessionId)` → `~/.vibe-station/projects/<pid>/session-data/<wid>/<sid>`.
+- `WorktreeRecord` (`types.ts:384`) has `createdAt: string` (ISO8601) — available for sort.
+- `LifecycleState` (`types.ts:8-14`): `"not_started" | "working" | "idle" | "waiting_for_human" | "done" | "exited"` — guard checks ALL sessions have `"done"`.
+- Device disk: `df -B1 <path>` gives bytes; `du -sb <path>` gives apparent size per directory.
+
+---
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    subgraph Browser
+        StorageSetting --> ClientAPI[api.getDiskUsage]
+        StorageSetting --> ClientDelete[api.deleteWorktree]
+        SettingsPanel --> StorageSetting
+    end
+    subgraph Daemon
+        DiskUsageRoute["GET /worktrees/disk-usage"]
+        DeleteRoute["DELETE /worktrees/:id (guard + always-purge)"]
+    end
+    ClientAPI --"GET /worktrees/disk-usage"--> DiskUsageRoute
+    ClientDelete --"DELETE /worktrees/:id"--> DeleteRoute
+    DiskUsageRoute --> du["du -sb (per worktree + session-data)"]
+    DiskUsageRoute --> df["df -B1 (device stats)"]
+    DeleteRoute --> Guard{all sessions done?}
+    Guard --"no"--> 409
+    Guard --"yes"--> Purge[worktreeRemove + manifest]
+```
+
+---
+
+## Design Details
+
+### Critical User Journeys
+
+**Happy path — delete a done worktree from Storage settings:**
+```
+User opens Settings → clicks Storage in nav
+  → StorageSetting renders with filter=Done, sort=creation-date-desc
+  → Device disk bar shows used/total/available
+  → Worktree list shows only done worktrees with per-row disk bar
+  → User checks one or more rows → "Delete selected" button activates
+  → Confirmation dialog lists worktrees + sizes + total freed
+  → User confirms → DELETE /worktrees/:id per selected worktree
+  → Daemon checks all sessions done → purges checkout + manifest
+  → UI removes rows, disk bar refreshes
+```
+
+**Error path — worktree no longer done at confirm time:**
+```
+User selects done worktree → opens confirm dialog
+  → Meanwhile a sibling session starts (lifecycle → working)
+  → User clicks Delete
+  → Daemon returns 409 { error: "worktree_not_done", sessions: [...] }
+  → Confirm dialog replaces button row with:
+      "! <branch> is no longer done — deletion cancelled."
+      [Close]
+```
+
+**Error path — filter=Done with no done worktrees:**
+```
+User opens Storage
+  → All worktrees are active
+  → List empty, hint: "No done worktrees. Switch to All to see active ones."
+```
+
+---
+
+### API Contracts
+
+#### GET /api/worktrees/disk-usage
+
+New endpoint. No auth change (same session-cookie auth as other routes).
+
+```
+GET /api/worktrees/disk-usage
+
+200 {
+  device: {
+    usedBytes: number,      // df: Used column
+    totalBytes: number,     // df: 1K-blocks * 1024
+    availableBytes: number, // df: Avail column
+    mountPoint: string      // df: Mounted on
+  },
+  worktrees: [
+    {
+      id: string,           // WorktreeRecord.id
+      diskBytes: number     // du -sb checkout + du -sb session-data/<id>, summed
+    }
+  ]
+}
+
+500 { error: "disk_usage_failed", details: string }
+```
+
+- `diskBytes` is apparent size (du -sb), not actual — matches user expectation
+- Runs du/df in parallel per worktree via `Promise.all`; individual failures return 0 for that worktree
+- Device stats from `df -B1` on `$VST_DATA_DIR` (the partition vst data lives on)
+
+#### DELETE /worktrees/:id (modified)
+
+```
+DELETE /worktrees/:id
+  (no longer reads ?purge — always purges)
+
+200 { ok: true }
+409 { error: "worktree_not_done", sessions: ["<id>", ...] }
+404 { error: "Worktree '<id>' not found" }
+```
+
+- `?purge` query param is ignored (never read); backward-compat: existing callers that sent `?purge=true` still get a 200
+
+---
+
+### Key Decisions
+
+#### Decision 1: Always-purge on DELETE
+- **Decision:** remove the `shouldPurge` branch; `worktreeRemove()` is called unconditionally
+- **Rationale:** dismiss (keep files) is removed; the only remaining caller (`client.ts:deleteWorktree`) always sent `?purge=true` anyway; backward compat: param still accepted but ignored
+- **Where:** `daemon/src/routes/worktrees.ts:862-890`
+
+#### Decision 2: done guard checks ALL sessions
+- **Decision:** `worktree.sessions.every(s => s.lifecycle.state === "done")` must be true; exited does NOT satisfy the guard
+- **Rationale:** `exited` means the agent crashed or was killed, not that the user marked work done — PRD is explicit that only `done` is deletable
+- **Where:** `daemon/src/routes/worktrees.ts` (new check before releaseSessionRuntime loop)
+
+#### Decision 3: Disk usage computed server-side per request
+- **Decision:** no caching; fresh `du`/`df` on each GET /worktrees/disk-usage call
+- **Rationale:** worktrees rarely change size between opens; complexity of cache invalidation outweighs benefit; `du` on typical worktree dirs completes in <200 ms
+- **Where:** `daemon/src/routes/worktrees.ts` (new route)
+
+#### Decision 4: Settings desktop → single `activeSection` state, no refs
+- **Decision:** remove all `useRef` / `scrollIntoView` from desktop path; reuse existing `activeTab` state for both mobile and desktop; render only `sections.find(s => s.id === activeSection).content`
+- **Rationale:** PRD §0 — mobile already works this way; unifying removes the dual-branch entirely; Storage needs full panel height, not a card in a scroll
+- **Where:** `web-ui/src/components/settings/SettingsPanel.tsx:22-241`
+
+#### Decision 5: Disk usage fetched once on StorageSetting mount; refresh after delete
+- **Decision:** single `useEffect` on mount; after a successful delete, re-fetch disk-usage
+- **Rationale:** avoids stale disk bar after deletion; no need for polling
+- **Where:** `web-ui/src/components/settings/StorageSetting.tsx`
+
+---
+
+## Risks / Open Questions
+
+| # | Question | Notes |
+|---|----------|-------|
+| 1 | `du -sb` on a large worktree with git history could take >200 ms | Mitigation: run all worktrees in parallel via Promise.all; acceptable for a settings screen |
+| 2 | Which partition for device disk bar? | Use `$VST_DATA_DIR` partition — that's where the checkouts live |
+| 3 | `exited` sessions — should they block deletion? | Decision 2: yes, only `done` passes. A crashed agent should be retried or manually marked done |
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Remove dismiss + add done guard (daemon + UI cleanup)
+
+- [ ] **1.1** `daemon/src/routes/worktrees.ts` — add done guard before `releaseSessionRuntime` loop: if any session `lifecycle.state !== "done"`, return `reply.status(409).send({ error: "worktree_not_done", sessions: [...non-done ids] })`
+- [ ] **1.2** `daemon/src/routes/worktrees.ts` — remove `const { purge } = req.query` and `shouldPurge` variable; call `worktreeRemove()` unconditionally (inside existing try/catch)
+- [ ] **1.3** `web-ui/src/api/client.ts` — delete `dismissWorktree()` method (lines 337-343)
+- [ ] **1.4** `web-ui/src/api/mock.ts` — delete `dismissWorktree()` mock (lines 416-423)
+- [ ] **1.5** `web-ui/src/components/layout/DashboardPanel.tsx` — remove `pendingDismiss` state (line 83), `showDismiss` (line 218), `dashboard-card-shell--dismissable` class (line 244), EyeOff button (lines 262-273), dismiss ConfirmDialog (lines 441-466)
+- [ ] **1.6** `web-ui/src/components/layout/LeftSidebar.tsx` — remove `pendingDismiss` state (line 609), `confirmDismissWorktree()` (lines 765-776), dismiss ConfirmDialogs (lines 1859-1870), context-menu item "Dismiss (keep files)" (lines 1990-1997)
+- [ ] **1.7** Remove any CSS classes introduced solely for dismiss affordance (e.g. `dashboard-card-shell--dismissable` in the stylesheet)
+
+**Verify phase 1:**
+- [ ] **1.T1** Manual — open Dashboard: no EyeOff / dismiss button on any done card
+- [ ] **1.T2** Manual — open LeftSidebar worktree context menu: no "Dismiss (keep files)" item
+- [ ] **1.T3** Integration — `DELETE /worktrees/:id` (no purge param) on a done worktree: returns 200 and removes the worktree from the list
+- [ ] **1.T4** Integration — `DELETE /worktrees/:id` on a working worktree: returns 409 `{ error: "worktree_not_done" }`
+- [ ] **1.T5** Regression — `DELETE /worktrees/:id?purge=true` on a done worktree: still returns 200 (param ignored, not rejected)
+- [ ] **1.T6** Regression — TypeScript build: `npm run build` (or `tsc --noEmit`) in `web-ui/` passes with no errors referencing `dismissWorktree`
+
+### Phase 2 — Settings desktop section-switcher
+
+- [ ] **2.1** `SettingsPanel.tsx` — remove the three worktree `useRef` hooks (`modesRef`, `appearanceRef`, `projectsRef`, `hiddenProjectsRef`) and the `scrollTo` callback (lines 23-26, 29, 58-60)
+- [ ] **2.2** `SettingsPanel.tsx` — remove `ref` field from the `Section` interface (line 13) and from every `sections` array entry (lines 31-56)
+- [ ] **2.3** `SettingsPanel.tsx` — unify mobile and desktop behind a single `activeTab` state: both branches read `sections.find(s => s.id === activeTab)`; remove the `if (isMobile)` hard split
+- [ ] **2.4** `SettingsPanel.tsx` desktop nav — wire each nav button to `setActiveTab(section.id)` instead of `scrollTo(section.ref)`; add active-state styling: when `activeTab === section.id`, apply background pill (e.g. `background: "var(--bg-hover)"`, `borderRadius: "var(--radius-sm)"`, `fontWeight: "var(--font-weight-medium)"`)
+- [ ] **2.5** `SettingsPanel.tsx` desktop content area — render only `sections.find(s => s.id === activeTab)?.content`; remove the `sections.map(...)` scroll loop (lines 207-238); remove `id`, `ref`, and `scrollMarginTop` from the content wrapper; remove the section-label caption (lines 212-222) — the section title is now in the nav
+- [ ] **2.6** Add `Storage` to the `sections` array (placeholder content `<div>Storage coming soon</div>` — replaced in Phase 4)
+
+**Verify phase 2:**
+- [ ] **2.T1** Manual — open Settings desktop: clicking each nav item shows only that section's content
+- [ ] **2.T2** Manual — active nav item has a filled pill; inactive items have no highlight
+- [ ] **2.T3** Manual — open Settings mobile: tab bar still works, one section at a time (regression)
+- [ ] **2.T4** Regression — all four existing sections (Modes, Appearance, Projects, Hidden projects) render their content correctly when selected
+
+### Phase 3 — Disk usage daemon endpoint
+
+- [ ] **3.1** `daemon/src/routes/worktrees.ts` — add `GET /worktrees/disk-usage` handler:
+  - Import `execFile` from `node:child_process` and `promisify` if not already present
+  - Device stats: `df -B1 <vstDataDir>` — parse `Used`, `1K-blocks`, `Avail`, `Mounted on` columns
+  - Per-worktree diskBytes: for each worktree across all projects, `du -sb <checkoutPath>` + `du -sb <sessionDataParentDir>` (parent = `~/.vibe-station/projects/<pid>/session-data/<wid>`) — sum both; run via `Promise.all`; individual failures → 0
+  - `checkoutPath` = `getWorktreePath(project.id, wt.id)`; `sessionDataParentDir` = `join(projectDir(project.id), "session-data", wt.id)`
+  - Response shape: `{ device: { usedBytes, totalBytes, availableBytes, mountPoint }, worktrees: [{ id, diskBytes }] }`
+- [ ] **3.2** `web-ui/src/api/client.ts` — add `getDiskUsage(): Promise<DiskUsageResponse>` hitting `GET /api/worktrees/disk-usage`
+- [ ] **3.3** `web-ui/src/api/mock.ts` — add `getDiskUsage()` mock returning plausible static data
+- [ ] **3.4** `web-ui/src/api/types.ts` — add `DiskUsageResponse`, `WorktreeDiskUsage`, `DeviceDiskInfo` interfaces
+
+**Verify phase 3:**
+- [ ] **3.T1** Integration — `curl http://localhost:<port>/api/worktrees/disk-usage` returns 200 JSON with `device` and `worktrees` array
+- [ ] **3.T2** Integration — each worktree entry in the response has a non-negative `diskBytes`
+- [ ] **3.T3** Integration — `device.availableBytes + device.usedBytes ≈ device.totalBytes` (within 5%)
+- [ ] **3.T4** Regression — TypeScript build in `daemon/` passes with no errors
+
+### Phase 4 — StorageSetting component
+
+- [ ] **4.1** Create `web-ui/src/components/settings/StorageSetting.tsx`:
+  - Props: `{ api: ApiInstance }`
+  - State: `diskUsage: DiskUsageResponse | null`, `loading: boolean`, `error: string | null`, `filter: "done" | "all"` (default `"done"`), `sort: "created" | "disk"` (default `"created"`), `selected: Set<string>`, `pendingDelete: Worktree[] | null`, `deleteError: string | null`
+  - On mount: fetch `api.getDiskUsage()` + `api.listWorktrees()` (or equivalent) in parallel
+  - After successful delete: re-fetch `getDiskUsage()`
+- [ ] **4.2** Device disk bar sub-component (inline in StorageSetting):
+  - Show `usedBytes / totalBytes` as a filled bar (CSS width %)
+  - Labels: `<usedHuman> / <totalHuman>` and `<availHuman> free` below
+  - Use `formatBytes(n)` helper (KB/MB/GB, 1 decimal place)
+- [ ] **4.3** Controls bar:
+  - "Select all" checkbox — checks all visible (post-filter) done worktrees
+  - Sort dropdown: `Creation date ↓` / `Disk usage ↓`
+  - Filter dropdown: `Done` / `All`
+- [ ] **4.4** Worktree list rows:
+  - Checkbox: enabled only when all sessions of that worktree are `done`
+  - Display: worktree id · branch, status dot (`● done` / `● idle` / etc.), creation date, mini disk bar (relative to max in list), human-readable size, delete icon (active if done, disabled with tooltip otherwise)
+  - Status dot: reuse `StatusDot` component (from `web-ui/src/components/layout/StatusDot.tsx`)
+  - Determine "all done" by checking `worktree.sessions` array — all `session.state === "done"`
+- [ ] **4.5** Per-row delete icon (`XIcon` or trash): calls `handleDelete([worktree])` which sets `pendingDelete`
+- [ ] **4.6** Bulk delete footer bar (visible when `selected.size > 0`): shows `N selected (X GB)` + `Delete selected` button
+- [ ] **4.7** Confirmation dialog (`pendingDelete !== null`):
+  - List each worktree: `• <branch> (<size>)`
+  - Total freed
+  - "This cannot be undone"
+  - Cancel / Delete buttons
+  - On confirm: call `api.deleteWorktree(id)` sequentially per selected; catch 409 → set `deleteError`; on `deleteError`, replace button row with inline error banner; on all success, close dialog + refresh
+- [ ] **4.8** Replace placeholder in Phase 2.6 with `<StorageSetting api={api} />`; pass `api` prop down from `SettingsPanel`
+- [ ] **4.9** Empty state: when filter=done and no done worktrees, show "No done worktrees. Switch to All to see active ones."
+- [ ] **4.10** Loading state: show spinner while initial fetch is in-flight
+
+**Verify phase 4:**
+- [ ] **4.T1** Manual — open Settings → Storage: device disk bar shows reasonable used/free values
+- [ ] **4.T2** Manual — filter=Done (default): only done worktrees shown; hint visible if none
+- [ ] **4.T3** Manual — filter=All: all worktrees shown; active worktrees have disabled checkbox + greyed delete icon
+- [ ] **4.T4** Manual — select 2 done worktrees → Delete selected → confirm → worktrees removed, disk bar updates
+- [ ] **4.T5** Manual — per-row delete on a done worktree → confirm → removed
+- [ ] **4.T6** Manual — sort by Disk usage: list reorders largest first
+- [ ] **4.T7** Regression — other settings sections (Modes, Appearance, Projects, Hidden projects) unaffected
+- [ ] **4.T8** Regression — TypeScript build in `web-ui/` passes with no errors
+
+---
+
+## Files & Phase Impact
+
+| File | Status | Phase | Description / Contract Change |
+|------|--------|-------|-------------------------------|
+| `daemon/src/routes/worktrees.ts` | Modified | 1.1–1.2 | Done guard (409) + always-purge; Contract: `DELETE /worktrees/:id` — see API Contracts |
+| `daemon/src/routes/worktrees.ts` | Modified | 3.1 | New `GET /worktrees/disk-usage` route — see API Contracts |
+| `web-ui/src/api/client.ts` | Modified | 1.3, 3.2 | Remove `dismissWorktree`; add `getDiskUsage(): Promise<DiskUsageResponse>` |
+| `web-ui/src/api/mock.ts` | Modified | 1.4, 3.3 | Remove `dismissWorktree` mock; add `getDiskUsage()` mock |
+| `web-ui/src/api/types.ts` | Modified | 3.4 | Add `DiskUsageResponse`, `WorktreeDiskUsage`, `DeviceDiskInfo` interfaces |
+| `web-ui/src/components/layout/DashboardPanel.tsx` | Modified | 1.5 | Remove `pendingDismiss`, `showDismiss`, EyeOff button, dismiss ConfirmDialog |
+| `web-ui/src/components/layout/LeftSidebar.tsx` | Modified | 1.6 | Remove `pendingDismiss`, `confirmDismissWorktree`, dismiss ConfirmDialogs, context-menu item |
+| `web-ui/src/components/settings/SettingsPanel.tsx` | Modified | 2.1–2.6 | Section-switcher: remove refs + scrollTo; unify behind `activeTab`; add Storage entry |
+| `web-ui/src/components/settings/StorageSetting.tsx` | New | 4.1–4.10 | Storage management section — device disk bar, filtered/sorted worktree list, multi-select delete |

--- a/daemon/src/routes/worktrees.ts
+++ b/daemon/src/routes/worktrees.ts
@@ -21,7 +21,7 @@ import {
 import { getRemoteUrl, resolveGithubRemote, fetchPrForBranch } from "../services/github.js";
 import { rollbackWorktreeCreate } from "../services/rollback.js";
 import { spawnSession } from "../services/spawn.js";
-import { worktreePath as getWorktreePath, cleanupSessionDataDir, sessionDataDir } from "../services/paths.js";
+import { worktreePath as getWorktreePath, cleanupSessionDataDir, sessionDataDir, vstHome, projectDir } from "../services/paths.js";
 import { listFiles } from "../services/fileList.js";
 import { buildIgnoreMatcher } from "../services/ignoreFilter.js";
 import { broadcastAll } from "../broadcaster.js";
@@ -857,16 +857,31 @@ export function registerWorktreeRoutes(app: FastifyInstance): void {
   });
 
   // DELETE /worktrees/:id
+  // Always purges (removes the git checkout from disk). The ?purge param is
+  // accepted but ignored for backward compat with existing callers.
+  // Only deletable when all agent sessions are `done` and all terminal sessions
+  // are `done` or `exited` — mirrors what POST /worktrees/:id/done produces.
   app.delete("/worktrees/:id", async (req, reply) => {
     const { id: wtId } = req.params as { id: string };
-    const { purge } = req.query as { purge?: string };
-    const shouldPurge = purge === "true" || purge === "1";
 
     // Find the project that owns this worktree
     const project = getAllProjects().find((p) => p.worktrees.some((w) => w.id === wtId));
     if (!project) return reply.status(404).send({ error: `Worktree '${wtId}' not found` });
 
     const worktree = project.worktrees.find((w) => w.id === wtId)!;
+
+    // Done guard: agents must be `done`; terminals accept `done` or `exited`
+    const notDone = worktree.sessions.filter((s) =>
+      s.type === "agent"
+        ? s.lifecycle.state !== "done"
+        : s.lifecycle.state !== "done" && s.lifecycle.state !== "exited",
+    );
+    if (notDone.length > 0) {
+      return reply.status(409).send({
+        error: "worktree_not_done",
+        sessions: notDone.map((s) => s.id),
+      });
+    }
 
     // Kill all sessions (tmux or direct-pty)
     for (const session of worktree.sessions) {
@@ -878,16 +893,13 @@ export function registerWorktreeRoutes(app: FastifyInstance): void {
       cleanupSessionDataDir(project.id, wtId, session.id);
     }
 
-    if (shouldPurge) {
-      // Hard delete: remove the git worktree checkout from disk
-      const wtPath = getWorktreePath(project.id, wtId);
-      try {
-        await worktreeRemove(project.absolutePath, wtPath);
-      } catch {
-        // best-effort — might already be gone
-      }
+    // Hard delete: remove the git worktree checkout from disk
+    const wtPath = getWorktreePath(project.id, wtId);
+    try {
+      await worktreeRemove(project.absolutePath, wtPath);
+    } catch {
+      // best-effort — might already be gone
     }
-    // Without purge: files stay on disk, branch stays. User can recover manually.
 
     // Remove from manifest (always)
     await mutateProject(project.id, (p) => ({
@@ -906,6 +918,65 @@ export function registerWorktreeRoutes(app: FastifyInstance): void {
     }
     broadcastAll({ type: "worktree:deleted", worktreeId: wtId });
     return reply.send({ ok: true });
+  });
+
+  // GET /worktrees/disk-usage
+  // Static segment "disk-usage" is preferred over ":id" by Fastify's radix router.
+  app.get("/worktrees/disk-usage", async (_req, reply) => {
+    try {
+      const { statfs } = await import("node:fs/promises");
+      const { execFile } = await import("node:child_process");
+      const { promisify } = await import("node:util");
+      const execFileAsync = promisify(execFile);
+      const { join: pathJoin } = await import("node:path");
+
+      async function diskUsageBytes(path: string): Promise<number> {
+        try {
+          const args = process.platform === "darwin" ? ["-sk", path] : ["-sb", path];
+          const { stdout } = await execFileAsync("du", args);
+          const n = parseInt(stdout.split("\t")[0] ?? "0", 10);
+          return process.platform === "darwin" ? n * 1024 : n;
+        } catch {
+          return 0;
+        }
+      }
+
+      const home = vstHome();
+      const fs = await statfs(home);
+      const totalBytes = fs.bsize * fs.blocks;
+      const availableBytes = fs.bsize * fs.bavail;
+      const usedBytes = totalBytes - fs.bsize * fs.bfree;
+
+      const allWorktrees = getAllProjects().flatMap((p) =>
+        p.worktrees.map((w) => ({ projectId: p.id, worktreeId: w.id })),
+      );
+
+      const worktreeUsages = await Promise.all(
+        allWorktrees.map(async ({ projectId, worktreeId }) => {
+          const checkoutPath = getWorktreePath(projectId, worktreeId);
+          const sessionDataParent = pathJoin(projectDir(projectId), "session-data", worktreeId);
+          const [checkoutBytes, sessionBytes] = await Promise.all([
+            diskUsageBytes(checkoutPath),
+            diskUsageBytes(sessionDataParent),
+          ]);
+          return { id: worktreeId, diskBytes: checkoutBytes + sessionBytes };
+        }),
+      );
+
+      return reply.send({
+        device: {
+          usedBytes,
+          totalBytes,
+          availableBytes,
+          mountPoint: home,
+        },
+        worktrees: worktreeUsages,
+      });
+    } catch (err) {
+      return reply
+        .status(500)
+        .send({ error: "disk_usage_failed", details: String(err) });
+    }
   });
 
   // GET /worktrees/:id/tree?path=&showHidden=true

--- a/docs/STORAGE-MANAGEMENT-PRD.md
+++ b/docs/STORAGE-MANAGEMENT-PRD.md
@@ -1,0 +1,343 @@
+# Storage Management UI — Visual PRD
+
+**Feature:** Settings → Storage Management  
+**Status:** Draft / Pre-implementation  
+**Scope:** Read worktree disk usage, surface device capacity, allow selective deletion of `done` worktrees. Also removes the "dismiss (keep files)" worktree action.
+
+---
+
+## 0. Settings panel — layout change (prerequisite)
+
+Before adding Storage, the desktop settings layout needs to change. Here is the current state and what it becomes.
+
+### Current desktop layout (scroll-to-anchor)
+
+The left nav has 4 items. Clicking one calls `scrollIntoView` — it does **not** hide other sections. All sections are always rendered stacked in a single scrollable column.
+
+```
++--------------------------------------------------------------------+
+|  Settings                                                           |
+|  +--------------+--------------------------------------------+     |
+|  | Settings     |  MODES                                     |     |
+|  |              |  +----------------------------------------+|     |
+|  |  Modes       |  |  ... ModesSetting card ...             ||     |
+|  |  Appearance  |  +----------------------------------------+|     |
+|  |  Projects    |                                             |     |
+|  |  Hidden      |  APPEARANCE                                 |     |
+|  |  projects    |  +----------------------------------------+|     |
+|  |              |  |  ... AppearanceSetting card ...        ||     |
+|  |              |  +----------------------------------------+|     |
+|  |              |                                             |     |
+|  |              |  PROJECTS                                   |     |
+|  |              |  +----------------------------------------+|     |
+|  |              |  |  ... ProjectsSetting card ...          ||     |
+|  |              |  +----------------------------------------+|     |
+|  |              |                                             |     |
+|  |              |  HIDDEN PROJECTS                            |     |
+|  |              |  +----------------------------------------+|     |
+|  |              |  |  ... HiddenProjectsSetting card ...    ||     |
+|  |              |  +----------------------------------------+|     |
+|  |              |                                             |     |
+|  |              |  v  (keep scrolling...)                    |     |
+|  +--------------+--------------------------------------------+     |
++--------------------------------------------------------------------+
+```
+
+**Problem:** Adding Storage would append a 5th card to an already-tall scroll.
+Storage needs full panel height for its own toolbar + list + footer — it cannot
+work as a card wedged at the bottom.
+
+---
+
+### Proposed desktop layout (section switcher)
+
+The left nav becomes a true section switcher — clicking a nav item sets
+`activeSection` state and renders **only that section's content** in the right
+column. The active item gets a filled background pill highlight. This is the
+same pattern mobile already uses (underline tabs, one section at a time).
+
+```
++--------------------------------------------------------------------+
+|  Settings                                                           |
+|  +--------------+--------------------------------------------+     |
+|  | Settings     |                                             |     |
+|  |              |  Modes                                      |     |
+|  |  Modes       |  +----------------------------------------+|     |
+|  |  Appearance  |  |                                        ||     |
+|  |  Projects    |  |  ... ModesSetting content ...          ||     |
+|  |  Hidden      |  |                                        ||     |
+|  |  projects    |  +----------------------------------------+|     |
+|  |> Storage <   |                                             |     |
+|  |              |                                             |     |
+|  +--------------+--------------------------------------------+     |
++--------------------------------------------------------------------+
+
+                   (click Storage in nav ->)
+
++--------------------------------------------------------------------+
+|  Settings                                                           |
+|  +--------------+--------------------------------------------+     |
+|  | Settings     |                                             |     |
+|  |              |  Storage                                    |     |
+|  |  Modes       |  +----------------------------------------+|     |
+|  |  Appearance  |  |  ... StorageSetting (full height) ...  ||     |
+|  |  Projects    |  |                                        ||     |
+|  |  Hidden      |  |                                        ||     |
+|  |  projects    |  +----------------------------------------+|     |
+|  |> Storage <   |                                             |     |
+|  |              |                                             |     |
+|  +--------------+--------------------------------------------+     |
++--------------------------------------------------------------------+
+```
+
+`> Storage <` denotes the active nav item with a filled background pill.
+All other nav items are plain text buttons as they are today.
+
+**Mobile** is unchanged — it already uses the underline tab switcher, and
+Storage simply becomes the 5th tab there.
+
+---
+
+## 1. Entry point
+
+Storage is a new item in the left settings nav — fifth after Hidden projects.
+No separate dialog or route needed; it renders in the same right-hand content
+area as every other section.
+
+---
+
+## 2. Full layout — Settings panel with Storage active
+
+The outer chrome is the settings panel with the new section-switcher nav.
+The right column is where `StorageSetting` fills the full available height.
+
+```
++------------------------------------------------------------------------------+
+|  Settings                                                                     |
+|  +----------------+----------------------------------------------------------+|
+|  | Settings       |  Storage                                                  ||
+|  |                |                                                            ||
+|  |  Modes         |  +------------------------------------------------------+ ||
+|  |  Appearance    |  |  Device disk                                          | ||
+|  |  Projects      |  |  ####################.......  52.3 GB / 100 GB       | ||
+|  |  Hidden        |  |  47.7 GB free                                         | ||
+|  |  projects      |  +------------------------------------------------------+ ||
+|  |                |                                                            ||
+|  |> Storage <     |  Worktrees  ──────────────────────────────────────────── ||
+|  |                |                                                            ||
+|  |                |  [ ] Select all   Sort: Creation date v   Show: Done v   ||
+|  |                |                                                            ||
+|  |                |  +- - - - - - - - - - - - - - - - - - - - - - - - - -+  ||
+|  |                |  |[v] vs-72 · management-ui-option      * done        |  ||
+|  |                |  |    Created Sep 2, 2026                              |  ||
+|  |                |  |    ####.....  1.2 GB                           [x] |  ||
+|  |                |  +- - - - - - - - - - - - - - - - - - - - - - - - - -+  ||
+|  |                |  +- - - - - - - - - - - - - - - - - - - - - - - - - -+  ||
+|  |                |  |[v] vs-68 · refactor/auth-middleware  * done        |  ||
+|  |                |  |    Created Aug 28, 2026                             |  ||
+|  |                |  |    #########  2.8 GB                           [x] |  ||
+|  |                |  +- - - - - - - - - - - - - - - - - - - - - - - - - -+  ||
+|  |                |  2 done worktrees shown  (2 others hidden by filter)      ||
+|  |                |                                                            ||
+|  |                |  ──────────────────────────────────────────────────────  ||
+|  |                |  2 selected (4.0 GB)              [ Delete selected [x] ] ||
+|  +----------------+----------------------------------------------------------+|
++------------------------------------------------------------------------------+
+```
+
+(# = filled bar, . = empty bar, * = status dot, [x] = delete icon, [v] = checked checkbox)
+
+**Default filter is "Done"** — only `done` worktrees are shown on first open.
+The hint line below the list (`2 others hidden by filter`) tells the user that
+active worktrees exist but are filtered out, so the empty-looking list is not
+confusing.
+
+**Mobile** — Storage becomes the 5th tab (unchanged underline tab pattern):
+
+```
++-------------------------------------------------------------+
+|  Modes  Appearance  Projects  Hidden  Storage               |
+|                                       ------                |
+|  ... StorageSetting content ...                             |
++-------------------------------------------------------------+
+```
+
+---
+
+## 3. Controls bar
+
+```
+[ ] Select all     Sort: Creation date v     Show: Done v
+```
+
+Three controls, left to right:
+
+| Control | Default | Options |
+|---------|---------|---------|
+| Select all checkbox | unchecked | checks all visible (filtered) rows |
+| Sort dropdown | Creation date (newest first) | Creation date / Disk usage (largest first) |
+| Show (filter) dropdown | Done | Done / All |
+
+### Show dropdown detail
+
+```
+Show: Done v
+  +-----------+
+  | > Done    |   only worktrees whose all sessions are lifecycle=done (default)
+  |   All     |   every worktree regardless of status
+  +-----------+
+```
+
+When "All" is selected, non-done rows are shown but their checkboxes and delete
+icons remain disabled (same rules as before). The controls bar summary count
+updates to reflect the full list: `4 worktrees · 3.1 GB`.
+
+---
+
+## 4. Row anatomy
+
+```
++---------------------------------------------------------------+
+|  [v]  vs-72 · management-ui-option             * done         |
+|        Created Sep 2, 2026 · 3 sessions                       |
+|        ####.....  1.2 GB                               [x]    |
++---------------------------------------------------------------+
+
+[v]         checkbox — only enabled when all sessions = done
+vs-72       worktree id
+branch      branch the worktree is on
+* done      status dot (reuses existing StatusDot colours/glyphs)
+Created     absolute creation date + session count
+####....    mini bar: this worktree / largest worktree in the list
+1.2 GB      disk used by git checkout + daemon data dir
+[x]         per-row delete (done only); greyed [/] + tooltip if not deletable
+```
+
+### Status rules for checkbox and delete icon
+
+| Lifecycle state | Checkbox | Per-row delete |
+|----------------|----------|----------------|
+| `done` | enabled | active |
+| anything else | disabled | greyed, tooltip: "Only done worktrees can be deleted" |
+
+---
+
+## 5. Sort options
+
+```
+Sort: Creation date v
+  +------------------+
+  | > Creation date  |   newest first (default)
+  |   Disk usage     |   largest first
+  +------------------+
+```
+
+---
+
+## 6. Bulk delete confirmation dialog
+
+Triggered by "Delete selected" or the per-row delete icon.
+
+```
++------------------------------------------------------+
+|  Delete 2 worktrees?                                  |
+|                                                        |
+|  This will permanently remove:                         |
+|                                                        |
+|  * vs-72 · management-ui-option       (1.2 GB)        |
+|  * vs-68 · refactor/auth-middleware   (2.8 GB)        |
+|                                                        |
+|  Total freed: 4.0 GB                                   |
+|                                                        |
+|  This cannot be undone.                                |
+|                                                        |
+|                [ Cancel ]  [ Delete worktrees [x] ]   |
++------------------------------------------------------+
+```
+
+If the daemon guard fires mid-flight (a session woke up between confirm and
+the request), an inline error banner replaces the button row:
+
+```
+|  ! vs-72 is no longer done — deletion cancelled.      |
+|                                         [ Close ]      |
+```
+
+---
+
+## 7. Empty / loading states
+
+**Loading (disk usage calculating):**
+```
+  Calculating disk usage...  (spinner)
+```
+
+**Filter = Done, but no done worktrees yet:**
+```
+  No done worktrees.
+  Worktrees appear here once you mark a session done,
+  or switch the filter to All to see active ones.
+```
+
+**No worktrees at all:**
+```
+  No worktrees yet.
+  Worktrees appear here once you spawn an agent.
+```
+
+---
+
+## 8. Daemon-side changes
+
+### 8a. Delete guard
+
+`DELETE /api/worktrees/:id` must refuse deletion if **any** session in the
+worktree is not in lifecycle state `done`.
+
+```
+409 Conflict
+{ "error": "worktree_not_done", "sessions": ["<id>", ...] }
+```
+
+### 8b. Remove "dismiss (keep files)"
+
+The current worktree delete flow offers two variants:
+- **Delete** — sends `DELETE /worktrees/:id?purge=true`, removes the git checkout and daemon records.
+- **Dismiss (keep files)** — sends `DELETE /worktrees/:id` (no `purge`), removes daemon records only, leaves the checkout on disk.
+
+"Dismiss (keep files)" is being removed entirely. Reasons:
+- It leaves orphaned checkouts with no way to re-import them into vst.
+- It creates a confusing half-deleted state (daemon has no record, disk has the files).
+- The Storage UI's delete flow is the right place to manage disk; a soft-delete that doesn't free space defeats the purpose.
+
+**Exact removal scope:**
+
+| Layer | File | What to remove |
+|-------|------|----------------|
+| API client | `web-ui/src/api/client.ts` lines 337-343 | `dismissWorktree()` method |
+| Mock API | `web-ui/src/api/mock.ts` lines 416-423 | `dismissWorktree()` mock |
+| Dashboard | `web-ui/src/components/layout/DashboardPanel.tsx` lines 83, 218, 244, 262-273, 441-466 | `pendingDismiss` state, `showDismiss` logic, EyeOff button, ConfirmDialog |
+| Sidebar | `web-ui/src/components/layout/LeftSidebar.tsx` lines 609, 765-776, 1859-1870, 1990-1997 | `pendingDismiss` state, `confirmDismissWorktree()`, both ConfirmDialogs, context menu item |
+| Daemon route | `daemon/src/routes/worktrees.ts` lines 859-909 | `?purge` query param check; make `purge=true` the only behaviour (always call `worktreeRemove()`) |
+
+After this change the `DELETE /worktrees/:id` route always purges — the `?purge` param is no longer read and can be removed from the handler.
+
+---
+
+## 9. Open questions
+
+1. **What counts as "disk usage"?**  
+   Candidate: `du -sh <worktree-checkout-path> + <daemon-data-dir-for-worktree>`.
+   Should we include git objects shared with the base repo (hard-linked in some
+   git worktree setups)? Probably show apparent size, not actual — simpler and
+   matches what users expect "the folder weighs" to mean.
+
+2. **Device disk bar scope**  
+   Show the partition that `$VST_DATA_DIR` lives on, or always `/`?
+
+3. **"Oldest first" sort direction**  
+   Could just be a toggle arrow next to "Creation date" rather than a separate
+   dropdown option — decide at implementation time.
+
+4. **Per-project grouping**  
+   Out of scope for v1, but a collapsed-by-project view could be useful later.

--- a/web-ui/src/api/client.ts
+++ b/web-ui/src/api/client.ts
@@ -14,6 +14,7 @@ import type {
   CreateProjectResponse,
   CreateSessionBody,
   CreateWorktreeBody,
+  DiskUsageResponse,
   FileScope,
   FsCheckResponse,
   FsCompleteResponse,
@@ -327,19 +328,16 @@ export function createClientApi() {
 
     async deleteWorktree(id: string): Promise<{ ok: true }> {
       const root = baseUrl();
-      // UI always purges (removes files from disk)
-      const res = await apiFetch(`${root}/worktrees/${encodeURIComponent(id)}?purge=true`, {
+      const res = await apiFetch(`${root}/worktrees/${encodeURIComponent(id)}`, {
         method: "DELETE",
       });
       return parseJson<{ ok: true }>(res);
     },
 
-    async dismissWorktree(id: string): Promise<{ ok: true }> {
+    async getDiskUsage(): Promise<DiskUsageResponse> {
       const root = baseUrl();
-      const res = await apiFetch(`${root}/worktrees/${encodeURIComponent(id)}`, {
-        method: "DELETE",
-      });
-      return parseJson<{ ok: true }>(res);
+      const res = await apiFetch(`${root}/worktrees/disk-usage`);
+      return parseJson<DiskUsageResponse>(res);
     },
 
     /**

--- a/web-ui/src/api/mock.ts
+++ b/web-ui/src/api/mock.ts
@@ -15,6 +15,7 @@ import type {
   CreateProjectResponse,
   CreateSessionBody,
   CreateWorktreeBody,
+  DiskUsageResponse,
   FileScope,
   FsCheckResponse,
   FsCompleteResponse,
@@ -404,6 +405,19 @@ export function createMockApi() {
     async deleteWorktree(id: string): Promise<{ ok: true }> {
       const idx = worktrees.findIndex((w) => w.id === id);
       if (idx === -1) throw new ApiError("not found", 404);
+      const wt = worktrees[idx]!;
+      const wtSessions = sessions.filter((s) => s.worktreeId === wt.id);
+      const notDone = wtSessions.filter((s) =>
+        s.type === "agent"
+          ? s.state !== "done"
+          : s.state !== "done" && s.state !== "exited",
+      );
+      if (notDone.length > 0) {
+        throw new ApiError(
+          JSON.stringify({ error: "worktree_not_done", sessions: notDone.map((s) => s.id) }),
+          409,
+        );
+      }
       worktrees.splice(idx, 1);
       for (let i = sessions.length - 1; i >= 0; i--) {
         if (sessions[i]!.worktreeId === id) sessions.splice(i, 1);
@@ -413,15 +427,21 @@ export function createMockApi() {
       return { ok: true };
     },
 
-    async dismissWorktree(id: string): Promise<{ ok: true }> {
-      const idx = worktrees.findIndex((w) => w.id === id);
-      if (idx === -1) throw new ApiError("not found", 404);
-      worktrees.splice(idx, 1);
-      for (let i = sessions.length - 1; i >= 0; i--) {
-        if (sessions[i]!.worktreeId === id) sessions.splice(i, 1);
-      }
-      emit({ type: "worktree:deleted", worktreeId: id });
-      return { ok: true };
+    async getDiskUsage(): Promise<DiskUsageResponse> {
+      const TOTAL = 100 * 1024 * 1024 * 1024; // 100 GB
+      const USED = 52 * 1024 * 1024 * 1024;   // 52 GB
+      return {
+        device: {
+          totalBytes: TOTAL,
+          usedBytes: USED,
+          availableBytes: TOTAL - USED,
+          mountPoint: "~/.vibe-station",
+        },
+        worktrees: worktrees.map((wt, i) => ({
+          id: wt.id,
+          diskBytes: (i + 1) * 400 * 1024 * 1024, // 400 MB, 800 MB, ...
+        })),
+      };
     },
 
     async markWorktreeDone(

--- a/web-ui/src/api/types.ts
+++ b/web-ui/src/api/types.ts
@@ -781,3 +781,20 @@ export interface FsCheckResponse {
    *  `isGit` is true — null otherwise (not a repo, or path doesn't exist). */
   hasCommits: boolean | null;
 }
+
+export interface DeviceDiskInfo {
+  usedBytes: number;
+  totalBytes: number;
+  availableBytes: number;
+  mountPoint: string;
+}
+
+export interface WorktreeDiskUsage {
+  id: string;
+  diskBytes: number;
+}
+
+export interface DiskUsageResponse {
+  device: DeviceDiskInfo;
+  worktrees: WorktreeDiskUsage[];
+}

--- a/web-ui/src/components/dialogs/ConfirmDialog.tsx
+++ b/web-ui/src/components/dialogs/ConfirmDialog.tsx
@@ -47,7 +47,7 @@ export function ConfirmDialog({
         </>
       }
     >
-      <p style={{ margin: 0, fontSize: "var(--font-size-sm)", color: "var(--fg-secondary)" }}>
+      <p style={{ margin: 0, fontSize: "var(--font-size-sm)", color: "var(--fg-secondary)", whiteSpace: "pre-wrap" }}>
         {message}
       </p>
     </Dialog>

--- a/web-ui/src/components/layout/DashboardPanel.tsx
+++ b/web-ui/src/components/layout/DashboardPanel.tsx
@@ -1,11 +1,10 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Columns3, EyeOff, LayoutList } from "lucide-react";
+import { Columns3, LayoutList } from "lucide-react";
 import { Link } from "react-router-dom";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 import type { ApiInstance } from "@/api";
 import type { ConnectionState } from "@/api/client";
-import type { HealthResponse, PrStatus, Session, Worktree } from "@/api/types";
-import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
+import type { HealthResponse, PrStatus, Session } from "@/api/types";
 import { StatusDot } from "@/components/layout/StatusDot";
 import { useSubscription } from "@/hooks/useSubscription";
 import { useWorkspaceStore } from "@/hooks/useStore";
@@ -80,11 +79,7 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
   const projects = useServerStore((s) => s.projects);
   const worktrees = useServerStore((s) => s.worktrees);
   const sessions = useServerStore((s) => s.sessions);
-  const [pendingDismiss, setPendingDismiss] = useState<Worktree | null>(null);
   const setActiveWorktree = useWorkspaceStore((s) => s.setActiveWorktree);
-  const activeWorktreeId = useWorkspaceStore((s) => s.activeWorktreeId);
-  const clearWorkspaceSelection = useWorkspaceStore((s) => s.clearWorkspaceSelection);
-
   const isMobile = useMediaQuery("(max-width: 768px)");
 
   const [dashboardView, setDashboardView] = useState<"list" | "kanban">(() => {
@@ -215,7 +210,6 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
       const wt = s.worktreeId != null ? worktreeById.get(s.worktreeId) : undefined;
       const sessionPr = wt ? worktreePrById.get(wt.id) ?? null : null;
       const proj = projectById[s.projectId];
-      const showDismiss = wt != null && (status === "done" || status === "exited");
       if (!wt) {
         // Direct (worktree-less) session — no worktree context to show, no
         // dismiss affordance (nothing to dismiss).
@@ -239,10 +233,7 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
       }
       const sessionsForWt = sessions.filter((s2) => s2.worktreeId === wt.id);
       return (
-        <div
-          key={s.id}
-          className={`dashboard-card-shell${showDismiss ? " dashboard-card-shell--dismissable" : ""}`}
-        >
+        <div key={s.id} className="dashboard-card-shell">
           <Link
             to={`/worktree/${wt.id}`}
             className="dashboard-card dashboard-card--session dashboard-card--worktree"
@@ -259,21 +250,6 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
             </span>
             <span className="dashboard-card__secondary">{proj?.name ?? ""}</span>
           </Link>
-          {showDismiss ? (
-            <button
-              type="button"
-              className="icon-btn dashboard-card__dismiss"
-              aria-label={`Dismiss ${sessionLabel(s)} (${wt.branch}) from tracking`}
-              title="Dismiss from tracking (keep files)"
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                setPendingDismiss(wt);
-              }}
-            >
-              <EyeOff size={16} />
-            </button>
-          ) : null}
         </div>
       );
     },
@@ -438,32 +414,6 @@ export function DashboardPanel({ api }: DashboardPanelProps) {
         ) : null}
       </div>
 
-      <ConfirmDialog
-        open={pendingDismiss !== null}
-        title="Dismiss worktree?"
-        message={
-          pendingDismiss
-            ? `Remove “${pendingDismiss.branch}” from vst tracking? Files and git branch stay on disk.`
-            : ""
-        }
-        confirmLabel="Dismiss"
-        onConfirm={() => {
-          void (async () => {
-            const wt = pendingDismiss;
-            if (!wt) return;
-            setPendingDismiss(null);
-            try {
-              await api.dismissWorktree(wt.id);
-              if (activeWorktreeId === wt.id) clearWorkspaceSelection();
-              // Store stays current via the `worktree:deleted` WS event handled
-              // by useServerSync.
-            } catch {
-              /* surface errors later */
-            }
-          })();
-        }}
-        onCancel={() => setPendingDismiss(null)}
-      />
     </div>
   );
 }

--- a/web-ui/src/components/layout/LeftSidebar.tsx
+++ b/web-ui/src/components/layout/LeftSidebar.tsx
@@ -606,7 +606,6 @@ export function LeftSidebar({
   /** Id of the project whose "Hidden worktrees" dialog is open, or null when closed. */
   const [hiddenWtDialogProjectId, setHiddenWtDialogProjectId] = useState<string | null>(null);
   const [pendingDelete, setPendingDelete] = useState<Worktree | null>(null);
-  const [pendingDismiss, setPendingDismiss] = useState<Worktree | null>(null);
   const [pendingTerminateSession, setPendingTerminateSession] = useState<Session | null>(null);
   const [pendingDeleteWorkspace, setPendingDeleteWorkspace] = useState<WorkspaceDoc | null>(null);
 
@@ -757,20 +756,6 @@ export function LeftSidebar({
       }
       // Store stays current via the `worktree:deleted` WS event handled in
       // useServerSync — no manual refresh needed.
-    } catch {
-      /* surface errors later */
-    }
-  }
-
-  async function confirmDismissWorktree() {
-    if (!pendingDismiss) return;
-    const worktree = pendingDismiss;
-    setPendingDismiss(null);
-    try {
-      await api.dismissWorktree(worktree.id);
-      if (activeWorktreeId === worktree.id) {
-        clearWorkspaceSelection();
-      }
     } catch {
       /* surface errors later */
     }
@@ -1857,19 +1842,6 @@ export function LeftSidebar({
       />
 
       <ConfirmDialog
-        open={pendingDismiss !== null}
-        title="Dismiss worktree?"
-        message={
-          pendingDismiss
-            ? `Remove “${pendingDismiss.branch}” from vst tracking? Files and git branch stay on disk. Any running sessions will be stopped.`
-            : ""
-        }
-        confirmLabel="Dismiss"
-        onConfirm={() => void confirmDismissWorktree()}
-        onCancel={() => setPendingDismiss(null)}
-      />
-
-      <ConfirmDialog
         open={pendingTerminateSession !== null}
         title="Terminate agent?"
         message={
@@ -1983,18 +1955,6 @@ export function LeftSidebar({
                 }}
               >
                 Mark as done
-              </button>
-              <button
-                type="button"
-                role="menuitem"
-                className="menu-pop__item"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setPendingDismiss(wtMenu.worktree);
-                  setWtMenu(null);
-                }}
-              >
-                Dismiss (keep files)
               </button>
               <button
                 type="button"

--- a/web-ui/src/components/settings/SettingsPanel.tsx
+++ b/web-ui/src/components/settings/SettingsPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useId, useRef, useState } from "react";
+import { useId, useState } from "react";
 import { motion } from "framer-motion";
 import type { ApiInstance } from "@/api";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
@@ -6,11 +6,11 @@ import { ModesSetting } from "./ModesSetting";
 import { AppearanceSetting } from "./AppearanceSetting";
 import { ProjectsSetting } from "./ProjectsSetting";
 import { HiddenProjectsSetting } from "./HiddenProjectsSetting";
+import { StorageSetting } from "./StorageSetting";
 
 interface Section {
   id: string;
   label: string;
-  ref: React.RefObject<HTMLElement | null>;
   content: React.ReactNode;
 }
 
@@ -20,48 +20,41 @@ interface SettingsPanelProps {
 
 export function SettingsPanel({ api }: SettingsPanelProps) {
   const isMobile = useMediaQuery("(max-width: 768px)");
-  const modesRef = useRef<HTMLElement | null>(null);
-  const appearanceRef = useRef<HTMLElement | null>(null);
-  const hiddenProjectsRef = useRef<HTMLElement | null>(null);
   const [activeTab, setActiveTab] = useState("modes");
   const tabLayoutId = useId();
-
-  const projectsRef = useRef<HTMLElement | null>(null);
 
   const sections: Section[] = [
     {
       id: "modes",
       label: "Modes",
-      ref: modesRef,
       content: <ModesSetting api={api} />,
     },
     {
       id: "appearance",
       label: "Appearance",
-      ref: appearanceRef,
       content: <AppearanceSetting />,
     },
     {
       id: "projects",
       label: "Projects",
-      ref: projectsRef,
       content: <ProjectsSetting api={api} />,
     },
     {
       id: "hidden-projects",
       label: "Hidden projects",
-      ref: hiddenProjectsRef,
       content: <HiddenProjectsSetting api={api} />,
+    },
+    {
+      id: "storage",
+      label: "Storage",
+      content: <StorageSetting api={api} />,
     },
   ];
 
-  const scrollTo = useCallback((ref: React.RefObject<HTMLElement | null>) => {
-    ref.current?.scrollIntoView({ behavior: "smooth", block: "start" });
-  }, []);
+  const activeSection = sections.find((s) => s.id === activeTab) ?? sections[0]!;
 
   // ── Mobile: underline tabs ───────────────────────────────────────────────
   if (isMobile) {
-    const activeSection = sections.find((s) => s.id === activeTab) ?? sections[0]!;
     return (
       <div
         className="settings-panel"
@@ -73,7 +66,6 @@ export function SettingsPanel({ api }: SettingsPanelProps) {
           overflow: "hidden",
         }}
       >
-        {/* Underline tab bar — matches design system `variant="underline"` */}
         <div
           role="tablist"
           style={{
@@ -127,7 +119,6 @@ export function SettingsPanel({ api }: SettingsPanelProps) {
           ))}
         </div>
 
-        {/* Active section content */}
         <div
           role="tabpanel"
           style={{
@@ -143,7 +134,7 @@ export function SettingsPanel({ api }: SettingsPanelProps) {
     );
   }
 
-  // ── Desktop: side nav + scrollable content ───────────────────────────────
+  // ── Desktop: side nav + active section only ──────────────────────────────
   return (
     <div
       className="settings-panel"
@@ -180,7 +171,7 @@ export function SettingsPanel({ api }: SettingsPanelProps) {
           <button
             key={section.id}
             type="button"
-            onClick={() => scrollTo(section.ref)}
+            onClick={() => setActiveTab(section.id)}
             className="settings-nav__link"
             style={{
               display: "block",
@@ -189,10 +180,14 @@ export function SettingsPanel({ api }: SettingsPanelProps) {
               padding: "var(--space-2) var(--space-3)",
               borderRadius: "var(--radius-sm)",
               border: "none",
-              background: "transparent",
+              background: activeTab === section.id ? "var(--bg-hover)" : "transparent",
               color: "var(--fg-primary)",
               cursor: "pointer",
               font: "inherit",
+              fontWeight:
+                activeTab === section.id
+                  ? "var(--font-weight-medium)"
+                  : "var(--font-weight-normal)",
             }}
           >
             {section.label}
@@ -204,38 +199,7 @@ export function SettingsPanel({ api }: SettingsPanelProps) {
         className="settings-content"
         style={{ overflow: "auto", minHeight: 0 }}
       >
-        {sections.map((section, i) => (
-          <div
-            key={section.id}
-            style={{ marginBottom: i < sections.length - 1 ? "var(--space-6)" : 0 }}
-          >
-            <div
-              style={{
-                fontSize: "var(--font-size-xs)",
-                fontWeight: "var(--font-weight-medium)",
-                color: "var(--fg-muted)",
-                textTransform: "uppercase",
-                letterSpacing: "0.06em",
-                marginBottom: "var(--space-2)",
-              }}
-            >
-              {section.label}
-            </div>
-            <section
-              id={`settings-${section.id}`}
-              ref={section.ref}
-              style={{
-                scrollMarginTop: "var(--space-5)",
-                border: "var(--border-width) solid var(--border-default)",
-                borderRadius: "var(--radius-lg, var(--radius-md))",
-                background: "var(--bg-card)",
-                padding: "var(--space-4) var(--space-5)",
-              }}
-            >
-              {section.content}
-            </section>
-          </div>
-        ))}
+        {activeSection.content}
       </div>
     </div>
   );

--- a/web-ui/src/components/settings/StorageSetting.tsx
+++ b/web-ui/src/components/settings/StorageSetting.tsx
@@ -1,0 +1,405 @@
+import { useCallback, useEffect, useState } from "react";
+import type { ApiInstance } from "@/api";
+import type { DiskUsageResponse, Session, Worktree } from "@/api/types";
+import { StatusDot } from "@/components/layout/StatusDot";
+import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
+import { sessionStatus } from "@/lib/worktreeStatus";
+
+interface StorageSettingProps {
+  api: ApiInstance;
+}
+
+type Filter = "done" | "all";
+type Sort = "created" | "disk";
+
+function formatBytes(n: number): string {
+  if (n === 0) return "—";
+  if (n >= 1024 ** 3) return `${(n / 1024 ** 3).toFixed(1)} GB`;
+  if (n >= 1024 ** 2) return `${(n / 1024 ** 2).toFixed(1)} MB`;
+  if (n >= 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${n} B`;
+}
+
+function isWorktreeDone(wt: Worktree, sessions: Session[]): boolean {
+  if (sessions.length === 0) return true;
+  return sessions.every((s) =>
+    s.type === "agent"
+      ? s.state === "done"
+      : s.state === "done" || s.state === "exited",
+  );
+}
+
+export function StorageSetting({ api }: StorageSettingProps) {
+  const [diskUsage, setDiskUsage] = useState<DiskUsageResponse | null>(null);
+  const [worktrees, setWorktrees] = useState<Worktree[]>([]);
+  const [sessionsByWorktree, setSessionsByWorktree] = useState<Record<string, Session[]>>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState<Filter>("done");
+  const [sort, setSort] = useState<Sort>("created");
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [pendingDelete, setPendingDelete] = useState<Worktree[] | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    try {
+      const [wts, sess, disk] = await Promise.all([
+        api.listWorktrees(),
+        api.listSessions(),
+        api.getDiskUsage(),
+      ]);
+      const grouped: Record<string, Session[]> = {};
+      for (const s of sess) {
+        if (s.worktreeId) {
+          grouped[s.worktreeId] ??= [];
+          grouped[s.worktreeId]!.push(s);
+        }
+      }
+      setWorktrees(wts);
+      setSessionsByWorktree(grouped);
+      setDiskUsage(disk);
+      setError(null);
+    } catch {
+      setError("Failed to load storage data.");
+    } finally {
+      setLoading(false);
+    }
+  }, [api]);
+
+  useEffect(() => {
+    void fetchData();
+  }, [fetchData]);
+
+  const doneMap = Object.fromEntries(
+    worktrees.map((wt) => [wt.id, isWorktreeDone(wt, sessionsByWorktree[wt.id] ?? [])]),
+  );
+
+  const diskMap = Object.fromEntries(
+    (diskUsage?.worktrees ?? []).map((w) => [w.id, w.diskBytes]),
+  );
+
+  // Apply filter
+  const filtered = worktrees.filter((wt) => filter === "all" || doneMap[wt.id]);
+
+  // Apply sort
+  const sorted = [...filtered].sort((a, b) => {
+    if (sort === "disk") return (diskMap[b.id] ?? 0) - (diskMap[a.id] ?? 0);
+    return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+  });
+
+  const hiddenCount = worktrees.length - filtered.length;
+  const doneCount = worktrees.filter((wt) => doneMap[wt.id]).length;
+  const totalFilteredDisk = filtered.reduce((sum, wt) => sum + (diskMap[wt.id] ?? 0), 0);
+
+  const maxDisk = Math.max(1, ...filtered.map((wt) => diskMap[wt.id] ?? 0));
+
+  const allDoneVisible = sorted.filter((wt) => doneMap[wt.id]);
+  const allChecked =
+    allDoneVisible.length > 0 && allDoneVisible.every((wt) => selected.has(wt.id));
+
+  function toggleSelectAll() {
+    if (allChecked) {
+      setSelected(new Set());
+    } else {
+      setSelected(new Set(allDoneVisible.map((wt) => wt.id)));
+    }
+  }
+
+  function toggleSelect(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  async function handleDelete(targets: Worktree[]) {
+    setDeleteError(null);
+    for (const wt of targets) {
+      try {
+        await api.deleteWorktree(wt.id);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : "An error occurred";
+        let label = wt.branch;
+        try {
+          const parsed = JSON.parse(msg) as { error?: string };
+          if (parsed.error !== "worktree_not_done") label = msg;
+        } catch {
+          label = msg;
+        }
+        setDeleteError(`! "${label}" — deletion cancelled.`);
+        break;
+      }
+    }
+    setPendingDelete(null);
+    setSelected(new Set());
+    setLoading(true);
+    await fetchData();
+  }
+
+  const selectedWorktrees = worktrees.filter((wt) => selected.has(wt.id));
+  const selectedDisk = selectedWorktrees.reduce((sum, wt) => sum + (diskMap[wt.id] ?? 0), 0);
+
+  if (loading) {
+    return (
+      <div style={{ padding: "var(--space-5)", color: "var(--fg-muted)" }}>
+        Calculating disk usage…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div style={{ padding: "var(--space-5)", color: "var(--fg-danger)" }}>{error}</div>
+    );
+  }
+
+  const device = diskUsage?.device;
+
+  return (
+    <div
+      style={{
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        gap: "var(--space-4)",
+        overflow: "hidden",
+      }}
+    >
+      {/* Device disk bar */}
+      {device && (
+        <div
+          style={{
+            border: "var(--border-width) solid var(--border-default)",
+            borderRadius: "var(--radius-md)",
+            background: "var(--bg-card)",
+            padding: "var(--space-3) var(--space-4)",
+          }}
+        >
+          <div style={{ fontSize: "var(--font-size-sm)", fontWeight: "var(--font-weight-medium)", marginBottom: "var(--space-2)" }}>
+            Device disk
+          </div>
+          <div
+            style={{
+              height: 8,
+              borderRadius: 4,
+              background: "var(--bg-input)",
+              overflow: "hidden",
+              marginBottom: "var(--space-2)",
+            }}
+          >
+            <div
+              style={{
+                height: "100%",
+                width: `${Math.min(100, (device.usedBytes / device.totalBytes) * 100).toFixed(1)}%`,
+                background: "var(--fg-accent)",
+                borderRadius: 4,
+              }}
+            />
+          </div>
+          <div style={{ display: "flex", justifyContent: "space-between", fontSize: "var(--font-size-xs)", color: "var(--fg-muted)" }}>
+            <span>{formatBytes(device.usedBytes)} / {formatBytes(device.totalBytes)}</span>
+            <span>{formatBytes(device.availableBytes)} free</span>
+          </div>
+        </div>
+      )}
+
+      {/* Section header */}
+      <div style={{ borderBottom: "var(--border-width) solid var(--border-default)", paddingBottom: "var(--space-2)" }}>
+        <span style={{ fontSize: "var(--font-size-xs)", fontWeight: "var(--font-weight-medium)", textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--fg-muted)" }}>
+          Worktrees
+        </span>
+      </div>
+
+      {/* Controls bar */}
+      <div style={{ display: "flex", alignItems: "center", gap: "var(--space-3)", flexWrap: "wrap" }}>
+        <label style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", fontSize: "var(--font-size-sm)", cursor: "pointer" }}>
+          <input
+            type="checkbox"
+            checked={allChecked}
+            onChange={toggleSelectAll}
+            disabled={allDoneVisible.length === 0}
+          />
+          Select all
+        </label>
+
+        <label style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", fontSize: "var(--font-size-sm)" }}>
+          Sort:
+          <select
+            value={sort}
+            onChange={(e) => setSort(e.target.value as Sort)}
+            style={{ font: "inherit", fontSize: "var(--font-size-sm)", background: "var(--bg-input)", border: "var(--border-width) solid var(--border-default)", borderRadius: "var(--radius-sm)", padding: "2px var(--space-2)" }}
+          >
+            <option value="created">Creation date ↓</option>
+            <option value="disk">Disk usage ↓</option>
+          </select>
+        </label>
+
+        <label style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", fontSize: "var(--font-size-sm)" }}>
+          Show:
+          <select
+            value={filter}
+            onChange={(e) => { setFilter(e.target.value as Filter); setSelected(new Set()); }}
+            style={{ font: "inherit", fontSize: "var(--font-size-sm)", background: "var(--bg-input)", border: "var(--border-width) solid var(--border-default)", borderRadius: "var(--radius-sm)", padding: "2px var(--space-2)" }}
+          >
+            <option value="done">Done</option>
+            <option value="all">All</option>
+          </select>
+        </label>
+
+        <span style={{ marginLeft: "auto", fontSize: "var(--font-size-xs)", color: "var(--fg-muted)" }}>
+          {filter === "done"
+            ? `${doneCount} done worktree${doneCount !== 1 ? "s" : ""} · ${formatBytes(totalFilteredDisk)}`
+            : `${filtered.length} worktree${filtered.length !== 1 ? "s" : ""} · ${formatBytes(totalFilteredDisk)}`}
+        </span>
+      </div>
+
+      {deleteError && (
+        <div style={{ padding: "var(--space-2) var(--space-3)", background: "var(--bg-danger-subtle, var(--bg-input))", border: "var(--border-width) solid var(--border-danger, var(--border-default))", borderRadius: "var(--radius-sm)", fontSize: "var(--font-size-sm)", color: "var(--fg-danger)" }}>
+          {deleteError}
+        </div>
+      )}
+
+      {/* Worktree list */}
+      <div style={{ flex: 1, overflowY: "auto", minHeight: 0, display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+        {sorted.length === 0 && filter === "done" && (
+          <div style={{ padding: "var(--space-5)", textAlign: "center", color: "var(--fg-muted)", fontSize: "var(--font-size-sm)" }}>
+            {worktrees.length === 0
+              ? "No worktrees yet. Worktrees appear here once you spawn an agent."
+              : "No done worktrees. Switch to All to see active ones."}
+          </div>
+        )}
+        {sorted.length === 0 && filter === "all" && (
+          <div style={{ padding: "var(--space-5)", textAlign: "center", color: "var(--fg-muted)", fontSize: "var(--font-size-sm)" }}>
+            No worktrees yet. Worktrees appear here once you spawn an agent.
+          </div>
+        )}
+
+        {sorted.map((wt) => {
+          const done = doneMap[wt.id] ?? false;
+          const bytes = diskMap[wt.id] ?? 0;
+          const barPct = Math.min(100, (bytes / maxDisk) * 100);
+          const wtSessions = sessionsByWorktree[wt.id] ?? [];
+          const mainSession = wtSessions.find((s) => s.type === "agent") ?? wtSessions[0];
+          const status = mainSession ? sessionStatus(mainSession.state) : "none";
+
+          return (
+            <div
+              key={wt.id}
+              style={{
+                display: "grid",
+                gridTemplateColumns: "auto 1fr auto",
+                alignItems: "center",
+                gap: "var(--space-3)",
+                padding: "var(--space-3)",
+                border: "var(--border-width) solid var(--border-default)",
+                borderRadius: "var(--radius-md)",
+                background: "var(--bg-card)",
+                opacity: done ? 1 : 0.7,
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={selected.has(wt.id)}
+                onChange={() => toggleSelect(wt.id)}
+                disabled={!done}
+                title={done ? undefined : "Only done worktrees can be deleted"}
+              />
+
+              <div style={{ minWidth: 0 }}>
+                <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", marginBottom: "var(--space-1)" }}>
+                  <StatusDot status={status} />
+                  <span style={{ fontWeight: "var(--font-weight-medium)", fontSize: "var(--font-size-sm)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                    {wt.id} · {wt.branch}
+                  </span>
+                </div>
+                <div style={{ fontSize: "var(--font-size-xs)", color: "var(--fg-muted)", marginBottom: "var(--space-1)" }}>
+                  Created {new Date(wt.createdAt).toLocaleDateString()} · {wtSessions.length} session{wtSessions.length !== 1 ? "s" : ""}
+                </div>
+                <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)" }}>
+                  <div style={{ flex: 1, height: 4, borderRadius: 2, background: "var(--bg-input)", overflow: "hidden", maxWidth: 120 }}>
+                    <div style={{ height: "100%", width: `${barPct.toFixed(1)}%`, background: "var(--fg-accent)", borderRadius: 2 }} />
+                  </div>
+                  <span style={{ fontSize: "var(--font-size-xs)", color: "var(--fg-muted)", whiteSpace: "nowrap" }}>
+                    {formatBytes(bytes)}
+                  </span>
+                </div>
+              </div>
+
+              <button
+                type="button"
+                className="icon-btn"
+                disabled={!done}
+                title={done ? "Delete worktree" : "Only done worktrees can be deleted"}
+                onClick={() => setPendingDelete([wt])}
+                style={{ opacity: done ? 1 : 0.3, cursor: done ? "pointer" : "not-allowed" }}
+              >
+                ×
+              </button>
+            </div>
+          );
+        })}
+
+        {hiddenCount > 0 && filter === "done" && (
+          <div style={{ fontSize: "var(--font-size-xs)", color: "var(--fg-muted)", textAlign: "center", padding: "var(--space-2)" }}>
+            {hiddenCount} other{hiddenCount !== 1 ? "s" : ""} hidden by filter
+          </div>
+        )}
+      </div>
+
+      {/* Bulk delete footer */}
+      {selected.size > 0 && (
+        <div
+          style={{
+            borderTop: "var(--border-width) solid var(--border-default)",
+            paddingTop: "var(--space-3)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
+          <span style={{ fontSize: "var(--font-size-sm)", color: "var(--fg-muted)" }}>
+            {selected.size} selected ({formatBytes(selectedDisk)})
+          </span>
+          <button
+            type="button"
+            className="btn btn--danger"
+            onClick={() => setPendingDelete(selectedWorktrees)}
+          >
+            Delete selected
+          </button>
+        </div>
+      )}
+
+      {/* Confirm dialog */}
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        title={
+          pendingDelete && pendingDelete.length === 1
+            ? "Delete worktree?"
+            : `Delete ${pendingDelete?.length ?? 0} worktrees?`
+        }
+        message={
+          pendingDelete
+            ? [
+                "This will permanently remove:",
+                ...pendingDelete.map(
+                  (wt) => `• ${wt.branch} (${formatBytes(diskMap[wt.id] ?? 0)})`,
+                ),
+                "",
+                `Total freed: ${formatBytes(pendingDelete.reduce((s, wt) => s + (diskMap[wt.id] ?? 0), 0))}`,
+                "",
+                "This cannot be undone.",
+              ].join("\n")
+            : ""
+        }
+        confirmLabel={pendingDelete?.length === 1 ? "Delete worktree" : "Delete worktrees"}
+        onConfirm={() => {
+          if (pendingDelete) void handleDelete(pendingDelete);
+        }}
+        onCancel={() => { setPendingDelete(null); setDeleteError(null); }}
+      />
+    </div>
+  );
+}

--- a/web-ui/src/styles/workspace.css
+++ b/web-ui/src/styles/workspace.css
@@ -3404,19 +3404,6 @@ textarea.input {
   position: relative;
 }
 
-.dashboard-card-shell--dismissable:hover .dashboard-card__dismiss {
-  opacity: 1;
-}
-
-.dashboard-card__dismiss {
-  position: absolute;
-  top: var(--space-1);
-  right: var(--space-1);
-  z-index: 2;
-  opacity: 0;
-  transition: opacity var(--transition-fast);
-}
-
 .dashboard-card {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

- **Storage section** added to settings: per-worktree disk usage rows with filter (Done/All), sort (creation date/disk usage), multi-select, bulk delete, and a confirmation dialog showing space freed
- **Device disk bar** at top using `statfs` — shows used/total/available for the mount point
- **Done guard** on the daemon `DELETE /worktrees/:id` — returns `409 worktree_not_done` if any agent session isn't `done` or any terminal session isn't `done`/`exited`; prevents deleting live work
- **`GET /worktrees/disk-usage`** new daemon route with cross-platform `du` (macOS `-sk`, Linux `-sb`) for per-worktree sizes
- **Settings section-switcher** on desktop — replaced scroll-to-anchor with a side-nav pill that swaps the active section (same `activeTab` state already used by mobile tabs)
- **Removed "Dismiss (keep files)"** from DashboardPanel, LeftSidebar, and CSS — the option no longer has daemon support

## Test plan

- [ ] Open Settings → Storage; confirm device bar shows real filesystem stats
- [ ] Filter = Done (default): only done worktrees shown; checkboxes and × buttons enabled only for done rows
- [ ] Filter = All: active/error worktrees appear at 0.7 opacity with disabled controls
- [ ] Sort by Disk usage ↓ and Creation date ↓ reorder the list correctly
- [ ] Select 2+ done worktrees → bulk footer appears with correct count and total size
- [ ] Confirm dialog shows per-worktree breakdown with correct singular/plural button label
- [ ] Deleting a worktree refreshes the list
- [ ] Attempt to delete an active worktree via the API directly → 409 returned
- [ ] Settings desktop nav: clicking each section shows only that section (no scroll)
- [ ] "Dismiss (keep files)" option is absent from right-click menu and card header