### PR TITLE
fix(desktop): route all external links to system browser in Tauri app

### DIFF
--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -18,6 +18,7 @@
         { "name": "cloudflared", "sidecar": true },
         { "name": "vst", "sidecar": true }
       ]
-    }
+    },
+    "shell:allow-open"
   ]
 }

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -7,12 +7,22 @@ mod tray;
 use std::path::PathBuf;
 
 use tauri::{Manager, WebviewWindowBuilder, WindowEvent};
+use tauri_plugin_shell::AppHandleExt;
+
+fn is_internal_url(url: &tauri::Url) -> bool {
+    url.host_str() == Some("localhost")
+        || url.scheme() == "tauri"
+        || (url.scheme() == "https" && url.host_str() == Some("tauri.localhost"))
+        || url.scheme() == "about"
+        || url.scheme() == "blob"
+}
 
 fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .setup(|app| {
             let app_handle = app.handle().clone();
+            let nav_handle = app.handle().clone();
 
             let cloudflared_bin: PathBuf = app_handle
                 .path()
@@ -101,6 +111,17 @@ fn main() {
                 .ok_or("no window config found")?;
             WebviewWindowBuilder::from_config(app.handle(), &conf)?
                 .initialization_script(&script)
+                .on_navigation(move |url| {
+                    if is_internal_url(url) {
+                        return true;
+                    }
+                    let url_str = url.to_string();
+                    let handle = nav_handle.clone();
+                    tauri::async_runtime::spawn(async move {
+                        let _ = handle.shell().open(url_str, None);
+                    });
+                    false
+                })
                 .build()?;
 
             tray::build_tray(&app_handle)?;
@@ -141,6 +162,18 @@ fn build_init_script(port: u16, token: &str, os_name: &str) -> String {
            }} else {{\
              tag();\
            }}\
+         }})();\
+         (function() {{\
+           document.addEventListener('click', function(e) {{\
+             var el = e.target && e.target.closest('a');\
+             if (!el) return;\
+             var href = el.getAttribute('href') || '';\
+             var isExternal = /^https?:/.test(href) && !/^https?:\\/\\/(localhost|tauri\\.localhost)(:\\d+)?(\\/|$)/.test(href);\
+             if (el.target === '_blank' && isExternal && window.__TAURI_INTERNALS__) {{\
+               e.preventDefault();\
+               window.__TAURI_INTERNALS__.invoke('plugin:shell|open', {{ path: href, openWith: null }});\
+             }}\
+           }}, true);\
          }})();"
     )
 }

--- a/web-ui/src/components/layout/TerminalPane.tsx
+++ b/web-ui/src/components/layout/TerminalPane.tsx
@@ -160,8 +160,16 @@ export function TerminalPane({ api, sessionId, session, channelToggle }: Termina
     fitRef.current = fit;
     term.loadAddon(fit);
 
-    // Make http:// and https:// URLs clickable — opens in a new tab
-    term.loadAddon(new WebLinksAddon((_, url) => window.open(url, "_blank", "noopener,noreferrer")));
+    // Make http:// and https:// URLs clickable — opens in system browser (Tauri) or new tab (browser dev)
+    term.loadAddon(new WebLinksAddon((_, url) => {
+      if (/^https?:/.test(url) && typeof (window as any).__TAURI_INTERNALS__ !== 'undefined') {
+        (window as any).__TAURI_INTERNALS__.invoke('plugin:shell|open', { path: url, openWith: null }).catch(() => {
+          window.open(url, '_blank', 'noopener,noreferrer');
+        });
+      } else {
+        window.open(url, '_blank', 'noopener,noreferrer');
+      }
+    }));
 
     term.open(host);
 


### PR DESCRIPTION
## Problem

External URLs (terminal hyperlinks, GitHub PR links) were opening inside the Tauri webview instead of the system browser. The existing `on_navigation` Rust callback correctly blocks same-webview navigations, but `window.open()` and `<a target="_blank">` clicks create a *new* WebviewWindow with no navigation handler — so those bypassed the guard entirely.

## Fix — three layers

**1. `capabilities/default.json`** — added `shell:allow-open` permission. Without this the `plugin:shell|open` IPC call fails silently at runtime.

**2. `web-ui/src/components/layout/TerminalPane.tsx`** — `WebLinksAddon` click handler now calls `plugin:shell|open` via `__TAURI_INTERNALS__` when running in the desktop app; falls back to `window.open` in browser dev mode. Scheme is validated (`/^https?:/`) before invoking.

**3. `desktop/src-tauri/src/main.rs` `build_init_script`** — appends a capture-phase anchor-click guard that intercepts `<a target="_blank">` clicks on externally-hosted `http/https` hrefs and routes them to `plugin:shell|open`. Internal `localhost`/`tauri.localhost` same-origin links are excluded so they continue to work normally inside the webview.

## What's NOT changed

- The existing `on_navigation` Rust callback (already correct for same-webview navigations)
- No `window.open` global override (too broad)
- No `setInterval` URL polling guard (fragile, fights React Router)
- Browser dev mode is unaffected — both JS guards check for `__TAURI_INTERNALS__` before invoking Tauri APIs

## Test plan

- [ ] Click a terminal hyperlink in the desktop app → opens in system browser, not webview
- [ ] Click a PR link in VcsPanel → opens in system browser
- [ ] In-app navigation (React Router route changes) still works
- [ ] Browser dev mode (no Tauri): terminal links fall back to `window.open` new tab