### PR TITLE
fix(dialogs): autofocus the prompt editor in NewAgentSessionDialog and NewAgentTabDialog

### DIFF
--- a/web-ui/src/components/dialogs/NewAgentSessionDialog.tsx
+++ b/web-ui/src/components/dialogs/NewAgentSessionDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { ApiInstance } from "@/api";
 import type { Mode, SupportedCli, Worktree } from "@/api/types";
 import { ApiError } from "@/api/errors";
@@ -60,6 +60,15 @@ export function NewAgentSessionDialog({
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [newModeOpen, setNewModeOpen] = useState(false);
+  const promptShellRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!editorReady) return;
+    const id = requestAnimationFrame(() => {
+      promptShellRef.current?.querySelector<HTMLElement>('[contenteditable="true"]')?.focus();
+    });
+    return () => cancelAnimationFrame(id);
+  }, [editorReady]);
 
   useEffect(() => {
     if (!open) return;
@@ -335,16 +344,18 @@ export function NewAgentSessionDialog({
       </button>
       <div className="field-label" style={{ marginTop: "var(--space-4)" }}>Initial prompt <span style={{ color: "var(--fg-muted)", fontWeight: "normal" }}>(optional)</span></div>
       {editorReady && (
-        <SkillEditor
-          editorKey={`newsession-${editorSeq}`}
-          initialText={initialPrompt}
-          commands={skillCommands}
-          ariaLabel="Initial prompt"
-          placeholder="Describe what you want the agent to do…"
-          className="chat-composer__textarea chat-composer__textarea--dialog"
-          onChangeText={(next) => setInitialPrompt(next)}
-          onSubmit={() => void submit()}
-        />
+        <div ref={promptShellRef}>
+          <SkillEditor
+            editorKey={`newsession-${editorSeq}`}
+            initialText={initialPrompt}
+            commands={skillCommands}
+            ariaLabel="Initial prompt"
+            placeholder="Describe what you want the agent to do…"
+            className="chat-composer__textarea chat-composer__textarea--dialog"
+            onChangeText={(next) => setInitialPrompt(next)}
+            onSubmit={() => void submit()}
+          />
+        </div>
       )}
       <div className="field-label" style={{ marginTop: "var(--space-4)" }}>
         Attachments <span style={{ color: "var(--fg-muted)", fontWeight: "normal" }}>(optional)</span>

--- a/web-ui/src/components/dialogs/NewAgentTabDialog.tsx
+++ b/web-ui/src/components/dialogs/NewAgentTabDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { ApiInstance } from "@/api";
 import type { Mode, SupportedCli } from "@/api/types";
 import { Dialog } from "./Dialog";
@@ -35,6 +35,15 @@ export function NewAgentTabDialog({
   const [files, setFiles] = useState<File[]>([]);
   const [clis, setClis] = useState<SupportedCli[]>([]);
   const { skillCommands, editorSeq, editorReady } = useSkillCommands(open, api);
+  const promptShellRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!editorReady) return;
+    const id = requestAnimationFrame(() => {
+      promptShellRef.current?.querySelector<HTMLElement>('[contenteditable="true"]')?.focus();
+    });
+    return () => cancelAnimationFrame(id);
+  }, [editorReady]);
 
   function setPrompt(value: string) {
     setPromptState(value);
@@ -143,16 +152,18 @@ export function NewAgentTabDialog({
         Prompt <span style={{ color: "var(--fg-muted)", fontWeight: "normal" }}>(optional)</span>
       </div>
       {editorReady && (
-        <SkillEditor
-          editorKey={`newtab-${editorSeq}`}
-          initialText={prompt}
-          commands={skillCommands}
-          ariaLabel="Prompt"
-          placeholder="Describe what you want the agent to do…"
-          className="chat-composer__textarea chat-composer__textarea--dialog"
-          onChangeText={(next) => setPrompt(next)}
-          onSubmit={() => void submit()}
-        />
+        <div ref={promptShellRef}>
+          <SkillEditor
+            editorKey={`newtab-${editorSeq}`}
+            initialText={prompt}
+            commands={skillCommands}
+            ariaLabel="Prompt"
+            placeholder="Describe what you want the agent to do…"
+            className="chat-composer__textarea chat-composer__textarea--dialog"
+            onChangeText={(next) => setPrompt(next)}
+            onSubmit={() => void submit()}
+          />
+        </div>
       )}
       <div className="field-label" style={{ marginTop: "var(--space-4)" }}>
         Attachments <span style={{ color: "var(--fg-muted)", fontWeight: "normal" }}>(optional)</span>


### PR DESCRIPTION
## Summary

Restores prompt autofocus in the **New Agent Session** and **New Agent Tab** dialogs. When the skill editor mounts, focus its contenteditable field so the user can start typing the prompt immediately without clicking into it.

## Changes

- `web-ui/src/components/dialogs/NewAgentSessionDialog.tsx`
- `web-ui/src/components/dialogs/NewAgentTabDialog.tsx`

Both dialogs add a `promptShellRef` + a `useEffect` that, once `editorReady` flips true, uses `requestAnimationFrame` to focus `[contenteditable="true"]` inside the `SkillEditor`. The RAF defers until after the frame paints so the editor is reliably mounted; the cleanup cancels any pending RAF if the dialog closes mid-mount.

## Verification

- `pnpm typecheck` passes.
- `pnpm lint` on the two changed files: 0 errors.
- Existing web-ui test failures (e.g. `NewAgentSessionDialog.channel.test.tsx`, `ChatPane`, `RemoteAccessSetting`) are pre-existing on `origin/main` and are not introduced by this change (verified against the base).
- Reviewed by a claude opus subagent: **approved** (diff confirmed clean — daemon untouched vs main — and the autofocus implementation correct).