### PR TITLE
fix(daemon): opencode ACP model forwarding and daemon crash on child exit

### DIFF
--- a/daemon/src/agent-plugins/opencode.ts
+++ b/daemon/src/agent-plugins/opencode.ts
@@ -58,7 +58,7 @@ async function* runTurnAcp(
   const promptFile = systemPromptPathFor(resolvedCtx, ctx.session.id);
   try {
     mkdirSync(dirname(configPath), { recursive: true });
-    writeOpenCodeConfig(configPath, [promptFile]);
+    writeOpenCodeConfig(configPath, [promptFile], ctx.model);
   } catch {
     /* best-effort — spawn still proceeds without instructions */
   }

--- a/daemon/src/services/acp/acpTransport.ts
+++ b/daemon/src/services/acp/acpTransport.ts
@@ -179,6 +179,13 @@ export class AcpConnection {
     const rl = createInterface({ input: child.stdout!, crlfDelay: Infinity });
     rl.on("line", (line) => this.handleLine(line));
 
+    child.stdout?.on("error", (err) => {
+      console.error("[acp] stdout error (pid %d):", child.pid ?? -1, err.message);
+      // Absorbed here; child.on("close") handles pending-request rejection.
+    });
+    child.stderr?.on("error", () => {});
+    child.stdin?.on("error", () => {});
+
     child.on("close", () => {
       // Reject every still-pending request — the process is gone, nothing
       // will ever answer them.

--- a/daemon/src/services/opencodeConfig.ts
+++ b/daemon/src/services/opencodeConfig.ts
@@ -14,16 +14,18 @@ import { writeFileSync } from "node:fs";
 export interface OpenCodeConfig {
   instructions: string[];
   permission: Record<string, Record<string, "allow" | "ask" | "deny">>;
+  model?: string;
 }
 
 /**
- * Write { instructions: [<absolutePaths>], permission: {...} } to <configPath>.
+ * Write { instructions: [<absolutePaths>], permission: {...}[, model: <model>] } to <configPath>.
  * Returns the config path for convenience.
  */
-export function writeOpenCodeConfig(configPath: string, instructionFiles: string[]): string {
+export function writeOpenCodeConfig(configPath: string, instructionFiles: string[], model?: string): string {
   const config: OpenCodeConfig = {
     instructions: instructionFiles,
     permission: { "*": { "*": "allow" } },
+    ...(model ? { model } : {}),
   };
   writeFileSync(configPath, JSON.stringify(config, null, 2), "utf8");
   return configPath;


### PR DESCRIPTION
## Summary

- **DeepSeek (and any non-default model) not responding via Rich Chat**: `runTurnAcp` was calling `writeOpenCodeConfig` without forwarding `ctx.model`, so `opencode acp` always started with opencode's own global default model rather than the mode's configured one. Fixed by passing `ctx.model` as the `model` field in the `OPENCODE_CONFIG` JSON — verified as a valid config key in the opencode source (`packages/core/src/config.ts`). The terminal path was unaffected (`getLaunchCommand` already passes `-m cfg.model`).
- **ACP child process crash killing the entire daemon**: `acpTransport.ts` had no error handlers on the child's stdio streams. When an opencode ACP process crashed after `initialize()` resolved, Node.js emitted an unhandled `error` event on the stdout `Socket`, propagating up and killing the daemon process. Added error handlers: stdout logs the error with pid for diagnosability and absorbs it (the existing `child.on("close")` handler already rejects all pending requests), stdin and stderr are silently absorbed.

## Files changed

- `daemon/src/services/opencodeConfig.ts` — add optional `model` field to `OpenCodeConfig` interface and `writeOpenCodeConfig` signature
- `daemon/src/agent-plugins/opencode.ts` — pass `ctx.model` to `writeOpenCodeConfig` in `runTurnAcp`
- `daemon/src/services/acp/acpTransport.ts` — add error handlers to `child.stdout`, `child.stdin`, `child.stderr`

## Test plan

- [ ] Create a DeepSeek Rich Chat session — confirm it responds using the correct model
- [ ] Confirm claude and other ACP modes are unaffected
- [ ] Kill an opencode ACP child process externally while a session is active — confirm daemon stays up and the session surfaces an error rather than hanging