### PR TITLE
fix(chat): suppress raw toolInput JSON when diffs are already shown

### DIFF
--- a/web-ui/src/components/chat/ToolRunSummary.test.tsx
+++ b/web-ui/src/components/chat/ToolRunSummary.test.tsx
@@ -142,5 +142,60 @@ describe("ToolRunSummary structured diffs (Decision 3/4, 4.T2)", () => {
     // once structured diffs are present.
     expect(screen.queryByText("not a unified diff at all")).toBeTruthy();
   });
+
+  it("suppresses raw toolInput JSON when structured diffs are present (ACP Edit path)", () => {
+    // ACP sends both rawInput ({file_path, old_string, new_string}) AND content diffs.
+    // Only the diff view should show — the JSON is redundant and was leaking through.
+    const editInput = { file_path: "/app/foo.ts", old_string: "const x = 1", new_string: "const x = 2" };
+    const tools = [
+      tool({
+        toolName: "Edit",
+        toolInput: editInput,
+        status: "completed",
+        diffs: [{ path: "/app/foo.ts", oldText: "const x = 1", newText: "const x = 2" }],
+      }),
+    ];
+    render(<ToolRunSummary tools={tools} live={false} />);
+    // Edit tool rows start expanded (isBash=false, isReadOnly=false), so no click needed.
+    expect(document.querySelector(".diff-line")).toBeTruthy();
+    // Raw JSON of the tool input must NOT appear alongside the diff.
+    expect(screen.queryByText(/old_string/)).toBeNull();
+    expect(screen.queryByText(/new_string/)).toBeNull();
+  });
+
+  it("shows raw toolInput JSON when there are no diffs (non-edit tools)", () => {
+    // For tools that have input but produce no diff, the pretty-printed JSON is the only body.
+    const tools = [
+      tool({
+        toolName: "Bash",
+        toolInput: { command: "echo hello" },
+        status: "completed",
+      }),
+    ];
+    render(<ToolRunSummary tools={tools} live={false} />);
+    const entryHeader = document.querySelector(".chat-tool-entry__header") as HTMLElement;
+    fireEvent.click(entryHeader);
+    // The input JSON body block must be visible.
+    expect(document.querySelector(".chat-tool-entry__pre")).toBeTruthy();
+  });
+
+  it("shows raw toolInput JSON for Bash even when result looks like a unified diff", () => {
+    // `git diff` output passes looksLikeUnifiedDiff — the input JSON must still show,
+    // because the command itself is not redundant with the diff text in the result.
+    const diffOutput = "diff --git a/foo.ts b/foo.ts\n--- a/foo.ts\n+++ b/foo.ts\n@@ -1 +1 @@\n-old\n+new";
+    const tools = [
+      tool({
+        toolName: "Bash",
+        toolInput: { command: "git diff HEAD" },
+        status: "completed",
+        result: { content: diffOutput },
+      }),
+    ];
+    render(<ToolRunSummary tools={tools} live={false} />);
+    const entryHeader = document.querySelector(".chat-tool-entry__header") as HTMLElement;
+    fireEvent.click(entryHeader);
+    // The input JSON body block must still be present (not suppressed by the diff result).
+    expect(document.querySelector(".chat-tool-entry__pre code")).toBeTruthy();
+  });
 });
 

--- a/web-ui/src/components/chat/ToolRunSummary.tsx
+++ b/web-ui/src/components/chat/ToolRunSummary.tsx
@@ -198,7 +198,7 @@ function ToolRunEntryRow({ tool, running, cwd }: { tool: ToolCallEntry; running:
       </button>
       {open && hasBody ? (
         <div className="chat-tool-entry__body">
-          {hasInputBody ? (
+          {hasInputBody && !hasDiffs ? (
             <pre className="chat-tool-entry__pre">
               <code>{pretty}</code>
             </pre>


### PR DESCRIPTION
## Summary

- The ACP adapter sends both `rawInput` (`{file_path, old_string, new_string}`) and structured content diffs for Edit/Write tool calls. The UI was rendering both the pretty-printed JSON block and the `DiffView` simultaneously, leaking raw JSON alongside the formatted diff in Rich Chat sessions.
- Fix: guard the input body block with `!hasDiffs` so it's only shown when no structured diff is present. The `!isDiff` clause considered and rejected — it would incorrectly suppress input JSON for Bash calls whose result happens to look like a diff (e.g. `git diff`), where the input is not redundant.
- File path is already visible in the collapsed row header via `summarizeToolInput`, so no information is lost.

## Test plan

- [ ] Existing 14 tests in `ToolRunSummary.test.tsx` all pass
- [ ] New test: Edit tool with both `toolInput` and `diffs` — JSON block absent, diff view present
- [ ] New test: Bash tool with no diffs — input JSON block still shown
- [ ] New test: Bash tool whose result is a unified diff — input JSON block still shown (regression guard for the `!isDiff` over-suppression case)
- [ ] Manual: open a Rich Chat session and make an edit — should show only the formatted diff, no JSON blob above it