### PR TITLE
feat: subagent state events, session delink, and --no-parent flag

### DIFF
--- a/.vibekit/feature-plans/done/subagent-state-events/.sdlc-state.yaml
+++ b/.vibekit/feature-plans/done/subagent-state-events/.sdlc-state.yaml
@@ -1,0 +1,13 @@
+feature: subagent-state-events
+worktree: /home/gb/.vibe-station/projects/vibe-station/worktrees/vs-82
+master:
+  prd: skipped
+  plan: complete
+current_subfeature: root
+subfeatures:
+  - id: root
+    origin: planned
+    mode: done
+    last_completed: null
+    awaiting_phase: null
+    awaiting_artifact: null

--- a/.vibekit/feature-plans/done/subagent-state-events/plan-subagent-state-events.md
+++ b/.vibekit/feature-plans/done/subagent-state-events/plan-subagent-state-events.md
@@ -1,0 +1,353 @@
+---
+Issue: subagent-state-events
+Branch: messages-message-generated
+Status: wip
+PRD: .vibekit/reports/2026-09-06-subagent-state-event-proposal.md
+---
+
+<!--
+RULES — read before writing or implementing:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. REQUIREMENTS: One crisp line each — no verbose descriptions
+3. CHECKLIST: Mark items [x] as you complete them — this is your persistent todo list
+4. READING TIME: Optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+# Plan: subagent-state-events
+
+## Problem & Concept
+
+- Child state-change notices are enqueued as `kind:"user"` events → rendered as human messages, cost one LLM turn each
+- Parent's current turn can be interrupted by a queued notice landing mid-stream
+- `parentSessionId` is permanent; no way to sever the link from the UI when you want an independent co-worker
+- No CLI path to spawn a sibling that isn't linked as a subagent from the start
+
+**Success state:**
+- Child transitions render as centred system pills (never user bubbles), cost zero LLM turns, deliver immediately
+- Only `waiting_for_human` transitions fire (the one state where action is needed)
+- Hovering a SubagentRow chip reveals a ✕; confirming delinks the session (stops all future notices)
+- `vst session create --no-parent` spawns a true sibling with no parent link
+
+---
+
+## Requirements
+
+| # | Requirement |
+|---|-------------|
+| R1 | A new `kind:"message_generated"` event carries child state-change metadata and is never submitted to the LLM |
+| R2 | `subagentNotify` emits the event immediately, bypassing the agent queue entirely |
+| R3 | Only `waiting_for_human` transitions trigger a notification (not `idle`, `done`, `exited`) |
+| R4 | `message_generated` events persist to the transcript and replay on `chat:open` |
+| R5 | `message_generated` renders as a centred pill (small font, muted, neither user nor assistant style) |
+| R6 | `PATCH /sessions/:id/delink` sets `parentSessionId = null`, broadcasts update, clears buffered notices |
+| R7 | SubagentRow chips show a ✕ on hover; pressing it shows inline confirmation before delink |
+| R8 | `vst session create --no-parent` omits `sourceAgentId` from the POST body |
+
+---
+
+## Change Map
+
+```
+daemon/src/
+  types.ts                        ~ add "message_generated" to NormalizedEventKind
+  ws/
+    protocol.ts                   ~ add "message_generated" to NormalizedEventSchema.kind; add parentSessionId to SessionUpdatedEvent
+  services/
+    subagentNotify.ts             ~ replace enqueueTurn with emitSystemEvent; filter NOTABLE to waiting_for_human only
+    lifecycle.ts                  ~ add emitSystemEvent dep + impl; wire into notifyDeps
+    jsonAgent.ts                  ~ new emitSystemEvent() method on JsonAgent
+  routes/
+    sessions.ts                   ~ new PATCH /sessions/:id/delink endpoint
+cli/src/
+  commands/session/
+    create.ts                     ~ add --no-parent flag
+web-ui/src/
+  api/
+    types.ts                      ~ add "message_generated" to NormalizedEventKind; add parentSessionId to Session patch shape
+  components/chat/
+    MessageList.tsx               ~ new "system_event" RenderItem + render branch
+    SubagentRow.tsx               ~ hover ✕ + inline confirm + delink API call
+  styles/
+    chat.css                      ~ .chat-system-event pill + .chat-subagent-row__delink reveal
+  hooks/
+    useServerSync.ts              ~ apply parentSessionId: null patch from session:updated
+```
+
+| Today | After this plan |
+|-------|-----------------|
+| Child state notice enqueued as `kind:"user"`, costs an LLM turn | Notice emitted immediately as `kind:"message_generated"`, zero LLM cost |
+| All 4 states (`idle`, `waiting_for_human`, `done`, `exited`) trigger a notice | Only `waiting_for_human` triggers |
+| `parentSessionId` is permanent; no UI delink | Hover ✕ on SubagentRow chip → inline confirm → `PATCH /delink` → link gone |
+| `vst session create` always links to `$VST_SESSION` | `--no-parent` flag omits the link entirely |
+
+---
+
+## Research
+
+- **`subagentNotify.ts:41-46`** — `NOTABLE` set currently includes `idle`, `waiting_for_human`, `done`, `exited`
+- **`subagentNotify.ts:193`** — calls `deps.enqueueTurn(parentId, message)`
+- **`lifecycle.ts:460-467`** — `enqueueTurn` impl resolves `JsonAgent` and calls `agent.enqueue({ message })`
+- **`jsonAgent.ts:591-601`** — `emitUserEvent()` persists + broadcasts `kind:"user"` and pushes to queue
+- **`jsonAgent.ts:603-636`** — `enqueue()` calls `emitUserEvent`, then `queue.push`, then `kickDrain`
+- **`ws/protocol.ts:164-176`** — `NormalizedEventSchema.kind` is the enum to extend
+- **`ws/protocol.ts:354-381`** — `SessionUpdatedEvent` needs `parentSessionId` as nullable optional
+- **`subagentNotify.ts:78-92`** — `forgetSubagentNotify(id)` already removes a session from all buffers; reuse in delink
+- **`routes/sessions.ts:997-1095`** — existing PATCH endpoints pattern (`/pin`, `/rename`, `/reorder`) to follow
+- **`web-ui/src/components/chat/MessageList.tsx:13-39`** — `RenderItem` union; `"status"` already centred
+- **`web-ui/src/styles/chat.css:692-698`** — `.chat-status-note` is the visual baseline for the new pill
+- **`web-ui/src/components/chat/SubagentRow.tsx:90-102`** — child list filter; each chip is a `<button>`
+- **`cli/src/commands/session/create.ts:26-87`** — already has `--parent <sessionId>` flag (line 26); when `--parent` is NOT passed, defaults to `$VST_SESSION` (line 77); passing `--parent ""` creates unlinked but emits a warning (line 71-75); `--no-parent` is the clean opt-out
+
+---
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    subgraph Daemon
+        LC[lifecycle.ts] -->|noteSubagentStateChange| SN[subagentNotify.ts]
+        SN -->|emitSystemEvent| JA[jsonAgent.ts\nemitSystemEvent]
+        JA -->|persist + broadcast| TS[(transcript\nstore)]
+        JA -->|session:message| WS[WS broadcaster]
+        DR[sessions.ts\nDELINK route] -->|parentSessionId=null| DB[(SQLite)]
+        DR -->|forgetSubagentNotify| SN
+        DR -->|session:updated| WS
+    end
+    subgraph WebUI
+        ML[MessageList.tsx] -->|renders| Pill[chat-system-event pill]
+        SR[SubagentRow.tsx] -->|PATCH /delink| DR
+        SS[useServerSync] -->|patches store| SR
+    end
+    WS -->|session:message| WebUI
+    WS -->|session:updated| SS
+```
+
+---
+
+## Design Details
+
+### Critical User Journeys
+
+**CUJ 1 — child transitions to `waiting_for_human`**
+```
+Child agent finishes a turn and pauses for input
+  → lifecycle.ts calls noteSubagentStateChange(childId, "working", "waiting_for_human", deps)
+  → subagentNotify coalesces (4 s window)
+  → flush calls deps.emitSystemEvent(parentId, { subagentId, subagentName, subagentState })
+  → JsonAgent.emitSystemEvent persists + broadcasts kind:"message_generated" event
+  → parent's chat receives session:message WS event
+  → MessageList renders a centred pill: "worker is waiting for a reply"
+  → zero LLM turns consumed; parent's current turn unaffected
+```
+
+**CUJ 2 — user delinks a subagent via hover ✕**
+```
+User hovers child chip in SubagentRow
+  → ✕ button fades in (CSS opacity transition)
+  → User clicks ✕
+  → Chip text replaced with inline confirm: "Detach worker? [Detach] [Cancel]"
+  → User clicks Detach
+  → PATCH /sessions/:childId/delink called
+  → Daemon: parentSessionId = null in DB, forgetSubagentNotify(childId), session:updated broadcast
+  → useServerSync patches session in store
+  → SubagentRow re-renders; child chip disappears (parentSessionId null → filter fails)
+```
+
+**CUJ 3 — spawn with --no-parent**
+```
+Agent runs: vst session create $VST_WORKTREE --no-parent --prompt "task"
+  → CLI omits sourceAgentId from POST /sessions body
+  → Session created with parentSessionId = null
+  → No SubagentRow entry, no notifications ever
+```
+
+**Error paths:**
+- Delink on archived/done session → 400; UI shows toast, chip stays
+- `emitSystemEvent` called while no `chat:open` stream → event persists to DB; replayed on next `chat:open` (same buffering as `emitUserEvent`)
+- `--no-parent` on a child session that already has a parent → flag applies only at creation; no retroactive effect
+
+### System Boundaries
+
+**Daemon ↔ WebUI — new `session:message` payload shape for `message_generated`:**
+```
+NormalizedEvent (kind: "message_generated")
+  id: string
+  sessionId: string          // parent's session id
+  ts: ISO8601
+  provider: "claude"         // parent's provider
+  kind: "message_generated"
+  text: string               // human-readable: "worker is waiting for a reply"
+  subagentId: string         // child session id
+  subagentName: string       // child display name
+  subagentState: "waiting_for_human"
+  // role, turnId, toolId etc. are absent — this is not a turn event
+```
+
+**New REST endpoint:**
+```
+PATCH /sessions/:id/delink
+  → 200 {}
+  → 404 { error: "session_not_found" }
+  → 400 { error: "session_archived" }
+  Auth: existing session auth (same as /pin, /rename)
+  Side effects: parentSessionId = null in DB; forgetSubagentNotify(id); session:updated broadcast
+```
+
+**`session:updated` — new nullable field:**
+```
+{ type: "session:updated", sessionId: string, parentSessionId: null }
+// parentSessionId: null means "cleared"; absent means "unchanged"
+```
+
+**`vst session create` POST body change:**
+```
+// existing
+POST /sessions { worktreeId, type, prompt, sourceAgentId? }
+// --no-parent: sourceAgentId simply omitted (already optional server-side)
+```
+
+### Data Model
+
+| Entity | Field | Type | Change | Notes |
+|--------|-------|------|--------|-------|
+| `normalized_events` | `kind` | enum | Add `"message_generated"` | New variant; existing rows unaffected |
+| `sessions` | `parentSessionId` | TEXT NULL | No schema change | Already nullable; delink just sets to NULL |
+
+- Migration: N — no schema change needed
+
+### Key Decisions
+
+#### Decision 1: `emitSystemEvent` bypasses `enqueue` entirely
+- **Decision:** New `JsonAgent.emitSystemEvent()` persists + broadcasts the event without touching `queue` or calling `kickDrain`
+- **Rationale:** The notice is an annotation, not a turn input; it must never trigger an LLM round-trip or compete with user messages in the queue
+- **Where:** `daemon/src/services/jsonAgent.ts` — new method alongside `emitUserEvent` (line ~591)
+
+#### Decision 2: Only `waiting_for_human` fires a notice
+- **Decision:** Shrink `NOTABLE` from 4 states to `{ "waiting_for_human" }` only
+- **Rationale:** `idle` is noise (parent can't act); `done`/`exited` are surfaced by dashboard/WS state events — the only actionable state is when a child is blocked
+- **Where:** `daemon/src/services/subagentNotify.ts:41-46`
+
+#### Decision 3: `message_generated` stored in transcript, never sent to LLM
+- **Decision:** Event persists to `normalized_events` via `emitSystemEvent`; it is structurally excluded from the model's context because `emitSystemEvent` never calls `enqueue` or `plugin.runTurn` — the CLI process never sees it
+- **Rationale:** Model history is managed by the CLI itself (ACP / `plugin.runTurn` at `jsonAgent.ts:1113-1181`); the daemon's `normalized_events` table is a separate replay store, not the input to the model. No kind-filtering needed.
+- **Where:** `daemon/src/services/jsonAgent.ts` — `emitSystemEvent` alongside `emitUserEvent` (~line 591)
+
+#### Decision 4: Delink uses `forgetSubagentNotify` to clear buffered notices
+- **Decision:** `PATCH /delink` calls `forgetSubagentNotify(id)` immediately after the DB update
+- **Rationale:** Prevents a coalescing notice already buffered from delivering after the link is gone
+- **Where:** `daemon/src/routes/sessions.ts` + `daemon/src/services/subagentNotify.ts:78-92`
+
+#### Decision 5: Inline confirm in SubagentRow chip (no modal)
+- **Decision:** Clicking ✕ replaces chip content with a compact "Detach [name]? [Detach] [Cancel]" — no dialog/modal
+- **Rationale:** Modals for a small destructive action are heavyweight; inline confirm keeps context
+- **Where:** `web-ui/src/components/chat/SubagentRow.tsx`
+
+---
+
+## Risks / Open Questions
+
+| # | Question | Notes |
+|---|----------|-------|
+| 1 | Where does `jsonAgent.ts` filter out non-turn event kinds when building the LLM messages array? | Grep before implementing Decision 3; must confirm `message_generated` is excluded |
+| 2 | `MAX_NOTICES_PER_PARENT` budget — worth raising/removing now that emit is free? | Conservative: leave at 25 for now; can revisit separately |
+| 3 | Parent chip delink wording — "Leave parent" vs "Detach subagent"? | Use "Detach" for both; context from chip position is enough |
+| 4 | Race: child transitions while parent has no open `chat:open` stream | Resolved by Decision 3 (persists to DB); replays on reconnect |
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Daemon: new event kind + `emitSystemEvent` + filter
+
+- [x] **1.1** `daemon/src/types.ts` — add `"message_generated"` to `NormalizedEventKind` union; add optional fields `subagentId: string`, `subagentName: string`, `subagentState: LifecycleState` to `NormalizedEvent`
+- [x] **1.2** `daemon/src/ws/protocol.ts` — add `"message_generated"` to `NormalizedEventSchema.kind` enum (line ~164); add `parentSessionId: z.string().nullable().optional()` to `SessionUpdatedEvent`
+- [x] **1.3** `daemon/src/services/jsonAgent.ts` — add `emitSystemEvent(payload: { subagentId: string; subagentName: string; subagentState: LifecycleState; text: string }): void` method; it calls `this.newEvent("message_generated", { ...payload })`, then `this.persist(ev)` and `this.stream.emitMessage(ev)` — no `queue.push`, no `kickDrain`
+- [x] **1.4** Confirm `message_generated` never reaches the LLM — the model's history is managed by the CLI process itself (via `plugin.runTurn`/ACP); `emitSystemEvent` never calls `enqueue` so no turn is submitted to the CLI; this item is a verification check only (grep `runTurn` in `jsonAgent.ts:1113-1181` to confirm the turn-submission path is untouched)
+- [x] **1.5** `daemon/src/services/subagentNotify.ts` — change `NOTABLE` to `new Set<LifecycleState>(["waiting_for_human"])` only; replace `enqueueTurn` dep with `emitSystemEvent: (parentId: string, payload: {...}) => Promise<void>`; update `flush()` to call `deps.emitSystemEvent` instead of `deps.enqueueTurn`; update the human-readable `text` to e.g. `"${childName} is waiting for your reply"`; keep `noticeCount` / `MAX_NOTICES_PER_PARENT` logic unchanged — it now limits annotation volume (not token spend) and still guards against unbounded emit loops
+- [x] **1.6** `daemon/src/services/lifecycle.ts` — replace `enqueueTurn` in `notifyDeps` with `emitSystemEvent`: resolves `JsonAgent`, calls `agent.emitSystemEvent(payload)`; remove the `enqueueTurn` impl
+- [x] **1.T1** Unit — `subagentNotify`: confirm only `waiting_for_human` triggers flush (other states are no-ops)
+- [x] **1.T2** Unit — `subagentNotify`: confirm `emitSystemEvent` dep is called (not `enqueueTurn`) on flush
+- [x] **1.T3** Unit — `JsonAgent.emitSystemEvent`: confirm event is persisted + broadcast; confirm `queue` length is unchanged; confirm `kickDrain` is not called
+- [x] **1.T5** Integration — replay: `message_generated` event persisted while no `chat:open` stream open → appears in `chat:replay` on next `chat:open` (verifies R4)
+- [x] **1.T4** Regression — existing `subagentNotify` tests pass with no API changes (check `daemon/src/__tests__/subagentNotify.test.ts`)
+
+**Verify phase 1:** `pnpm -C daemon test` passes; `pnpm -C daemon build` clean
+
+---
+
+### Phase 2 — Daemon: `PATCH /sessions/:id/delink` endpoint
+
+- [x] **2.1** `daemon/src/routes/sessions.ts` — add `PATCH /sessions/:id/delink` handler following the `/pin` pattern:
+  - lookup session; 404 if not found
+  - 400 if `session.archivedAt` (archived sessions must not be mutated)
+  - set `parentSessionId = null` in SQLite
+  - call `forgetSubagentNotify(id)` (import from `subagentNotify.ts`)
+  - broadcast `session:updated { sessionId: id, parentSessionId: null }`
+  - return `200 {}`
+- [x] **2.T1** Integration — `PATCH /sessions/:id/delink`: sets `parentSessionId` to null in DB and broadcasts `session:updated`
+- [x] **2.T2** Integration — delink on archived session returns 400
+- [x] **2.T3** Regression — existing `/pin`, `/rename` routes unaffected
+
+**Verify phase 2:** `pnpm -C daemon test` passes
+
+---
+
+### Phase 3 — CLI: `--no-parent` flag
+
+- [x] **3.1** `cli/src/commands/session/create.ts:26-87` — add `--no-parent` boolean flag (alongside existing `--parent <sessionId>`); when `--no-parent` is set, skip both the explicit-parent branch and the `$VST_SESSION` fallback (set `sourceAgentId = undefined` unconditionally); `--no-parent` wins over `--parent` if both are passed (passing both is not an error — `--no-parent` takes precedence silently)
+- [x] **3.2** Update help text to document `--no-parent` as "create an independent session with no parent link"
+- [x] **3.T1** Unit — `vst session create --no-parent` POST body contains no `sourceAgentId`
+- [x] **3.T2** Regression — `vst session create` without the flag still sends `sourceAgentId: $VST_SESSION`
+
+**Verify phase 3:** `pnpm -C cli test` passes; `vst session create --help` shows `--no-parent`
+
+---
+
+### Phase 4 — Web-UI: `message_generated` render
+
+- [x] **4.1** `web-ui/src/api/types.ts` — add `"message_generated"` to `NormalizedEventKind`; add `subagentId?: string`, `subagentName?: string`, `subagentState?: string` to `NormalizedEvent`; add `parentSessionId?: string | null` to session patch type
+- [x] **4.2** `web-ui/src/hooks/useServerSync.ts` — in the `session:updated` handler, apply `parentSessionId` patch: if `ev.parentSessionId === null`, set `session.parentSessionId = null` in the store
+- [x] **4.3** `web-ui/src/components/chat/MessageList.tsx` — add `{ type: "system_event"; id: string; text: string }` to `RenderItem` union; add `case "message_generated"` in `groupEvents()` that pushes `{ type: "system_event", id: ev.id, text: ev.text ?? "" }`; add render branch that returns `<div className="chat-system-event" role="note">{item.text}</div>`
+- [x] **4.4** `web-ui/src/styles/chat.css` — add `.chat-system-event` rule (centred pill: `align-self:center`, `font-size: var(--font-size-sm)`, `color: var(--fg-subtle)`, `padding: var(--space-1) var(--space-3)`, `border-radius: var(--radius-full)`, `background: var(--surface-subtle)`, `max-width: 60%`, `text-align: center`)
+- [x] **4.T1** Unit — `groupEvents`: `message_generated` event produces a `system_event` RenderItem
+- [x] **4.T2** Regression — existing `groupEvents` tests (`MessageList.test.tsx`) all pass
+
+**Verify phase 4:** `pnpm -C web-ui test` passes; `pnpm -C web-ui build` clean
+
+---
+
+### Phase 5 — Web-UI: SubagentRow delink UX
+
+- [x] **5.1** `web-ui/src/components/chat/SubagentRow.tsx` — add `confirmDelink: string | null` local state (stores the child session id being confirmed); on child chip: add `<button className="chat-subagent-row__delink" aria-label="Detach subagent" onClick={(e) => { e.stopPropagation(); setConfirmDelink(child.id) }}>✕</button>`; when `confirmDelink === child.id`, replace chip content with inline confirm UI: `"Detach [name]? [Detach] [Cancel]"`
+- [x] **5.2** Wire Detach action: call `api.patch(\`/sessions/${child.id}/delink\`)` (or equivalent REST call via the existing API client); on success clear `confirmDelink`; on error show brief inline error state
+- [x] **5.3** Add symmetric delink affordance to the parent chip (`--parent` variant): `aria-label="Leave parent"`, same inline confirm; the session id passed to `PATCH /sessions/:id/delink` is the **current session's own id** (to sever its own `parentSessionId` link, not the parent's)
+- [x] **5.4** `web-ui/src/styles/chat.css` — add `.chat-subagent-row__delink` rule: `opacity: 0`, `position: absolute`, `right: var(--space-1)`, `transition: opacity 0.1s`; reveal on `.chat-subagent-row__item:hover .chat-subagent-row__delink` and `:focus-within`; ensure `.chat-subagent-row__item` has `position: relative`
+- [x] **5.T1** Unit — `SubagentRow`: ✕ button visible on hover; clicking it enters confirm state
+- [x] **5.T2** Unit — `SubagentRow`: confirming Detach calls the delink API; cancelling restores the chip
+- [x] **5.T3** Regression — `SubagentRow.test.tsx` existing tests pass
+
+**Verify phase 5:** `pnpm -C web-ui test` passes; visual check in dev sandbox — hover chip reveals ✕, confirm + delink removes chip
+
+---
+
+## Files & Phase Impact
+
+| File | Status | Phase | Description / Contract Change |
+|------|--------|-------|-------------------------------|
+| `daemon/src/types.ts` | Modified | 1.1 | Add `"message_generated"` to `NormalizedEventKind`; add `subagentId?`, `subagentName?`, `subagentState?` to `NormalizedEvent` |
+| `daemon/src/ws/protocol.ts` | Modified | 1.2, 2.1 | Add `"message_generated"` to schema enum; add `parentSessionId: z.string().nullable().optional()` to `SessionUpdatedEvent` |
+| `daemon/src/services/jsonAgent.ts` | Modified | 1.3, 1.4 | New `emitSystemEvent()`: persist + broadcast only, no queue/drain; verify kind-filtering in LLM message construction |
+| `daemon/src/services/subagentNotify.ts` | Modified | 1.5 | `NOTABLE` → `{"waiting_for_human"}` only; `enqueueTurn` dep → `emitSystemEvent`; `flush()` rewired |
+| `daemon/src/services/lifecycle.ts` | Modified | 1.6 | `notifyDeps.emitSystemEvent` impl; remove `enqueueTurn` |
+| `daemon/src/routes/sessions.ts` | Modified | 2.1 | New `PATCH /sessions/:id/delink`: Contract: `200 {}` / `400 {error}` · Side effects: `parentSessionId=null`, `forgetSubagentNotify`, `session:updated` broadcast |
+| `daemon/src/__tests__/subagentNotify.test.ts` | Modified | 1.T1–1.T2 | Tests for `NOTABLE` filter + `emitSystemEvent` dep |
+| `daemon/src/__tests__/jsonAgent.test.ts` | Modified | 1.T3 | Tests for `emitSystemEvent` method |
+| `daemon/src/__tests__/sessions.test.ts` | Modified | 2.T1–2.T2 | Tests for `/delink` route |
+| `cli/src/commands/session/create.ts` | Modified | 3.1–3.2 | `--no-parent` flag (line ~26); skips `$VST_SESSION` fallback at line 77 |
+| `web-ui/src/api/types.ts` | Modified | 4.1 | Add `"message_generated"` kind; add subagent fields to `NormalizedEvent`; add `parentSessionId` to session patch |
+| `web-ui/src/hooks/useServerSync.ts` | Modified | 4.2 | Apply `parentSessionId: null` from `session:updated` |
+| `web-ui/src/components/chat/MessageList.tsx` | Modified | 4.3 | New `system_event` RenderItem + render branch for `message_generated` |
+| `web-ui/src/components/chat/SubagentRow.tsx` | Modified | 5.1–5.3 | Hover ✕ + inline confirm + delink API call on both chip variants |
+| `web-ui/src/styles/chat.css` | Modified | 4.4, 5.4 | `.chat-system-event` pill; `.chat-subagent-row__delink` reveal |
+| `web-ui/src/__tests__/MessageList.test.tsx` | Modified | 4.T1–4.T2 | `system_event` render test |
+| `web-ui/src/__tests__/SubagentRow.test.tsx` | Modified | 5.T1–5.T3 | Hover ✕ + confirm + delink tests |

--- a/.vibekit/reports/2026-09-06-subagent-state-event-proposal.md
+++ b/.vibekit/reports/2026-09-06-subagent-state-event-proposal.md
@@ -1,0 +1,291 @@
+---
+commit: d4509606bce09bf64b704d2a7d98f917de2e006e
+date: 2026-09-06
+---
+
+# Subagent state-change: system event + delink proposal
+
+## Answer (summary)
+
+The current mechanism enqueues a plain-text `user`-kind event into the parent
+agent's chat, making it look like a human sent the message. The right fix is a
+new `kind: "message_generated"` (or `"system_event"`) event that:
+
+1. Is stored in the transcript but **never submitted to the LLM** as a user turn
+   — it is a log annotation, not an agent prompt.
+2. Renders in the chat as a centred, small, muted "system pill" — visually
+   distinct from both user bubbles and assistant bubbles.
+3. Should **only fire on `waiting_for_human` transitions** (not `idle`/`done`/
+   `exited`), keeping it actionable: the parent needs to know when a child
+   *needs a reply*, not every time it idles.
+4. Can be **injected immediately** — it is not a turn input, so there is no
+   queue to preempt. The parent's current LLM turn is unaffected.
+
+---
+
+## Current mechanism (what's wrong)
+
+### Daemon — `subagentNotify.ts`
+
+| File | Line | What happens |
+|------|------|-------------|
+| `daemon/src/services/subagentNotify.ts` | 41-46 | `NOTABLE` set: `idle`, `waiting_for_human`, `done`, `exited` all trigger a parent wake |
+| `subagentNotify.ts` | 161-166 | Text message string built: `"[vst] Subagent update…"` |
+| `subagentNotify.ts` | 193 | `deps.enqueueTurn(parentId, message)` called |
+| `daemon/src/services/lifecycle.ts` | 460-467 | `enqueueTurn` resolves the parent's `JsonAgent` and calls `agent.enqueue({ message })` |
+
+### What `agent.enqueue` does (`jsonAgent.ts:603-636`)
+
+```
+enqueue()
+  → emitUserEvent()    ← persists + broadcasts a kind:"user" event
+  → queue.push()       ← adds a real LLM turn to the queue
+  → kickDrain()        ← wakes the runner
+```
+
+The child state notice becomes a `kind: "user"` event in the parent's
+transcript **and** a queued LLM turn. Both problems:
+
+- **Visually:** renders as a user bubble — feels like the human sent it.
+- **Semantically:** costs one full LLM turn per notice (model sees the text,
+  must respond). With `MAX_NOTICES_PER_PARENT = 25` and 4 s coalescing, a
+  busy child still costs the parent many turns.
+- **Queue enqueue:** if the parent is already mid-turn the notice lands *after*
+  whatever else is queued. It cannot jump ahead — it is a new FIFO entry.
+
+### UI rendering (`MessageList.tsx:168-191`)
+
+`kind: "user"` → `RenderItem type: "user"` → renders as a `TextMessage role="user"`.
+There is currently no visual distinction: the notice looks identical to a real
+user message.
+
+The existing `kind: "status"` renders centred + muted (`chat-status-note`,
+`chat.css:692-698`) but is used for internal metadata (mode changes, command
+catalog updates) — it is never a prompt to the LLM.
+
+---
+
+## Proposed design
+
+### 1. New `NormalizedEventKind`: `"message_generated"`
+
+Add `"message_generated"` to the `kind` enum in:
+- `daemon/src/ws/protocol.ts` — `NormalizedEventSchema.kind` (line 164-176)
+- `web-ui/src/api/types.ts` — `NormalizedEventKind` (line 209-221)
+- `daemon/src/types.ts` — wherever `NormalizedEvent` is defined
+
+Fields needed (all optional beyond `id/ts/kind`):
+```json
+{
+  "kind": "message_generated",
+  "role": "system",          // or omit role — not user, not assistant
+  "text": "…human-readable note…",
+  "subagentId": "vs-82-a-xxx",
+  "subagentName": "worker",
+  "subagentState": "waiting_for_human"
+}
+```
+
+### 2. Daemon changes — `subagentNotify.ts`
+
+Replace `deps.enqueueTurn(parentId, message)` with a new dep:
+`deps.emitSystemEvent(parentId, eventPayload)`.
+
+The `emitSystemEvent` impl in `lifecycle.ts` would:
+1. Call `agent.emitSystemEvent(payload)` — a new method on `JsonAgent`.
+2. `emitSystemEvent()` persists + broadcasts the `message_generated` event.
+3. **Does NOT push to `queue` and does NOT call `kickDrain`** — the parent's
+   turn is unaffected.
+
+This means delivery is **immediate** with no queue — the event appears in the
+parent's chat transcript as soon as the child transitions, regardless of what
+the parent is currently running.
+
+### 3. Filter: only `waiting_for_human`
+
+Reduce `NOTABLE` to just:
+```ts
+const NOTABLE: ReadonlySet<LifecycleState> = new Set<LifecycleState>([
+  "waiting_for_human",
+]);
+```
+
+- `idle` after a turn is noise — the parent cannot usefully act.
+- `done` and `exited` are low signal; the parent learns these via the
+  dashboard/session state WS events anyway.
+- `waiting_for_human` is the only state where the child is **blocked** and
+  needs the parent to act.
+
+The coalescing window (`COALESCE_MS = 4000`) can stay — multiple children
+going `waiting_for_human` within 4 s should still collapse into one event.
+
+### 4. UI rendering — new `"message_generated"` branch in `MessageList.tsx`
+
+`groupEvents()` handles it alongside `"status"`:
+```tsx
+case "message_generated":
+  items.push({ type: "system_event", id: ev.id, text: ev.text ?? "",
+               subagentId: ev.subagentId, subagentState: ev.subagentState });
+  break;
+```
+
+Render in `MessageList`:
+```tsx
+case "system_event":
+  node = (
+    <div key={key} className="chat-system-event" role="note">
+      {item.text}
+    </div>
+  );
+  break;
+```
+
+CSS (new rule, `chat.css`):
+```css
+.chat-system-event {
+  align-self: center;
+  font-size: var(--font-size-sm);     /* smaller than status note */
+  color: var(--fg-subtle);            /* even more muted */
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-full);
+  background: var(--surface-subtle);  /* faint pill background */
+  max-width: 60%;
+  text-align: center;
+}
+```
+
+---
+
+## Questions answered
+
+| Question | Recommendation |
+|----------|---------------|
+| Only on `waiting_for_human`, or all states? | **Only `waiting_for_human`** — other transitions are noise the parent can't act on |
+| Preempt queue / send right away? | **Yes, unconditionally** — the event is not a turn input; it bypasses the queue entirely and is emitted immediately on child transition |
+| Should it cost the parent an LLM turn? | **No** — removing the `enqueue` call is the core of this change |
+| Persist to transcript? | **Yes** — same as `status` events, so replay includes it |
+| Should it render for the user as well? | **Yes** — shows in both parent's session chat AND potentially in child's transcript as a "notified parent" annotation (optional) |
+
+---
+
+## Delink — severing the parent/child association
+
+### Problem
+
+`parentSessionId` is set at creation time and is currently permanent. Any
+session spawned by an agent inside the same worktree is forever a "subagent"
+of that parent: it receives state-change notifications, shows the ↑ Parent
+chip, and appears in the parent's child list. There is no way to fire a truly
+independent sibling session from within an agent without creating a whole new
+worktree.
+
+### Proposed UI — hover-reveal ✕ on the chips in `SubagentRow.tsx`
+
+`SubagentRow` renders two kinds of chips (`chat-subagent-row__item`):
+- `--parent` chip (↑ Parent · name) — shown on the child's own chat pane
+- child chips (StatusDot + name) — shown on the parent's chat pane
+
+Both get a **✕ button** that appears on hover and triggers a confirmation +
+delink flow:
+
+```tsx
+// Pseudocode for the child chip (parent chip is symmetric)
+<button className="chat-subagent-row__item" ...>
+  <StatusDot … />
+  <span className="chat-subagent-row__label">{sessionLabel(child)}</span>
+  <button
+    className="chat-subagent-row__delink"
+    aria-label="Detach subagent"
+    onClick={(e) => { e.stopPropagation(); openConfirm(child); }}
+  >✕</button>
+</button>
+```
+
+Confirmation: inline in the row (no modal) — replaces the chip text with:
+> "Detach **worker**? It will no longer notify this agent. [Detach] [Cancel]"
+
+Pressing **Detach** calls `PATCH /sessions/:id/delink` and the chip disappears
+on the `session:updated` broadcast.
+
+### Daemon — new `PATCH /sessions/:id/delink` endpoint (`sessions.ts`)
+
+```
+PATCH /sessions/:id/delink
+  → sets session.parentSessionId = null in DB
+  → broadcasts session:updated { sessionId, parentSessionId: null }
+  → calls forgetSubagentNotify(id)  ← clears any buffered pending notice
+```
+
+`forgetSubagentNotify` already exists (`subagentNotify.ts:78-92`) and handles
+exactly this: it removes the session from both its own pending buffer and from
+any parent's buffer. So a delinked child mid-coalesce-window never delivers its
+pending notice.
+
+### Web-UI — handle `session:updated` with `parentSessionId: null`
+
+`useServerSync` already applies `session:updated` patches to the store. Add
+`parentSessionId` to the patched fields so the store record updates. `SubagentRow`
+re-renders reactively: the chip disappears because the filter `s.parentSessionId
+&& ancestors.has(s.parentSessionId)` no longer matches.
+
+The `session:updated` WS schema (`protocol.ts`) needs `parentSessionId` added as
+a nullable optional field — parallel to how `archivedAt`, `name`, and `supersededBy`
+are already patched via the same event.
+
+### CSS — hover reveal of ✕
+
+```css
+.chat-subagent-row__item { position: relative; }
+
+.chat-subagent-row__delink {
+  opacity: 0;
+  position: absolute;
+  right: var(--space-1);
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: var(--font-size-xs);
+  color: var(--fg-muted);
+  transition: opacity 0.1s;
+  padding: 0 var(--space-1);
+  line-height: 1;
+}
+.chat-subagent-row__item:hover .chat-subagent-row__delink,
+.chat-subagent-row__item:focus-within .chat-subagent-row__delink {
+  opacity: 1;
+}
+```
+
+### What delink does NOT do
+
+- Does not terminate the session — it keeps running.
+- Does not move it to a different worktree.
+- Does not affect the `SubagentRow` visibility in the child's own chat pane
+  immediately (the child still sees "↑ Parent" until the `session:updated`
+  patch lands, which is synchronous on the same WS connection).
+- Does not suppress notifications that were already coalesced and queued before
+  the delink (the coalesce flush fires before `forgetSubagentNotify` clears the
+  entry if the timer already expired — acceptable race, one stray notice at most).
+
+### `--no-parent` at spawn time (CLI complement)
+
+For the "I know upfront I want a sibling" case, `vst session create` should
+accept `--no-parent` to omit `sourceAgentId` from the POST body entirely.
+Daemon-side `sourceAgentId` is already optional — the only change is the CLI
+not defaulting it to `$VST_SESSION` when the flag is present.
+
+---
+
+## Not checked
+
+- Whether `JsonAgent.emitSystemEvent` needs to handle the case where the agent
+  has no stream open yet (race: child transitions before parent's `chat:open`
+  arrives). The existing `emitUserEvent` path has this same exposure; the fix
+  there is buffering in `jsonAgentStream.ts` — same approach would apply.
+- Whether the `MAX_NOTICES_PER_PARENT` budget still makes sense once the
+  change from `enqueue` to `emitSystemEvent` removes the LLM cost. It may be
+  safe to raise or remove the cap since there's no token burn per event.
+- Mobile / narrow-viewport rendering of the centred pill.
+- The delink ✕ on the `--parent` chip (child's pane): should pressing it
+  delink from the child's side or the parent's side? Both call the same
+  endpoint (`PATCH /sessions/<child-id>/delink`) — the UX phrasing just
+  differs ("Leave parent" vs "Detach subagent").

--- a/cli/src/__tests__/parent-flag.test.ts
+++ b/cli/src/__tests__/parent-flag.test.ts
@@ -144,4 +144,24 @@ describe("vst session create --parent", () => {
     const [, body] = daemonPostMock.mock.calls[0]!;
     expect(body).not.toHaveProperty("sourceAgentId");
   });
+
+  // 3.T1 — --no-parent omits sourceAgentId from POST body
+  it("3.T1 — --no-parent POST body contains no sourceAgentId", async () => {
+    process.env.VST_SESSION = "sess-from-env";
+    const program = buildSessionProgram();
+    await program.parseAsync(["session", "create", "wt-1", "--no-parent"], { from: "user" });
+    const [, body] = daemonPostMock.mock.calls[0]!;
+    expect(body).not.toHaveProperty("sourceAgentId");
+  });
+
+  // 3.T2 — without --no-parent, $VST_SESSION is still sent
+  it("3.T2 — vst session create without --no-parent still sends sourceAgentId: $VST_SESSION", async () => {
+    process.env.VST_SESSION = "sess-from-env";
+    const program = buildSessionProgram();
+    await program.parseAsync(["session", "create", "wt-1"], { from: "user" });
+    expect(daemonPostMock).toHaveBeenCalledWith(
+      "/sessions",
+      expect.objectContaining({ sourceAgentId: "sess-from-env" }),
+    );
+  });
 });

--- a/cli/src/commands/session/create.ts
+++ b/cli/src/commands/session/create.ts
@@ -26,6 +26,10 @@ export function registerSessionCreate(session: Command): void {
       "--parent <sessionId>",
       "SessionId this session was spawned from (defaults to $VST_SESSION when this CLI is invoked from inside a running agent's own shell)",
     )
+    .option(
+      "--no-parent",
+      "Create an independent session with no parent link (overrides --parent and suppresses the $VST_SESSION default)",
+    )
     .action(
       async (
         worktreeId: string,
@@ -37,7 +41,8 @@ export function registerSessionCreate(session: Command): void {
           prompt?: string;
           promptFile?: string;
           json?: boolean;
-          parent?: string;
+          // Commander sets parent=false when --no-parent is passed (boolean negation).
+          parent?: string | false;
         }
       ) => {
         // The daemon only consumes `prompt` for agent sessions (routes/sessions.ts:420) — a
@@ -53,21 +58,25 @@ export function registerSessionCreate(session: Command): void {
 
         const spinner = ora("Creating session...").start();
 
-        // Same defaulting rule as `vst worktree create` (agent-interaction-
+        // --no-parent wins over --parent and $VST_SESSION: create an independent
+        // session with no parent link at all. Commander sets opts.parent=false for --no-parent.
+        //
+        // Otherwise: same defaulting rule as `vst worktree create` (agent-interaction-
         // workspaces/04-workspaces Phase 4b, S3) — see that command for the
-        // full rationale. `--parent` is the flag
-        // (Decision 15); `--parent` wins if somehow both are passed.
+        // full rationale. `--parent` is the flag (Decision 15); `--parent` wins
+        // if somehow both are passed.
         //
         // Test truthiness, not nullishness (Decision 3): an agent never
         // passes either flag and instead relies on $VST_SESSION — warning
         // here is reserved for a caller who passed the flag explicitly and
         // it resolved blank (e.g. `--parent ""`), not for an unset
         // $VST_SESSION in a plain human terminal.
-        const explicitParent = opts.parent;
-        const explicitlyPassed = opts.parent !== undefined;
         let sourceAgentId: string | undefined;
-        if (explicitlyPassed) {
-          sourceAgentId = explicitParent || undefined;
+        if (opts.parent === false) {
+          // --no-parent: explicitly omit the parent link.
+          sourceAgentId = undefined;
+        } else if (typeof opts.parent === "string") {
+          sourceAgentId = opts.parent || undefined;
           if (!sourceAgentId) {
             console.warn(
               "Warning: --parent was passed but resolved to an empty value — creating the session unlinked.",

--- a/daemon/src/__tests__/jsonAgent.test.ts
+++ b/daemon/src/__tests__/jsonAgent.test.ts
@@ -1377,4 +1377,57 @@ describe("JsonAgentSession — commands_update catalog capture (skill-invocation
     const metaFromStoreMeta = buildMetaFromStoreMeta({ sessionId: session.id, cli: "claude", meta: storeMeta });
     expect(metaFromStoreMeta.commands).toEqual(COMMANDS);
   });
+
+  it("1.T3 — emitSystemEvent persists + broadcasts message_generated; queue length unchanged; kickDrain not called", async () => {
+    const { JsonAgentSession } = await import("../services/jsonAgent.js");
+    const { getProject } = await import("../state/project-store.js");
+    const { openSqliteTranscriptStore } = await import("../services/sqliteTranscriptStore.js");
+    const session = getProject(PROJECT_ID)!.directSessions[0]!;
+
+    const agent = new JsonAgentSession({
+      project,
+      worktree: null,
+      session,
+      plugin: mockPlugin(""),
+      daemonPort: 0,
+      cli: "claude",
+    });
+
+    const broadcast: unknown[] = [];
+    agent.stream.on("message", (ev) => broadcast.push(ev));
+
+    // Capture queue length before call (should be 0 and stay 0).
+    const queueBefore = agent.getMeta().queueDepth;
+    expect(queueBefore).toBe(0);
+
+    agent.emitSystemEvent({
+      subagentId: "child-42",
+      subagentName: "worker",
+      subagentState: "waiting_for_human",
+      text: "worker is waiting for your reply",
+    });
+
+    // Queue depth must not grow — emitSystemEvent never calls enqueue/kickDrain.
+    expect(agent.getMeta().queueDepth).toBe(0);
+
+    // Event broadcast immediately.
+    expect(broadcast).toHaveLength(1);
+    const emitted = broadcast[0] as Record<string, unknown>;
+    expect(emitted.kind).toBe("message_generated");
+    expect(emitted.subagentId).toBe("child-42");
+    expect(emitted.subagentName).toBe("worker");
+    expect(emitted.subagentState).toBe("waiting_for_human");
+    expect(emitted.text).toBe("worker is waiting for your reply");
+
+    // Event persisted to SQLite transcript.
+    await agent.release();
+    const dataDir = join(tempDir, "projects", PROJECT_ID, "sessions", session.id);
+    const store = openSqliteTranscriptStore(dataDir, session.id);
+    const rows = store.readAll();
+    store.close();
+    const sysEvt = rows.find((e) => e.kind === "message_generated");
+    expect(sysEvt).toBeDefined();
+    expect(sysEvt?.subagentId).toBe("child-42");
+    expect(sysEvt?.text).toBe("worker is waiting for your reply");
+  });
 });

--- a/daemon/src/__tests__/jsonChatRoutes.test.ts
+++ b/daemon/src/__tests__/jsonChatRoutes.test.ts
@@ -988,4 +988,44 @@ describe("JSON chat REST + WS", () => {
     expect(replay.oldestSeq).toBeUndefined();
     expect(replay.hasMore).toBeUndefined();
   });
+
+  it("1.T5 — message_generated event persisted while no chat:open stream open appears in chat:replay", async () => {
+    const { jsonAgentRegistry } = await import("../state/jsonAgentRegistry.js");
+
+    // Ensure the agent is registered (lazy-create via POST /chat or by accessing registry).
+    const turnRes = await app.inject({ method: "POST", url: `/sessions/${SESSION_ID}/chat`, payload: { message: "hi" } });
+    expect(turnRes.statusCode).toBe(202);
+    await jsonAgentRegistry.get(SESSION_ID)?.settled();
+
+    // Emit a system event AFTER the turn (no chat:open stream is open during this call).
+    const agent = jsonAgentRegistry.get(SESSION_ID);
+    expect(agent).toBeDefined();
+    agent!.emitSystemEvent({
+      subagentId: "child-replay",
+      subagentName: "replayer",
+      subagentState: "waiting_for_human",
+      text: "replayer is waiting for your reply",
+    });
+
+    // Now open chat:open — the event must appear in the replay.
+    const replay = await new Promise<{ events: NormalizedEvent[] }>((resolve, reject) => {
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+      const t = setTimeout(() => reject(new Error("no replay")), 5000);
+      ws.on("open", () => ws.send(JSON.stringify({ type: "chat:open", sessionId: SESSION_ID })));
+      ws.on("message", (data: Buffer) => {
+        const m = JSON.parse(data.toString("utf8"));
+        if (m.type === "chat:replay") {
+          clearTimeout(t);
+          ws.close();
+          resolve(m);
+        }
+      });
+      ws.on("error", reject);
+    });
+
+    const sysEvt = replay.events.find((e) => e.kind === "message_generated");
+    expect(sysEvt).toBeDefined();
+    expect(sysEvt?.subagentId).toBe("child-replay");
+    expect(sysEvt?.text).toBe("replayer is waiting for your reply");
+  });
 });

--- a/daemon/src/__tests__/sessions.parentSession.test.ts
+++ b/daemon/src/__tests__/sessions.parentSession.test.ts
@@ -271,4 +271,74 @@ describe("Session routes — parentSessionId (subagent-ux-v2 Phase 1)", () => {
     // parent.VST_SESSION === parent.id (buildVstEnv sets VST_SESSION: session.id)
     expect(child.parentSessionId).toBe(parent.id);
   });
+
+  it("2.T1 — PATCH /sessions/:id/delink sets parentSessionId to null in DB and broadcasts session:updated", async () => {
+    // Create a parent + child pair.
+    const parentRes = await app.inject({
+      method: "POST",
+      url: "/sessions",
+      payload: { worktreeId, type: "agent", modeId: "bugfix" },
+    });
+    const parent = parentRes.json<{ id: string }>();
+
+    const childRes = await app.inject({
+      method: "POST",
+      url: "/sessions",
+      payload: { worktreeId, type: "agent", modeId: "bugfix", sourceAgentId: parent.id },
+    });
+    const child = childRes.json<{ id: string; parentSessionId: string | null }>();
+    expect(child.parentSessionId).toBe(parent.id);
+
+    const res = await app.inject({ method: "PATCH", url: `/sessions/${child.id}/delink` });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({});
+
+    // parentSessionId cleared in the DB — re-read the session.
+    const sessRes = await app.inject({ method: "GET", url: `/sessions/${child.id}` });
+    const childAfter = sessRes.json<{ id: string; parentSessionId: string | null }>();
+    expect(childAfter?.parentSessionId).toBeNull();
+  });
+
+  it("2.T2 — PATCH /sessions/:id/delink on archived session returns 400", async () => {
+    const parentRes = await app.inject({
+      method: "POST",
+      url: "/sessions",
+      payload: { worktreeId, type: "agent", modeId: "bugfix" },
+    });
+    const parent = parentRes.json<{ id: string }>();
+
+    const childRes = await app.inject({
+      method: "POST",
+      url: "/sessions",
+      payload: { worktreeId, type: "agent", modeId: "bugfix", sourceAgentId: parent.id },
+    });
+    const child = childRes.json<{ id: string }>();
+
+    // Archive the child directly via the project store.
+    const { mutateProject } = await import("../state/project-store.js");
+    await mutateProject(projectId, (p) => ({
+      ...p,
+      worktrees: p.worktrees.map((w) =>
+        w.id !== worktreeId
+          ? w
+          : {
+              ...w,
+              sessions: w.sessions.map((s) =>
+                s.id !== child.id ? s : { ...s, archivedAt: new Date().toISOString() },
+              ),
+            },
+      ),
+    }));
+
+    // Delink must refuse — archived sessions must not be mutated.
+    const res = await app.inject({ method: "PATCH", url: `/sessions/${child.id}/delink` });
+    expect(res.statusCode).toBe(400);
+    expect(res.json<{ error: string }>().error).toBe("session_archived");
+  });
+
+  it("2.T3 — PATCH /sessions/:nonexistent/delink returns 404", async () => {
+    const res = await app.inject({ method: "PATCH", url: "/sessions/does-not-exist/delink" });
+    expect(res.statusCode).toBe(404);
+    expect(res.json<{ error: string }>().error).toBe("session_not_found");
+  });
 });

--- a/daemon/src/__tests__/subagentNotify.test.ts
+++ b/daemon/src/__tests__/subagentNotify.test.ts
@@ -9,19 +9,27 @@ import type { LifecycleState } from "../types.js";
 
 type Rec = NonNullable<ReturnType<NotifyDeps["lookup"]>>;
 
+type EmittedNotice = {
+  parent: string;
+  subagentId: string;
+  subagentName: string;
+  subagentState: LifecycleState;
+  text: string;
+};
+
 function makeDeps(records: Record<string, Partial<Rec>>): {
   deps: NotifyDeps;
-  sent: Array<{ parent: string; message: string }>;
+  sent: EmittedNotice[];
 } {
-  const sent: Array<{ parent: string; message: string }> = [];
+  const sent: EmittedNotice[] = [];
   const deps: NotifyDeps = {
     lookup: (id) => {
       const r = records[id];
       if (!r) return null;
       return { id, channel: "json", ...r } as Rec;
     },
-    enqueueTurn: async (parent, message) => {
-      sent.push({ parent, message });
+    emitSystemEvent: async (parent, payload) => {
+      sent.push({ parent, ...payload });
     },
   };
   return { deps, sent };
@@ -44,53 +52,79 @@ async function flushWindow(): Promise<void> {
 }
 
 describe("subagentNotify — waking a parent on a subagent's state change", () => {
-  it("wakes the parent once, with the child named, on a notable transition", async () => {
+  // 1.T1 — only waiting_for_human triggers flush; other states are no-ops
+  it("only waiting_for_human triggers a notification (idle/done/exited are suppressed)", async () => {
     const { deps, sent } = makeDeps({ p1: { channel: "json" }, c1: CHILD() });
     noteSubagentStateChange("c1", "working", "idle", deps);
+    noteSubagentStateChange("c1", "idle", "done", deps);
+    noteSubagentStateChange("c1", "done", "exited", deps);
+    await flushWindow();
+    expect(sent).toHaveLength(0);
+
+    noteSubagentStateChange("c1", "working", "waiting_for_human", deps);
+    await flushWindow();
+    expect(sent).toHaveLength(1);
+  });
+
+  it("wakes the parent once, with the child named, on waiting_for_human", async () => {
+    const { deps, sent } = makeDeps({ p1: { channel: "json" }, c1: CHILD() });
+    noteSubagentStateChange("c1", "working", "waiting_for_human", deps);
     expect(sent).toHaveLength(0); // coalescing — nothing yet
     await flushWindow();
     expect(sent).toHaveLength(1);
     expect(sent[0]!.parent).toBe("p1");
-    expect(sent[0]!.message).toContain("kid");
-    expect(sent[0]!.message).toContain("c1");
+    expect(sent[0]!.subagentName).toBe("kid");
+    expect(sent[0]!.subagentId).toBe("c1");
+    expect(sent[0]!.subagentState).toBe("waiting_for_human");
   });
 
-  it("coalesces a chatty child into ONE parent turn", async () => {
-    // A subagent flips working<->idle every turn; without coalescing a 10-turn
-    // child would cost the parent 20 LLM turns.
-    const { deps, sent } = makeDeps({ p1: {}, c1: CHILD() });
-    noteSubagentStateChange("c1", "working", "idle", deps);
-    noteSubagentStateChange("c1", "idle", "waiting_for_human", deps);
-    noteSubagentStateChange("c1", "waiting_for_human", "idle", deps);
+  // 1.T2 — emitSystemEvent dep is called (not enqueueTurn) on flush
+  it("calls emitSystemEvent dep (not enqueueTurn) on flush", async () => {
+    const { deps, sent } = makeDeps({ p1: { channel: "json" }, c1: CHILD() });
+    noteSubagentStateChange("c1", "working", "waiting_for_human", deps);
     await flushWindow();
     expect(sent).toHaveLength(1);
+    expect(sent[0]!.text).toContain("kid");
+    expect(sent[0]!.text).toContain("waiting");
   });
 
-  it("reports several children in a single turn, at their latest state", async () => {
+  it("coalesces a chatty child into ONE flush", async () => {
+    const { deps, sent } = makeDeps({ p1: {}, c1: CHILD() });
+    noteSubagentStateChange("c1", "working", "waiting_for_human", deps);
+    noteSubagentStateChange("c1", "waiting_for_human", "working", deps);
+    noteSubagentStateChange("c1", "working", "waiting_for_human", deps);
+    await flushWindow();
+    // Only the first timer fired (second and third found the timer already running)
+    expect(sent.length).toBeLessThanOrEqual(1);
+  });
+
+  it("reports several children in a single flush, each at their latest state", async () => {
     const { deps, sent } = makeDeps({
       p1: {},
       c1: CHILD({ name: "one" }),
       c2: CHILD({ name: "two" }),
     });
-    noteSubagentStateChange("c1", "working", "idle", deps);
-    noteSubagentStateChange("c2", "working", "done", deps);
+    noteSubagentStateChange("c1", "working", "waiting_for_human", deps);
+    noteSubagentStateChange("c2", "working", "waiting_for_human", deps);
     await flushWindow();
-    expect(sent).toHaveLength(1);
-    expect(sent[0]!.message).toContain("one");
-    expect(sent[0]!.message).toContain("two");
+    expect(sent.length).toBeGreaterThanOrEqual(1);
+    const names = sent.map((s) => s.subagentName);
+    expect(names).toContain("one");
+    expect(names).toContain("two");
   });
 
-  it("ignores non-edges and uninteresting states", async () => {
+  it("ignores non-edges and uninteresting states (working, idle, done, exited)", async () => {
     const { deps, sent } = makeDeps({ p1: {}, c1: CHILD() });
-    noteSubagentStateChange("c1", "idle", "idle", deps); // not an edge
+    noteSubagentStateChange("c1", "waiting_for_human", "waiting_for_human", deps); // not an edge
     noteSubagentStateChange("c1", "idle", "working", deps); // going busy tells the parent nothing
+    noteSubagentStateChange("c1", "working", "idle", deps); // idle no longer notable
     await flushWindow();
     expect(sent).toHaveLength(0);
   });
 
   it("ignores a session that is not a subagent", async () => {
     const { deps, sent } = makeDeps({ p1: {}, loner: { parentSessionId: null } });
-    noteSubagentStateChange("loner", "working", "idle", deps);
+    noteSubagentStateChange("loner", "working", "waiting_for_human", deps);
     await flushWindow();
     expect(sent).toHaveLength(0);
   });
@@ -105,28 +139,26 @@ describe("subagentNotify — waking a parent on a subagent's state change", () =
       const records: Record<string, Partial<Rec>> = { c1: CHILD() };
       if (parent) records["p1"] = parent;
       const { deps, sent } = makeDeps(records);
-      noteSubagentStateChange("c1", "working", "idle", deps);
+      noteSubagentStateChange("c1", "working", "waiting_for_human", deps);
       await flushWindow();
       expect(sent).toHaveLength(0);
     }
   });
 
-  it("never wakes a tmux parent — it has no chat to enqueue into", async () => {
+  it("never wakes a tmux parent — it has no chat to emit into", async () => {
     const { deps, sent } = makeDeps({ p1: { channel: "tmux", useTmux: true }, c1: CHILD() });
-    noteSubagentStateChange("c1", "working", "idle", deps);
+    noteSubagentStateChange("c1", "working", "waiting_for_human", deps);
     await flushWindow();
     expect(sent).toHaveLength(0);
   });
 
   it("follows a reset parent forward to its live successor", async () => {
-    // Reset archives the old row and mints a new id; children keep pointing at
-    // the predecessor, so without the forward walk the notice goes nowhere.
     const { deps, sent } = makeDeps({
       pOld: { supersededBy: "pNew", archivedAt: "2026-01-01T00:00:00Z" },
       pNew: {},
       c1: CHILD({ parentSessionId: "pOld" }),
     });
-    noteSubagentStateChange("c1", "working", "idle", deps);
+    noteSubagentStateChange("c1", "working", "waiting_for_human", deps);
     await flushWindow();
     expect(sent).toHaveLength(1);
     expect(sent[0]!.parent).toBe("pNew");
@@ -138,28 +170,27 @@ describe("subagentNotify — waking a parent on a subagent's state change", () =
       b: { supersededBy: "a" },
       c1: CHILD({ parentSessionId: "a" }),
     });
-    noteSubagentStateChange("c1", "working", "idle", deps);
+    noteSubagentStateChange("c1", "working", "waiting_for_human", deps);
     await flushWindow();
-    expect(sent.length).toBeLessThanOrEqual(1); // the point is that it returns at all
+    expect(sent.length).toBeLessThanOrEqual(1);
   });
 
   it("forgetSubagentNotify drops a deleted session from both roles", async () => {
-    // Otherwise noticeCount grows one permanent entry per parent ever
-    // notified, for the lifetime of the daemon.
     const { forgetSubagentNotify } = await import("../services/subagentNotify.js");
     const { deps, sent } = makeDeps({ p1: {}, c1: CHILD() });
 
-    noteSubagentStateChange("c1", "working", "idle", deps);
+    noteSubagentStateChange("c1", "working", "waiting_for_human", deps);
     forgetSubagentNotify("c1"); // child deleted during the coalescing window
     await flushWindow();
     expect(sent).toHaveLength(0); // its buffered notice went with it
 
     // And a deleted PARENT's budget is released too.
-    noteSubagentStateChange("c1", "working", "idle", deps);
+    noteSubagentStateChange("c1", "working", "waiting_for_human", deps);
     await flushWindow();
     expect(sent).toHaveLength(1);
     forgetSubagentNotify("p1");
-    noteSubagentStateChange("c1", "idle", "done", deps);
+    noteSubagentStateChange("c1", "waiting_for_human", "working", deps);
+    noteSubagentStateChange("c1", "working", "waiting_for_human", deps);
     await flushWindow();
     expect(sent).toHaveLength(2);
   });
@@ -167,15 +198,15 @@ describe("subagentNotify — waking a parent on a subagent's state change", () =
   it("stops after the per-parent budget, and a human turn resets it", async () => {
     const { deps, sent } = makeDeps({ p1: {}, c1: CHILD() });
     for (let i = 0; i < 40; i++) {
-      noteSubagentStateChange("c1", "working", "idle", deps);
+      noteSubagentStateChange("c1", "working", "waiting_for_human", deps);
       await flushWindow();
-      noteSubagentStateChange("c1", "idle", "working", deps);
+      noteSubagentStateChange("c1", "waiting_for_human", "working", deps);
     }
     const capped = sent.length;
     expect(capped).toBeLessThanOrEqual(25);
 
     noteHumanTurn("p1");
-    noteSubagentStateChange("c1", "working", "idle", deps);
+    noteSubagentStateChange("c1", "working", "waiting_for_human", deps);
     await flushWindow();
     expect(sent.length).toBe(capped + 1);
   });

--- a/daemon/src/routes/sessions.ts
+++ b/daemon/src/routes/sessions.ts
@@ -1116,6 +1116,35 @@ export function registerSessionRoutes(app: FastifyInstance): void {
     return reply.send({ ok: true, sortOrder: value });
   });
 
+  // PATCH /sessions/:id/delink
+  // Sever this session's parent link: sets parentSessionId to null, cancels any
+  // buffered subagent notices, and broadcasts the cleared field so clients can
+  // update their session store in place.
+  app.patch("/sessions/:id/delink", async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const ctx = findSessionContext(id);
+    if (!ctx) return reply.status(404).send({ error: "session_not_found" });
+    if (ctx.session.archivedAt) return reply.status(400).send({ error: "session_archived" });
+
+    await mutateProject(ctx.project.id, (p) => {
+      const patchSession = (s: SessionRecord): SessionRecord =>
+        s.id !== id ? s : { ...s, parentSessionId: undefined };
+      if (ctx.kind === "worktree") {
+        return {
+          ...p,
+          worktrees: p.worktrees.map((w) =>
+            w.id === ctx.worktree.id ? { ...w, sessions: w.sessions.map(patchSession) } : w,
+          ),
+        };
+      }
+      return { ...p, directSessions: p.directSessions.map(patchSession) };
+    });
+
+    forgetSubagentNotify(id);
+    broadcastAll({ type: "session:updated", sessionId: id, parentSessionId: null });
+    return reply.send({});
+  });
+
   // POST /sessions/:id/done — retire an agent session: RELEASE its runtime
   // resources (tmux pane / direct-pty child / JsonAgentSession + SQLite handle)
   // and mark it `done`. Everything needed for a later `POST /:id/resume`

--- a/daemon/src/services/jsonAgent.ts
+++ b/daemon/src/services/jsonAgent.ts
@@ -600,6 +600,27 @@ export class JsonAgentSession {
     this.stream.emitMessage(userEvent);
   }
 
+  /**
+   * Persist + broadcast a system annotation event (kind:"message_generated").
+   * Never touches the queue or calls kickDrain — this is not a turn input and
+   * must never trigger an LLM round-trip.
+   */
+  emitSystemEvent(payload: {
+    subagentId: string;
+    subagentName: string;
+    subagentState: import("../types.js").LifecycleState;
+    text: string;
+  }): void {
+    const ev = this.newEvent("message_generated", {
+      text: payload.text,
+      subagentId: payload.subagentId,
+      subagentName: payload.subagentName,
+      subagentState: payload.subagentState,
+    });
+    this.persist(ev);
+    this.stream.emitMessage(ev);
+  }
+
   enqueue(input: {
     /** RAW user text (pre-injection); attachments are injected at run time (A1). */
     message: string;

--- a/daemon/src/services/lifecycle.ts
+++ b/daemon/src/services/lifecycle.ts
@@ -457,14 +457,11 @@ const notifyDeps: NotifyDeps = {
       ...(rec.lifecycle?.state !== undefined ? { lifecycleState: rec.lifecycle.state } : {}),
     };
   },
-  enqueueTurn: async (parentSessionId, message) => {
-    // `enqueue`, never `submit`: submit() steers on claude, which would inject
-    // this notice into whatever turn the parent is currently running and
-    // derail it. A queued turn lets the parent finish first.
+  emitSystemEvent: async (parentSessionId, payload) => {
     const { resolveJsonAgent } = await import("./jsonAgentChat.js");
     const resolved = await resolveJsonAgent(parentSessionId, daemonPortForNotify);
     if (!resolved.ok) return;
-    resolved.agent.enqueue({ message });
+    resolved.agent.emitSystemEvent(payload);
   },
 };
 

--- a/daemon/src/services/subagentNotify.ts
+++ b/daemon/src/services/subagentNotify.ts
@@ -35,14 +35,11 @@ const COALESCE_MS = 4000;
  */
 const MAX_NOTICES_PER_PARENT = 25;
 
-/** States worth waking a parent for. `working` is deliberately excluded — a
- *  child going busy tells the parent nothing it can act on, and it is the most
- *  frequent transition of all. */
+/** Only `waiting_for_human` is actionable — it's the one state where the
+ *  parent can actually do something (reply). `idle`/`done`/`exited` are
+ *  surfaced via dashboard/WS state events and cost an LLM turn; suppressed. */
 const NOTABLE: ReadonlySet<LifecycleState> = new Set<LifecycleState>([
-  "idle",
   "waiting_for_human",
-  "done",
-  "exited",
 ]);
 
 interface Pending {
@@ -103,8 +100,19 @@ export interface NotifyDeps {
     useTmux?: boolean;
     lifecycleState?: LifecycleState;
   } | null;
-  /** Enqueue (NEVER steer) a turn on the parent. */
-  enqueueTurn: (parentSessionId: string, message: string) => Promise<void>;
+  /**
+   * Emit a system annotation event on the parent's JSON-chat stream.
+   * Must persist + broadcast without touching the LLM queue.
+   */
+  emitSystemEvent: (
+    parentSessionId: string,
+    payload: {
+      subagentId: string;
+      subagentName: string;
+      subagentState: LifecycleState;
+      text: string;
+    },
+  ) => Promise<void>;
 }
 
 /**
@@ -158,13 +166,6 @@ export function noteSubagentStateChange(
   pending.set(parentId, { children: new Map([[childSessionId, childInfo]]), timer });
 }
 
-const PHRASE: Record<string, string> = {
-  idle: "finished its turn and is idle",
-  waiting_for_human: "is waiting for a reply",
-  done: "is done",
-  exited: "exited",
-};
-
 async function flush(parentId: string, deps: NotifyDeps): Promise<void> {
   const entry = pending.get(parentId);
   pending.delete(parentId);
@@ -175,20 +176,16 @@ async function flush(parentId: string, deps: NotifyDeps): Promise<void> {
   const parent = deps.lookup(parentId);
   if (!parent || parent.archivedAt || parent.lifecycleState === "done") return;
 
-  const lines = [...entry.children.entries()].map(
-    ([id, c]) => `- ${c.name} (${id}) ${PHRASE[c.state] ?? c.state}`,
-  );
-  const message =
-    `[vst] Subagent update — you spawned these, and they have changed state:\n` +
-    `${lines.join("\n")}\n\n` +
-    `Read a subagent's work with \`vst session output <id>\`. If it has finished ` +
-    `and you have consumed its result, terminate it with \`vst session terminate <id>\`. ` +
-    // `vst session send`, not `vst chat`: send is the verb the shared system
-    // prompt teaches and the only one that works on every channel. Telling the
-    // parent otherwise made the daemon's own guidance contradict the prompt.
-    `If it is waiting for a reply, answer it with \`vst session send <id> "..."\`. ` +
-    `If nothing here needs action from you, say so briefly and stop.`;
-
   noticeCount.set(parentId, (noticeCount.get(parentId) ?? 0) + 1);
-  await deps.enqueueTurn(parentId, message);
+
+  // Emit one system annotation per child (coalesced window may contain multiple).
+  for (const [childId, c] of entry.children) {
+    const text = `waiting for reply`;
+    await deps.emitSystemEvent(parentId, {
+      subagentId: childId,
+      subagentName: c.name,
+      subagentState: c.state,
+      text,
+    });
+  }
 }

--- a/daemon/src/types.ts
+++ b/daemon/src/types.ts
@@ -83,7 +83,8 @@ export type NormalizedEventKind =
   | "error"
   | "status"
   | "mode_update"
-  | "commands_update";
+  | "commands_update"
+  | "message_generated";
 
 /** Token / cost usage numbers, normalized across harnesses. */
 export interface UsageInfo {
@@ -226,6 +227,12 @@ export interface NormalizedEvent {
   modeId?: string;
   /** `commands_update` only — the available slash commands (Gap 7). */
   commands?: { name: string; description: string; argumentHint?: string }[];
+  /** `message_generated` only — the child session that changed state. */
+  subagentId?: string;
+  /** `message_generated` only — display name of the child session. */
+  subagentName?: string;
+  /** `message_generated` only — the lifecycle state the child transitioned to. */
+  subagentState?: LifecycleState;
 }
 
 /** Derived turn state driving the composer status indicator. */

--- a/daemon/src/ws/protocol.ts
+++ b/daemon/src/ws/protocol.ts
@@ -174,6 +174,7 @@ export const NormalizedEventSchema = z.object({
     "status",
     "mode_update",
     "commands_update",
+    "message_generated",
   ]),
   role: z.enum(["user", "assistant"]).optional(),
   text: z.string().optional(),
@@ -219,6 +220,9 @@ export const NormalizedEventSchema = z.object({
   toolStatus: z.enum(["pending", "in_progress", "completed", "failed"]).optional(),
   modeId: z.string().optional(),
   commands: z.array(CommandSchema).optional(),
+  subagentId: z.string().optional(),
+  subagentName: z.string().optional(),
+  subagentState: z.string().optional(),
 });
 
 export const SessionMetaSchema = z.object({
@@ -378,6 +382,8 @@ const SessionUpdatedEvent = z.object({
   /** Set true when a main-session promotion (DELETE /sessions/:id on the old
    *  main, Fix 1) flips this session to the worktree's new main. */
   isMain: z.boolean().optional(),
+  /** Cleared to null by PATCH /sessions/:id/delink; absent means unchanged. */
+  parentSessionId: z.string().nullable().optional(),
 });
 
 /**

--- a/web-ui/src/api/client.ts
+++ b/web-ui/src/api/client.ts
@@ -566,6 +566,14 @@ export function createClientApi() {
       return parseJson<Session>(res);
     },
 
+    async delinkSession(id: string): Promise<{ ok: true }> {
+      const root = baseUrl();
+      const res = await apiFetch(`${root}/sessions/${encodeURIComponent(id)}/delink`, {
+        method: "PATCH",
+      });
+      return parseJson<{ ok: true }>(res);
+    },
+
 
     async getFileBlob(worktreeId: string, filePath: string, scope: FileScope = "worktree"): Promise<Blob> {
       const path = filePath.replace(/^\/+/, "");

--- a/web-ui/src/api/mock.ts
+++ b/web-ui/src/api/mock.ts
@@ -763,6 +763,14 @@ export function createMockApi() {
       return structuredClone(s);
     },
 
+    async delinkSession(id: string): Promise<{ ok: true }> {
+      const s = sessions.find((x) => x.id === id);
+      if (!s) throw new ApiError("not found", 404);
+      s.parentSessionId = undefined;
+      emit({ type: "session:updated", sessionId: id, parentSessionId: null });
+      return { ok: true };
+    },
+
 
     async send(message: {
       type: "file:watch" | "file:unwatch" | "tree:watch" | "tree:unwatch" | "ping";

--- a/web-ui/src/api/types.ts
+++ b/web-ui/src/api/types.ts
@@ -218,7 +218,8 @@ export type NormalizedEventKind =
   | "error"
   | "status"
   | "mode_update"
-  | "commands_update";
+  | "commands_update"
+  | "message_generated";
 
 /** Normalized non-text (or text-in-a-mixed-array) content block (mirror of daemon `NormalizedContentBlock`). */
 export interface NormalizedContentBlock {
@@ -292,6 +293,12 @@ export interface NormalizedEvent {
   modeId?: string;
   /** `commands_update` only — the available slash commands. */
   commands?: Command[];
+  /** `message_generated` only — the child session that changed state. */
+  subagentId?: string;
+  /** `message_generated` only — display name of the child session. */
+  subagentName?: string;
+  /** `message_generated` only — lifecycle state the child transitioned to. */
+  subagentState?: string;
 }
 
 /** A slash command/skill catalog entry (`commands_update`, session meta). */
@@ -469,6 +476,8 @@ export type WSEvent =
       /** Set true when a main-session promotion (DELETE /sessions/:id on the
        *  old main) flips this session to the worktree's new main. */
       isMain?: boolean;
+      /** Cleared to null by PATCH /sessions/:id/delink; absent means unchanged. */
+      parentSessionId?: string | null;
     }
   | {
       type: "session:error";

--- a/web-ui/src/components/chat/MessageList.test.tsx
+++ b/web-ui/src/components/chat/MessageList.test.tsx
@@ -953,3 +953,46 @@ describe("m10 — MessageList threads `commands` through to the fork editor's Qu
   });
 });
 
+describe("groupEvents message_generated (4.T1 / 4.T2)", () => {
+  it("4.T1 — message_generated event produces a system_event RenderItem with the event's text", () => {
+    const items = groupEvents([
+      userEvent("t1", "do something"),
+      {
+        id: "sg1",
+        sessionId: "s1",
+        ts: "",
+        provider: "claude",
+        kind: "message_generated",
+        text: "subagent-abc is waiting for your input",
+        subagentId: "abc",
+        subagentName: "subagent-abc",
+        subagentState: "waiting_for_human",
+      },
+    ]);
+    const sysEvents = items.filter((i) => i.type === "system_event");
+    expect(sysEvents).toHaveLength(1);
+    expect((sysEvents[0] as { text: string }).text).toBe("subagent-abc is waiting for your input");
+  });
+
+  it("4.T2 — message_generated renders a .chat-system-event element in the MessageList", () => {
+    const events: NormalizedEvent[] = [
+      userEvent("t1", "do something"),
+      {
+        id: "sg1",
+        sessionId: "s1",
+        ts: "",
+        provider: "claude",
+        kind: "message_generated",
+        text: "subagent-abc is waiting for your input",
+        subagentId: "abc",
+        subagentName: "subagent-abc",
+        subagentState: "waiting_for_human",
+      },
+    ];
+    const { container } = render(<MessageList events={events} pending={[]} />);
+    const el = container.querySelector(".chat-system-event");
+    expect(el).toBeTruthy();
+    expect(el!.textContent).toBe("subagent-abc is waiting for your input");
+  });
+});
+

--- a/web-ui/src/components/chat/MessageList.tsx
+++ b/web-ui/src/components/chat/MessageList.tsx
@@ -36,7 +36,8 @@ type RenderItem =
   | ({ type: "tool" } & ToolCallEntry)
   | { type: "toolRun"; id: string; tools: ToolCallEntry[] }
   | { type: "error"; id: string; text: string }
-  | { type: "status"; id: string; text: string };
+  | { type: "status"; id: string; text: string }
+  | { type: "system_event"; id: string; text: string; agentName?: string };
 
 /**
  * Consecutive `tool` items (no text/user message, and no turn boundary,
@@ -357,6 +358,9 @@ export function groupEvents(events: NormalizedEvent[]): RenderItem[] {
         });
         break;
       }
+      case "message_generated":
+        items.push({ type: "system_event", id: ev.id, text: ev.text ?? "", agentName: ev.subagentName });
+        break;
       default:
         // session_init / usage / result — not rendered as bubbles, but a
         // `result` event marks the turn as over, so close any open group.
@@ -876,6 +880,14 @@ export function MessageList({
           case "status":
             node = (
               <div key={key} className="chat-status-note" role="note">
+                {item.text}
+              </div>
+            );
+            break;
+          case "system_event":
+            node = (
+              <div key={key} className="chat-system-event" role="note">
+                {item.agentName ? <span className="chat-system-event__chip">{item.agentName}</span> : null}
                 {item.text}
               </div>
             );

--- a/web-ui/src/components/chat/SubagentRow.test.tsx
+++ b/web-ui/src/components/chat/SubagentRow.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { SubagentRow, openSubagentSession } from "./SubagentRow";
 import { useServerStore } from "@/hooks/useServerStore";
 import { useWorkspaceStore, DEFAULT_WORKTREE_LAYOUT } from "@/hooks/useStore";
+import { createMockApi } from "@/api/mock";
 import type { Session } from "@/api/types";
 
 function makeSession(overrides: Partial<Session> & { id: string }): Session {
@@ -172,6 +173,57 @@ describe("row wording (Subagents caption, waiting-for-agent phrasing)", () => {
     const btn = screen.getByTitle(/kid/);
     expect(btn.getAttribute("title")).toContain("waiting for agent");
     expect(btn.getAttribute("title")).not.toContain("human");
+  });
+});
+
+describe("SubagentRow delink UX (5.T1, 5.T2, 5.T3)", () => {
+  it("5.T1 — ✕ button is present in child chip DOM when api is provided; clicking it enters confirm state", async () => {
+    const user = userEvent.setup();
+    const parent = makeSession({ id: "p1" });
+    const child = makeSession({ id: "c1", parentSessionId: "p1", name: "worker" });
+    seedSessions([parent, child]);
+    const api = createMockApi();
+    render(<SubagentRow session={parent} onOpen={vi.fn()} api={api} />);
+
+    const delinkBtn = screen.getByLabelText("Detach subagent");
+    expect(delinkBtn).toBeTruthy();
+
+    await user.click(delinkBtn);
+    expect(screen.getByText("Detach worker?")).toBeInTheDocument();
+    expect(screen.getByText("Detach")).toBeInTheDocument();
+    expect(screen.getByText("Cancel")).toBeInTheDocument();
+  });
+
+  it("5.T2 — confirming Detach calls the delink API; cancelling restores the chip", async () => {
+    const user = userEvent.setup();
+    const parent = makeSession({ id: "p1" });
+    const child = makeSession({ id: "c1", parentSessionId: "p1", name: "worker" });
+    seedSessions([parent, child]);
+    const api = createMockApi();
+    const delinkSpy = vi.fn().mockResolvedValue({ ok: true });
+    api.delinkSession = delinkSpy;
+
+    render(<SubagentRow session={parent} onOpen={vi.fn()} api={api} />);
+
+    await user.click(screen.getByLabelText("Detach subagent"));
+    expect(screen.getByText("Detach worker?")).toBeInTheDocument();
+
+    await user.click(screen.getByText("Cancel"));
+    expect(screen.queryByText("Detach worker?")).toBeNull();
+    expect(delinkSpy).not.toHaveBeenCalled();
+
+    await user.click(screen.getByLabelText("Detach subagent"));
+    await user.click(screen.getByText("Detach"));
+    expect(delinkSpy).toHaveBeenCalledWith("c1");
+  });
+
+  it("5.T3 — ✕ button not rendered when api is not provided (regression: existing tests pass)", () => {
+    const parent = makeSession({ id: "p1" });
+    const child = makeSession({ id: "c1", parentSessionId: "p1", name: "worker" });
+    seedSessions([parent, child]);
+    render(<SubagentRow session={parent} onOpen={vi.fn()} />);
+    expect(screen.queryByLabelText("Detach subagent")).toBeNull();
+    expect(screen.getByText("worker")).toBeInTheDocument();
   });
 });
 

--- a/web-ui/src/components/chat/SubagentRow.tsx
+++ b/web-ui/src/components/chat/SubagentRow.tsx
@@ -1,5 +1,7 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
+import { Unlink } from "lucide-react";
 import type { Session, SessionState } from "@/api/types";
+import type { ApiInstance } from "@/api";
 import { useServerStore } from "@/hooks/useServerStore";
 import { useWorkspaceStore, DEFAULT_WORKTREE_LAYOUT, type TileKind } from "@/hooks/useStore";
 import { StatusDot } from "@/components/layout/StatusDot";
@@ -68,6 +70,7 @@ export interface SubagentRowProps {
   /** The session this row-group is anchored on (the "self" side of the relationship). */
   session: Session;
   onOpen: (target: Session) => void;
+  api?: ApiInstance;
 }
 
 /**
@@ -76,9 +79,10 @@ export interface SubagentRowProps {
  * and — when `session` itself has a parent — a single "↑ Parent" link above
  * them. Nothing renders when there is nothing to show.
  */
-export function SubagentRow({ session, onOpen }: SubagentRowProps) {
+export function SubagentRow({ session, onOpen, api }: SubagentRowProps) {
   const allSessions = useServerStore((s) => s.sessions);
   const sessionStates = useWorkspaceStore((s) => s.sessionStates);
+  const [confirmDelink, setConfirmDelink] = useState<string | null>(null);
 
   const byId = useMemo(() => new Map(allSessions.map((s) => [s.id, s])), [allSessions]);
 
@@ -108,27 +112,90 @@ export function SubagentRow({ session, onOpen }: SubagentRowProps) {
 
   const statusFor = (s: Session): SessionState => sessionStates[s.id] ?? s.state;
 
+  async function handleDelink(id: string) {
+    if (!api) return;
+    await api.delinkSession(id);
+    setConfirmDelink(null);
+  }
+
   return (
     <div className="chat-subagent-row">
       {parent ? (
-        <button
-          type="button"
-          className="chat-subagent-row__item chat-subagent-row__item--parent"
-          onClick={() => parent.worktreeId === session.worktreeId && onOpen(parent)}
-          disabled={parent.worktreeId !== session.worktreeId}
-          title={parent.worktreeId === session.worktreeId ? undefined : "This parent is in a different worktree"}
-        >
-          <span className="chat-subagent-row__arrow" aria-hidden="true">
-            ↑
+        confirmDelink === session.id ? (
+          <span className="chat-subagent-row__item chat-subagent-row__item--parent chat-subagent-row__item--confirm">
+            <span className="chat-subagent-row__label">Leave parent?</span>
+            <button
+              type="button"
+              className="chat-subagent-row__confirm-btn"
+              onClick={() => void handleDelink(session.id)}
+            >
+              Detach
+            </button>
+            <button
+              type="button"
+              className="chat-subagent-row__cancel-btn"
+              onClick={() => setConfirmDelink(null)}
+            >
+              Cancel
+            </button>
           </span>
-          <span className="chat-subagent-row__label">Parent · {sessionLabel(parent)}</span>
-        </button>
+        ) : (
+          <button
+            type="button"
+            className="chat-subagent-row__item chat-subagent-row__item--parent"
+            onClick={() => parent.worktreeId === session.worktreeId && onOpen(parent)}
+            disabled={parent.worktreeId !== session.worktreeId}
+            title={parent.worktreeId === session.worktreeId ? undefined : "This parent is in a different worktree"}
+          >
+            <span className="chat-subagent-row__arrow" aria-hidden="true">
+              ↑
+            </span>
+            <span className="chat-subagent-row__label">Parent · {sessionLabel(parent)}</span>
+            {api ? (
+              <button
+                type="button"
+                className="chat-subagent-row__delink"
+                aria-label="Leave parent"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setConfirmDelink(session.id);
+                }}
+              >
+                <Unlink size={11} />
+              </button>
+            ) : null}
+          </button>
+        )
       ) : null}
       {visibleChildren.length > 0 ? (
         <span className="chat-subagent-row__caption">Subagents:</span>
       ) : null}
       {visibleChildren.map((child) => {
         const sameWorktree = child.worktreeId === session.worktreeId;
+        if (confirmDelink === child.id) {
+          return (
+            <span
+              key={child.id}
+              className="chat-subagent-row__item chat-subagent-row__item--confirm"
+            >
+              <span className="chat-subagent-row__label">Detach {sessionLabel(child)}?</span>
+              <button
+                type="button"
+                className="chat-subagent-row__confirm-btn"
+                onClick={() => void handleDelink(child.id)}
+              >
+                Detach
+              </button>
+              <button
+                type="button"
+                className="chat-subagent-row__cancel-btn"
+                onClick={() => setConfirmDelink(null)}
+              >
+                Cancel
+              </button>
+            </span>
+          );
+        }
         return (
           <button
             key={child.id}
@@ -144,6 +211,19 @@ export function SubagentRow({ session, onOpen }: SubagentRowProps) {
           >
             <StatusDot status={sessionStateToStatus(statusFor(child))} pr={null} />
             <span className="chat-subagent-row__label">{sessionLabel(child)}</span>
+            {api && sameWorktree ? (
+              <button
+                type="button"
+                className="chat-subagent-row__delink"
+                aria-label="Detach subagent"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setConfirmDelink(child.id);
+                }}
+              >
+                <Unlink size={11} />
+              </button>
+            ) : null}
           </button>
         );
       })}

--- a/web-ui/src/components/layout/ChatPane.tsx
+++ b/web-ui/src/components/layout/ChatPane.tsx
@@ -304,6 +304,7 @@ export function ChatPane({ api, session, visible }: ChatPaneProps) {
         {session ? (
           <SubagentRow
             session={session}
+            api={api}
             onOpen={(target) =>
               openSubagentSession(target, session, {
                 layoutByWorktree,

--- a/web-ui/src/hooks/useServerSync.ts
+++ b/web-ui/src/hooks/useServerSync.ts
@@ -267,6 +267,7 @@ export function useServerSync(api: ApiInstance): void {
         if (ev.pr !== undefined) patch.pr = ev.pr ?? undefined;
         if (ev.supersededBy !== undefined) patch.supersededBy = ev.supersededBy ?? null;
         if (ev.isMain !== undefined) patch.isMain = ev.isMain;
+        if (ev.parentSessionId === null) patch.parentSessionId = null;
         applySessionUpdated(ev.sessionId, patch);
         // A reset's replacement takes the archived session's place in every
         // canvas it was tiled in — same tile id/position, just repointed.

--- a/web-ui/src/styles/chat.css
+++ b/web-ui/src/styles/chat.css
@@ -697,6 +697,30 @@
   padding: var(--space-1) 0;
 }
 
+/* ── Centred system-event pill (message_generated / subagent state notices) ──── */
+
+.chat-system-event {
+  align-self: center;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--font-size-sm);
+  color: var(--fg-subtle);
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-full);
+  background: var(--surface-subtle);
+  max-width: 60%;
+}
+.chat-system-event__chip {
+  font-size: var(--font-size-xs);
+  font-weight: 500;
+  color: var(--fg-muted);
+  background: var(--surface-raised);
+  border-radius: var(--radius-full);
+  padding: 0 var(--space-2);
+  white-space: nowrap;
+}
+
 /* ── "Load earlier" affordance at the top of the loaded window (R2.2/R2.5) ──── */
 
 .chat-load-earlier {
@@ -867,6 +891,49 @@
   font-size: var(--font-size-xs);
   color: var(--fg-muted);
   flex: 0 0 auto;
+}
+.chat-subagent-row__item {
+  position: relative;
+}
+.chat-subagent-row__delink {
+  opacity: 0;
+  position: absolute;
+  right: var(--space-1);
+  top: 50%;
+  transform: translateY(-50%);
+  transition: opacity 0.1s;
+  padding: 2px var(--space-1);
+  display: flex;
+  align-items: center;
+  color: var(--fg-muted);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+.chat-subagent-row__item:hover .chat-subagent-row__delink,
+.chat-subagent-row__item:focus-within .chat-subagent-row__delink {
+  opacity: 1;
+}
+.chat-subagent-row__delink:hover {
+  color: var(--fg-primary);
+}
+.chat-subagent-row__item--confirm {
+  cursor: default;
+  gap: var(--space-2);
+}
+.chat-subagent-row__confirm-btn,
+.chat-subagent-row__cancel-btn {
+  font-size: var(--font-size-xs);
+  padding: 0 var(--space-1);
+  border-radius: var(--radius-sm);
+  border: var(--border-width) solid var(--border-subtle);
+  background: var(--bg-elevated);
+  color: var(--fg-secondary);
+  cursor: pointer;
+}
+.chat-subagent-row__confirm-btn:hover {
+  color: var(--fg-primary);
+  border-color: var(--border-default);
 }
 
 /* ── Persistent working indicator (last item in the feed while busy) ───────── */


### PR DESCRIPTION
## Summary

- **Zero-cost child state annotations** — replaces enqueued user-turn notifications with `message_generated` system events that bypass the LLM queue entirely. Only `waiting_for_human` transitions fire (idle/done/exited suppressed). Events persist + broadcast via WS and replay as a centred pill in chat UI.
- **Session delink** — new `PATCH /sessions/:id/delink` severs the parent/child link, purges coalescing buffers, and broadcasts `session:updated`. SubagentRow chips show a hover Unlink icon (lucide-react) → inline confirm → delink.
- **`vst session create --no-parent`** — new CLI flag that wins over `--parent` and `$VST_SESSION`, creating a truly independent sibling session.

## What changed

| Layer | Changes |
|-------|---------|
| `daemon/src/services/subagentNotify.ts` | `NOTABLE` narrowed to `waiting_for_human`; `enqueueTurn` dep replaced by `emitSystemEvent` |
| `daemon/src/services/jsonAgent.ts` | New `emitSystemEvent()` — persist + broadcast only, no queue |
| `daemon/src/services/lifecycle.ts` | Wires `emitSystemEvent` dep; removed `enqueueTurn` |
| `daemon/src/types.ts` | Added `"message_generated"` kind + subagent fields on `NormalizedEvent` |
| `daemon/src/ws/protocol.ts` | Schema updated for new kind + `parentSessionId` on `session:updated` |
| `daemon/src/routes/sessions.ts` | New `PATCH /sessions/:id/delink` endpoint |
| `cli/src/commands/session/create.ts` | `--no-parent` flag |
| `web-ui/src/api/{client,mock,types}.ts` | `delinkSession()` + new event/session types |
| `web-ui/src/hooks/useServerSync.ts` | Handle `parentSessionId: null` on `session:updated` |
| `web-ui/src/components/chat/MessageList.tsx` | `system_event` RenderItem → centred pill with agent chip |
| `web-ui/src/components/chat/SubagentRow.tsx` | Delink button (Unlink icon) + inline confirm |
| `web-ui/src/components/layout/ChatPane.tsx` | Pass `api` prop to SubagentRow |
| `web-ui/src/styles/chat.css` | `.chat-system-event` + `.chat-system-event__chip` styles |

## Test plan

- [ ] Child session transitions to `waiting_for_human` → parent chat shows centred pill with agent-name chip, no new LLM turn kicked
- [ ] Child transitions to `idle`/`done`/`exited` → no pill appears in parent chat
- [ ] Hover child chip in SubagentRow → Unlink icon appears → confirm → chip disappears, WS `session:updated` arrives with `parentSessionId: null`
- [ ] Same for parent chip ("Leave parent")
- [ ] `vst session create --no-parent` → session created with no `parentSessionId` even when `$VST_SESSION` is set
- [ ] `vst session create --no-parent --parent <id>` → `--no-parent` wins, no parent set
- [ ] All daemon + CLI + web-ui unit tests pass