### PR TITLE
fix(remote-sessions): device name, LAN visibility, and revoke guard

### DIFF
--- a/daemon/src/broadcaster.ts
+++ b/daemon/src/broadcaster.ts
@@ -1,7 +1,7 @@
 import type { ServerMessage } from "./ws/protocol.js";
 import type { WSConnection } from "./ws/connection.js";
 import type { TokenScope } from "./types.js";
-import { getActiveBrowserSessions } from "./state/auth-state.js";
+import { getActiveBrowserSessions, getDeviceNameForToken } from "./state/auth-state.js";
 
 /**
  * WS broadcaster: manages broadcast events to connected clients.
@@ -22,6 +22,7 @@ export type TokenSession = {
   expiresAt: number | null;
   lastSeenAt: number;
   connections: number;
+  deviceName?: string;
 };
 
 /** Token-level session map. One entry per unique auth token (0+ WS connections each). */
@@ -47,10 +48,11 @@ export function registerConnection(conn: WSConnection): void {
         expiresAt: conn.tokenExpiresAt ?? null,
         lastSeenAt: now,
         connections: 1,
+        deviceName: getDeviceNameForToken(conn.tokenId),
       });
     }
     const session = tokenSessions.get(conn.tokenId)!;
-    broadcastAll({ type: "remote:connected", session: { tokenId: session.tokenId, scope: session.scope, connections: session.connections, issuedAt: session.issuedAt, lastSeenAt: session.lastSeenAt, expiresAt: session.expiresAt ?? undefined } });
+    broadcastAll({ type: "remote:connected", session: { tokenId: session.tokenId, scope: session.scope, connections: session.connections, issuedAt: session.issuedAt, lastSeenAt: session.lastSeenAt, expiresAt: session.expiresAt ?? undefined, deviceName: session.deviceName } });
   }
 }
 
@@ -91,6 +93,7 @@ export function getRemoteSessions(): TokenSession[] {
       expiresAt: m.expiresAt,
       lastSeenAt: m.issuedAt,
       connections: 0,
+      deviceName: m.deviceName,
     });
   }
 

--- a/daemon/src/routes/auth.ts
+++ b/daemon/src/routes/auth.ts
@@ -25,19 +25,20 @@ export function registerAuthRoutes(app: FastifyInstance, persistEpoch: () => Pro
   });
 
   // GET /auth/sessions — list currently connected remote (browser/mobile) sessions.
-  // Returns 403 for requests arriving via the Cloudflare tunnel so that browser
-  // clients see a clear "desktop only" signal rather than a generic error.
+  // Available to all session types. Includes isDesktop so the UI can adapt its
+  // display (e.g. hide revoke buttons for non-desktop viewers).
   app.get("/auth/sessions", async (req, reply) => {
-    if (req.headers["cf-connecting-ip"]) {
-      return reply.status(403).send({ error: "DESKTOP_ONLY" });
-    }
-    return reply.send({ sessions: getRemoteSessions() });
+    const authPayload = (req as typeof req & { authPayload?: TokenPayload }).authPayload;
+    // Loopback callers have no authPayload (auth guard is bypassed for them).
+    const isDesktop = !authPayload;
+    return reply.send({ sessions: getRemoteSessions(), isDesktop });
   });
 
   // POST /auth/sessions/:id/revoke — revoke a remote session by tokenId.
-  // Marks the token as revoked (in-memory) and closes all its WS connections.
+  // Desktop (loopback) only — browser sessions cannot revoke other sessions.
   app.post("/auth/sessions/:id/revoke", async (req, reply) => {
-    if (req.headers["cf-connecting-ip"]) {
+    const authPayload = (req as typeof req & { authPayload?: TokenPayload }).authPayload;
+    if (authPayload) {
       return reply.status(403).send({ error: "DESKTOP_ONLY" });
     }
     const { id } = req.params as { id: string };
@@ -48,9 +49,12 @@ export function registerAuthRoutes(app: FastifyInstance, persistEpoch: () => Pro
   });
 
   // POST /auth/revoke-browser — bump browserEpoch to invalidate all browser tokens.
-  // Any valid token (any scope) can call this. CLI running locally can revoke all
-  // remote browser sessions.
-  app.post("/auth/revoke-browser", async (_req, reply) => {
+  // Desktop (loopback) only.
+  app.post("/auth/revoke-browser", async (req, reply) => {
+    const authPayload = (req as typeof req & { authPayload?: TokenPayload }).authPayload;
+    if (authPayload) {
+      return reply.status(403).send({ error: "DESKTOP_ONLY" });
+    }
     const newEpoch = await bumpBrowserEpoch(persistEpoch);
     closeConnectionsByScope("browser", 4403, "Session revoked");
     return reply.send({ ok: true, browserEpoch: newEpoch });

--- a/daemon/src/routes/mobileAuth.ts
+++ b/daemon/src/routes/mobileAuth.ts
@@ -20,6 +20,18 @@ interface OneTimeCode {
 
 const oneTimeCodes = new Map<string, OneTimeCode>();
 
+/** Extract a short human-readable device label from a User-Agent string. */
+function parseDeviceName(ua: string): string {
+  if (/iPhone/.test(ua)) return "iPhone";
+  if (/iPad/.test(ua)) return "iPad";
+  const androidMatch = ua.match(/Android[^;]*;\s*([^)]+)\)/);
+  if (androidMatch) return androidMatch[1].trim().split(" ").slice(0, 2).join(" ");
+  if (/Macintosh/.test(ua)) return "Mac";
+  if (/Windows/.test(ua)) return "Windows PC";
+  if (/Linux/.test(ua)) return "Linux";
+  return "Browser";
+}
+
 // Periodic cleanup of stale codes (older than 60s)
 setInterval(() => {
   const cutoff = Date.now() - 60_000;
@@ -240,12 +252,14 @@ export function registerMobileAuthRoutes(app: FastifyInstance, opts: MobileAuthO
     // connected a WS yet, so tokenSessions (WS-derived) would otherwise be empty
     // until it enters the app. tokenId is the payload half of the token.
     const tokenId = cookieValue.slice(0, cookieValue.lastIndexOf("."));
+    const rawUa = req.headers["user-agent"] ?? "";
     recordBrowserSession({
       tokenId,
       scope: "browser",
       issuedAt: Date.now(),
       expiresAt: Date.now() + BROWSER_MAX_AGE_SECONDS * 1000,
       epoch: state.browserEpoch,
+      deviceName: parseDeviceName(rawUa),
     });
 
     // `Secure` is only valid over HTTPS. The tunnel is HTTPS, but the local /

--- a/daemon/src/state/auth-state.ts
+++ b/daemon/src/state/auth-state.ts
@@ -23,6 +23,8 @@ export interface BrowserSession {
   expiresAt: number | null;
   /** browserEpoch at mint time — used to drop tokens invalidated by revoke-all. */
   epoch: number;
+  /** Human-readable device name parsed from the User-Agent at QR exchange time. */
+  deviceName?: string;
 }
 
 export interface AuthState {
@@ -69,6 +71,11 @@ export function getActiveBrowserSessions(): BrowserSession[] {
     out.push(session);
   }
   return out;
+}
+
+/** Return the deviceName for a minted browser session, if available. */
+export function getDeviceNameForToken(tokenId: string): string | undefined {
+  return _state?.mintedBrowserSessions.get(tokenId)?.deviceName;
 }
 
 /** Revoke a specific token by its payloadB64 id. Future verifyToken calls will reject it. */

--- a/daemon/src/ws/protocol.ts
+++ b/daemon/src/ws/protocol.ts
@@ -533,7 +533,7 @@ const SessionForkEvent = z.object({
 
 const RemoteConnectedEvent = z.object({
   type: z.literal("remote:connected"),
-  session: z.object({ tokenId: z.string(), scope: z.string(), connections: z.number(), issuedAt: z.number(), lastSeenAt: z.number(), expiresAt: z.number().optional() }),
+  session: z.object({ tokenId: z.string(), scope: z.string(), connections: z.number(), issuedAt: z.number(), lastSeenAt: z.number(), expiresAt: z.number().optional(), deviceName: z.string().optional() }),
 });
 
 const RemoteDisconnectedEvent = z.object({

--- a/web-ui/src/api/client.ts
+++ b/web-ui/src/api/client.ts
@@ -1180,10 +1180,9 @@ export function createClientApi() {
       return parseJson<LocalQrResponse>(res);
     },
 
-    async listAuthSessions(): Promise<AuthSession[]> {
+    async listAuthSessions(): Promise<{ sessions: AuthSession[]; isDesktop: boolean }> {
       const res = await apiFetch(`${baseUrl()}/auth/sessions`);
-      const data = await parseJson<{ sessions: AuthSession[] }>(res);
-      return data.sessions;
+      return parseJson<{ sessions: AuthSession[]; isDesktop: boolean }>(res);
     },
 
     async revokeAuthSession(tokenId: string): Promise<void> {

--- a/web-ui/src/api/mock.ts
+++ b/web-ui/src/api/mock.ts
@@ -1515,7 +1515,7 @@ export function createMockApi() {
     async getMobileQr(): Promise<MobileQrResponse> { return { qrUrl: "https://mock.trycloudflare.com/mobile-auth?code=mock", expiresAt: Date.now() + 30_000 }; },
     async getLocalQr(): Promise<LocalQrResponse> { return { qrUrl: "http://192.168.1.42:7421/mobile-auth?code=mock-local", expiresAt: Date.now() + 30_000, connectionType: "lan" }; },
     async revokeAllBrowserSessions(): Promise<{ ok: boolean; browserEpoch: number }> { return { ok: true, browserEpoch: 0 }; },
-    async listAuthSessions(): Promise<AuthSession[]> { return []; },
+    async listAuthSessions(): Promise<{ sessions: AuthSession[]; isDesktop: boolean }> { return { sessions: [], isDesktop: true }; },
     async revokeAuthSession(_tokenId: string): Promise<void> {},
   };
 

--- a/web-ui/src/api/types.ts
+++ b/web-ui/src/api/types.ts
@@ -599,7 +599,7 @@ export type WSEvent =
     }
   | {
       type: "remote:connected";
-      session: { tokenId: string; scope: string; connections: number; issuedAt: number; lastSeenAt: number; expiresAt?: number };
+      session: { tokenId: string; scope: string; connections: number; issuedAt: number; lastSeenAt: number; expiresAt?: number; deviceName?: string };
     }
   | {
       type: "remote:disconnected";
@@ -614,6 +614,7 @@ export interface AuthSession {
   issuedAt: number;
   lastSeenAt: number;
   expiresAt?: number;
+  deviceName?: string;
 }
 
 export type DiffScope = "local" | "branch" | "none";

--- a/web-ui/src/components/settings/RemoteAccessSetting.tsx
+++ b/web-ui/src/components/settings/RemoteAccessSetting.tsx
@@ -113,7 +113,9 @@ export function RemoteAccessSetting({ api }: RemoteAccessSettingProps) {
 
   // ── Remote sessions ─────────────────────────────────────────────────────────
   const [sessions, setSessions] = useState<AuthSession[]>([]);
-  const [isRemoteSession, setIsRemoteSession] = useState(false);
+  // isDesktop: true when viewing from the desktop app (loopback), false for browser sessions.
+  // Starts as false so browser viewers never see a spurious revoke button; corrected on first fetch.
+  const [isDesktop, setIsDesktop] = useState(false);
 
   // ── QR overlay state ────────────────────────────────────────────────────────
   const [activeQr, setActiveQr] = useState<ActiveQrType | null>(null);
@@ -144,13 +146,11 @@ export function RemoteAccessSetting({ api }: RemoteAccessSettingProps) {
   // ── Fetch remote sessions ───────────────────────────────────────────────────
   const fetchSessions = useCallback(async () => {
     try {
-      const list = await api.listAuthSessions();
+      const { sessions: list, isDesktop: desktop } = await api.listAuthSessions();
       setSessions(list);
-    } catch (err) {
-      if (err instanceof ApiError && err.status === 403) {
-        setIsRemoteSession(true);
-      }
-      // non-403 errors: silently ignore (session list is non-critical)
+      setIsDesktop(desktop);
+    } catch {
+      // silently ignore (session list is non-critical)
     }
   }, [api]);
 
@@ -439,14 +439,6 @@ export function RemoteAccessSetting({ api }: RemoteAccessSettingProps) {
     );
   }
 
-  if (isRemoteSession) {
-    return (
-      <div style={{ padding: "var(--space-5)", color: "var(--fg-muted)", fontSize: "var(--font-size-sm)" }}>
-        Remote session management can only be done from the primary desktop session.
-      </div>
-    );
-  }
-
   // Truncate tunnel URL for display
   const truncatedUrl = tunnel.tunnelUrl
     ? tunnel.tunnelUrl.replace(/^https?:\/\//, "").slice(0, 40) +
@@ -561,7 +553,7 @@ export function RemoteAccessSetting({ api }: RemoteAccessSettingProps) {
           <div style={{ fontWeight: "var(--font-weight-medium)", fontSize: "var(--font-size-sm)" }}>
             Active sessions
           </div>
-          {sessions.length > 0 && (
+          {isDesktop && sessions.length > 0 && (
             <button
               type="button"
               className="btn btn--danger"
@@ -586,7 +578,7 @@ export function RemoteAccessSetting({ api }: RemoteAccessSettingProps) {
         )}
 
         <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
-          {/* Fixed desktop entry */}
+          {/* Current session entry */}
           <div style={{
             display: "flex",
             alignItems: "center",
@@ -599,7 +591,9 @@ export function RemoteAccessSetting({ api }: RemoteAccessSettingProps) {
           }}>
             <div>
               <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", marginBottom: 2 }}>
-                <span style={{ fontWeight: "var(--font-weight-medium)", fontSize: "var(--font-size-sm)" }}>Desktop</span>
+                <span style={{ fontWeight: "var(--font-weight-medium)", fontSize: "var(--font-size-sm)" }}>
+                  {isDesktop ? "Desktop" : "This browser"}
+                </span>
                 <span style={{ fontSize: "var(--font-size-xs)", color: "var(--fg-muted)", background: "var(--bg-input)", borderRadius: "var(--radius-sm)", padding: "1px 6px" }}>
                   this session
                 </span>
@@ -625,10 +619,7 @@ export function RemoteAccessSetting({ api }: RemoteAccessSettingProps) {
               <div>
                 <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", marginBottom: 2 }}>
                   <span style={{ fontWeight: "var(--font-weight-medium)", fontSize: "var(--font-size-sm)" }}>
-                    {/* TODO: mobile scope is browser for now — no dedicated "mobile" scope is
-                        minted yet. Re-enable the "Mobile" label when a real mobile scope exists.
-                        {s.scope === "mobile" ? "Mobile" : "Browser"} */}
-                    Browser
+                    {s.deviceName ?? "Browser"}
                   </span>
                   <span style={{ fontSize: "var(--font-size-xs)", color: "var(--fg-muted)", background: "var(--bg-input)", borderRadius: "var(--radius-sm)", padding: "1px 6px" }}>
                     {s.scope}
@@ -645,14 +636,16 @@ export function RemoteAccessSetting({ api }: RemoteAccessSettingProps) {
                   Last seen {formatRelative(s.lastSeenAt)} · issued {s.issuedAt ? formatRelative(s.issuedAt) : "unknown"}
                 </div>
               </div>
-              <button
-                type="button"
-                className="btn btn--secondary"
-                disabled={revokingId === s.tokenId || revokingAll}
-                onClick={() => void handleRevokeOne(s.tokenId)}
-              >
-                {revokingId === s.tokenId ? "…" : "Revoke"}
-              </button>
+              {isDesktop && (
+                <button
+                  type="button"
+                  className="btn btn--secondary"
+                  disabled={revokingId === s.tokenId || revokingAll}
+                  onClick={() => void handleRevokeOne(s.tokenId)}
+                >
+                  {revokingId === s.tokenId ? "…" : "Revoke"}
+                </button>
+              )}
             </div>
           ))}
 


### PR DESCRIPTION
## Summary

- **Device name**: Browser sessions now show a parsed device label (iPhone, iPad, Android model, Mac, Windows PC, Linux) instead of the hardcoded "Browser". User-Agent is captured at QR exchange time and propagated through `BrowserSession` → `TokenSession` → REST response and `remote:connected` WS event.

- **LAN session identity**: `GET /auth/sessions` now returns `isDesktop` (true for loopback/desktop, false for browser tokens) instead of a 403. All session types can view the sessions list. The UI uses the flag to label the "this session" card correctly ("Desktop" vs "This browser") and to hide revoke buttons for non-desktop viewers.

- **Revoke guard**: `POST /auth/sessions/:id/revoke` and `POST /auth/revoke-browser` now reject with 403 if `authPayload` is set — blocking both LAN and tunnel browser tokens. Previously only Cloudflare tunnel requests were blocked via the CF-Connecting-IP header.

## Test plan

- [ ] Desktop: sessions list shows "Desktop / this session" + remote sessions with device names; revoke buttons present and functional
- [ ] LAN browser: sessions list shows "This browser / this session" + other sessions; revoke buttons hidden
- [ ] Tunnel browser: same as LAN browser — can view sessions, cannot revoke
- [ ] Attempt revoke via `curl -X POST http://<lan-ip>:<port>/auth/sessions/<id>/revoke` with a browser cookie — should return 403
- [ ] QR scan from iPhone → session shows "iPhone"; from Android → shows model name; from Mac browser → shows "Mac"