### PR TITLE
fix(chat): show bash command in Ran block for Claude ACP and OpenCode

### DIFF
--- a/daemon/src/services/acp/normalize.ts
+++ b/daemon/src/services/acp/normalize.ts
@@ -207,9 +207,19 @@ export function normalizeSessionUpdate(
       // populates `toolResult` — an in-progress update with no content leaves
       // `toolResult` undefined rather than overwriting a previously-set result.
       const text = textFromToolCallContent(raw.content);
+      // Propagate rawInput from refinement events (Claude ACP emits the full
+      // bash command in a tool_call_update after the initial empty tool_call).
+      // `raw.input` is a fallback for adapters that use that field name instead.
+      const rawInputValue = raw.rawInput ?? raw.input;
+      const refinedInput =
+        rawInputValue != null &&
+        !(typeof rawInputValue === "object" && Object.keys(rawInputValue as Record<string, unknown>).length === 0)
+          ? rawInputValue
+          : undefined;
       base = stamp({
         kind: "tool_result",
         toolId: toolCallId,
+        toolInput: refinedInput,
         toolResult: raw.content !== undefined ? { content: text, isError: status === "failed" } : undefined,
         toolStatus:
           status === "pending" || status === "in_progress" || status === "completed" || status === "failed"

--- a/web-ui/src/components/chat/MessageList.tsx
+++ b/web-ui/src/components/chat/MessageList.tsx
@@ -291,6 +291,7 @@ export function groupEvents(events: NormalizedEvent[]): RenderItem[] {
         markToolCallDuringThinking(ev.turnId);
         const target = ev.toolId ? toolRefById.get(ev.toolId) : undefined;
         if (target) {
+          if (ev.toolInput != null) target.toolInput = ev.toolInput;
           if (ev.toolResult !== undefined) {
             target.result = { content: ev.toolResult.content, isError: ev.toolResult.isError };
           }

--- a/web-ui/src/components/chat/ToolRunSummary.tsx
+++ b/web-ui/src/components/chat/ToolRunSummary.tsx
@@ -138,7 +138,10 @@ function ToolRunEntryRow({ tool, running, cwd }: { tool: ToolCallEntry; running:
     READ_ONLY_TOOL_NAMES.has(name);
   // Edit/Write/Delete/Move tools start expanded so diffs are immediately visible.
   const [open, setOpen] = useState(!isBash && !isReadOnly);
-  const inlineFull = summarizeToolInput(tool.toolInput, tool.locations, cwd);
+  // For bash/execute tools, `locations` holds the cwd directory, not a file —
+  // skip it so the cwd path isn't shown inline as if it were the command. No
+  // known bash adapter populates locations with anything else today.
+  const inlineFull = summarizeToolInput(tool.toolInput, isBash ? undefined : tool.locations, cwd);
   // Cap long inline text (e.g. Task tool prompts) so it doesn't overflow the row.
   const INLINE_CAP = 80;
   const inline = inlineFull.length > INLINE_CAP ? `${inlineFull.slice(0, INLINE_CAP)}…` : inlineFull;
@@ -146,7 +149,14 @@ function ToolRunEntryRow({ tool, running, cwd }: { tool: ToolCallEntry; running:
   // `toolInput` is often `{}` for an ACP adapter that reports the target via
   // `locations` instead (see summarizeToolInput) — an empty-object body adds
   // nothing over the inline location text above, so don't expand into one.
-  const hasInputBody = tool.toolInput != null && pretty !== "undefined" && pretty !== "{}";
+  // For OpenCode bash calls, toolInput is `{ cwd: '/path' }` — useless metadata
+  // that confuses the user when shown as a JSON body; treat it as no body.
+  const inputKeys =
+    isBash && tool.toolInput != null && typeof tool.toolInput === "object"
+      ? Object.keys(tool.toolInput as Record<string, unknown>)
+      : null;
+  const isCwdOnlyInput = inputKeys !== null && inputKeys.length === 1 && inputKeys[0] === "cwd";
+  const hasInputBody = !isCwdOnlyInput && tool.toolInput != null && pretty !== "undefined" && pretty !== "{}";
   const result = tool.result;
   const resultText = result?.content ? capForDisplay(result.content) : "";
   const hasResultBody = resultText.length > 0;


### PR DESCRIPTION
## Problem

Two separate issues with the **Ran** block in Rich Chat mode:

### Issue 1 — Claude ACP: command never shown
Claude's ACP adapter emits a `tool_call` with empty `toolInput: {}` initially (command still streaming), then a `tool_call_update` refinement carrying the full `rawInput: { command: 'ls -la', ... }`. The normalize path was dropping `rawInput` from the `tool_call_update → tool_result` mapping, so the command was never persisted or displayed. Only the generic "Ran ✓" label showed, with no command text.

### Issue 2 — OpenCode (DeepSeek): shows cwd path inline + JSON body instead of command
OpenCode's ACP adapter puts only `{ cwd: '/worktree/path' }` in the bash `tool_call` input — the actual command is not available. Two display bugs followed:
- The cwd path leaked into the inline label (via the `locations` fallback in `summarizeToolInput`), showing the full worktree path as if it were the command
- When expanded, `{"cwd": "/path/..."}` showed as a JSON body followed by the output — confusing and useless

## Fix

**`daemon/src/services/acp/normalize.ts`** — When `tool_call_update` carries a non-empty `rawInput` (or `input`), include it as `toolInput` on the emitted `tool_result` event rather than dropping it.

**`web-ui/src/components/chat/MessageList.tsx`** — In the `tool_result` handler, if `ev.toolInput` is non-null, update the matched `tool_use` entry's `toolInput`. This lets the ACP refinement's command propagate back to the already-rendered row.

**`web-ui/src/components/chat/ToolRunSummary.tsx`** — Two display fixes for bash/execute tools:
- Skip `locations` when computing the inline label (bash locations is the cwd, not a file path — passing it caused the cwd to show inline as if it were the command)
- Suppress the expandable JSON body when `toolInput` contains only a `cwd` key (OpenCode's pattern) — there's nothing useful to expand into

## Scope
- Fix 1 (normalize + MessageList) only affects future sessions; stored transcripts with empty \`toolInput\` aren't retroactively updated.
- Fix 3 (display) cleans up both existing and future OpenCode bash rows.