### PR TITLE
fix(daemon): prevent VST_DAEMON_URL=http://127.0.0.1:0 in spawned agent envs

### DIFF
--- a/daemon/src/assets/agent-subagent-richchat.md
+++ b/daemon/src/assets/agent-subagent-richchat.md
@@ -21,6 +21,16 @@ That is the whole thing. No flags to look up, no tool to find.
   it runs inside this conversation, creates no session, and the user cannot
   see or open it. Do not go looking through your tool list for a way to spawn
   a session; there is no tool for it, only the command above.
+- **To MESSAGE a vst subagent, use `vst session send`, NOT harness tools.**
+  `SendMessage`, `ListAgents`, and `ToolSearch` are Claude harness tools —
+  they operate within the harness process and cannot see or reach vst sessions.
+  If you search for a tool to contact a subagent, you will find `SendMessage`
+  and it will fail with "No agent named … is reachable". The correct command:
+  ```bash
+  vst session send <subagent-id> "your message" --wait
+  ```
+  The session id comes from the output of `vst session create` (the line
+  printed when you spawned it) or from `vst session ls --worktree=$VST_WORKTREE --json`.
 - **When to use which.** Use `Task` for a short internal lookup whose result
   you will consume within this same turn. Spawn a vst subagent for anything
   the user might want to watch, open, or keep running — and ALWAYS when the

--- a/daemon/src/assets/agent-system-prompt.md
+++ b/daemon/src/assets/agent-system-prompt.md
@@ -103,6 +103,10 @@ sessions coordinate via files (e.g. write a spec file, let the sibling implement
 
 ### Send a message to a session
 
+> **Harness tools (`SendMessage`, `ListAgents`) cannot reach vst sessions.**
+> They are Claude harness internals and will always fail with "No agent named …
+> is reachable". Use `vst session send` below — it is the only correct channel.
+
 If you only know a session by its UI-set display name (e.g. "send a message
 to reviewer"), resolve it to an id first — don't guess or construct one:
 

--- a/daemon/src/main.ts
+++ b/daemon/src/main.ts
@@ -18,7 +18,8 @@ import * as cloudflared from "./services/cloudflared.js";
 import { resolveTunnelPort } from "./services/tunnelPort.js";
 import { loadAll } from "./state/project-store.js";
 import { recoverNotStartedSessions, sweepDirectPtySessionsOnBoot } from "./services/recover.js";
-import { startLifecyclePoller, stopLifecyclePoller, setNotifyDaemonPort } from "./services/lifecycle.js";
+import { startLifecyclePoller, stopLifecyclePoller } from "./services/lifecycle.js";
+import { setDaemonPort } from "./services/daemonPort.js";
 import { startPrPoller, stopPrPoller } from "./services/prPoller.js";
 import { readSettings } from "./services/config.js";
 import { setSkillPaths } from "./services/userSkillCatalog.js";
@@ -233,9 +234,11 @@ async function main() {
   // The tunnel requires explicit user action to enable after each restart.
   await cloudflared.restoreOnBoot(resolveTunnelPort(port));
 
-  // Subagent → parent notifications resolve the parent's agent lazily and need
-  // the port to do it (subagent-ux-v2).
-  setNotifyDaemonPort(port);
+  // Publish the real port process-wide. Everything that spawns an agent puts
+  // it in VST_DAEMON_URL, and callers without a live Fastify handle (WS chat
+  // open, subagent notifications, timers) read it from here instead of passing
+  // a placeholder 0.
+  setDaemonPort(port);
   // Detect tmux pane death + drive session:exited / state transitions
   startLifecyclePoller();
   // Poll for PR outcome (open/merged/closed) on the orthogonal `session.pr`

--- a/daemon/src/routes/projects.ts
+++ b/daemon/src/routes/projects.ts
@@ -27,6 +27,7 @@ import { projectDir, assertSafeToDelete } from "../services/paths.js";
 import { readSettings } from "../services/config.js";
 import { broadcastAll } from "../broadcaster.js";
 import { releaseSessionRuntime } from "../services/sessionRuntime.js";
+import { resolveDaemonPort } from "../services/daemonPort.js";
 import type { ProjectRecord, SessionRecord } from "../types.js";
 
 /**
@@ -494,7 +495,7 @@ export function registerProjectRoutes(app: FastifyInstance): void {
         });
       }
 
-      const daemonPort = (app.server.address() as { port?: number })?.port ?? 7421;
+      const daemonPort = resolveDaemonPort((app.server.address() as { port?: number })?.port);
 
       if (useWorktree) {
         // Create worktree + session. `branch` was resolved and validated

--- a/daemon/src/routes/sessions.ts
+++ b/daemon/src/routes/sessions.ts
@@ -8,6 +8,7 @@ import { killSession, newSession, pasteBuffer, capturePane, hasSession, sendKeys
 import { directPtyRegistry } from "../state/directPtyRegistry.js";
 import { spawnSession, spawnSessionFromArgv, spawnDirectSession } from "../services/spawn.js";
 import { resolvedContextOf } from "../services/context.js";
+import { resolveDaemonPort, getDaemonPort } from "../services/daemonPort.js";
 import type { AgentPlugin } from "../services/spawn.js";
 import {
   cleanupSessionDataDir,
@@ -712,7 +713,7 @@ export function registerSessionRoutes(app: FastifyInstance): void {
       // create (Decision 2/8) — the process starts on turn 1, auto-enqueued from
       // the create-dialog prompt via the JSON turn queue.
       if (type === "agent" && modeId) {
-        const daemonPort = (app.server.address() as { port?: number })?.port ?? 7421;
+        const daemonPort = resolveDaemonPort((app.server.address() as { port?: number })?.port);
         void spawnNewSessionForChannel({
           project,
           session: sessionRecord,
@@ -861,7 +862,7 @@ export function registerSessionRoutes(app: FastifyInstance): void {
     // JSON-channel sessions do NOT spawn a TTY at create (Decision 2/8) — the
     // process starts on turn 1, auto-enqueued from the create-dialog prompt.
     if (type === "agent" && modeId) {
-      const daemonPort = (app.server.address() as { port?: number })?.port ?? 7421;
+      const daemonPort = resolveDaemonPort((app.server.address() as { port?: number })?.port);
       void spawnNewSessionForChannel({
         project,
         worktree,
@@ -1322,7 +1323,7 @@ export function registerSessionRoutes(app: FastifyInstance): void {
             project,
             ctx: resolvedContextOf(project, worktree ?? null),
             session,
-            daemonPort: 0,
+            daemonPort: getDaemonPort(),
             ...(mode.model ? { model: mode.model } : {}),
           };
           const env: Record<string, string> = {
@@ -1332,7 +1333,7 @@ export function registerSessionRoutes(app: FastifyInstance): void {
             ...(worktree ? { VST_WORKTREE: worktree.id } : {}),
             VST_PROJECT: project.id,
             VST_DATA_DIR: `${process.env.HOME ?? "~"}/.vibe-station/projects/${project.id}`,
-            VST_DAEMON_URL: `http://127.0.0.1:${(app.server.address() as { port?: number })?.port ?? 7421}`,
+            VST_DAEMON_URL: `http://127.0.0.1:${resolveDaemonPort((app.server.address() as { port?: number })?.port)}`,
             ...plugin.getEnvironment(launchCfg),
           };
 
@@ -1367,7 +1368,7 @@ export function registerSessionRoutes(app: FastifyInstance): void {
           // first prompt on every future resume would silently re-issue a
           // stale instruction to an agent that may have finished long ago.
           const replayInitialPrompt = !session.agentChatId && !!session.initialPrompt;
-          const daemonPort = (app.server.address() as { port?: number })?.port ?? 7421;
+          const daemonPort = resolveDaemonPort((app.server.address() as { port?: number })?.port);
 
           if (isWorktreeSession) {
             const { buildPrompt } = await import("../services/promptBuilder.js");
@@ -1669,7 +1670,7 @@ export function registerSessionRoutes(app: FastifyInstance): void {
     // here instead would be the exact bug reset-with-mode-switch exists to
     // avoid: the stored record would show the new mode while the spawned
     // process still ran the old CLI.
-    const daemonPort = (app.server.address() as { port?: number })?.port ?? 7421;
+    const daemonPort = resolveDaemonPort((app.server.address() as { port?: number })?.port);
     void spawnNewSessionForChannel({
       project,
       worktree: ctx.kind === "worktree" ? ctx.worktree : undefined,
@@ -1738,7 +1739,7 @@ export function registerSessionRoutes(app: FastifyInstance): void {
         attachments.push(att);
       }
 
-      const daemonPort = (app.server.address() as { port?: number })?.port ?? 7421;
+      const daemonPort = resolveDaemonPort((app.server.address() as { port?: number })?.port);
       // D8 — steer a running turn by default; `queue: true` opts out.
       let res;
       try {
@@ -1842,7 +1843,7 @@ export function registerSessionRoutes(app: FastifyInstance): void {
       attachments.push(att);
     }
 
-    const daemonPort = (app.server.address() as { port?: number })?.port ?? 7421;
+    const daemonPort = resolveDaemonPort((app.server.address() as { port?: number })?.port);
     let res;
     try {
       res = await enqueueChatTurn({ sessionId: id, message, attachments, daemonPort });
@@ -1983,7 +1984,7 @@ export function registerSessionRoutes(app: FastifyInstance): void {
     }
     const { turnId, message, attachmentIds } = parsed.data;
 
-    const daemonPort = (app.server.address() as { port?: number })?.port ?? 7421;
+    const daemonPort = resolveDaemonPort((app.server.address() as { port?: number })?.port);
     const resolved = await resolveJsonAgent(id, daemonPort);
     if (!resolved.ok) {
       return reply.status(resolved.reason === "not_found" ? 404 : 400).send({ error: resolved.message });
@@ -2046,7 +2047,7 @@ export function registerSessionRoutes(app: FastifyInstance): void {
       });
     }
 
-    const daemonPort = (app.server.address() as { port?: number })?.port ?? 7421;
+    const daemonPort = resolveDaemonPort((app.server.address() as { port?: number })?.port);
     const resolved = await resolveJsonAgent(id, daemonPort);
     if (!resolved.ok) {
       return reply.status(resolved.reason === "not_found" ? 404 : 400).send({ error: resolved.message });
@@ -2086,7 +2087,7 @@ export function registerSessionRoutes(app: FastifyInstance): void {
   }): Promise<void> {
     const { project, worktree, session, plugin, model, context } = opts;
     const cwd = worktree ? worktreePath(project.id, worktree.id) : project.absolutePath;
-    const daemonPort = (app.server.address() as { port?: number })?.port ?? 7421;
+    const daemonPort = resolveDaemonPort((app.server.address() as { port?: number })?.port);
 
     const restoreArgv = await plugin.getRestoreCommand?.({
       session,
@@ -2102,7 +2103,7 @@ export function registerSessionRoutes(app: FastifyInstance): void {
         project,
         ctx: resolvedContextOf(project, worktree ?? null),
         session,
-        daemonPort: 0,
+        daemonPort: getDaemonPort(),
         ...(model ? { model } : {}),
       };
       const env: Record<string, string> = {
@@ -2225,7 +2226,7 @@ export function registerSessionRoutes(app: FastifyInstance): void {
 
     const fromJson = current === "json";
     const toJson = target === "json";
-    const daemonPort = (app.server.address() as { port?: number })?.port ?? 7421;
+    const daemonPort = resolveDaemonPort((app.server.address() as { port?: number })?.port);
 
     // R1.1 idle gate — only a live JSON session has a turn queue/holds to protect.
     if (fromJson) {
@@ -2462,7 +2463,7 @@ export function registerSessionRoutes(app: FastifyInstance): void {
     const { id } = req.params as { id: string };
     const ctx = findJsonSessionContext(id);
     if (!ctx) return reply.status(404).send({ error: `Session '${id}' not found` });
-    const daemonPort = (app.server.address() as { port?: number })?.port ?? 7421;
+    const daemonPort = resolveDaemonPort((app.server.address() as { port?: number })?.port);
     return reply.send(await readSessionMeta(ctx, daemonPort));
   });
 }

--- a/daemon/src/routes/worktrees.ts
+++ b/daemon/src/routes/worktrees.ts
@@ -25,6 +25,7 @@ import {
 import { getRemoteUrl, resolveGithubRemote, fetchPrForBranch } from "../services/github.js";
 import { rollbackWorktreeCreate } from "../services/rollback.js";
 import { spawnSession } from "../services/spawn.js";
+import { resolveDaemonPort } from "../services/daemonPort.js";
 import { worktreePath as getWorktreePath, cleanupSessionDataDir, sessionDataDir, vstHome, projectDir } from "../services/paths.js";
 import { listFiles } from "../services/fileList.js";
 import { buildIgnoreMatcher } from "../services/ignoreFilter.js";
@@ -594,7 +595,7 @@ export function registerWorktreeRoutes(app: FastifyInstance): void {
         userPrompt: result.data.prompt,
       });
 
-      const daemonPort = (app.server.address() as { port?: number })?.port ?? 7421;
+      const daemonPort = resolveDaemonPort((app.server.address() as { port?: number })?.port);
 
       const apiWorktreeEarly = serializeWorktree(projectId, createdWorktree);
       broadcastAll({

--- a/daemon/src/server.ts
+++ b/daemon/src/server.ts
@@ -20,6 +20,7 @@ import { registerAuthRoutes } from "./routes/auth.js";
 import { registerMobileAuthRoutes } from "./routes/mobileAuth.js";
 import { registerWSEndpoint } from "./ws/server.js";
 import { COOKIE_NAME, verifyToken } from "./auth.js";
+import { setDaemonPort } from "./services/daemonPort.js";
 import type { AuthState } from "./state/auth-state.js";
 import type { TokenPayload } from "./types.js";
 
@@ -239,6 +240,15 @@ export async function buildServer(opts: BuildServerOptions = {}) {
   }
 
   await registerWSEndpoint(app, noAuth ? undefined : authState);
+
+  // Publish the bound port process-wide the moment we start listening, so code
+  // with no Fastify handle (WS handlers, timers, lifecycle notifications) can
+  // put a REACHABLE VST_DAEMON_URL in an agent's spawn env. Covers ephemeral
+  // ports (`listen({ port: 0 })`) too, where the requested port isn't the real one.
+  app.addHook("onListen", async () => {
+    const addr = app.server.address() as { port?: number } | null;
+    if (addr?.port) setDaemonPort(addr.port);
+  });
 
   return app;
 }

--- a/daemon/src/services/context.ts
+++ b/daemon/src/services/context.ts
@@ -36,6 +36,7 @@
 import { join } from "node:path";
 import { homedir } from "node:os";
 import type { ProjectRecord, WorktreeRecord, SessionRecord } from "../types.js";
+import { resolveDaemonPort } from "./daemonPort.js";
 import {
   worktreePath,
   sessionDataDir,
@@ -141,7 +142,11 @@ export function buildVstEnv(opts: BuildVstEnvOptions): Record<string, string> {
     ...(worktree ? { VST_WORKTREE: worktree.id } : {}),
     VST_PROJECT: project.id,
     VST_DATA_DIR: `${process.env.HOME ?? "~"}/.vibe-station/projects/${project.id}`,
-    VST_DAEMON_URL: `http://127.0.0.1:${daemonPort}`,
+    // Never emit port 0: a caller with no live server handle passes 0, and an
+    // agent with VST_DAEMON_URL=http://127.0.0.1:0 cannot reach the daemon at
+    // all (`vst …` → "Failed to reach daemon"). resolveDaemonPort() falls back
+    // to the registered/persisted port.
+    VST_DAEMON_URL: `http://127.0.0.1:${resolveDaemonPort(daemonPort)}`,
     PATH: `${vstBinDir}:${process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin"}`,
     VST_SKILL_PATH: vstSkillPath,
   };

--- a/daemon/src/services/daemonPort.ts
+++ b/daemon/src/services/daemonPort.ts
@@ -1,0 +1,51 @@
+/**
+ * Single source of truth for "what port is this daemon actually listening on".
+ *
+ * The port is threaded through dozens of call sites as a plain `daemonPort`
+ * number, and it ends up inside every agent process's `VST_DAEMON_URL` (see
+ * `buildVstEnv`). Any call site that could not reach a live Fastify instance
+ * used to pass a placeholder `0` — and because `JsonAgentSession` caches the
+ * port it was FIRST created with, that placeholder could be baked into the
+ * spawn env of every later turn, giving agents `VST_DAEMON_URL=http://
+ * 127.0.0.1:0` and a `vst` CLI that cannot reach the daemon at all.
+ *
+ * `setDaemonPort()` is called once at boot with the real port; everything else
+ * asks for it here. `getDaemonPort()` additionally falls back to the port the
+ * daemon persisted in `~/.vibe-station/config.json` (the same file the CLI
+ * reads) so out-of-band callers — timers, WS handlers, boot-time recovery —
+ * still get a usable port, and only then to the well-known default.
+ */
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const DEFAULT_PORT = 7421;
+
+let listeningPort = 0;
+
+/** Record the port the HTTP server bound to. Called once from main(). */
+export function setDaemonPort(port: number): void {
+  listeningPort = port > 0 ? port : 0;
+}
+
+/** The daemon's port: registered → persisted config → default. Never 0. */
+export function getDaemonPort(): number {
+  if (listeningPort > 0) return listeningPort;
+  try {
+    const raw = readFileSync(join(homedir(), ".vibe-station", "config.json"), "utf8");
+    const cfg = JSON.parse(raw) as { port?: number };
+    if (typeof cfg.port === "number" && cfg.port > 0) return cfg.port;
+  } catch {
+    /* no config yet — fall through to the default */
+  }
+  return DEFAULT_PORT;
+}
+
+/**
+ * Normalize a threaded `daemonPort`. `0`/`undefined`/`null` mean "the caller
+ * had no live server handle" — resolve the real port instead of emitting a
+ * URL nothing listens on. Note `?? DEFAULT` does NOT do this: `0 ?? 7421` is 0.
+ */
+export function resolveDaemonPort(port: number | undefined | null): number {
+  return typeof port === "number" && port > 0 ? port : getDaemonPort();
+}

--- a/daemon/src/services/lifecycle.ts
+++ b/daemon/src/services/lifecycle.ts
@@ -473,7 +473,10 @@ export const notifyDeps: NotifyDeps = {
   // Async: emit the message_generated pill on the parent's chat stream.
   emitPill: async (parentSessionId, payload) => {
     const { resolveJsonAgent } = await import("./jsonAgentChat.js");
-    const resolved = await resolveJsonAgent(parentSessionId, daemonPortForNotify);
+    // Real port, not a placeholder: this call can be the one that CREATES the
+    // parent's JsonAgentSession, which freezes the port used for its spawn env.
+    const { getDaemonPort } = await import("./daemonPort.js");
+    const resolved = await resolveJsonAgent(parentSessionId, getDaemonPort());
     if (!resolved.ok) return;
     // FIX-D2: if the parent had no live agent when populateNoticeSlot ran (the
     // registry was empty), it returned `true` without actually populating the
@@ -493,9 +496,3 @@ export const notifyDeps: NotifyDeps = {
   },
 };
 
-/** Set once at boot so the notifier can resolve agents without threading the
- *  port through every lifecycle call site. */
-let daemonPortForNotify = 0;
-export function setNotifyDaemonPort(port: number): void {
-  daemonPortForNotify = port;
-}

--- a/daemon/src/ws/handlers/chatOpen.ts
+++ b/daemon/src/ws/handlers/chatOpen.ts
@@ -27,6 +27,7 @@ import {
   readSessionMeta,
   type JsonSessionContext,
 } from "../../services/jsonAgentChat.js";
+import { getDaemonPort } from "../../services/daemonPort.js";
 import type { NormalizedEvent, SessionMeta } from "../../types.js";
 
 /** Default bounded replay window on open (turns). Reduced from 20 → 15 (Part B). */
@@ -66,7 +67,12 @@ export async function handleChatOpen(
 
   // Resolve (lazily create) the JsonAgentSession so we can attach to its stream
   // and read its current meta. No spawn happens here — only on enqueue.
-  const resolved = await resolveJsonAgent(sessionId, 0).catch(() => null);
+  // The port matters: `resolveJsonAgent` CREATES the JsonAgentSession on first
+  // call and freezes the port it was given, and every later turn spawns its CLI
+  // with VST_DAEMON_URL=http://127.0.0.1:<that port>. Opening a chat in the UI is
+  // usually the first touch of a session, so passing a placeholder 0 here handed
+  // agents an unreachable daemon URL.
+  const resolved = await resolveJsonAgent(sessionId, getDaemonPort()).catch(() => null);
 
   if (!resolved || !resolved.ok) {
     // Not a JSON session or mode unresolved — no live stream to attach; send a


### PR DESCRIPTION
## Summary

- Agents were being spawned with `VST_DAEMON_URL=http://127.0.0.1:0` (port 0), making every `vst` CLI call fail with "Failed to reach daemon". Since the CLI returns the env value directly when `VST_DAEMON_URL` is set, it never fell back to `config.json` — leaving the agent completely unable to use `vst`.
- Root cause: all port lookups used `(app.server.address() as { port?: number })?.port ?? 7421`, but `0 ?? 7421` is `0` in JavaScript (nullish coalescing doesn't catch falsy), so callers without a live server handle silently passed port 0 into the env.
- Two `launchCfg` structs in the restore and tty-toggle paths hard-coded `daemonPort: 0` as a placeholder; this value was visible to any plugin's `getEnvironment()` and latent in the URL-building logic.
- Also adds a prompt-level warning so agents never try to use harness tools (`SendMessage`, `ListAgents`) to communicate with vst sessions — the other failure mode observed in the same transcripts.

## What changed

**`daemon/src/services/daemonPort.ts`** (new) — single source of truth:
- `setDaemonPort(port)` — called once at boot with the real OS-assigned port
- `getDaemonPort()` — registered port → `config.json` → 7421; never returns 0
- `resolveDaemonPort(n)` — if `n > 0` use it, else delegate to `getDaemonPort()`; replaces every `?? 7421` pattern

**`daemon/src/main.ts`** — calls `setDaemonPort(port)` after `findFreePort()` resolves

**`daemon/src/server.ts`** — `onListen` hook also calls `setDaemonPort` with the actually-bound port (covers `buildServer()` callers in tests)

**`daemon/src/routes/sessions.ts`** — all `?? 7421` → `resolveDaemonPort(...)`; two `daemonPort: 0` launchCfg stubs → `getDaemonPort()`

**`daemon/src/routes/{projects,worktrees}.ts`**, **`daemon/src/ws/handlers/chatOpen.ts`**, **`daemon/src/services/lifecycle.ts`** — same `?? 7421` → `resolveDaemonPort(...)` sweep

**`daemon/src/services/context.ts`** — `buildVstEnv()` wraps its `daemonPort` arg with `resolveDaemonPort()` as last-line defence

**`daemon/src/assets/agent-{system-prompt,subagent-richchat}.md`** — explicit warning that `SendMessage`/`ListAgents`/`ToolSearch` are harness internals that cannot reach vst sessions; `vst session send` is the only correct channel

## Test plan

- [ ] Spawn a new worktree agent and confirm `env | grep VST_DAEMON_URL` shows a real port (not 0)
- [ ] Open an existing session (restore path) and confirm same
- [ ] Toggle a session from json → tty and confirm same
- [ ] Subagent notifications reach the parent (lifecycle.ts path exercises `getDaemonPort()`)
- [ ] `vst session create` succeeds from inside a spawned agent