### PR TITLE
fix(daemon): correct resolveVstSkillSource path — 3 levels up, not 4

### DIFF
--- a/daemon/src/lib/resolveVstPaths.ts
+++ b/daemon/src/lib/resolveVstPaths.ts
@@ -57,7 +57,7 @@ export function resolveVstCliBinSource(): string | undefined {
 export function resolveVstSkillSource(): string | undefined {
   if (process.env.VST_SKILL_PATH) return process.env.VST_SKILL_PATH;
   const here = dirname(fileURLToPath(import.meta.url));
-  const candidate = resolve(here, "../../../../skill/SKILL.md");
+  const candidate = resolve(here, "../../../skill/SKILL.md");
   return existsSync(candidate) ? candidate : undefined;
 }
 


### PR DESCRIPTION
## Root cause

`resolveVstSkillSource()` in `daemon/src/lib/resolveVstPaths.ts` used `../../../../skill/SKILL.md` (4 `../` hops) to find the bundled skill file. `here` is `daemon/src/lib`, which is only 3 levels from the repo root:

```
daemon/src/lib  →  daemon/src  →  daemon  →  repo-root  →  (parent, wrong!)
```

`existsSync` on the overshot path always returned `false`, so the function silently returned `undefined` on every cold boot.

## Impact

- `setupVstEnvironment()` skipped installing `skill/SKILL.md` → `~/.vibe-station/skill/vst/SKILL.md`
- `installHarnessSkillDirs()` returned early for the same reason
- Daemon skill catalog was empty; `GET /skills` returned `[]`
- `useSkillCommands` hook set `skillCommands = []` → slash-completion popover never opened in **new agent dialogs and direct agent chats**
- Sessions that had already received an ACP `available_commands_update` event were unaffected (their `session:meta.commands` populated independently), which is why the bug only manifested in fresh/pre-event contexts

## Fix

One-line change: `../../../../` → `../../../`

## Opus review summary

- **Traversal arithmetic confirmed correct** — 3 hops from `daemon/src/lib` lands exactly at repo root
- **No other callers need changes** — both `setupVstEnvironment()` and `installHarnessSkillDirs()` go through this single function
- **Prod/bundled mode risk is low** — `VST_SKILL_PATH` env var override (line 58) insulates Tauri builds; the `../../../` fallback is dev-only, same pattern as `resolveVstCliBinSource()`'s `isDev` guard
- **Test gap noted** — no unit test asserts the function returns non-undefined in the dev tree; a minimal test with real FS would catch this regression; not a blocker