### PR TITLE
fix(remote-access): mark current session and track lastSeenAt for all sessions

### DIFF
--- a/daemon/src/routes/mobileAuth.ts
+++ b/daemon/src/routes/mobileAuth.ts
@@ -296,13 +296,13 @@ export function registerMobileAuthRoutes(app: FastifyInstance, opts: MobileAuthO
     const currentNonce = parseSessionCookie(cookies[COOKIE_NAME] ?? "")?.nonce ?? null;
     const loopbackAddresses = new Set(["127.0.0.1", "::1", "::ffff:127.0.0.1"]);
     const isLoopback = loopbackAddresses.has(req.ip ?? "");
-    const sessions = sessionStore.list().map((row) => ({
-      ...row,
-      isCurrent:
+    const sessions = sessionStore.list().map((row) => {
+      const isCurrent =
         currentNonce !== null
           ? row.nonce === currentNonce
-          : isLoopback && loopbackAddresses.has(row.createdIp ?? ""),
-    }));
+          : isLoopback && loopbackAddresses.has(row.createdIp ?? "");
+      return { ...row, isCurrent };
+    });
     return reply.send({ sessions });
   });
 

--- a/daemon/src/server.ts
+++ b/daemon/src/server.ts
@@ -26,7 +26,7 @@ import {
   parseSessionCookie,
   generateSessionCookieWithNonce,
 } from "./auth.js";
-import { isLive, needsBump, bump } from "./state/auth-session-store.js";
+import { isLive, needsBump, bump, touchLastSeen } from "./state/auth-session-store.js";
 
 const here = dirname(fileURLToPath(import.meta.url));
 
@@ -167,6 +167,7 @@ export async function buildServer(opts: BuildServerOptions = {}) {
       if (!isLive(parsed.nonce)) return reply.status(401).send({ error: "Session expired or revoked." });
 
       // Sliding bump: re-issue cookie when lastSeenAt is >1 h ago to reset HMAC TTL clock.
+      // Must run before touchLastSeen — bump checks cache.lastSeenAt and touchLastSeen resets it.
       if (needsBump(parsed.nonce)) {
         bump(parsed.nonce);
         const newCookie = generateSessionCookieWithNonce(token, parsed.nonce);
@@ -176,6 +177,10 @@ export async function buildServer(opts: BuildServerOptions = {}) {
           : `HttpOnly; SameSite=Strict; Path=/; Max-Age=${SESSION_MAX_AGE_SECONDS}`;
         void reply.header("Set-Cookie", `${COOKIE_NAME}=${newCookie}; ${attrs}`);
       }
+
+      // Update lastSeenAt on every request (throttled to once per 5 min in the store).
+      // Runs after bump so needsBump's cache read is not clobbered by the touch.
+      touchLastSeen(parsed.nonce);
     });
   }
 

--- a/daemon/src/state/auth-session-store.ts
+++ b/daemon/src/state/auth-session-store.ts
@@ -77,6 +77,26 @@ export function needsBump(nonce: string): boolean {
   return Date.now() - cached.lastSeenAt > 60 * 60 * 1000;
 }
 
+const TOUCH_THROTTLE_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Update lastSeenAt only — does not touch expiry. Throttled to one DB write
+ * per TOUCH_THROTTLE_MS so every authenticated request can call this cheaply.
+ */
+export function touchLastSeen(nonce: string): void {
+  const now = Date.now();
+  const cached = cache.get(nonce);
+  if (cached && now - cached.lastSeenAt < TOUCH_THROTTLE_MS) return;
+  try {
+    getDb()
+      .prepare("UPDATE auth_sessions SET lastSeenAt=? WHERE nonce=?")
+      .run(String(now), nonce);
+    if (cached) cache.set(nonce, { ...cached, lastSeenAt: now });
+  } catch {
+    // best-effort
+  }
+}
+
 /** Slide the session expiry window forward and re-issue the HMAC clock. */
 export function bump(nonce: string): void {
   const now = Date.now();

--- a/web-ui/src/components/settings/RemoteAccessSetting.tsx
+++ b/web-ui/src/components/settings/RemoteAccessSetting.tsx
@@ -631,6 +631,19 @@ export function RemoteAccessSetting({ api }: RemoteAccessSettingProps) {
                       >
                         {session.createdVia === "qr" ? "QR" : "Password"}
                       </span>
+                      {session.isCurrent && (
+                        <span
+                          style={{
+                            fontSize: "var(--font-size-xs)",
+                            color: "var(--fg-muted)",
+                            background: "var(--bg-input)",
+                            borderRadius: "var(--radius-sm)",
+                            padding: "1px 6px",
+                          }}
+                        >
+                          this session
+                        </span>
+                      )}
                     </div>
                     <div style={{ fontSize: "var(--font-size-xs)", color: "var(--fg-muted)" }}>
                       Last seen {formatRelative(session.lastSeenAt)}


### PR DESCRIPTION
## Summary

- **"This session" chip** — connected-devices list in Remote Access settings now shows a muted `this session` badge alongside the QR/Password badge for the session the viewer is currently authenticated with (`session.isCurrent`).
- **Accurate last-seen for all sessions** — `lastSeenAt` was only written to the DB at the 1h session-expiry bump, so active sessions showed stale timestamps. Added `touchLastSeen()` to `auth-session-store`: updates only `lastSeenAt` (not expiry), throttled to one DB write per 5 min per session. Called from the auth middleware on every authenticated request, after the `needsBump`/`bump` block (ordering matters — touch resets `cache.lastSeenAt`, so it must not precede the bump check).

## Test plan

- [ ] Open Remote Access settings while logged in — your session should show a `this session` chip.
- [ ] `Last seen` for your session should read "just now" / recent time, not the creation timestamp.
- [ ] Other connected sessions (e.g. a mobile QR session) should also show refreshing last-seen times as they make requests.
- [ ] After ~1h idle, a session should still get its expiry bumped (bump check is not broken by the touch ordering fix).