### PR TITLE
fix(daemon): use process.execPath in vst shim instead of bare node

### DIFF
--- a/daemon/src/lib/resolveVstPaths.ts
+++ b/daemon/src/lib/resolveVstPaths.ts
@@ -70,7 +70,7 @@ export async function setupVstEnvironment(): Promise<void> {
     try {
       await mkdir(binDir, { recursive: true });
       const shimContent = src.endsWith(".js")
-        ? `#!/bin/sh\nexec node ${src} "$@"\n`
+        ? `#!/bin/sh\nexec "${process.execPath}" "${src}" "$@"\n`
         : `#!/bin/sh\nexec ${src} "$@"\n`;
       await writeFile(shimPath, shimContent, { encoding: "utf8", mode: 0o755 });
       await chmod(shimPath, 0o755);


### PR DESCRIPTION
## Summary

- The `vst` shim written at daemon startup used `exec node main.js` in dev mode
- On macOS Tauri, GUI apps don't source shell profiles so `node` isn't on PATH — the shim was found but immediately failed
- Replace bare `node` with `process.execPath` (absolute path to the Node binary already running the daemon)
- Also quotes both paths to handle spaces in paths

## Test plan

- [ ] Start `tauri dev` on macOS, ask a rich chat agent to run `vst session create` — should succeed
- [ ] Verify shim content at `~/.vibe-station/bin/vst` shows the absolute node path
- [ ] Prod build unaffected (uses native binary, this branch is never hit)