### PR TITLE
fix(dev,daemon): rebuild web-ui on dev start, scope worktree-delete guard to Storage panel

### DIFF
--- a/daemon/src/__tests__/worktrees.test.ts
+++ b/daemon/src/__tests__/worktrees.test.ts
@@ -795,6 +795,31 @@ describe("Worktree routes", () => {
     expect(listRes.json<WorktreeRecord[]>()).toHaveLength(0);
   });
 
+  it("DELETE /worktrees/:id enforces the done guard ONLY with ?enforceDone=true", async () => {
+    // The guard belongs to Settings → Storage's bulk delete (which offers done
+    // worktrees only). The sidebar's explicit single delete omits the flag and
+    // force-cleans the live sessions instead.
+    const createRes = await app.inject({
+      method: "POST",
+      url: "/worktrees",
+      payload: { projectId, branch: `guard-optin-${Date.now()}`, modeId: "bug-fix" },
+    });
+    const wt = createRes.json<WorktreeRecord>();
+
+    const guarded = await app.inject({
+      method: "DELETE",
+      url: `/worktrees/${wt.id}?enforceDone=true`,
+    });
+    // The fresh worktree's main session is not `done`, so the opt-in guard fires.
+    expect(guarded.statusCode).toBe(409);
+    expect(guarded.json().error).toBe("worktree_not_done");
+
+    // The same delete WITHOUT the flag force-cleans and succeeds.
+    const forced = await app.inject({ method: "DELETE", url: `/worktrees/${wt.id}` });
+    expect(forced.statusCode).toBe(200);
+    expect(forced.json().ok).toBe(true);
+  });
+
   it("DELETE /worktrees/:id broadcasts session:deleted per session BEFORE worktree:deleted", async () => {
     // Client-side tile cleanup keys off `session:deleted`; without the cascade
     // a deleted worktree's tiles survived in every canvas as empty ghosts.

--- a/daemon/src/routes/worktrees.ts
+++ b/daemon/src/routes/worktrees.ts
@@ -941,10 +941,18 @@ export function registerWorktreeRoutes(app: FastifyInstance): void {
   // DELETE /worktrees/:id
   // Always purges (removes the git checkout from disk). The ?purge param is
   // accepted but ignored for backward compat with existing callers.
-  // Only deletable when all agent sessions are `done` and all terminal sessions
-  // are `done` or `exited` — mirrors what POST /worktrees/:id/done produces.
+  //
+  // The "done guard" (409 `worktree_not_done`) is OPT-IN via `?enforceDone=true`.
+  // The delete itself never needed it: every session is released + its data dir
+  // cleaned up unconditionally below, so deleting a worktree with live sessions
+  // is a supported force-cleanup. The guard exists for Settings → Storage, whose
+  // bulk-delete UI deliberately only offers *done* worktrees and wants a
+  // server-side safety net against deleting something still running. The left
+  // sidebar's single "Remove worktree" action is an explicit, confirmed
+  // per-worktree destructive action, so it omits the flag and is not gated.
   app.delete("/worktrees/:id", async (req, reply) => {
     const { id: wtId } = req.params as { id: string };
+    const { enforceDone } = req.query as { enforceDone?: string };
 
     // Find the project that owns this worktree
     const project = getAllProjects().find((p) => p.worktrees.some((w) => w.id === wtId));
@@ -952,17 +960,19 @@ export function registerWorktreeRoutes(app: FastifyInstance): void {
 
     const worktree = project.worktrees.find((w) => w.id === wtId)!;
 
-    // Done guard: agents must be `done`; terminals accept `done` or `exited`
-    const notDone = worktree.sessions.filter((s) =>
-      s.type === "agent"
-        ? s.lifecycle.state !== "done"
-        : s.lifecycle.state !== "done" && s.lifecycle.state !== "exited",
-    );
-    if (notDone.length > 0) {
-      return reply.status(409).send({
-        error: "worktree_not_done",
-        sessions: notDone.map((s) => s.id),
-      });
+    // Done guard (opt-in): agents must be `done`; terminals accept `done` or `exited`
+    if (enforceDone === "true" || enforceDone === "1") {
+      const notDone = worktree.sessions.filter((s) =>
+        s.type === "agent"
+          ? s.lifecycle.state !== "done"
+          : s.lifecycle.state !== "done" && s.lifecycle.state !== "exited",
+      );
+      if (notDone.length > 0) {
+        return reply.status(409).send({
+          error: "worktree_not_done",
+          sessions: notDone.map((s) => s.id),
+        });
+      }
     }
 
     // Kill all sessions (tmux or direct-pty)

--- a/scripts/dev-start.sh
+++ b/scripts/dev-start.sh
@@ -4,7 +4,12 @@
 # 1. Creates a stub sidecar binary so Tauri's build.rs resource-path check
 #    passes at compile time. The stub is never actually invoked in dev because
 #    detect_running_daemon() finds the tsx-launched daemon in config.json first.
-# 2. Runs the daemon (tsx watch) and Vite dev server concurrently.
+# 2. Builds web-ui/dist, which the daemon serves (via fastify-static) to any
+#    client that isn't the desktop window itself — LAN/tunnel clients, and
+#    `curl` against the daemon port. The desktop window always loads Vite
+#    directly instead, so it never needed this, but without it those other
+#    clients get whatever dist was last built for, however stale.
+# 3. Runs the daemon (tsx watch) and Vite dev server concurrently.
 #
 # Called from desktop/src-tauri/tauri.conf.json beforeDevCommand.
 # CWD when invoked: desktop/ (where `tauri dev` is run)
@@ -50,6 +55,11 @@ if [[ ! -f "$VST_STUB" ]]; then
   chmod +x "$VST_STUB"
   echo "[dev-start] created vst stub: $VST_STUB"
 fi
+
+# Build web-ui/dist so the daemon serves current UI to non-Vite clients from
+# the moment it starts, instead of a build left over from a previous session.
+echo "[dev-start] building web-ui/dist..."
+pnpm --filter @vibestation/web build
 
 # Launch daemon (tsx watch) + Vite dev server concurrently.
 # --kill-others-on-fail: if either exits, kill the other (prevents orphaned daemon).

--- a/web-ui/src/api/client.ts
+++ b/web-ui/src/api/client.ts
@@ -338,9 +338,19 @@ export function createClientApi() {
       return parseJson<Worktree>(res);
     },
 
-    async deleteWorktree(id: string): Promise<{ ok: true }> {
+    /**
+     * Delete a worktree (always purges the checkout from disk). Live sessions
+     * are released/killed by the daemon as part of the delete.
+     *
+     * `enforceDone: true` opts into the daemon's safety net: the call fails
+     * with a 409 `worktree_not_done` if any session is still running. Only
+     * Settings → Storage passes it (its bulk-delete UI offers *done* worktrees
+     * only); explicit single deletes leave it off and force-clean instead.
+     */
+    async deleteWorktree(id: string, opts?: { enforceDone?: boolean }): Promise<{ ok: true }> {
       const root = baseUrl();
-      const res = await apiFetch(`${root}/worktrees/${encodeURIComponent(id)}`, {
+      const qs = opts?.enforceDone ? "?enforceDone=true" : "";
+      const res = await apiFetch(`${root}/worktrees/${encodeURIComponent(id)}${qs}`, {
         method: "DELETE",
       });
       return parseJson<{ ok: true }>(res);

--- a/web-ui/src/api/mock.ts
+++ b/web-ui/src/api/mock.ts
@@ -407,21 +407,24 @@ export function createMockApi() {
       return structuredClone(wt);
     },
 
-    async deleteWorktree(id: string): Promise<{ ok: true }> {
+    async deleteWorktree(id: string, opts?: { enforceDone?: boolean }): Promise<{ ok: true }> {
       const idx = worktrees.findIndex((w) => w.id === id);
       if (idx === -1) throw new ApiError("not found", 404);
       const wt = worktrees[idx]!;
-      const wtSessions = sessions.filter((s) => s.worktreeId === wt.id);
-      const notDone = wtSessions.filter((s) =>
-        s.type === "agent"
-          ? s.state !== "done"
-          : s.state !== "done" && s.state !== "exited",
-      );
-      if (notDone.length > 0) {
-        throw new ApiError(
-          JSON.stringify({ error: "worktree_not_done", sessions: notDone.map((s) => s.id) }),
-          409,
+      // Mirrors the daemon: the done guard is opt-in (Settings → Storage only).
+      if (opts?.enforceDone) {
+        const wtSessions = sessions.filter((s) => s.worktreeId === wt.id);
+        const notDone = wtSessions.filter((s) =>
+          s.type === "agent"
+            ? s.state !== "done"
+            : s.state !== "done" && s.state !== "exited",
         );
+        if (notDone.length > 0) {
+          throw new ApiError(
+            JSON.stringify({ error: "worktree_not_done", sessions: notDone.map((s) => s.id) }),
+            409,
+          );
+        }
       }
       worktrees.splice(idx, 1);
       for (let i = sessions.length - 1; i >= 0; i--) {

--- a/web-ui/src/components/layout/LeftSidebar.test.tsx
+++ b/web-ui/src/components/layout/LeftSidebar.test.tsx
@@ -1085,6 +1085,79 @@ describe("LeftSidebar", () => {
     });
   });
 
+  // ─── Worktree delete ("Delete worktree…" in the ⋯ menu) ────────────────
+  // The daemon's `worktree_not_done` guard is opt-in (`?enforceDone=true`) and
+  // belongs to Settings → Storage's bulk delete. The sidebar's explicit,
+  // confirmed single delete force-cleans instead: it must succeed even when
+  // the worktree still has running sessions.
+  describe("delete worktree", () => {
+    async function openDeleteConfirm(user: ReturnType<typeof userEvent.setup>) {
+      await screen.findByRole("link", { name: /Open worktree wt-1/i });
+      const wtRow = screen.getByRole("link", { name: /Open worktree wt-1/i }).closest(".tree-row")!;
+      const trigger = wtRow.querySelector("[data-wt-menu-trigger]")! as HTMLElement;
+      await user.click(trigger);
+      await user.click(await screen.findByRole("menuitem", { name: /^Delete worktree…$/i }));
+      await user.click(await screen.findByRole("button", { name: /^Delete$/i }));
+    }
+
+    it("deletes a worktree whose sessions are NOT done, in a single unguarded call", async () => {
+      // `wt-1`'s main session is `working` in the mock fixture — the exact case
+      // that used to 409 and vanish into an empty catch.
+      const user = userEvent.setup();
+      const localApi = createMockApi();
+      const delSpy = vi.spyOn(localApi, "deleteWorktree");
+      const doneSpy = vi.spyOn(localApi, "markWorktreeDone");
+      const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+      try {
+        render(
+          <MemoryRouter>
+            <Harness api={localApi}>
+              <LeftSidebar api={localApi} />
+            </Harness>
+          </MemoryRouter>,
+        );
+        await openDeleteConfirm(user);
+
+        await waitFor(() => {
+          expect(screen.queryByRole("link", { name: /Open worktree wt-1/i })).toBeNull();
+        });
+        expect(delSpy).toHaveBeenCalledTimes(1);
+        // No `enforceDone` opt-in from the sidebar, and no extra "mark done"
+        // round trip — one call does the whole job.
+        expect(delSpy).toHaveBeenCalledWith("wt-1");
+        expect(doneSpy).not.toHaveBeenCalled();
+        expect(alertSpy).not.toHaveBeenCalled();
+      } finally {
+        alertSpy.mockRestore();
+      }
+    });
+
+    it("a failed delete surfaces the error instead of failing silently", async () => {
+      const user = userEvent.setup();
+      const localApi = createMockApi();
+      const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+      vi.spyOn(localApi, "deleteWorktree").mockRejectedValue(
+        new Error("Worktree 'wt-1' not found"),
+      );
+      try {
+        render(
+          <MemoryRouter>
+            <Harness api={localApi}>
+              <LeftSidebar api={localApi} />
+            </Harness>
+          </MemoryRouter>,
+        );
+        await openDeleteConfirm(user);
+
+        await waitFor(() => {
+          expect(alertSpy).toHaveBeenCalledWith(expect.stringContaining("not found"));
+        });
+      } finally {
+        alertSpy.mockRestore();
+      }
+    });
+  });
+
   // ─── Inline rename (Part 03 Phase 3 — double-click, no modal fallback) ──
   // The modal `RenameDialog` is removed entirely (Decision 8); the sidebar
   // now mirrors TabsStrip.tsx's inline double-click rename exactly.

--- a/web-ui/src/components/layout/LeftSidebar.tsx
+++ b/web-ui/src/components/layout/LeftSidebar.tsx
@@ -771,14 +771,22 @@ export function LeftSidebar({
     const worktree = pendingDelete;
     setPendingDelete(null);
     try {
+      // No `enforceDone` here: this is an explicit, confirmed single-worktree
+      // delete, and the confirm copy already promises attached sessions go
+      // with it — the daemon releases/kills them as part of the delete. Only
+      // Settings → Storage opts into the `worktree_not_done` guard.
       await api.deleteWorktree(worktree.id);
       if (activeWorktreeId === worktree.id) {
         clearWorkspaceSelection();
       }
       // Store stays current via the `worktree:deleted` WS event handled in
       // useServerSync — no manual refresh needed.
-    } catch {
-      /* surface errors later */
+    } catch (err) {
+      // Previously a bare `catch { /* surface errors later */ }`, which made a
+      // failed removal look like nothing happened at all. Same mechanism as
+      // `confirmTerminateSession` below — web-ui still has no toast/banner
+      // infra, so this uses the browser-native alert rather than inventing it.
+      window.alert(err instanceof Error ? err.message : "Failed to remove worktree.");
     }
   }
 

--- a/web-ui/src/components/settings/StorageSetting.tsx
+++ b/web-ui/src/components/settings/StorageSetting.tsx
@@ -116,7 +116,10 @@ export function StorageSetting({ api }: StorageSettingProps) {
     setDeleteError(null);
     for (const wt of targets) {
       try {
-        await api.deleteWorktree(wt.id);
+        // enforceDone: this panel only ever offers *done* worktrees for
+        // deletion (non-done rows are disabled), and opts into the daemon's
+        // 409 `worktree_not_done` safety net in case that state went stale.
+        await api.deleteWorktree(wt.id, { enforceDone: true });
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : "An error occurred";
         let label = wt.branch;


### PR DESCRIPTION
## Summary
- Daemon-served clients (LAN/tunnel) were seeing stale UI because `scripts/dev-start.sh` never rebuilt `web-ui/dist` — the desktop window bypasses this entirely by loading Vite directly on `:5180`, so only remote clients were affected. `dev-start.sh` now builds `web-ui/dist` before launching the daemon.
- Fixed the left sidebar's "Remove worktree" silently doing nothing for worktrees with non-done sessions: the `409 worktree_not_done` guard on `DELETE /worktrees/:id` (added for the Settings → Storage panel's bulk-delete flow) is now opt-in via `?enforceDone=true`. The Storage panel passes it to keep its existing guarded/filtered behavior; the sidebar's single-worktree delete does not, so its confirm dialog's promised session cleanup now actually happens instead of silently failing.
- Replaced the empty `catch {}` in the sidebar's `confirmDeleteWorktree` with `window.alert` for any remaining real errors (matching the existing pattern used elsewhere in that file).

## Test plan
- [x] `web-ui` LeftSidebar.test.tsx — 54/54 passing, including new delete-worktree coverage
- [x] daemon `worktrees.test.ts` — 71/71 passing, including new `enforceDone` coverage
- [x] `tsc -b --noEmit` clean on touched files, ESLint 0 errors
- [x] Manually rebuilt `web-ui/dist` in the live main checkout and verified the daemon (`:7421`) now serves the fresh bundle hash

https://claude.ai/code/session_01PzpQ4QnzyxoP69iWHS8sHB