### PR TITLE
fix(remote-sessions): badge the viewer's own entry instead of a phantom 'This session' card

### DIFF
--- a/daemon/src/routes/auth.ts
+++ b/daemon/src/routes/auth.ts
@@ -4,6 +4,39 @@ import { bumpBrowserEpoch, revokeTokenId } from "../state/auth-state.js";
 import { closeConnectionsByTokenId, closeConnectionsByScope, getRemoteSessions } from "../broadcaster.js";
 import type { TokenPayload } from "../types.js";
 
+/**
+ * Parse a raw Cookie header string and return the value for a given cookie name.
+ * Mirrors the helper in ws/server.ts — kept local so the route has no dependency
+ * on the WS layer.
+ */
+function parseCookieValue(cookieHeader: string, name: string): string {
+  for (const part of cookieHeader.split(";")) {
+    const eqIdx = part.indexOf("=");
+    if (eqIdx === -1) continue;
+    const k = part.slice(0, eqIdx).trim();
+    const v = part.slice(eqIdx + 1).trim();
+    if (k === name) return v;
+  }
+  return "";
+}
+
+/**
+ * Derive the caller's tokenId from the raw token on the request (cookie or
+ * Authorization header). A token is `<tokenId>.<signature>`, so the id is
+ * everything before the final dot — the same derivation used in ws/server.ts.
+ * Returns undefined when the request carries no token (e.g. desktop/loopback).
+ */
+function currentTokenIdOf(req: { headers: Record<string, unknown> }): string | undefined {
+  const auth = typeof req.headers.authorization === "string" ? req.headers.authorization : "";
+  const cookieHeader = typeof req.headers.cookie === "string" ? req.headers.cookie : "";
+  const bearer = auth.startsWith("Bearer ") ? auth.slice(7) : "";
+  const token = bearer || parseCookieValue(cookieHeader, COOKIE_NAME);
+  if (!token) return undefined;
+  const dot = token.lastIndexOf(".");
+  if (dot <= 0) return undefined;
+  return token.slice(0, dot);
+}
+
 export function registerAuthRoutes(app: FastifyInstance, persistEpoch: () => Promise<void>): void {
   // POST /auth/logout — clear the cookie (per-device; no epoch bump)
   app.post("/auth/logout", async (_req, reply) => {
@@ -35,7 +68,11 @@ export function registerAuthRoutes(app: FastifyInstance, persistEpoch: () => Pro
     const isDesktop = !authPayload || authPayload.scope === "tauri";
     // currentScope: the caller's token scope; loopback-with-no-token is treated as 'tauri'.
     const currentScope: string = authPayload?.scope ?? "tauri";
-    return reply.send({ sessions: getRemoteSessions(), isDesktop, currentScope });
+    // currentTokenId: lets a browser/mobile viewer find *itself* in the sessions
+    // list (it has a real entry there) and badge it as "this session". Undefined
+    // for desktop/loopback callers, which carry no token and have no list entry.
+    const currentTokenId = currentTokenIdOf(req as unknown as { headers: Record<string, unknown> });
+    return reply.send({ sessions: getRemoteSessions(), isDesktop, currentScope, currentTokenId });
   });
 
   // POST /auth/sessions/:id/revoke — revoke a remote session by tokenId.

--- a/web-ui/src/api/client.ts
+++ b/web-ui/src/api/client.ts
@@ -1228,9 +1228,9 @@ export function createClientApi() {
       return parseJson<LocalQrResponse>(res);
     },
 
-    async listAuthSessions(): Promise<{ sessions: AuthSession[]; isDesktop: boolean; currentScope?: string }> {
+    async listAuthSessions(): Promise<{ sessions: AuthSession[]; isDesktop: boolean; currentScope?: string; currentTokenId?: string }> {
       const res = await apiFetch(`${baseUrl()}/auth/sessions`);
-      return parseJson<{ sessions: AuthSession[]; isDesktop: boolean; currentScope?: string }>(res);
+      return parseJson<{ sessions: AuthSession[]; isDesktop: boolean; currentScope?: string; currentTokenId?: string }>(res);
     },
 
     async revokeAuthSession(tokenId: string): Promise<void> {

--- a/web-ui/src/api/mock.ts
+++ b/web-ui/src/api/mock.ts
@@ -1540,7 +1540,7 @@ export function createMockApi() {
     async getMobileQr(): Promise<MobileQrResponse> { return { qrUrl: "https://mock.trycloudflare.com/mobile-auth?code=mock", expiresAt: Date.now() + 30_000 }; },
     async getLocalQr(): Promise<LocalQrResponse> { return { qrUrl: "http://192.168.1.42:7421/mobile-auth?code=mock-local", expiresAt: Date.now() + 30_000, connectionType: "lan" }; },
     async revokeAllBrowserSessions(): Promise<{ ok: boolean; browserEpoch: number }> { return { ok: true, browserEpoch: 0 }; },
-    async listAuthSessions(): Promise<{ sessions: AuthSession[]; isDesktop: boolean; currentScope?: string }> { return { sessions: [], isDesktop: true, currentScope: "tauri" }; },
+    async listAuthSessions(): Promise<{ sessions: AuthSession[]; isDesktop: boolean; currentScope?: string; currentTokenId?: string }> { return { sessions: [], isDesktop: true, currentScope: "tauri", currentTokenId: undefined }; },
     async revokeAuthSession(_tokenId: string): Promise<void> {},
   };
 

--- a/web-ui/src/components/settings/RemoteAccessSetting.tsx
+++ b/web-ui/src/components/settings/RemoteAccessSetting.tsx
@@ -116,9 +116,12 @@ export function RemoteAccessSetting({ api }: RemoteAccessSettingProps) {
   // isDesktop: true when viewing from the desktop app (loopback), false for browser sessions.
   // Starts as false so browser viewers never see a spurious revoke button; corrected on first fetch.
   const [isDesktop, setIsDesktop] = useState(false);
-  // currentScope: the caller's token scope ('tauri', 'browser', 'mobile', etc.).
-  // Used to derive the correct label for the current-session card.
-  const [currentScope, setCurrentScope] = useState<string | null>(null);
+  // currentTokenId: the viewer's own tokenId, when it has one. Browser/mobile
+  // viewers appear as a real entry in `sessions`, so we badge that entry as
+  // "this session" instead of rendering a separate hardcoded card. Desktop
+  // (tauri/loopback) callers have no token and no list entry, so they keep the
+  // hardcoded "Desktop · this session" card.
+  const [currentTokenId, setCurrentTokenId] = useState<string | null>(null);
 
   // ── QR overlay state ────────────────────────────────────────────────────────
   const [activeQr, setActiveQr] = useState<ActiveQrType | null>(null);
@@ -149,10 +152,10 @@ export function RemoteAccessSetting({ api }: RemoteAccessSettingProps) {
   // ── Fetch remote sessions ───────────────────────────────────────────────────
   const fetchSessions = useCallback(async () => {
     try {
-      const { sessions: list, isDesktop: desktop, currentScope: scope } = await api.listAuthSessions();
+      const { sessions: list, isDesktop: desktop, currentTokenId: tokenId } = await api.listAuthSessions();
       setSessions(list);
       setIsDesktop(desktop);
-      setCurrentScope(scope ?? null);
+      setCurrentTokenId(tokenId ?? null);
     } catch {
       // silently ignore (session list is non-critical)
     }
@@ -582,28 +585,32 @@ export function RemoteAccessSetting({ api }: RemoteAccessSettingProps) {
         )}
 
         <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
-          {/* Current session entry */}
-          <div style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            gap: "var(--space-3)",
-            padding: "var(--space-3)",
-            border: "var(--border-width) solid var(--border-default)",
-            borderRadius: "var(--radius-md)",
-            background: "var(--bg-card)",
-          }}>
-            <div>
-              <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", marginBottom: 2 }}>
-                <span style={{ fontWeight: "var(--font-weight-medium)", fontSize: "var(--font-size-sm)" }}>
-                  {currentScope === "tauri" ? "Desktop" : currentScope === "browser" ? "This session" : isDesktop ? "Desktop" : "This session"}
-                </span>
-                <span style={{ fontSize: "var(--font-size-xs)", color: "var(--fg-muted)", background: "var(--bg-input)", borderRadius: "var(--radius-sm)", padding: "1px 6px" }}>
-                  this session
-                </span>
+          {/* Desktop has no entry in the sessions list (no tokenId), so it gets a
+              hardcoded card. Browser/mobile viewers are IN the list — their own
+              entry is badged below instead. */}
+          {isDesktop && (
+            <div style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: "var(--space-3)",
+              padding: "var(--space-3)",
+              border: "var(--border-width) solid var(--border-default)",
+              borderRadius: "var(--radius-md)",
+              background: "var(--bg-card)",
+            }}>
+              <div>
+                <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", marginBottom: 2 }}>
+                  <span style={{ fontWeight: "var(--font-weight-medium)", fontSize: "var(--font-size-sm)" }}>
+                    Desktop
+                  </span>
+                  <span style={{ fontSize: "var(--font-size-xs)", color: "var(--fg-muted)", background: "var(--bg-input)", borderRadius: "var(--radius-sm)", padding: "1px 6px" }}>
+                    this session
+                  </span>
+                </div>
               </div>
             </div>
-          </div>
+          )}
 
           {/* Remote sessions sorted by lastSeenAt desc */}
           {[...sessions].sort((a, b) => b.lastSeenAt - a.lastSeenAt).map((s) => (
@@ -625,6 +632,11 @@ export function RemoteAccessSetting({ api }: RemoteAccessSettingProps) {
                   <span style={{ fontWeight: "var(--font-weight-medium)", fontSize: "var(--font-size-sm)" }}>
                     {s.deviceName ?? "Browser"}
                   </span>
+                  {s.tokenId === currentTokenId && (
+                    <span style={{ fontSize: "var(--font-size-xs)", color: "var(--fg-muted)", background: "var(--bg-input)", borderRadius: "var(--radius-sm)", padding: "1px 6px" }}>
+                      this session
+                    </span>
+                  )}
                   <span style={{ fontSize: "var(--font-size-xs)", color: "var(--fg-muted)", background: "var(--bg-input)", borderRadius: "var(--radius-sm)", padding: "1px 6px" }}>
                     {s.scope}
                   </span>


### PR DESCRIPTION
## The bug

For a browser/mobile viewer, the **Active sessions** list rendered a hardcoded card at the top labelled *This session* — which represented nothing. A browser viewer already has a **real entry** in the sessions list (it has a `tokenId`). Worse, the `this session` badge sat on that phantom card rather than on the real entry, so nothing in the actual list told you which row was you.

## The fix

- `GET /auth/sessions` now returns `currentTokenId`, derived from the raw token on the request (Authorization bearer or the auth cookie) as `token.slice(0, token.lastIndexOf("."))` — the same derivation `ws/server.ts` already uses. It is `undefined` for desktop/loopback callers, which carry no token.
- The UI matches list entries by `tokenId` and puts the `this session` badge on the matching row.
- The hardcoded card is now rendered **only** when `isDesktop` — desktop has no `tokenId` and therefore no list entry, so it legitimately needs its own "Desktop · this session" card.

## Files

- `daemon/src/routes/auth.ts` — local cookie parser + `currentTokenIdOf()`, added to the response
- `web-ui/src/api/client.ts` / `web-ui/src/api/mock.ts` — `currentTokenId?: string` on the return type
- `web-ui/src/components/settings/RemoteAccessSetting.tsx` — `currentScope` state replaced by `currentTokenId`; desktop-only hardcoded card; badge on the matching list entry

## Verification

- `pnpm --filter @vibestation/cli typecheck` ✅ (`cli/src/daemon` is a symlink to `daemon/src`, so this covers the daemon change)
- `pnpm --filter @vibestation/web typecheck` ✅

https://claude.ai/code/session_012bNxd3diDx3CebEwijufFo