### PR TITLE
feat(ui): top bar overflow menu, sidebar branding, tool pane X, keyboard shortcuts

### DIFF
--- a/web-ui/src/components/chat/SkillEditor.tsx
+++ b/web-ui/src/components/chat/SkillEditor.tsx
@@ -477,8 +477,11 @@ function SkillEditorPlugin({
             selectActivePopoverItem();
             return true;
           }
+          const isTouchDevice = typeof navigator !== "undefined" && navigator.maxTouchPoints > 0;
+          const isModifiedEnter = !!event && (event.ctrlKey || event.metaKey);
           const isNewlineCombo = !!event && (event.shiftKey || event.altKey);
-          if (isNewlineCombo) {
+          // On touch phones, plain Enter adds a newline; Ctrl/Cmd+Enter still sends.
+          if (isNewlineCombo || (isTouchDevice && !isModifiedEnter)) {
             event?.preventDefault();
             editor.dispatchCommand(INSERT_LINE_BREAK_COMMAND, false);
             return true;

--- a/web-ui/src/components/layout/LeftSidebar.tsx
+++ b/web-ui/src/components/layout/LeftSidebar.tsx
@@ -1,8 +1,9 @@
-import { Check, ChevronDown, ChevronRight, Eye, EyeOff, Filter, Folder, FolderOpen, FolderPlus, FolderTree, Moon, MoreHorizontal, Pin, Plus, SlidersHorizontal, Trash2, Type } from "lucide-react";
+import { Check, ChevronDown, ChevronRight, Eye, EyeOff, Filter, Folder, FolderOpen, FolderPlus, FolderTree, Home, Moon, MoreHorizontal, Pin, Plus, Trash2, Type } from "lucide-react";
 import { useTheme } from "@/hooks/useTheme";
 import { createPortal } from "react-dom";
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
+import pkgJson from "../../../package.json";
 import {
   DndContext,
   PointerSensor,
@@ -912,8 +913,6 @@ export function LeftSidebar({
     return e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0;
   }
 
-  const isSettings = location.pathname === "/settings";
-
   return (
     <div
       className={`left-sidebar ${collapsed ? "left-sidebar--collapsed" : ""}`}
@@ -924,18 +923,31 @@ export function LeftSidebar({
         className="left-sidebar__scroll"
         style={{ flex: 1, overflow: "auto", padding: collapsed ? "var(--space-1)" : "var(--space-2)" }}
       >
+        <div className="left-sidebar__brand" aria-hidden>
+          {!collapsed ? (
+            <div className="left-sidebar__brand-inner">
+              <span className="left-sidebar__brand-name">Vibe Station</span>
+              <Logo size={11} />
+              <span className="left-sidebar__brand-version">{pkgJson.version}</span>
+            </div>
+          ) : (
+            <div className="left-sidebar__brand-inner">
+              <Logo size={13} />
+            </div>
+          )}
+        </div>
         <div style={{ display: "flex", flexDirection: "column", gap: "2px" }}>
           <Link
             to="/"
             className="left-sidebar__nav-item"
-            aria-label="Vibe Station Home"
+            aria-label="Home"
             onClick={() => {
               clearWorkspaceSelection();
               if (isMobile) setMobileSidebarOpen(false);
             }}
           >
-            <Logo size={16} />
-            {!collapsed ? "Vibe Station Home" : null}
+            <Home size={16} />
+            {!collapsed ? "Home" : null}
           </Link>
           <button
             type="button"
@@ -1775,19 +1787,6 @@ export function LeftSidebar({
         </DndContext>
       </div>
       <div className="left-sidebar__footer">
-        <Link
-          to="/settings"
-          className={`left-sidebar__nav-item${isSettings ? " left-sidebar__nav-item--active" : ""}`}
-          title="Settings"
-          aria-label="Settings"
-          aria-current={isSettings ? "page" : undefined}
-          onClick={() => {
-            if (isMobile) setMobileSidebarOpen(false);
-          }}
-        >
-          <SlidersHorizontal size={16} aria-hidden />
-          {!collapsed ? "Settings" : null}
-        </Link>
         <div className="left-sidebar__icon-row">
           <button
             type="button"

--- a/web-ui/src/components/layout/ToolPanel.tsx
+++ b/web-ui/src/components/layout/ToolPanel.tsx
@@ -35,6 +35,16 @@ interface ToolPanelProps {
    * ToolPanel can determine on its own.
    */
   hidePanelControls?: boolean;
+  /**
+   * Called when the user wants to remove this ToolPanel from the workspace
+   * canvas tile it is currently inside. When present alongside
+   * `hidePanelControls`, the X close button is rendered — the one action
+   * the tile's own header X does NOT cover (the header X removes the whole
+   * tile chrome; this X is discoverable from within the tools tab bar
+   * itself). Not passed in classic/docked mode — the top bar toggle
+   * already hides the panel there, so the X would be redundant.
+   */
+  onClose?: () => void;
 }
 
 const TABS: { id: ToolTab; label: string }[] = [
@@ -57,6 +67,7 @@ export function ToolPanel({
   baseBranch,
   branch,
   hidePanelControls = false,
+  onClose,
 }: ToolPanelProps) {
   const { toolPanelTab, setToolPanelTab, toggleToolPanel } = useLayout();
 
@@ -81,7 +92,11 @@ export function ToolPanel({
         {/* Panel-level controls — fullscreen + close act on the whole tool
             panel (whichever tool is shown), so they live on the selector bar.
             Hidden inside a workspace-canvas tile — see `hidePanelControls`'s
-            doc comment; the tile's own header already owns both concepts. */}
+            doc comment; the tile's own header already owns both concepts.
+            When inside a canvas tile, show only the X close button (wired to
+            `onClose`, which removes the tools tile) — the tile header's own
+            X already removes the whole tile, but an X inside the tab bar
+            is more discoverable from within the tools content itself. */}
         {!hidePanelControls ? (
           <div className="tool-panel__tabs-actions">
             <ToolFullscreenButton />
@@ -91,6 +106,18 @@ export function ToolPanel({
               aria-label="Close tool panel"
               title="Close tool panel"
               onClick={() => toggleToolPanel()}
+            >
+              <X size={13} />
+            </button>
+          </div>
+        ) : onClose ? (
+          <div className="tool-panel__tabs-actions">
+            <button
+              type="button"
+              className="tab tab--icon tool-bar-btn"
+              aria-label="Close tool tile"
+              title="Close tool tile"
+              onClick={onClose}
             >
               <X size={13} />
             </button>

--- a/web-ui/src/components/layout/TopBar.tsx
+++ b/web-ui/src/components/layout/TopBar.tsx
@@ -4,13 +4,17 @@ import {
   ChevronUp,
   Columns2,
   LayoutGrid,
+  MoreHorizontal,
   PanelLeft,
   PanelRight,
   PanelTop,
   Rows2,
   Search,
+  Settings,
   SquareTerminal,
 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { useLayout } from "@/hooks/useLayout";
 import type { Project, Session, Worktree } from "@/api/types";
 import { sessionLabel } from "@/lib/sessionLabel";
@@ -20,17 +24,18 @@ import { ToolbarOutlet, WORKSPACE_CANVAS_TOOLBAR_KEY } from "@/components/layout
 
 function shortcutHints() {
   if (typeof navigator === "undefined") {
-    return { fileTree: "⌘⇧F", preview: "⌘⇧P", terminal: "⌘⇧Z", quickOpen: "⌘P" };
+    return { fileTree: "⌘⇧F", preview: "⌘⇧P", terminal: "⌘⇧Z", quickOpen: "⌘P", toolPane: "⌘\\" };
   }
   const mac = /Mac|iPhone|iPod|iPad/i.test(navigator.platform ?? navigator.userAgent);
   if (mac) {
-    return { fileTree: "⌘⇧F", preview: "⌘⇧P", terminal: "⌘⇧Z", quickOpen: "⌘P" };
+    return { fileTree: "⌘⇧F", preview: "⌘⇧P", terminal: "⌘⇧Z", quickOpen: "⌘P", toolPane: "⌘\\" };
   }
   return {
     fileTree: "Ctrl+Shift+F",
     preview: "Ctrl+Shift+P",
     terminal: "Ctrl+Shift+Z",
     quickOpen: "Ctrl+P",
+    toolPane: "Ctrl+\\",
   };
 }
 
@@ -85,6 +90,7 @@ export function TopBar({
     terminalDockVisible,
     toggleTerminalDock,
     toolSplitOrientation,
+    toolSplitOrientationUserSet,
     toggleToolSplitOrientation,
     canvasToolbarVisible,
     toggleCanvasToolbar,
@@ -97,8 +103,38 @@ export function TopBar({
     layoutMode: paneLayoutMode,
     setLayoutMode,
   } = useLayout();
+  // On mobile the layout defaults to vertical stacking regardless of the stored value;
+  // mirror the same logic as Layout.tsx so the overflow button reflects actual state.
+  const effectiveSplitOrientation =
+    !toolSplitOrientationUserSet && isMobile ? "vertical" : toolSplitOrientation;
   const project = projects.find((p) => p.id === activeProjectId);
   const wt = worktrees.find((w) => w.id === activeWorktreeId);
+
+  const navigate = useNavigate();
+  const [overflowOpen, setOverflowOpen] = useState(false);
+  const overflowMenuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!overflowOpen) return;
+    let raf: number;
+    const onDown = (e: MouseEvent) => {
+      raf = requestAnimationFrame(() => {
+        if (!overflowMenuRef.current?.contains(e.target as Node)) {
+          setOverflowOpen(false);
+        }
+      });
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOverflowOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+      cancelAnimationFrame(raf);
+    };
+  }, [overflowOpen]);
 
   const hints = shortcutHints();
 
@@ -262,6 +298,18 @@ export function TopBar({
           <ToolbarOutlet paneKey={WORKSPACE_CANVAS_TOOLBAR_KEY} />
         ) : null}
         <ConnectionStatus />
+        {layoutMode !== "workspace" && layoutMode !== "direct-session" ? (
+          <button
+            type="button"
+            className="icon-btn"
+            aria-label="Settings"
+            title="Settings"
+            aria-current={layoutMode === "settings" ? "page" : undefined}
+            onClick={() => navigate("/settings")}
+          >
+            <Settings size={18} />
+          </button>
+        ) : null}
         {layoutMode === "workspace" || layoutMode === "direct-session" ? (
           <>
             <button
@@ -273,125 +321,133 @@ export function TopBar({
             >
               <Search size={18} />
             </button>
-            <div className="top-bar__pane-toggles" role="toolbar" aria-label="Workspace panes">
-              {canvasChipWorktreeId ? (
-                // One visually-merged pill holding TWO independent buttons:
-                // enter/leave canvas mode, and (thin, narrower) disclose the
-                // canvas's own toolbar. They read as a unit because they act
-                // on the same thing, but each stays a real, separately
-                // focusable/labelled <button> — the chevron is never a
-                // decoration hanging off the grid button.
-                <div className="top-bar__canvas-chip">
+            <div className="top-bar__overflow-wrapper">
+              <button
+                type="button"
+                className="icon-btn"
+                aria-label="More options"
+                title="More options"
+                aria-expanded={overflowOpen}
+                aria-haspopup="true"
+                onClick={() => setOverflowOpen((o) => !o)}
+              >
+                <MoreHorizontal size={18} />
+              </button>
+              {overflowOpen ? (
+                <div className="top-bar__overflow-menu" role="menu" ref={overflowMenuRef}>
+                  {canvasChipWorktreeId ? (
+                    <>
+                      <button
+                        type="button"
+                        className={`top-bar__overflow-item${inCanvasMode ? " top-bar__overflow-item--active" : ""}`}
+                        role="menuitemcheckbox"
+                        aria-checked={inCanvasMode}
+                        onClick={() => {
+                          setLayoutMode(canvasChipWorktreeId, inCanvasMode ? "classic" : "workspace");
+                          setOverflowOpen(false);
+                        }}
+                      >
+                        <LayoutGrid size={14} />
+                        <span>{inCanvasMode ? "Canvas layout (on)" : "Canvas layout"}</span>
+                      </button>
+                      <button
+                        type="button"
+                        className="top-bar__overflow-item"
+                        role="menuitem"
+                        disabled={!inCanvasMode}
+                        title={
+                          !inCanvasMode
+                            ? "Switch to canvas mode first"
+                            : canvasToolbarVisible
+                              ? "Hide canvas toolbar"
+                              : "Show canvas toolbar"
+                        }
+                        onClick={() => {
+                          toggleCanvasToolbar();
+                          setOverflowOpen(false);
+                        }}
+                      >
+                        {canvasToolbarVisible ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+                        <span>{canvasToolbarVisible ? "Hide toolbar" : "Show toolbar"}</span>
+                      </button>
+                    </>
+                  ) : null}
                   <button
                     type="button"
-                    className={`top-bar__pane-btn ${inCanvasMode ? "top-bar__pane-btn--on" : ""}`}
-                    aria-pressed={inCanvasMode}
-                    aria-label="Toggle workspace canvas layout"
-                    title={
-                      inCanvasMode
-                        ? "Switch to classic layout"
-                        : "Switch to workspace canvas (tiled/free-form panes)"
-                    }
-                    onClick={() =>
-                      setLayoutMode(canvasChipWorktreeId, inCanvasMode ? "classic" : "workspace")
-                    }
+                    className="top-bar__overflow-item"
+                    role="menuitemcheckbox"
+                    aria-checked={effectiveSplitOrientation === "vertical"}
+                    disabled={paneLayoutMode === "workspace"}
+                    onClick={() => {
+                      toggleToolSplitOrientation();
+                      setOverflowOpen(false);
+                    }}
                   >
-                    <LayoutGrid size={17} />
+                    {effectiveSplitOrientation === "horizontal" ? <Columns2 size={14} /> : <Rows2 size={14} />}
+                    <span>
+                      {effectiveSplitOrientation === "horizontal"
+                        ? "Split: horizontal"
+                        : "Split: vertical"}
+                    </span>
                   </button>
                   <button
                     type="button"
-                    className="top-bar__pane-btn top-bar__canvas-chip-chevron"
-                    aria-expanded={inCanvasMode ? canvasToolbarVisible : undefined}
-                    // Same visible-but-disabled treatment as the split-
-                    // orientation / terminal-dock buttons below: outside
-                    // canvas mode there's no dedicated bar to disclose, but
-                    // unmounting it would make the chip's second half blink
-                    // in and out as the mode toggles.
-                    disabled={!inCanvasMode}
-                    aria-label={
-                      !inCanvasMode
-                        ? "Show canvas toolbar"
-                        : canvasToolbarVisible
-                          ? "Hide canvas toolbar"
-                          : "Show canvas toolbar"
-                    }
-                    title={
-                      !inCanvasMode
-                        ? "Only available in canvas mode — switch to the workspace canvas first"
-                        : canvasToolbarVisible
-                          ? "Hide canvas toolbar (mode, save, add tile)"
-                          : "Show canvas toolbar (mode, save, add tile)"
-                    }
-                    onClick={toggleCanvasToolbar}
+                    className={`top-bar__overflow-item${terminalDockVisible ? " top-bar__overflow-item--active" : ""}`}
+                    role="menuitemcheckbox"
+                    aria-checked={terminalDockVisible}
+                    disabled={paneLayoutMode === "workspace"}
+                    onClick={() => {
+                      toggleTerminalDock();
+                      setOverflowOpen(false);
+                    }}
                   >
-                    {inCanvasMode && canvasToolbarVisible ? (
-                      <ChevronUp size={15} />
-                    ) : (
-                      <ChevronDown size={15} />
-                    )}
+                    <SquareTerminal size={14} />
+                    <span>
+                      Terminal
+                      {paneLayoutMode !== "workspace" ? ` (${hints.terminal})` : ""}
+                    </span>
+                  </button>
+                  <button
+                    type="button"
+                    className="top-bar__overflow-item"
+                    role="menuitem"
+                    onClick={() => {
+                      setOverflowOpen(false);
+                      navigate("/settings");
+                    }}
+                  >
+                    <Settings size={14} />
+                    <span>Settings</span>
                   </button>
                 </div>
               ) : null}
-              <button
-                type="button"
-                className="top-bar__pane-btn"
-                aria-label="Toggle agent/tools split orientation"
-                disabled={paneLayoutMode === "workspace"}
-                title={
-                  paneLayoutMode === "workspace"
-                    ? "Not applicable in canvas mode — each pane is its own tile"
-                    : toolSplitOrientation === "horizontal"
-                      ? "Stack agent and tools vertically"
-                      : "Place agent and tools side by side"
-                }
-                onClick={toggleToolSplitOrientation}
-              >
-                {toolSplitOrientation === "horizontal" ? <Columns2 size={17} /> : <Rows2 size={17} />}
-              </button>
-              <button
-                type="button"
-                className={`top-bar__pane-btn ${terminalDockVisible ? "top-bar__pane-btn--on" : ""}`}
-                aria-pressed={terminalDockVisible}
-                aria-label="Toggle terminal dock"
-                disabled={paneLayoutMode === "workspace"}
-                title={
-                  paneLayoutMode === "workspace"
-                    ? "Not applicable in canvas mode — every terminal is its own tile (use Windows)"
-                    : `Toggle terminal dock (${hints.terminal})`
-                }
-                onClick={toggleTerminalDock}
-              >
-                <SquareTerminal size={17} />
-              </button>
-              <button
-                type="button"
-                className={`top-bar__pane-btn ${
-                  (paneLayoutMode === "workspace" ? hasWorktreeToolsTile : toolPanelVisible)
-                    ? "top-bar__pane-btn--on"
-                    : ""
-                }`}
-                aria-pressed={paneLayoutMode === "workspace" ? hasWorktreeToolsTile : toolPanelVisible}
-                aria-label={
-                  paneLayoutMode === "workspace"
-                    ? hasWorktreeToolsTile
-                      ? "Remove Tools tile from canvas"
-                      : "Add Tools tile to canvas"
-                    : "Toggle tool panel"
-                }
-                title={
-                  paneLayoutMode === "workspace"
-                    ? hasWorktreeToolsTile
-                      ? "Remove Tools tile from canvas"
-                      : "Add Tools tile to canvas"
-                    : "Toggle tool panel"
-                }
-                onClick={paneLayoutMode === "workspace" ? toggleWorktreeToolsTile : toggleToolPanel}
-              >
-                {/* Vertical split docks the tool panel to the top, so mirror
-                    that with a top-panel icon instead of the right-panel one. */}
-                {toolSplitOrientation === "vertical" ? <PanelTop size={17} /> : <PanelRight size={17} />}
-              </button>
             </div>
+            <button
+              type="button"
+              className={`top-bar__pane-btn ${
+                (paneLayoutMode === "workspace" ? hasWorktreeToolsTile : toolPanelVisible)
+                  ? "top-bar__pane-btn--on"
+                  : ""
+              }`}
+              aria-pressed={paneLayoutMode === "workspace" ? hasWorktreeToolsTile : toolPanelVisible}
+              aria-label={
+                paneLayoutMode === "workspace"
+                  ? hasWorktreeToolsTile
+                    ? "Remove Tools tile from canvas"
+                    : "Add Tools tile to canvas"
+                  : "Toggle tool panel"
+              }
+              title={
+                paneLayoutMode === "workspace"
+                  ? hasWorktreeToolsTile
+                    ? "Remove Tools tile from canvas"
+                    : "Add Tools tile to canvas"
+                  : `Toggle tool panel (${hints.toolPane})`
+              }
+              onClick={paneLayoutMode === "workspace" ? toggleWorktreeToolsTile : toggleToolPanel}
+            >
+              {toolSplitOrientation === "vertical" ? <PanelTop size={17} /> : <PanelRight size={17} />}
+            </button>
           </>
         ) : null}
       </div>

--- a/web-ui/src/hooks/useWorkspaceKeyboardShortcuts.ts
+++ b/web-ui/src/hooks/useWorkspaceKeyboardShortcuts.ts
@@ -3,7 +3,10 @@ import { useWorkspaceStore } from "@/hooks/useStore";
 
 /**
  * ⌘/Ctrl+Shift+F/P → Files/Preview tool tab; ⌘/Ctrl+Shift+Z → terminal dock;
- * ⌘/Ctrl+P quick-open files; Alt+N → new agent in the current worktree;
+ * ⌘/Ctrl+P quick-open files; ⌘/Ctrl+\ → toggle tool pane;
+ * ⌘/Ctrl+Shift+G → new agent in current worktree;
+ * ⌘/Ctrl+Shift+M → new worktree in the current project;
+ * Alt+N → new agent in the current worktree;
  * Alt+Shift+N → new worktree in the current project.
  *
  * The new-agent/new-worktree shortcuts deliberately use bare Alt (no ⌘/Ctrl)
@@ -30,6 +33,7 @@ export function useWorkspaceKeyboardShortcuts(
 
     const setToolPanelTab = useWorkspaceStore.getState().setToolPanelTab;
     const toggleTerminalDock = useWorkspaceStore.getState().toggleTerminalDock;
+    const toggleToolPanel = useWorkspaceStore.getState().toggleToolPanel;
 
     const onKey = (e: KeyboardEvent) => {
       const t = e.target as HTMLElement | null;
@@ -73,6 +77,15 @@ export function useWorkspaceKeyboardShortcuts(
 
       if (inEditable) return;
 
+      // ⌘/Ctrl+\ — toggle tool pane (layout-agnostic: `e.key === "\\"` matches
+      // the backslash on US and similar layouts; Ctrl+Shift+\ produces
+      // `e.key === "|"` so this never conflicts).
+      if (!e.shiftKey && e.key === "\\") {
+        e.preventDefault();
+        toggleToolPanel();
+        return;
+      }
+
       if (e.shiftKey) {
         const k = e.key.length === 1 ? e.key.toUpperCase() : e.key;
         if (k === "F") {
@@ -84,6 +97,20 @@ export function useWorkspaceKeyboardShortcuts(
         } else if (k === "Z") {
           e.preventDefault();
           if (!canvasMode) toggleTerminalDock();
+        } else if (e.code === "KeyG") {
+          // ⌘/Ctrl+Shift+G — new agent in current worktree (replaces the
+          // original Ctrl+Shift+A which Chrome on Windows captures for its
+          // tab search UI before the page can preventDefault()).
+          if (onNewAgent && !canvasMode) {
+            e.preventDefault();
+            onNewAgent();
+          }
+        } else if (e.code === "KeyM") {
+          // ⌘/Ctrl+Shift+M — new worktree in the current project.
+          if (onNewWorktree) {
+            e.preventDefault();
+            onNewWorktree();
+          }
         }
       }
     };

--- a/web-ui/src/routes/Workspace.tsx
+++ b/web-ui/src/routes/Workspace.tsx
@@ -14,7 +14,7 @@ import { SettingsPanel } from "@/components/settings/SettingsPanel";
 import { PaneOutletProvider, PaneOutlet } from "@/components/layout/paneOutlets";
 import { PaneHostLayer, type PaneKey } from "@/components/layout/PaneHostLayer";
 import { WorkspaceCanvas } from "@/components/layout/WorkspaceCanvas";
-import { useWorkspaceStore } from "@/hooks/useStore";
+import { useWorkspaceStore, removeTileFromCanvas } from "@/hooks/useStore";
 import { useLayout } from "@/hooks/useLayout";
 import { useServerStore } from "@/hooks/useServerStore";
 import { useServerSync } from "@/hooks/useServerSync";
@@ -398,6 +398,29 @@ export function Workspace() {
         return <TerminalPane api={api} sessionId={id} session={sessions.find((s) => s.id === id)} />;
       }
       const wtId = key.slice("tools:".length);
+      const onCloseToolsTile = inWorkspaceCanvas
+        ? () => {
+            const store = useWorkspaceStore.getState();
+            let canvas;
+            if (isWorkspaceView && viewedWorkspace) {
+              canvas = store.workspaceDocs[viewedWorkspace.id] ?? null;
+            } else if (wtId) {
+              canvas = store.layoutByWorktree[wtId]?.scratchCanvas ?? null;
+            }
+            if (!canvas) return;
+            const existing = canvas.tiles.find(
+              (t: { kind: string; worktreeId?: string }) =>
+                t.kind === "tools" && (t.worktreeId ?? wtId) === wtId,
+            );
+            if (!existing) return;
+            const next = removeTileFromCanvas(canvas, existing.id);
+            if (isWorkspaceView && viewedWorkspace) {
+              store.updateWorkspaceDoc(viewedWorkspace.id, next);
+            } else if (wtId) {
+              store.updateScratchCanvas(wtId, next);
+            }
+          }
+        : undefined;
       return (
         <ToolPanel
           api={api}
@@ -405,10 +428,11 @@ export function Workspace() {
           baseBranch={worktrees.find((w) => w.id === wtId)?.baseBranch}
           branch={worktrees.find((w) => w.id === wtId)?.branch}
           hidePanelControls={inWorkspaceCanvas}
+          onClose={onCloseToolsTile}
         />
       );
     },
-    [sessions, worktrees, inWorkspaceCanvas],
+    [sessions, worktrees, inWorkspaceCanvas, isWorkspaceView, viewedWorkspace],
   );
   const worktreePaneHostLayer = (
     <PaneHostLayer paneKeys={worktreePaneKeys} renderPane={renderWorktreePane} />

--- a/web-ui/src/styles/workspace.css
+++ b/web-ui/src/styles/workspace.css
@@ -396,22 +396,6 @@
   color: var(--fg-muted);
 }
 
-.left-sidebar__brand {
-  display: block;
-  /* left padding matches scroll-area(8px) + tree-row(8px) so text sits
-     at the same x-position as the status dot column */
-  padding: var(--space-2) var(--space-4);
-  font-weight: var(--font-weight-semibold);
-  font-size: var(--font-size-base);
-  text-decoration: none;
-  color: inherit;
-  cursor: pointer;
-  flex-shrink: 0;
-}
-
-.left-sidebar__brand:hover {
-  background: var(--bg-hover);
-}
 
 .left-sidebar__footer {
   display: flex;
@@ -421,6 +405,37 @@
   padding: var(--space-2);
   border-top: var(--border-width) solid var(--border-default);
   flex-shrink: 0;
+}
+
+.left-sidebar__brand {
+  display: flex;
+  align-items: center;
+  padding: var(--space-1) var(--space-1) var(--space-4);
+  pointer-events: none;
+  user-select: none;
+}
+
+.left-sidebar__brand-inner {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  opacity: 0.38;
+}
+
+.left-sidebar__brand-name {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--text-1);
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
+.left-sidebar__brand-version {
+  font-size: 0.6rem;
+  font-weight: 400;
+  color: var(--text-1);
+  opacity: 0.7;
+  white-space: nowrap;
 }
 
 .left-sidebar__nav-item {
@@ -1487,6 +1502,60 @@
     background var(--transition-fast),
     opacity var(--transition-fast);
   opacity: 0.55;
+}
+
+/* Overflow menu — position: relative wrapper + absolute popover */
+.top-bar__overflow-wrapper {
+  position: relative;
+}
+
+.top-bar__overflow-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 200;
+  min-width: 200px;
+  background: var(--bg-overlay);
+  border: var(--border-width) solid var(--border-default);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg, 0 4px 12px rgba(0,0,0,0.15));
+  padding: var(--space-1) 0;
+}
+
+.top-bar__overflow-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--font-size-sm);
+  font-family: inherit;
+  color: var(--fg-secondary);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  box-sizing: border-box;
+  transition: background var(--transition-fast);
+}
+
+.top-bar__overflow-item:hover {
+  background: var(--bg-hover);
+  color: var(--fg-primary);
+}
+
+.top-bar__overflow-item--active {
+  color: var(--fg-primary);
+}
+
+.top-bar__overflow-item:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.top-bar__overflow-item:disabled:hover {
+  background: transparent;
+  color: var(--fg-secondary);
 }
 
 /* Hover = a NEUTRAL, transient highlight (grey bg, mid opacity). Deliberately a


### PR DESCRIPTION
## Summary

- **Top bar overflow menu** — Moves workspace canvas toggle, split orientation, terminal dock, and Settings into a `⋯` popover; only Search and the panel toggle remain inline. The overflow button shows the mobile-aware effective split orientation (vertical by default on phones, matching what `Layout.tsx` renders).
- **Left sidebar** — Adds a non-interactive product branding row at the top (`Vibe Station [logo] v0.0.0`, 38% opacity, left-aligned, not a nav item). Renames the Home link to use `<Home>` icon + "Home" label. Removes the Settings link from the footer (now in the overflow menu).
- **Settings on dashboard** — Settings icon button appears in the top bar when not in worktree/direct-session view (dashboard, workspace-view, settings page), giving it a persistent home outside the overflow.
- **ToolPanel X button** — Inverts visibility: absent in classic docked mode (the top bar toggle covers it), present only inside a workspace canvas tile via a new `onClose` prop wired to the tile-close callback in `Workspace.tsx`.
- **Keyboard shortcuts** — Adds three Ctrl/⌘ shortcuts that don't conflict with Chrome: `Ctrl+\` (toggle tool pane), `Ctrl+Shift+G` (new agent in current worktree — chose G over A since Chrome on Windows ≥v86 captures Ctrl+Shift+A for tab search), `Ctrl+Shift+M` (new agent in new worktree). G and M use `e.code` for layout-independence.
- **Mobile Enter = newline** — On touch devices (`navigator.maxTouchPoints > 0`), plain Enter in any `SkillEditor` mount site (Composer / all new-agent dialogs) inserts a line break instead of sending; Ctrl/⌘+Enter still sends.

## Test plan

- [ ] Top bar in worktree view shows only Search + `⋯` + panel toggle
- [ ] `⋯` opens overflow with canvas mode, toolbar toggle, split, terminal, Settings — active states reflect correctly
- [ ] Dashboard top bar shows Settings icon (top right); clicking navigates to `/settings`
- [ ] Left sidebar brand row is non-interactive (no hover/click), left-aligned, clearly a watermark
- [ ] Home link shows `<Home>` icon + "Home" label; Settings link gone from sidebar footer
- [ ] ToolPanel X absent in classic mode; present (and removes tile) in workspace canvas tile
- [ ] `Ctrl+\` toggles tool pane; `Ctrl+Shift+G` opens new-agent dialog; `Ctrl+Shift+M` opens new-worktree dialog
- [ ] On a touch phone, Enter in rich chat / new-agent dialog adds newline; Ctrl+Enter sends
- [ ] `tsc -b --noEmit` clean