### PR TITLE
fix(desktop): terminate from unlauncher fails with JS "Load failed"

### DIFF
--- a/daemon/src/server.ts
+++ b/daemon/src/server.ts
@@ -114,9 +114,13 @@ export async function buildServer(opts: BuildServerOptions = {}) {
   await app.register(fastifyCookie);
 
   // CORS — reflect the request origin (any origin) and allow credentials.
+  // allowedHeaders must be explicit: @fastify/cors does not reliably reflect
+  // Authorization in preflights for uncached DELETE/PATCH URLs (each session id
+  // is unique, so the preflight cache never hits), causing WebKit "Load failed".
   await app.register(fastifyCors, {
     origin: true,
     credentials: true,
+    allowedHeaders: ["Content-Type", "Authorization"],
   });
 
   // ── Auth guard ───────────────────────────────────────────────────────────────

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -25,7 +25,8 @@
       }
     ],
     "security": {
-      "capabilities": ["default"]
+      "capabilities": ["default"],
+      "csp": "default-src 'self'; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:*; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Summary

Fixes the "Load failed" JS error when trying to terminate agent sessions from the desktop app's unlauncher panel. The same action worked fine from a LAN browser session because it goes through the Vite proxy (same-origin), but the Tauri desktop app makes direct cross-origin requests to the daemon.

Two root causes stacked:

- **CORS preflight not reflecting `Authorization`** — `@fastify/cors` without `allowedHeaders` doesn't reliably include `Authorization` in preflight responses for uncached URLs. Session-terminate is a DELETE to a unique path (session id), so the CORS preflight cache never hits; every terminate fires a fresh OPTIONS that could be rejected by WebKit, producing "Load failed" before the request reaches the server.
- **Tauri implicit CSP blocks `http://127.0.0.1:*`** — Tauri 2's default `connect-src 'self'` only covers `tauri://localhost`, not the daemon's loopback address. In production builds, every API call was blocked by the browser engine before any network activity.

## Changes

- `daemon/src/server.ts` — add `allowedHeaders: ["Content-Type", "Authorization"]` to the `@fastify/cors` registration so all preflights include the correct `Access-Control-Allow-Headers`.
- `desktop/src-tauri/tauri.conf.json` — add explicit `csp` to permit `http://127.0.0.1:*` and `ws://127.0.0.1:*` so production Tauri builds can reach the daemon.

## Test plan

- [x] Dev sandbox started with the patched code
- [x] `OPTIONS` preflight for `DELETE /api/sessions/:id` returns `Access-Control-Allow-Headers: Content-Type, Authorization` (confirmed via `curl`)
- [x] `DELETE /api/sessions/nonexistent` returns `404 application/json` (request reaches daemon, not blocked by CORS/CSP)
- [ ] Manual smoke test: terminate an agent from the desktop unlauncher — should no longer show "Load failed" popup