### PR TITLE
feat(ui): key enter-as-newline off soft keyboard, not touch capability

### DIFF
--- a/.vibekit/reports/2026-09-10-enter-key-soft-keyboard-detection.md
+++ b/.vibekit/reports/2026-09-10-enter-key-soft-keyboard-detection.md
@@ -1,0 +1,89 @@
+<!--
+RULES — read before writing this report:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. ANSWER FIRST: the finding goes at the top, before any evidence
+3. EVERY CLAIM CITED: file:line, a command + its output, or a screenshot
+4. READING TIME: optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+# Report: Enter-as-newline should key off "soft keyboard showing", not touch capability
+
+**Date:** 2026-09-10 · **Commit:** 00a3338 · **Scope:** `web-ui/src/components/chat/SkillEditor.tsx` + its 6 mount sites · **Method:** code inspection (grep + read)
+
+## Answer
+- Yes, the change makes sense: the current `navigator.maxTouchPoints > 0` check is a **hardware capability**, not a **current input mode** — a phone in split-screen, an external-keyboard iPad, or a laptop with a touchscreen all have `maxTouchPoints > 0` yet a physical keyboard is present, so plain-Enter silently inserts a newline instead of sending.
+- The entire fix is **one function** in `SkillEditor.tsx` — every prompt field (Rich Chat composer, queued-turn editor, and all 4 agent dialogs) renders the **same** `<SkillEditor>`, so the `KEY_ENTER_COMMAND` handler at `SkillEditor.tsx:472-494` is the single site that needs changing.
+- Do it via the **VirtualKeyboard API** (`navigator.virtualKeyboard.overlayContentRect.height > 0`) where supported (Chromium 94+), falling back to a coarse-heuristic when absent — this is "keyboard currently showing", not "device has touch".
+
+## Evidence
+| Claim | Source |
+|-------|--------|
+| Enter/newline decision lives in one `KEY_ENTER_COMMAND` handler | `web-ui/src/components/chat/SkillEditor.tsx:472-494` |
+| Current check is touch *capability*: `navigator.maxTouchPoints > 0` | `web-ui/src/components/chat/SkillEditor.tsx:480` |
+| Rich Chat composer mounts `<SkillEditor>` | `web-ui/src/components/chat/Composer.tsx:147` |
+| Queued-turn editor mounts `<SkillEditor>` | `web-ui/src/components/chat/QueuedTurnEditor.tsx:117` |
+| NewAgentDialog mounts `<SkillEditor>` | `web-ui/src/components/dialogs/NewAgentDialog.tsx:1550` |
+| NewAgentTabDialog mounts `<SkillEditor>` | `web-ui/src/components/dialogs/NewAgentTabDialog.tsx:156` |
+| NewAgentSessionDialog mounts `<SkillEditor>` | `web-ui/src/components/dialogs/NewAgentSessionDialog.tsx:348` |
+| NewAgentDirectDialog mounts `<SkillEditor>` | `web-ui/src/components/dialogs/NewAgentDirectDialog.tsx:199` |
+| Existing tests cover the key table at the Composer mount site | `web-ui/src/components/chat/SkillEditor.test.tsx:273-317` |
+
+## Detail
+
+### Current behaviour
+- `KEY_ENTER_COMMAND` handler logic (`SkillEditor.tsx:480-488`):
+  - `isTouchDevice = navigator.maxTouchPoints > 0`
+  - `isModifiedEnter = ctrlKey || metaKey`
+  - `isNewlineCombo = shiftKey || altKey`
+  - newline iff `isNewlineCombo || (isTouchDevice && !isModifiedEnter)`
+- Net effect on any touch-capable machine: **plain Enter = newline; Ctrl/Cmd+Enter = send** (the `onSubmitRef.current()` call at `SkillEditor.tsx:490`).
+- `maxTouchPoints` is fixed per-device, read once per keydown, never changes → the decision can't track "is the soft keyboard up right now".
+
+### Why "touch capable" is the wrong predicate
+| Scenario | `maxTouchPoints > 0` | Physical kb present | Desired plain-Enter |
+|----------|:---------------------:|:-------------------:|:-------------------:|
+| Phone, on-screen kb | yes | no | newline |
+| Phone + Bluetooth/hardware kb | yes | yes | send |
+| Tablet + external keyboard | yes | yes | send |
+| Touchscreen laptop, hardware kb | yes | yes | send |
+| Desktop (no touch) | no | yes | send |
+
+### Option A — VirtualKeyboard API (recommended)
+- `navigator.virtualKeyboard` exposes `overlayContentRect` whose `.height > 0` while the on-screen keyboard is showing; fires a `virtualkeyboardchange` event on show/hide. Chromium 94+, incl. Android; not in Firefox/Safari.
+- Exactly the "currently showing" signal requested — no re-measure, event-driven.
+- In `KEY_ENTER_COMMAND`: replace `isTouchDevice` with `isSoftKeyboardVisible()`.
+- Also enables a `visualViewport`-independent sentinel; no layout heuristics needed when present.
+
+### Option B — coarse media query fallback
+- `matchMedia("(any-hover: none)")` / `(any-pointer: coarse)` — still **capability**, not current state; only a fallback. Same "hardware present" flaw as today, so not a true fix on its own.
+
+### Option C — viewport delta heuristic (last resort)
+- Compare `visualViewport.height` vs `window.innerHeight` while the field is focused; on-screen kb shrinks the visual viewport. Heuristic, browser-dependent, not event-driven — fragile; only useful where VirtualKeyboard API is unavailable and media queries are unhelpful.
+
+### Recommended composition
+```
+isSoftKeyboardVisible():
+  if navigator.virtualKeyboard exists → return virtualKeyboard.overlayContentRect.height > 0
+  else → fall back to (any-hover:none) [capability] or visualViewport delta heuristic
+```
+- Cache the VirtualKeyboard decision on `virtualkeyboardchange`, don't re-read every keydown.
+- Keep `isModifiedEnter` (Ctrl/Cmd+Enter always sends) and `isNewlineCombo` (Shift/Alt+Enter always newline) unchanged — they are modifier intent, orthogonal to the device question.
+- Update the hint copy in `Composer.tsx:220-224` (currently advertises "Enter sends" unconditionally) to match the runtime decision.
+
+### Test strategy
+- `SkillEditor.test.tsx:273-317` is the key-table suite — add cases:
+  - virtual keyboard "hidden" (`overlayContentRect.height = 0`) + touch-capable navigator → plain Enter **sends**
+  - virtual keyboard "showing" (`height > 0`) → plain Enter **newline**
+  - VirtualKeyboard API absent → fallback branch exercised
+- jsdom must stub `navigator.virtualKeyboard` (not present by default) — mock in the test setup, mirroring how `maxTouchPoints` is currently assumed.
+
+## Not checked
+- Safari/iOS: VirtualKeyboard API unsupported there; the fallback path's exact behaviour on iOS Safari (which uses a different, historically buggy virtual-keyboard model) is unverified — needs a device check, not just code.
+- Whether the daemon/terminal channel has the same Enter-vs-newline concern (this report covers only the `<SkillEditor>` prompt surfaces).
+
+## Follow-ups
+| # | Question | Why it matters |
+|---|----------|-----------------|
+| 1 | Confirm target browser support for `navigator.virtualKeyboard` (Tauri webview = Chromium?) | Determines whether the API path or the heuristic fallback is the primary on the desktop app |
+| 2 | Verify iOS Safari fallback on a real device | The API is absent there; the fallback must not regress plain-Enter-sends |
+| 3 | Should the hint line be dynamic? | `Composer.tsx:220-224` advertises "Enter sends" statically, which is wrong when a soft keyboard forces newline |

--- a/web-ui/src/components/chat/Composer.tsx
+++ b/web-ui/src/components/chat/Composer.tsx
@@ -5,7 +5,7 @@ import { useAttachmentDrafts } from "@/hooks/useAttachmentDrafts";
 import { loadDraft, useComposerDraft } from "@/hooks/useComposerDraft";
 import { migrateV1Draft } from "@/lib/skillInvocation";
 import { AttachmentChip } from "./AttachmentChip";
-import { SkillEditor, type SkillEditorHandle } from "./SkillEditor";
+import { SkillEditor, useSoftKeyboardVisible, type SkillEditorHandle } from "./SkillEditor";
 
 /** How long the Send button is held (disabled) at its position after OUR OWN
  *  send emptied the box while a turn is still running — see `justSent`. */
@@ -61,6 +61,7 @@ export function Composer({
   const draft = useComposerDraft(sessionId);
 
   const [argFocused, setArgFocused] = useState(false);
+  const softKeyboardVisible = useSoftKeyboardVisible();
 
   const { drafts, readyAttachments, error, uploadFiles, removeDraft, reset } = useAttachmentDrafts(
     api,
@@ -220,8 +221,10 @@ export function Composer({
           <>Enter or → exits to the message · Backspace removes an argument, then the skill · Ctrl+Enter sends</>
         ) : (
           <>
-            <span aria-hidden>⤓</span> Drop files here · Enter / Ctrl+Enter to send · Shift+Enter or Alt+Enter for
-            newline
+            <span aria-hidden>⤓</span> Drop files here ·{" "}
+            {softKeyboardVisible
+              ? "Enter for newline · Ctrl/Cmd+Enter to send"
+              : "Enter / Ctrl+Enter to send · Shift+Enter or Alt+Enter for newline"}
           </>
         )}
       </div>

--- a/web-ui/src/components/chat/SkillEditor.test.tsx
+++ b/web-ui/src/components/chat/SkillEditor.test.tsx
@@ -316,6 +316,117 @@ describe("§10 three mount sites — key table (Composer: Enter sends)", () => {
   });
 });
 
+describe("§10b soft-keyboard Enter behaviour (vs hardware touch capability)", () => {
+  function withVirtualKeyboard(height: number) {
+    const listeners: Array<() => void> = [];
+    const vk = {
+      overlaysContent: false,
+      overlayContentRect: { height },
+      addEventListener: (_type: string, cb: () => void) => listeners.push(cb),
+      removeEventListener: () => {},
+    };
+    Object.defineProperty(navigator, "virtualKeyboard", {
+      configurable: true,
+      value: vk,
+    });
+    return {
+      setHeight(h: number) {
+        vk.overlayContentRect.height = h;
+        listeners.forEach((cb) => cb());
+      },
+      restore() {
+        delete (navigator as { virtualKeyboard?: unknown }).virtualKeyboard;
+      },
+    };
+  }
+
+  it("plain Enter sends when no soft keyboard is present (normal keyboard path)", async () => {
+    const { onSend, ref } = renderComposer("hello there");
+    await act(async () => ref.current?.focus());
+    await key(editorEl(), "Enter");
+    await waitFor(() => expect(onSend).toHaveBeenCalled());
+  });
+
+  it("plain Enter inserts a newline when the virtual keyboard is showing", async () => {
+    const vk = withVirtualKeyboard(300);
+    try {
+      const { onSend, ref } = renderComposer("hello");
+      await act(async () => ref.current?.focus());
+      await key(editorEl(), "Enter");
+      expect(onSend).not.toHaveBeenCalled();
+      expect(ref.current?.getText()).toContain("\n");
+    } finally {
+      vk.restore();
+    }
+  });
+
+  it("plain Enter switches to newline when the keyboard appears mid-session (virtualkeyboardchange)", async () => {
+    const vk = withVirtualKeyboard(0);
+    try {
+      const { onSend, ref } = renderComposer("hello there");
+      await act(async () => ref.current?.focus());
+      await key(editorEl(), "Enter");
+      await waitFor(() => expect(onSend).toHaveBeenCalled());
+      onSend.mockClear();
+
+      // Keyboard appears while the editor is already mounted.
+      await act(async () => vk.setHeight(300));
+      await key(editorEl(), "Enter");
+      expect(onSend).not.toHaveBeenCalled();
+      expect(ref.current?.getText()).toContain("\n");
+    } finally {
+      vk.restore();
+    }
+  });
+
+  it("Ctrl+Enter still sends while the virtual keyboard is showing", async () => {
+    const vk = withVirtualKeyboard(300);
+    try {
+      const { onSend, ref } = renderComposer("hello");
+      await act(async () => ref.current?.focus());
+      await key(editorEl(), "Enter", { ctrlKey: true });
+      await waitFor(() => expect(onSend).toHaveBeenCalled());
+    } finally {
+      vk.restore();
+    }
+  });
+
+  it("plain Enter sends when the virtual keyboard is hidden (height 0)", async () => {
+    const vk = withVirtualKeyboard(0);
+    try {
+      const { onSend, ref } = renderComposer("hello there");
+      await act(async () => ref.current?.focus());
+      await key(editorEl(), "Enter");
+      await waitFor(() => expect(onSend).toHaveBeenCalled());
+    } finally {
+      vk.restore();
+    }
+  });
+
+  it("coarse-pointer fallback (no VirtualKeyboard API): plain Enter inserts a newline", async () => {
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = ((query: string) => ({
+      matches: query.includes("any-pointer: coarse") && query.includes("any-hover: none"),
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    })) as unknown as typeof window.matchMedia;
+    try {
+      const { onSend, ref } = renderComposer("hello");
+      await act(async () => ref.current?.focus());
+      await key(editorEl(), "Enter");
+      expect(onSend).not.toHaveBeenCalled();
+      expect(ref.current?.getText()).toContain("\n");
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
+  });
+});
+
 describe("Popover selection materializes a chip", () => {
   it("clicking a popover option inserts a chip with empty args, caret after it", async () => {
     const { ref } = renderComposer("/cod");

--- a/web-ui/src/components/chat/SkillEditor.tsx
+++ b/web-ui/src/components/chat/SkillEditor.tsx
@@ -317,6 +317,54 @@ function segmentsToNodes(segments: ReturnType<typeof parseSkillSegments>): Lexic
   return nodes;
 }
 
+/** Whether a soft (on-screen) keyboard is currently shown. Drives the
+ *  plain-Enter = newline decision: a physical keyboard (even on a
+ *  touch-capable device) should send on plain Enter; a soft keyboard should
+ *  insert a newline so the user can still multi-line (Ctrl/Cmd+Enter sends).
+ *  Uses the VirtualKeyboard API where available (Chromium 94+), which reports
+ *  the *current* state; falls back to a coarse capability heuristic
+ *  (`any-pointer: coarse` + `any-hover: none`, i.e. a primary touch input
+ *  with no hover) where the API is absent (Firefox/Safari). */
+export function useSoftKeyboardVisible(): boolean {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    interface VirtualKeyboardLike {
+      overlaysContent: boolean;
+      overlayContentRect: { height: number };
+      addEventListener: (type: string, cb: () => void) => void;
+      removeEventListener: (type: string, cb: () => void) => void;
+    }
+    const nav =
+      typeof navigator !== "undefined"
+        ? (navigator as Navigator & { virtualKeyboard?: VirtualKeyboardLike })
+        : undefined;
+    const vk = nav?.virtualKeyboard;
+
+    if (vk) {
+      // Required opt-in: without `overlaysContent = true`, `overlayContentRect`
+      // is never populated and `virtualkeyboardchange` may never fire, so the
+      // height-based detection is a silent no-op. Overlay mode (rather than the
+      // default resize) also keeps the app layout from squishing on keyboard
+      // show — this app doesn't rely on the visual viewport shrinking.
+      vk.overlaysContent = true;
+      const update = () => setVisible((vk.overlayContentRect?.height ?? 0) > 0);
+      update();
+      vk.addEventListener("virtualkeyboardchange", update);
+      return () => vk.removeEventListener("virtualkeyboardchange", update);
+    }
+
+    const coarse =
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(any-pointer: coarse) and (any-hover: none)").matches;
+    setVisible(coarse);
+    return undefined;
+  }, []);
+
+  return visible;
+}
+
 /** Adjacency + keymap + clipboard plugin: everything that needs the editor
  *  instance and Lexical command registration (caret contract, Enter/Escape/
  *  newline, popover keyboard nav, copy/cut/paste). Rendered as a child of
@@ -345,6 +393,9 @@ function SkillEditorPlugin({
   pasteSuppressRef: React.MutableRefObject<boolean>;
 }) {
   const [editor] = useLexicalComposerContext();
+  const softKeyboardVisible = useSoftKeyboardVisible();
+  const softKeyboardRef = useRef(softKeyboardVisible);
+  softKeyboardRef.current = softKeyboardVisible;
   const onSubmitRef = useRef(onSubmit);
   onSubmitRef.current = onSubmit;
   const onEscapeRef = useRef(onEscape);
@@ -477,11 +528,11 @@ function SkillEditorPlugin({
             selectActivePopoverItem();
             return true;
           }
-          const isTouchDevice = typeof navigator !== "undefined" && navigator.maxTouchPoints > 0;
           const isModifiedEnter = !!event && (event.ctrlKey || event.metaKey);
           const isNewlineCombo = !!event && (event.shiftKey || event.altKey);
-          // On touch phones, plain Enter adds a newline; Ctrl/Cmd+Enter still sends.
-          if (isNewlineCombo || (isTouchDevice && !isModifiedEnter)) {
+          // On a showing soft keyboard, plain Enter adds a newline (there's no
+          // Shift+Enter combo on most touch keyboards); Ctrl/Cmd+Enter still sends.
+          if (isNewlineCombo || (softKeyboardRef.current && !isModifiedEnter)) {
             event?.preventDefault();
             editor.dispatchCommand(INSERT_LINE_BREAK_COMMAND, false);
             return true;


### PR DESCRIPTION
## Summary

Plain Enter in the Rich Chat prompt editor previously inserted a newline
whenever the device reported touch *capability*
(`navigator.maxTouchPoints > 0`), even when a physical keyboard was
present (touchscreen laptop, tablet + external keyboard, etc.). This
change keys the decision off whether a soft keyboard is **currently
showing** instead.

All prompt fields (Rich Chat composer, queued-turn editor, and all 4
agent dialogs) share a single `<SkillEditor>`, so the change is one site:
`SkillEditor.tsx`'s `KEY_ENTER_COMMAND` handler.

## How it works

- New `useSoftKeyboardVisible()` hook: uses the **VirtualKeyboard API**
  (`navigator.virtualKeyboard.overlayContentRect.height > 0`,
  Chromium 94+) with the required `overlaysContent = true` opt-in, and a
  coarse `any-pointer: coarse AND any-hover: none` fallback where the API
  is absent (Firefox/Safari).
- `KEY_ENTER_COMMAND`: plain Enter = newline only when a soft keyboard is
  showing; Ctrl/Cmd+Enter always sends; Shift/Alt+Enter always newline.
- Composer hint reflects the runtime soft-keyboard state.

## Testing

- 32 `SkillEditor` tests pass (incl. new: no-soft-keyboard sends,
  soft-keyboard newline, mid-session `virtualkeyboardchange` transition,
  coarse-pointer fallback, Ctrl+Enter-sends).
- Typecheck + lint clean.
- Verified in a docker-isolated UI (`scripts/dev-sandbox.sh`): a normal
  keyboard still sends on plain Enter and inserts no newline.
- Reviewer (claude-opus subagent) approved; addressed all findings
  (overlaysContent opt-in + test gaps + hint copy).

Note: 2 pre-existing `MessageList.test.tsx` failures (subagent
notification copy) fail identically on the base commit and are unrelated
to this change.

## Files

- `web-ui/src/components/chat/SkillEditor.tsx`
- `web-ui/src/components/chat/Composer.tsx`
- `web-ui/src/components/chat/SkillEditor.test.tsx`
- `.vibekit/reports/2026-09-10-enter-key-soft-keyboard-detection.md`