### PR TITLE
fix(remote-sessions): correct desktop identity — token-before-loopback, tauri scope, proxy IP, UI label

### DIFF
--- a/daemon/src/routes/auth.ts
+++ b/daemon/src/routes/auth.ts
@@ -29,16 +29,20 @@ export function registerAuthRoutes(app: FastifyInstance, persistEpoch: () => Pro
   // display (e.g. hide revoke buttons for non-desktop viewers).
   app.get("/auth/sessions", async (req, reply) => {
     const authPayload = (req as typeof req & { authPayload?: TokenPayload }).authPayload;
-    // Loopback callers have no authPayload (auth guard is bypassed for them).
-    const isDesktop = !authPayload;
-    return reply.send({ sessions: getRemoteSessions(), isDesktop });
+    // isDesktop: true for the Tauri desktop app (scope='tauri') or a plain loopback
+    // caller with no token (CLI tools, etc.). Browser/mobile sessions have a verified
+    // token with scope='browser'/'mobile' and are not desktop.
+    const isDesktop = !authPayload || authPayload.scope === "tauri";
+    // currentScope: the caller's token scope; loopback-with-no-token is treated as 'tauri'.
+    const currentScope: string = authPayload?.scope ?? "tauri";
+    return reply.send({ sessions: getRemoteSessions(), isDesktop, currentScope });
   });
 
   // POST /auth/sessions/:id/revoke — revoke a remote session by tokenId.
-  // Desktop (loopback) only — browser sessions cannot revoke other sessions.
+  // Desktop (loopback, scope=null or 'tauri') only — browser/mobile sessions cannot revoke.
   app.post("/auth/sessions/:id/revoke", async (req, reply) => {
     const authPayload = (req as typeof req & { authPayload?: TokenPayload }).authPayload;
-    if (authPayload) {
+    if (authPayload && authPayload.scope !== "tauri") {
       return reply.status(403).send({ error: "DESKTOP_ONLY" });
     }
     const { id } = req.params as { id: string };
@@ -49,10 +53,10 @@ export function registerAuthRoutes(app: FastifyInstance, persistEpoch: () => Pro
   });
 
   // POST /auth/revoke-browser — bump browserEpoch to invalidate all browser tokens.
-  // Desktop (loopback) only.
+  // Desktop (loopback, scope=null or 'tauri') only.
   app.post("/auth/revoke-browser", async (req, reply) => {
     const authPayload = (req as typeof req & { authPayload?: TokenPayload }).authPayload;
-    if (authPayload) {
+    if (authPayload && authPayload.scope !== "tauri") {
       return reply.status(403).send({ error: "DESKTOP_ONLY" });
     }
     const newEpoch = await bumpBrowserEpoch(persistEpoch);

--- a/daemon/src/routes/mobileAuth.ts
+++ b/daemon/src/routes/mobileAuth.ts
@@ -25,7 +25,11 @@ function parseDeviceName(ua: string): string {
   if (/iPhone/.test(ua)) return "iPhone";
   if (/iPad/.test(ua)) return "iPad";
   const androidMatch = ua.match(/Android[^;]*;\s*([^)]+)\)/);
-  if (androidMatch) return androidMatch[1].trim().split(" ").slice(0, 2).join(" ");
+  if (androidMatch) {
+    const model = (androidMatch[1] ?? "").trim().split(" ").slice(0, 2).join(" ");
+    // Modern Android Chrome (v110+) sends 'K' as a privacy-preserving model placeholder.
+    return model.length <= 2 ? "Android" : model;
+  }
   if (/Macintosh/.test(ua)) return "Mac";
   if (/Windows/.test(ua)) return "Windows PC";
   if (/Linux/.test(ua)) return "Linux";

--- a/daemon/src/server.ts
+++ b/daemon/src/server.ts
@@ -87,6 +87,14 @@ export async function buildServer(opts: BuildServerOptions = {}) {
 
   const app = Fastify({
     logger: opts.logger ?? false,
+    // Honour X-Forwarded-For ONLY when the TCP peer is itself loopback (the Vite
+    // dev proxy). The daemon binds 0.0.0.0, so `trustProxy: true` would let any
+    // LAN client forge `X-Forwarded-For: 127.0.0.1` and hit the loopback auth
+    // bypass. proxy-addr walks the chain right-to-left and stops at the first
+    // untrusted hop, so a forged leading entry relayed through Vite is ignored
+    // as well. cloudflared connections are identified by CF-Connecting-IP and
+    // the loopback bypass is skipped for them before the IP is consulted.
+    trustProxy: "loopback",
     // Mirrors the Vite dev proxy rewrite so /api/auth/login and /auth/login both
     // reach the same route handler regardless of caller (browser, CLI, curl).
     rewriteUrl: (req) => {
@@ -152,7 +160,21 @@ export async function buildServer(opts: BuildServerOptions = {}) {
             return reply.status(403).send({ error: "Forbidden." });
           }
         }
-        // Trusted loopback (CSRF check passed) — no credentials needed for any route.
+        // Trusted loopback (CSRF check passed) — always allowed, but if a token IS
+        // present (e.g. Tauri Bearer or browser cookie from Vite proxy), verify it
+        // and attach authPayload so routes can distinguish caller scope ('tauri' vs
+        // 'browser') rather than treating all loopback callers as desktop.
+        const authHeader = req.headers.authorization;
+        const cookies = (req as typeof req & { cookies?: Record<string, string> }).cookies ?? {};
+        const rawToken = authHeader?.startsWith("Bearer ")
+          ? authHeader.slice(7)
+          : (cookies[COOKIE_NAME] ?? "");
+        if (rawToken && authState) {
+          const result = verifyToken(rawToken, authState);
+          if (result.ok) {
+            (req as typeof req & { authPayload?: TokenPayload }).authPayload = result.payload;
+          }
+        }
         return;
       }
 

--- a/daemon/src/ws/server.ts
+++ b/daemon/src/ws/server.ts
@@ -50,14 +50,10 @@ type WSAuthResult = {
 function authenticateWS(req: FastifyRequest, authState: AuthState | undefined): WSAuthResult | false {
   if (!authState) return { scope: null, tokenId: null, issuedAt: null, expiresAt: null };
 
-  // Same loopback bypass as the HTTP guard in server.ts.
-  // The local desktop UI connects from loopback and never has a cookie or Bearer token,
-  // so without this bypass it would be closed with 4401.
   const viaTunnel = !!req.headers["cf-connecting-ip"];
-  const ip = req.socket.remoteAddress ?? "";
-  if (!viaTunnel && (ip === "127.0.0.1" || ip === "::1" || ip === "::ffff:127.0.0.1")) {
-    return { scope: null, tokenId: null, issuedAt: null, expiresAt: null };
-  }
+  // Use req.ip instead of socket.remoteAddress so X-Forwarded-For set by the
+  // Vite dev proxy (xfwd: true) is respected when trustProxy is enabled.
+  const ip = req.ip;
 
   const auth = req.headers.authorization;
   const rawToken = auth?.startsWith("Bearer ") ? auth.slice(7) : null;
@@ -65,7 +61,32 @@ function authenticateWS(req: FastifyRequest, authState: AuthState | undefined): 
   const cookieHeader = req.headers.cookie ?? "";
   const cookieToken = parseCookieValue(cookieHeader, COOKIE_NAME);
 
-  const token = rawToken ?? cookieToken;
+  // Also read token from query param — browsers can't set WS headers, so the
+  // Tauri app passes its Bearer token as ?token=... in the upgrade URL.
+  const urlParams = new URLSearchParams(req.url?.split("?")[1] ?? "");
+  const queryToken = urlParams.get("token") ?? "";
+
+  const token: string | null = rawToken || cookieToken || queryToken || null;
+
+  if (!viaTunnel && (ip === "127.0.0.1" || ip === "::1" || ip === "::ffff:127.0.0.1")) {
+    // Trusted loopback — always allowed. If a token IS present (Tauri Bearer,
+    // browser cookie from Vite proxy, or query param), verify it so the
+    // connection carries the correct scope instead of null.
+    if (token) {
+      const result = verifyToken(token, authState);
+      if (result.ok) {
+        const tokenId = token.slice(0, token.lastIndexOf("."));
+        return {
+          scope: result.payload.scope,
+          tokenId,
+          issuedAt: result.payload.iat,
+          expiresAt: result.payload.exp ?? null,
+        };
+      }
+    }
+    return { scope: null, tokenId: null, issuedAt: null, expiresAt: null };
+  }
+
   if (!token) return false;
 
   const result = verifyToken(token, authState);

--- a/web-ui/src/api/client.ts
+++ b/web-ui/src/api/client.ts
@@ -56,17 +56,33 @@ function baseUrl() {
   return "/api";
 }
 
+function tauriToken(): string {
+  const t = (window as unknown as Record<string, unknown>).__VST_TOKEN__;
+  return typeof t === "string" ? t : "";
+}
+
 function wsUrl() {
   const base = baseUrl();
+  let url: string;
   // Relative base (e.g. "/api") — connect to /ws on the same origin (Vite proxies it).
   if (base.startsWith("/")) {
-    return `${window.location.origin.replace(/^http/, "ws")}/ws`;
+    url = `${window.location.origin.replace(/^http/, "ws")}/ws`;
+  } else {
+    const u = new URL(base);
+    u.protocol = u.protocol === "https:" ? "wss:" : "ws:";
+    u.pathname = "/ws";
+    u.search = "";
+    url = u.toString();
   }
-  const u = new URL(base);
-  u.protocol = u.protocol === "https:" ? "wss:" : "ws:";
-  u.pathname = "/ws";
-  u.search = "";
-  return u.toString();
+  // Browsers can't set custom headers on WebSocket upgrades, so the Tauri app
+  // passes its identity token as a query param instead.
+  const token = tauriToken();
+  if (token) {
+    const u = new URL(url);
+    u.searchParams.set("token", token);
+    url = u.toString();
+  }
+  return url;
 }
 
 /**
@@ -89,12 +105,18 @@ async function parseJson<T>(res: Response): Promise<T> {
 /** Thin fetch wrapper that always sends credentials (session cookie).
  *  credentials: 'include' is required because in dev the web UI (port 5173)
  *  and daemon (port 7421) are different origins — 'same-origin' would silently
- *  drop the cookie. */
+ *  drop the cookie. When running inside the Tauri shell, also sends the
+ *  injected VST_TOKEN as a Bearer header so the daemon can identify the
+ *  request as 'tauri'-scoped rather than a generic loopback caller. */
 function apiFetch(url: string, init?: RequestInit): Promise<Response> {
+  const token = tauriToken();
+  const authHeaders: Record<string, string> = token
+    ? { Authorization: `Bearer ${token}` }
+    : {};
   return fetch(url, {
     ...init,
     credentials: "include",
-    headers: { ...init?.headers },
+    headers: { ...authHeaders, ...init?.headers },
   });
 }
 
@@ -1196,9 +1218,9 @@ export function createClientApi() {
       return parseJson<LocalQrResponse>(res);
     },
 
-    async listAuthSessions(): Promise<{ sessions: AuthSession[]; isDesktop: boolean }> {
+    async listAuthSessions(): Promise<{ sessions: AuthSession[]; isDesktop: boolean; currentScope?: string }> {
       const res = await apiFetch(`${baseUrl()}/auth/sessions`);
-      return parseJson<{ sessions: AuthSession[]; isDesktop: boolean }>(res);
+      return parseJson<{ sessions: AuthSession[]; isDesktop: boolean; currentScope?: string }>(res);
     },
 
     async revokeAuthSession(tokenId: string): Promise<void> {

--- a/web-ui/src/api/mock.ts
+++ b/web-ui/src/api/mock.ts
@@ -1537,7 +1537,7 @@ export function createMockApi() {
     async getMobileQr(): Promise<MobileQrResponse> { return { qrUrl: "https://mock.trycloudflare.com/mobile-auth?code=mock", expiresAt: Date.now() + 30_000 }; },
     async getLocalQr(): Promise<LocalQrResponse> { return { qrUrl: "http://192.168.1.42:7421/mobile-auth?code=mock-local", expiresAt: Date.now() + 30_000, connectionType: "lan" }; },
     async revokeAllBrowserSessions(): Promise<{ ok: boolean; browserEpoch: number }> { return { ok: true, browserEpoch: 0 }; },
-    async listAuthSessions(): Promise<{ sessions: AuthSession[]; isDesktop: boolean }> { return { sessions: [], isDesktop: true }; },
+    async listAuthSessions(): Promise<{ sessions: AuthSession[]; isDesktop: boolean; currentScope?: string }> { return { sessions: [], isDesktop: true, currentScope: "tauri" }; },
     async revokeAuthSession(_tokenId: string): Promise<void> {},
   };
 

--- a/web-ui/src/components/settings/RemoteAccessSetting.tsx
+++ b/web-ui/src/components/settings/RemoteAccessSetting.tsx
@@ -116,6 +116,9 @@ export function RemoteAccessSetting({ api }: RemoteAccessSettingProps) {
   // isDesktop: true when viewing from the desktop app (loopback), false for browser sessions.
   // Starts as false so browser viewers never see a spurious revoke button; corrected on first fetch.
   const [isDesktop, setIsDesktop] = useState(false);
+  // currentScope: the caller's token scope ('tauri', 'browser', 'mobile', etc.).
+  // Used to derive the correct label for the current-session card.
+  const [currentScope, setCurrentScope] = useState<string | null>(null);
 
   // ── QR overlay state ────────────────────────────────────────────────────────
   const [activeQr, setActiveQr] = useState<ActiveQrType | null>(null);
@@ -146,9 +149,10 @@ export function RemoteAccessSetting({ api }: RemoteAccessSettingProps) {
   // ── Fetch remote sessions ───────────────────────────────────────────────────
   const fetchSessions = useCallback(async () => {
     try {
-      const { sessions: list, isDesktop: desktop } = await api.listAuthSessions();
+      const { sessions: list, isDesktop: desktop, currentScope: scope } = await api.listAuthSessions();
       setSessions(list);
       setIsDesktop(desktop);
+      setCurrentScope(scope ?? null);
     } catch {
       // silently ignore (session list is non-critical)
     }
@@ -592,7 +596,7 @@ export function RemoteAccessSetting({ api }: RemoteAccessSettingProps) {
             <div>
               <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", marginBottom: 2 }}>
                 <span style={{ fontWeight: "var(--font-weight-medium)", fontSize: "var(--font-size-sm)" }}>
-                  {isDesktop ? "Desktop" : "This browser"}
+                  {currentScope === "tauri" ? "Desktop" : currentScope === "browser" ? "This session" : isDesktop ? "Desktop" : "This session"}
                 </span>
                 <span style={{ fontSize: "var(--font-size-xs)", color: "var(--fg-muted)", background: "var(--bg-input)", borderRadius: "var(--radius-sm)", padding: "1px 6px" }}>
                   this session

--- a/web-ui/vite.config.ts
+++ b/web-ui/vite.config.ts
@@ -22,17 +22,20 @@ export default defineConfig({
         target: "http://127.0.0.1:7421",
         rewrite: (p) => p.replace(/^\/api/, ""),
         changeOrigin: true, // ensures Cookie / Set-Cookie headers flow correctly
+        xfwd: true, // forward real client IP in X-Forwarded-For
       },
       // QR mobile login — /mobile-auth is daemon-handled but not under /api,
       // so it needs its own proxy entry when the tunnel points at Vite.
       "/mobile-auth": {
         target: "http://127.0.0.1:7421",
         changeOrigin: true,
+        xfwd: true,
       },
       "/ws": {
         target: "ws://127.0.0.1:7421",
         ws: true,
         changeOrigin: true,
+        xfwd: true,
       },
     },
   },


### PR DESCRIPTION
## Root cause

The HTTP and WS auth guards short-circuited on loopback **before** looking at any credential. Every caller arriving from `127.0.0.1` — the Tauri desktop shell, but also any browser tab going through the Vite dev proxy — got no `authPayload` and was therefore treated as "desktop". That produced wrong "Desktop" labels for browser sessions, let browser sessions call desktop-only revoke routes, and gave WS connections a `null` scope.

## Changes

1. **Token before loopback bypass** (`daemon/src/server.ts`, `daemon/src/ws/server.ts`)
   Loopback callers are still always allowed, but if a Bearer/cookie/`?token=` credential is present it is verified and `authPayload` / WS scope is attached. Routes can now distinguish `tauri` from `browser` on loopback.

2. **Tauri asserts its scope** (`web-ui/src/api/client.ts`)
   `apiFetch` sends `Authorization: Bearer __VST_TOKEN__` when running in the Tauri shell; the WS upgrade URL carries `?token=…` (browsers can't set WS headers). Desktop-only routes in `daemon/src/routes/auth.ts` now gate on `scope === 'tauri'` (or no token at all for CLI/curl) instead of `!authPayload`.

3. **Vite proxy IP forwarding** (`web-ui/vite.config.ts`, `daemon/src/server.ts`, `daemon/src/ws/server.ts`)
   `xfwd: true` on the `/api`, `/mobile-auth` and `/ws` proxy entries; the daemon trusts `X-Forwarded-For` **only from loopback peers** (`trustProxy: "loopback"`, see below); the WS guard reads `req.ip` instead of `socket.remoteAddress`.

4. **UI label from `currentScope`** (`daemon/src/routes/auth.ts`, `web-ui/src/components/settings/RemoteAccessSetting.tsx`)
   `/auth/sessions` returns `currentScope`; the current-session card shows "Desktop" / "This browser" from it, falling back to the old `isDesktop` behaviour when talking to an older daemon.

5. **Android device name** (`daemon/src/routes/mobileAuth.ts`)
   Chrome 110+ on Android sends `"K"` as a privacy placeholder model; `parseDeviceName` now falls back to `"Android"` for model strings of ≤ 2 chars.

## Review fixes applied on top of the original implementation

- **`trustProxy: true` → `trustProxy: "loopback"`.** The daemon binds `0.0.0.0`, so with `trustProxy: true` any LAN client could send `X-Forwarded-For: 127.0.0.1` (no `cf-connecting-ip`) and hit the loopback auth bypass — full unauthenticated access. With `"loopback"`, XFF is honoured only when the TCP peer is loopback (the Vite proxy), and proxy-addr stops at the first untrusted hop so a forged leading entry relayed through Vite is ignored too. The tunnel guard (`cf-connecting-ip`) still runs before the IP check.
- `androidMatch[1]` guarded for `noUncheckedIndexedAccess` (was a typecheck error).
- Label fallback for pre-`currentScope` daemons restored to "This browser" (unchanged behaviour instead of a new "This session" string).

## Verification

- `pnpm --filter @vibestation/cli typecheck` and `pnpm --filter @vibestation/web typecheck` pass.
- Daemon test suite: 1097 passed; the 2 failures in `sessions.test.ts` (spawn-failure unhandled rejection) reproduce identically on `main` and are unrelated.
- `tokenId` derivation (`token.slice(0, lastIndexOf("."))`) matches the existing non-loopback WS path and the mint path in `mobileAuth.ts`.
- `@fastify/cookie` is registered before the `onRequest` guard, so `req.cookies` is populated when the loopback branch reads it.
- `tauri`-scoped WS connections are excluded from the remote-sessions list by `REMOTE_SCOPES` in the broadcaster.