### PR TITLE
feat(ui): tool pane UX polish — font controls, split toggle, file tree nav, menu styling

### DIFF
--- a/web-ui/src/components/chat/StatusBar.tsx
+++ b/web-ui/src/components/chat/StatusBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import type { ApiInstance } from "@/api";
 import type { SessionMeta, TurnState } from "@/api/types";
 import { ModelSwitch } from "./ModelSwitch";
@@ -23,6 +23,8 @@ interface StatusBarProps {
   atBottom?: boolean;
   /** Notice slot (subagent-ux-v2) — when running, overrides the status label. */
   noticeSlot?: { children: Record<string, string>; running: boolean };
+  /** Font -/+ controls rendered to the left of the channel toggle overlay. */
+  fontControls?: ReactNode;
 }
 
 function fmt(n: number): string {
@@ -61,7 +63,7 @@ export function turnLabel(state: TurnState | undefined, queue: number): string {
  * branching). Fields absent from `meta` (e.g. costUsd, contextWindow) hide
  * gracefully.
  */
-export function StatusBar({ meta, queueDepth = 0, onStop, api, sessionId, atBottom = true, noticeSlot }: StatusBarProps) {
+export function StatusBar({ meta, queueDepth = 0, onStop, api, sessionId, atBottom = true, noticeSlot, fontControls }: StatusBarProps) {
   const usage = meta?.usage;
   const state = meta?.turnState;
   const queue = Math.max(queueDepth, meta?.queueDepth ?? 0);
@@ -178,27 +180,33 @@ export function StatusBar({ meta, queueDepth = 0, onStop, api, sessionId, atBott
       </div>
       {/* Positioned via CSS as a top-right overlay of the whole `.chat-pane`
           (item 4) — NOT visually anchored to this row, even though it's
-          declared here alongside the rest of the toggle's gating logic. */}
-      {canToggle ? (
-        <ChannelToggleButton
-          api={api!}
-          sessionId={sessionId!}
-          direction="toTerminal"
-          triggerDisabled={!idle}
-          confirmBlocked={!idle}
-          blockedMessage="The session just went busy — wait for it to finish (or clear the queue) before switching."
-          {...(() => {
-            const warnings = [
-              supportsResume === false
-                ? `⚠ ${cli} can't resume in the terminal — this switch starts a FRESH terminal conversation instead of continuing this one. Your Rich Chat history stays intact and untouched.`
-                : null,
-              importsHistory === false
-                ? `⚠ ${cli} can't read its terminal history yet — anything you do in the terminal won't appear back in Rich Chat, though the agent still remembers it.`
-                : null,
-            ].filter((w): w is string => w !== null);
-            return warnings.length > 0 ? { warning: warnings.join("\n\n") } : {};
-          })()}
-        />
+          declared here alongside the rest of the toggle's gating logic. Font
+          controls are co-located here for discoverability. */}
+      {canToggle || fontControls ? (
+        <div className="chat-font-overlay">
+          {fontControls}
+          {canToggle ? (
+            <ChannelToggleButton
+              api={api!}
+              sessionId={sessionId!}
+              direction="toTerminal"
+              triggerDisabled={!idle}
+              confirmBlocked={!idle}
+              blockedMessage="The session just went busy — wait for it to finish (or clear the queue) before switching."
+              {...(() => {
+                const warnings = [
+                  supportsResume === false
+                    ? `⚠ ${cli} can't resume in the terminal — this switch starts a FRESH terminal conversation instead of continuing this one. Your Rich Chat history stays intact and untouched.`
+                    : null,
+                  importsHistory === false
+                    ? `⚠ ${cli} can't read its terminal history yet — anything you do in the terminal won't appear back in Rich Chat, though the agent still remembers it.`
+                    : null,
+                ].filter((w): w is string => w !== null);
+                return warnings.length > 0 ? { warning: warnings.join("\n\n") } : {};
+              })()}
+            />
+          ) : null}
+        </div>
       ) : null}
     </div>
   );

--- a/web-ui/src/components/layout/AgentPaneSlot.tsx
+++ b/web-ui/src/components/layout/AgentPaneSlot.tsx
@@ -1,3 +1,4 @@
+import { Minus, Plus } from "lucide-react";
 import type { ApiInstance } from "@/api";
 import type { PrStatus, Session } from "@/api/types";
 import { TerminalPane } from "./TerminalPane";
@@ -45,14 +46,26 @@ interface AgentPaneSlotProps {
  */
 export function AgentPaneSlot({ api, sessionId, session, branch = null, pr = null }: AgentPaneSlotProps) {
   const isJson = session?.channel === "json";
+  const bumpTerminalFont = useWorkspaceStore((s) => s.bumpTerminalFont);
   // The channel toggle is handed to `TerminalPane` so a single owner decides its
   // placement: a top-right overlay while the terminal is live, but rendered
   // in-flow BELOW the "Session exited / Resume" banner once the session exits
   // (json-mode-followups item 4). Driving that off `TerminalPane`'s own banner
   // state — instead of second-guessing it here — is why the toggle can no longer
   // land on top of the banner and swallow clicks meant for Resume.
+  // Font size buttons are co-located with the toggle for discoverability.
   const channelToggle =
-    !isJson && session ? <TerminalChannelToggle api={api} session={session} /> : null;
+    !isJson && session ? (
+      <div className="terminal-font-overlay">
+        <button type="button" className="terminal-font-overlay__btn" aria-label="Decrease agent font" onClick={() => bumpTerminalFont(-0.05)}>
+          <Minus size={11} />
+        </button>
+        <button type="button" className="terminal-font-overlay__btn" aria-label="Increase agent font" onClick={() => bumpTerminalFont(0.05)}>
+          <Plus size={11} />
+        </button>
+        <TerminalChannelToggle api={api} session={session} />
+      </div>
+    ) : null;
   // The attachment-upload overlay is still a plain top-corner overlay that only
   // makes sense on a live terminal, so keep gating it out once the pane exits.
   // `done` releases the pane exactly like `exited` does (the daemon kills the

--- a/web-ui/src/components/layout/ChangedFileList.tsx
+++ b/web-ui/src/components/layout/ChangedFileList.tsx
@@ -122,6 +122,7 @@ export function ChangedFileList({ entries, loading, error, controlled }: Changed
   );
   const { cursorPath, setCursorPath, handleKeyDown, isTabbable } = useRovingListNav(rovingRows, {
     onOpen: selectFile,
+    openOnArrow: true,
   });
 
   if (error) {

--- a/web-ui/src/components/layout/ChatPane.tsx
+++ b/web-ui/src/components/layout/ChatPane.tsx
@@ -1,3 +1,4 @@
+import { Minus, Plus } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 import type { ApiInstance } from "@/api";
 import type { Attachment, Session } from "@/api/types";
@@ -47,6 +48,7 @@ export function ChatPane({ api, session, visible }: ChatPaneProps) {
   const enabled = visible && isJson && !!sessionId;
 
   const terminalFontScale = useWorkspaceStore((s) => s.terminalFontScale);
+  const bumpTerminalFont = useWorkspaceStore((s) => s.bumpTerminalFont);
   const layoutByWorktree = useWorkspaceStore((s) => s.layoutByWorktree);
   const workspaceDocs = useWorkspaceStore((s) => s.workspaceDocs);
   const insertTileIntoWorkspaceDoc = useWorkspaceStore((s) => s.insertTileIntoWorkspaceDoc);
@@ -321,6 +323,16 @@ export function ChatPane({ api, session, visible }: ChatPaneProps) {
           api={api}
           {...(sessionId ? { sessionId } : {})}
           noticeSlot={noticeSlot}
+          fontControls={
+            <div className="chat-font-overlay__btns">
+              <button type="button" className="terminal-font-overlay__btn" aria-label="Decrease chat font" onClick={() => bumpTerminalFont(-0.05)}>
+                <Minus size={11} />
+              </button>
+              <button type="button" className="terminal-font-overlay__btn" aria-label="Increase chat font" onClick={() => bumpTerminalFont(0.05)}>
+                <Plus size={11} />
+              </button>
+            </div>
+          }
         />
         {session ? (
           <SubagentRow

--- a/web-ui/src/components/layout/FilePreviewPane.tsx
+++ b/web-ui/src/components/layout/FilePreviewPane.tsx
@@ -1,3 +1,4 @@
+import { Minus, Plus } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 import type { ApiInstance } from "@/api";
 import type { DiffScope, FileScope } from "@/api/types";
@@ -46,7 +47,11 @@ export function FilePreviewPane({ api, worktreeId, scope: fileScope = "worktree"
       ? "none"
       : (scopeFromStore ?? "none");
   const commitSha = controlled?.commitSha;
-  const previewFontScale = useWorkspaceStore((s) => s.previewFontScale);
+  const previewFontScaleGlobal = useWorkspaceStore((s) => s.previewFontScale);
+  const previewFontScaleByWorktree = useWorkspaceStore((s) => s.previewFontScaleByWorktree);
+  const previewFontScale = (worktreeId ? previewFontScaleByWorktree[worktreeId] : undefined) ?? previewFontScaleGlobal;
+  const bumpPreviewFontForWorktree = useWorkspaceStore((s) => s.bumpPreviewFontForWorktree);
+  const bumpPreviewFont = useWorkspaceStore((s) => s.bumpPreviewFont);
 
   const { theme } = useTheme();
   const themeMode = theme;
@@ -321,9 +326,25 @@ export function FilePreviewPane({ api, worktreeId, scope: fileScope = "worktree"
 
   const useCodeChrome = scope === "local" || scope === "branch" || scope === "commit" || (!isMd && scope === "none");
 
+  const bump = (delta: number) => {
+    if (worktreeId) bumpPreviewFontForWorktree(worktreeId, delta);
+    else bumpPreviewFont(delta);
+  };
+  const fontOverlay = (
+    <div className="preview-font-overlay">
+      <button type="button" className="preview-font-overlay__btn" aria-label="Decrease preview font" onClick={() => bump(-0.05)}>
+        <Minus size={11} />
+      </button>
+      <button type="button" className="preview-font-overlay__btn" aria-label="Increase preview font" onClick={() => bump(0.05)}>
+        <Plus size={11} />
+      </button>
+    </div>
+  );
+
   return (
-    <div className="pane pane-stack">
+    <div className="pane pane-stack" style={{ position: "relative" }}>
       {diffInfo}
+      {fontOverlay}
       <div
         ref={setBodyRef}
         onScroll={handleScroll}

--- a/web-ui/src/components/layout/FileTreeSidebar.tsx
+++ b/web-ui/src/components/layout/FileTreeSidebar.tsx
@@ -392,6 +392,7 @@ export function FileTreeSidebar({ api, contextId, scope: fileScope = "worktree" 
       else openFile(path);
     },
     onToggle: (path) => toggle(path),
+    openOnArrow: true,
   });
 
   // Keep DOM focus following the roving cursor so subsequent key events land
@@ -481,6 +482,8 @@ export function FileTreeSidebar({ api, contextId, scope: fileScope = "worktree" 
               ? "Worktree files, git markers loading"
               : "Worktree files"
         }
+        tabIndex={-1}
+        onKeyDown={handleKeyDown}
         onFocusCapture={() => setFocusedPane("file-tree")}
       >
         <div style={{ minWidth: "max-content" }}>
@@ -522,7 +525,6 @@ export function FileTreeSidebar({ api, contextId, scope: fileScope = "worktree" 
                   style={{ paddingLeft: `calc(${row.level} * var(--space-4) + var(--space-2))` }}
                   onClick={() => (isDir ? toggle(row.path) : openFile(row.path))}
                   onFocus={() => setCursorPath(row.path)}
-                  onKeyDown={handleKeyDown}
                 >
                   <span className="tree-row__kind-icon" aria-hidden>
                     {isDir ? (

--- a/web-ui/src/components/layout/MasterDetailShell.tsx
+++ b/web-ui/src/components/layout/MasterDetailShell.tsx
@@ -1,11 +1,14 @@
-import type { ReactNode } from "react";
+import { type ReactNode } from "react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
-import { FolderTree } from "lucide-react";
-import { useWorkspaceStore } from "@/hooks/useStore";
+import { Columns2, FolderTree, Rows2 } from "lucide-react";
+import { DEFAULT_WORKTREE_LAYOUT, useWorkspaceStore } from "@/hooks/useStore";
 
 interface MasterDetailShellProps {
   /** Uniquely identifies this shell's persisted split size (`autoSaveId`). */
   storageKey: string;
+  /** Worktree id used to persist the split orientation in the store. When
+   *  omitted the toggle still works but orientation resets on remount. */
+  worktreeId?: string | null;
   /** Whether to render the file-tree-visibility toggle button. Default true. */
   treeToggle?: boolean;
   /** The master (left) pane — a file tree or a changed-file list. */
@@ -30,9 +33,14 @@ interface MasterDetailShellProps {
  * preference, not per-content state, unlike the `controlled` overrides
  * `FilePreviewPane`/`ChangedFileList` need (Decision 6).
  */
-export function MasterDetailShell({ storageKey, treeToggle = true, leftPane, rightPane, topbarExtra }: MasterDetailShellProps) {
+export function MasterDetailShell({ storageKey, worktreeId, treeToggle = true, leftPane, rightPane, topbarExtra }: MasterDetailShellProps) {
   const treeVisible = useWorkspaceStore((s) => s.fileTreeVisible);
   const toggleFileTree = useWorkspaceStore((s) => s.toggleFileTree);
+  const layoutByWorktree = useWorkspaceStore((s) => s.layoutByWorktree);
+  const setMasterDetailVertical = useWorkspaceStore((s) => s.setMasterDetailVertical);
+  const vertical = worktreeId
+    ? !!(layoutByWorktree[worktreeId] ?? DEFAULT_WORKTREE_LAYOUT).masterDetailVertical
+    : false;
 
   return (
     <div className="files-panel">
@@ -49,16 +57,32 @@ export function MasterDetailShell({ storageKey, treeToggle = true, leftPane, rig
             <FolderTree size={15} />
           </button>
         ) : null}
+        {treeVisible && worktreeId ? (
+          <button
+            type="button"
+            className={`files-topbar__tree-toggle${vertical ? " files-topbar__tree-toggle--on" : ""}`}
+            aria-label={vertical ? "Switch to side-by-side layout" : "Switch to stacked layout"}
+            aria-pressed={vertical}
+            title={vertical ? "Side-by-side layout" : "Stacked layout"}
+            onClick={() => setMasterDetailVertical(worktreeId, !vertical)}
+          >
+            {vertical ? <Columns2 size={15} /> : <Rows2 size={15} />}
+          </button>
+        ) : null}
         {topbarExtra}
       </div>
 
       {treeVisible ? (
-        <PanelGroup direction="horizontal" autoSaveId={`vs-files-${storageKey}`} style={{ width: "100%", flex: 1, minHeight: 0 }}>
-          <Panel defaultSize={34} minSize={16} maxSize={60}>
+        <PanelGroup
+          direction={vertical ? "vertical" : "horizontal"}
+          autoSaveId={`vs-files-${storageKey}-${vertical ? "v" : "h"}`}
+          style={{ width: "100%", flex: 1, minHeight: 0 }}
+        >
+          <Panel defaultSize={vertical ? 40 : 34} minSize={16} maxSize={60}>
             <div className="pane-fill-host">{leftPane}</div>
           </Panel>
-          <PanelResizeHandle className="resize-handle resize-handle--col" />
-          <Panel defaultSize={66} minSize={30}>
+          <PanelResizeHandle className={vertical ? "resize-handle resize-handle--row" : "resize-handle resize-handle--col"} />
+          <Panel defaultSize={vertical ? 60 : 66} minSize={30}>
             {rightPane}
           </Panel>
         </PanelGroup>

--- a/web-ui/src/components/layout/PaneTools.tsx
+++ b/web-ui/src/components/layout/PaneTools.tsx
@@ -1,4 +1,4 @@
-import { Maximize2, Minimize2, Minus, Plus, X } from "lucide-react";
+import { Maximize2, Minimize2, X } from "lucide-react";
 import { useWorkspaceStore, type WorkspacePaneFullscreen } from "@/hooks/useStore";
 
 interface PaneToolsProps {
@@ -22,32 +22,12 @@ interface PaneToolsProps {
  * whichever agent view (tmux terminal or Rich Chat) is currently visible.
  */
 export function PaneTools({ fsTarget, onCloseDock }: PaneToolsProps) {
-  const bumpTerminalFont = useWorkspaceStore((s) => s.bumpTerminalFont);
   const workspacePaneFullscreen = useWorkspaceStore((s) => s.workspacePaneFullscreen);
   const setWorkspacePaneFullscreen = useWorkspaceStore((s) => s.setWorkspacePaneFullscreen);
   const fsActive = workspacePaneFullscreen === fsTarget;
 
   return (
     <div className="tabs-strip__tools">
-      <div className="tabs-strip__zoom" aria-label="Agent font zoom">
-        <span className="tabs-strip__zoom-label">Aa</span>
-        <button
-          type="button"
-          className="tab tab--icon"
-          aria-label="Decrease agent font"
-          onClick={() => bumpTerminalFont(-0.05)}
-        >
-          <Minus size={11} />
-        </button>
-        <button
-          type="button"
-          className="tab tab--icon"
-          aria-label="Increase agent font"
-          onClick={() => bumpTerminalFont(0.05)}
-        >
-          <Plus size={11} />
-        </button>
-      </div>
       <div className="tabs-strip__fs">
         <button
           type="button"

--- a/web-ui/src/components/layout/ToolPanel.tsx
+++ b/web-ui/src/components/layout/ToolPanel.tsx
@@ -100,15 +100,6 @@ export function ToolPanel({
         {!hidePanelControls ? (
           <div className="tool-panel__tabs-actions">
             <ToolFullscreenButton />
-            <button
-              type="button"
-              className="tab tab--icon tool-bar-btn"
-              aria-label="Close tool panel"
-              title="Close tool panel"
-              onClick={() => toggleToolPanel()}
-            >
-              <X size={13} />
-            </button>
           </div>
         ) : onClose ? (
           <div className="tool-panel__tabs-actions">
@@ -135,7 +126,7 @@ export function ToolPanel({
               <FilesPanel api={api} worktreeId={worktreeId} scope={scope} />
             ) : null}
             {toolPanelTab === "devices" ? <DevicesPanel /> : null}
-            {toolPanelTab === "artifacts" ? <ArtifactsPanel /> : null}
+            {toolPanelTab === "artifacts" ? <ArtifactsPanel worktreeId={worktreeId} /> : null}
             {toolPanelTab === "vcs" ? (
               <VcsPanel api={api} worktreeId={worktreeId} baseBranch={baseBranch} branch={branch} />
             ) : null}

--- a/web-ui/src/components/layout/TopBar.tsx
+++ b/web-ui/src/components/layout/TopBar.tsx
@@ -379,7 +379,7 @@ export function TopBar({
                     aria-checked={effectiveSplitOrientation === "vertical"}
                     disabled={paneLayoutMode === "workspace"}
                     onClick={() => {
-                      toggleToolSplitOrientation();
+                      toggleToolSplitOrientation(effectiveSplitOrientation);
                       setOverflowOpen(false);
                     }}
                   >
@@ -402,10 +402,8 @@ export function TopBar({
                     }}
                   >
                     <SquareTerminal size={14} />
-                    <span>
-                      Terminal
-                      {paneLayoutMode !== "workspace" ? ` (${hints.terminal})` : ""}
-                    </span>
+                    <span>Terminal</span>
+                    {paneLayoutMode !== "workspace" ? <span className="top-bar__overflow-kbd">{hints.terminal}</span> : null}
                   </button>
                   <button
                     type="button"
@@ -446,7 +444,7 @@ export function TopBar({
               }
               onClick={paneLayoutMode === "workspace" ? toggleWorktreeToolsTile : toggleToolPanel}
             >
-              {toolSplitOrientation === "vertical" ? <PanelTop size={17} /> : <PanelRight size={17} />}
+              {effectiveSplitOrientation === "vertical" ? <PanelTop size={17} /> : <PanelRight size={17} />}
             </button>
           </>
         ) : null}

--- a/web-ui/src/components/layout/WorkspaceCanvas.tsx
+++ b/web-ui/src/components/layout/WorkspaceCanvas.tsx
@@ -1212,7 +1212,7 @@ export function WorkspaceCanvas({
                   title="Save this arrangement as a named workspace"
                   onClick={() => setSavePromptOpen(true)}
                 >
-                  <Save size={14} /> Save as workspace
+                  <Save size={14} />
                 </button>
               )}
             </div>

--- a/web-ui/src/components/tools/ArtifactsPanel.tsx
+++ b/web-ui/src/components/tools/ArtifactsPanel.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
-import { Copy, Download, FileText, FolderUp, Image as ImageIcon, Package, Trash2, Upload } from "lucide-react";
+import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
+import { Columns2, Copy, Download, FileText, FolderUp, Image as ImageIcon, Package, Rows2, Trash2, Upload } from "lucide-react";
+import { DEFAULT_WORKTREE_LAYOUT, useWorkspaceStore } from "@/hooks/useStore";
 
 /**
  * Artifacts tool — files the agent produced outside the worktree (screenshots,
@@ -29,10 +31,78 @@ function kindIcon(kind: ArtifactKind) {
   return <FileText size={14} aria-hidden />;
 }
 
-export function ArtifactsPanel() {
+interface ArtifactsPanelProps {
+  worktreeId?: string | null;
+}
+
+export function ArtifactsPanel({ worktreeId }: ArtifactsPanelProps) {
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const layoutByWorktree = useWorkspaceStore((s) => s.layoutByWorktree);
+  const setMasterDetailVertical = useWorkspaceStore((s) => s.setMasterDetailVertical);
+  const vertical = worktreeId
+    ? !!(layoutByWorktree[worktreeId] ?? DEFAULT_WORKTREE_LAYOUT).masterDetailVertical
+    : false;
   const items = SAMPLE;
   const selected = items.find((a) => a.id === selectedId) ?? null;
+
+  const list = (
+    <ul className="artifacts-list" role="listbox" aria-label="Artifacts">
+      {items.map((a) => (
+        <li key={a.id}>
+          <button
+            type="button"
+            role="option"
+            aria-selected={a.id === selectedId}
+            data-active={a.id === selectedId}
+            className="artifacts-list__row"
+            onClick={() => setSelectedId(a.id)}
+          >
+            <span className="artifacts-list__icon">{kindIcon(a.kind)}</span>
+            <span className="artifacts-list__name">{a.name}</span>
+            <span className="artifacts-list__meta">{a.size} · {a.when} · {a.source}</span>
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+
+  const detail = (
+    <div className="artifacts-detail">
+      {selected ? (
+        <>
+          <div className="artifacts-detail__head">
+            <span className="artifacts-detail__title">{selected.name}</span>
+            <div className="artifacts-detail__actions">
+              <button type="button" className="artifacts-detail__btn" disabled title="Download (coming soon)">
+                <Download size={14} />
+              </button>
+              <button type="button" className="artifacts-detail__btn" disabled title="Copy path (coming soon)">
+                <Copy size={14} />
+              </button>
+              <button type="button" className="artifacts-detail__btn" disabled title="Delete (coming soon)">
+                <Trash2 size={14} />
+              </button>
+            </div>
+          </div>
+          <div className="artifacts-detail__view">
+            {selected.kind === "image" ? (
+              <div className="artifacts-detail__image-ph" aria-hidden>
+                <ImageIcon size={32} />
+                <span>Image preview</span>
+              </div>
+            ) : (
+              <pre className="artifacts-detail__text-ph" aria-hidden>{`// ${selected.name}\n// text/log preview renders here`}</pre>
+            )}
+          </div>
+        </>
+      ) : (
+        <div className="artifacts-detail__empty">
+          <Package size={28} aria-hidden />
+          <p>Select an artifact to preview it here. Tapping opens an image lightbox or text viewer with download, copy-path, and delete.</p>
+        </div>
+      )}
+    </div>
+  );
 
   return (
     <div className="artifacts-panel">
@@ -46,62 +116,32 @@ export function ArtifactsPanel() {
             <FolderUp size={14} /> Upload folder
           </button>
         </div>
+        {worktreeId ? (
+          <button
+            type="button"
+            className={`files-topbar__tree-toggle${vertical ? " files-topbar__tree-toggle--on" : ""}`}
+            aria-label={vertical ? "Switch to side-by-side layout" : "Switch to stacked layout"}
+            aria-pressed={vertical}
+            title={vertical ? "Side-by-side layout" : "Stacked layout"}
+            onClick={() => setMasterDetailVertical(worktreeId, !vertical)}
+          >
+            {vertical ? <Columns2 size={15} /> : <Rows2 size={15} />}
+          </button>
+        ) : null}
       </div>
-      <div className="artifacts-panel__split">
-        <ul className="artifacts-list" role="listbox" aria-label="Artifacts">
-          {items.map((a) => (
-            <li key={a.id}>
-              <button
-                type="button"
-                role="option"
-                aria-selected={a.id === selectedId}
-                data-active={a.id === selectedId}
-                className="artifacts-list__row"
-                onClick={() => setSelectedId(a.id)}
-              >
-                <span className="artifacts-list__icon">{kindIcon(a.kind)}</span>
-                <span className="artifacts-list__name">{a.name}</span>
-                <span className="artifacts-list__meta">{a.size} · {a.when} · {a.source}</span>
-              </button>
-            </li>
-          ))}
-        </ul>
-        <div className="artifacts-detail">
-          {selected ? (
-            <>
-              <div className="artifacts-detail__head">
-                <span className="artifacts-detail__title">{selected.name}</span>
-                <div className="artifacts-detail__actions">
-                  <button type="button" className="artifacts-detail__btn" disabled title="Download (coming soon)">
-                    <Download size={14} />
-                  </button>
-                  <button type="button" className="artifacts-detail__btn" disabled title="Copy path (coming soon)">
-                    <Copy size={14} />
-                  </button>
-                  <button type="button" className="artifacts-detail__btn" disabled title="Delete (coming soon)">
-                    <Trash2 size={14} />
-                  </button>
-                </div>
-              </div>
-              <div className="artifacts-detail__view">
-                {selected.kind === "image" ? (
-                  <div className="artifacts-detail__image-ph" aria-hidden>
-                    <ImageIcon size={32} />
-                    <span>Image preview</span>
-                  </div>
-                ) : (
-                  <pre className="artifacts-detail__text-ph" aria-hidden>{`// ${selected.name}\n// text/log preview renders here`}</pre>
-                )}
-              </div>
-            </>
-          ) : (
-            <div className="artifacts-detail__empty">
-              <Package size={28} aria-hidden />
-              <p>Select an artifact to preview it here. Tapping opens an image lightbox or text viewer with download, copy-path, and delete.</p>
-            </div>
-          )}
-        </div>
-      </div>
+      <PanelGroup
+        direction={vertical ? "vertical" : "horizontal"}
+        autoSaveId={`vs-artifacts${worktreeId ? `-${worktreeId}` : ""}-${vertical ? "v" : "h"}`}
+        className="artifacts-panel__split"
+      >
+        <Panel defaultSize={vertical ? 40 : 34} minSize={20}>
+          {list}
+        </Panel>
+        <PanelResizeHandle className={vertical ? "resize-handle resize-handle--row" : "resize-handle resize-handle--col"} />
+        <Panel defaultSize={vertical ? 60 : 66} minSize={30}>
+          {detail}
+        </Panel>
+      </PanelGroup>
     </div>
   );
 }

--- a/web-ui/src/components/tools/FilesPanel.tsx
+++ b/web-ui/src/components/tools/FilesPanel.tsx
@@ -1,4 +1,4 @@
-import { FileText, Minus, Plus, X } from "lucide-react";
+import { FileText, Plus, X } from "lucide-react";
 import type { ApiInstance } from "@/api";
 import type { FileScope } from "@/api/types";
 import { useWorkspaceStore } from "@/hooks/useStore";
@@ -31,7 +31,6 @@ export function FilesPanel({ api, worktreeId, scope = "worktree" }: FilesPanelPr
 
   const activeFilePath = useWorkspaceStore((s) => s.activeFilePath);
   const setActiveFile = useWorkspaceStore((s) => s.setActiveFile);
-  const bumpPreviewFont = useWorkspaceStore((s) => s.bumpPreviewFont);
 
   const topbarExtra = (
     <>
@@ -65,21 +64,13 @@ export function FilesPanel({ api, worktreeId, scope = "worktree" }: FilesPanelPr
           <Plus size={13} />
         </button>
       </div>
-      <div className="files-topbar__controls">
-        <span className="files-topbar__zoom-label" aria-hidden>Aa</span>
-        <button type="button" className="tab tab--icon" aria-label="Decrease preview font" onClick={() => bumpPreviewFont(-0.05)}>
-          <Minus size={11} />
-        </button>
-        <button type="button" className="tab tab--icon" aria-label="Increase preview font" onClick={() => bumpPreviewFont(0.05)}>
-          <Plus size={11} />
-        </button>
-      </div>
     </>
   );
 
   return (
     <MasterDetailShell
       storageKey={wt}
+      worktreeId={worktreeId}
       topbarExtra={topbarExtra}
       leftPane={<FileTreeSidebar api={api} contextId={worktreeId} scope={scope} />}
       rightPane={<FilePreviewPane api={api} worktreeId={worktreeId} scope={scope} />}

--- a/web-ui/src/components/tools/VcsCommitView.tsx
+++ b/web-ui/src/components/tools/VcsCommitView.tsx
@@ -67,6 +67,7 @@ export function VcsCommitView({ api, worktreeId, sha, onBack }: VcsCommitViewPro
   return (
     <MasterDetailShell
       storageKey={`commit-${worktreeId}`}
+      worktreeId={worktreeId}
       topbarExtra={topbarExtra}
       leftPane={
         <ChangedFileList

--- a/web-ui/src/hooks/useRovingListNav.ts
+++ b/web-ui/src/hooks/useRovingListNav.ts
@@ -14,6 +14,9 @@ export interface UseRovingListNavOptions {
   onOpen: (path: string) => void;
   /** Called on ArrowRight/ArrowLeft for a row with `expandable: true`. */
   onToggle?: (path: string) => void;
+  /** When true, ArrowUp/ArrowDown also call `onOpen` for non-expandable rows,
+   *  giving instant preview-as-you-navigate behaviour (like VSCode's explorer). */
+  openOnArrow?: boolean;
 }
 
 export interface UseRovingListNavResult {
@@ -48,13 +51,19 @@ export function useRovingListNav(
       case "ArrowDown": {
         e.preventDefault();
         const next = idx < 0 ? rows[0] : rows[idx + 1];
-        if (next) setCursorPath(next.path);
+        if (next) {
+          setCursorPath(next.path);
+          if (opts.openOnArrow && !next.expandable) opts.onOpen(next.path);
+        }
         break;
       }
       case "ArrowUp": {
         e.preventDefault();
         const prev = idx < 0 ? rows[0] : rows[idx - 1];
-        if (prev) setCursorPath(prev.path);
+        if (prev) {
+          setCursorPath(prev.path);
+          if (opts.openOnArrow && !prev.expandable) opts.onOpen(prev.path);
+        }
         break;
       }
       case "ArrowRight":

--- a/web-ui/src/hooks/useStore.ts
+++ b/web-ui/src/hooks/useStore.ts
@@ -54,6 +54,10 @@ export interface WorktreeLayout {
    * `/workspaces/:id` view always shows its toolbar regardless of this flag.
    */
   canvasToolbarVisible: boolean;
+  /** Whether the master-detail split in the tools pane (Files/VCS/Artifacts) is
+   *  vertical (tree on top, preview below) vs horizontal (side by side). Shared
+   *  across all three tool tabs for a given worktree. */
+  masterDetailVertical?: boolean;
 }
 
 export const DEFAULT_WORKTREE_LAYOUT: WorktreeLayout = {
@@ -65,6 +69,7 @@ export const DEFAULT_WORKTREE_LAYOUT: WorktreeLayout = {
   activeWorkspaceId: null,
   scratchCanvas: null,
   canvasToolbarVisible: true,
+  masterDetailVertical: false,
 };
 
 export type TileKind = "agent" | "terminal" | "tools";
@@ -186,6 +191,9 @@ export interface WorkspaceState {
    *  mode is controlled exclusively by the "Diff view" (GitCompare) button. */
   treeScopeByWorktree: Record<string, "local" | "branch">;
   previewFontScale: number;
+  /** Per-worktree preview font scale for the tools pane (Files/VCS/Artifacts).
+   *  Falls back to the global `previewFontScale` when a worktree has no entry. */
+  previewFontScaleByWorktree: Record<string, number>;
   /** Whether the Files tool shows its file-tree column (persisted, view pref). */
   fileTreeVisible: boolean;
   terminalFontScale: number;
@@ -212,8 +220,10 @@ export interface WorkspaceState {
   setToolPanelTab: (tab: ToolTab) => void;
   /** Toggle the bottom terminal dock. */
   toggleTerminalDock: () => void;
-  /** Flip the agent pane ↔ tool panel split between horizontal and vertical. */
-  toggleToolSplitOrientation: () => void;
+  /** Flip the agent pane ↔ tool panel split between horizontal and vertical.
+   *  Pass the current *effective* orientation so mobile's implicit override is
+   *  respected — without it the first press on mobile is a no-op. */
+  toggleToolSplitOrientation: (effectiveOrientation?: ToolSplitOrientation) => void;
   /** Show/hide the workspace-canvas toolbar's disclosure under the crumb (classic per-worktree canvas placement only). */
   toggleCanvasToolbar: () => void;
   /**
@@ -235,6 +245,10 @@ export interface WorkspaceState {
   setDiffScopeForWorktree: (worktreeId: string, scope: DiffScope) => void;
   setTreeScopeForWorktree: (worktreeId: string, scope: "local" | "branch") => void;
   bumpPreviewFont: (delta: number) => void;
+  /** Bump the preview font scale for a specific worktree's tools pane. */
+  bumpPreviewFontForWorktree: (worktreeId: string, delta: number) => void;
+  /** Toggle the master-detail split orientation for a specific worktree's tools pane. */
+  setMasterDetailVertical: (worktreeId: string, vertical: boolean) => void;
   /** Show/hide the Files tool's file-tree column. */
   toggleFileTree: () => void;
   bumpTerminalFont: (delta: number) => void;
@@ -582,6 +596,7 @@ const initial = {
   diffScopeByWorktree: {} as Record<string, DiffScope>,
   treeScopeByWorktree: {} as Record<string, "local" | "branch">,
   previewFontScale: 1,
+  previewFontScaleByWorktree: {} as Record<string, number>,
   fileTreeVisible: true,
   terminalFontScale: 1,
   leftSidebarCollapsed: false,
@@ -649,13 +664,14 @@ export const useWorkspaceStore = create<WorkspaceState>()(
             }
             return next;
           }),
-        toggleToolSplitOrientation: () =>
+        toggleToolSplitOrientation: (effectiveOrientation) =>
           set((s) => {
             const key = layoutKey(s);
             const cur = key
               ? (s.layoutByWorktree[key] ?? DEFAULT_WORKTREE_LAYOUT)
               : DEFAULT_WORKTREE_LAYOUT;
-            const next = cur.toolSplitOrientation === "horizontal" ? "vertical" : "horizontal";
+            const from = effectiveOrientation ?? cur.toolSplitOrientation;
+            const next = from === "horizontal" ? "vertical" : "horizontal";
             return patchLayout(s, { toolSplitOrientation: next, toolSplitOrientationUserSet: true });
           }),
         toggleCanvasToolbar: () =>
@@ -802,6 +818,26 @@ export const useWorkspaceStore = create<WorkspaceState>()(
           set((s) => ({
             previewFontScale: Math.min(1.5, Math.max(0.75, Math.round((s.previewFontScale + delta) * 100) / 100)),
           })),
+        bumpPreviewFontForWorktree: (worktreeId, delta) =>
+          set((s) => {
+            const cur = s.previewFontScaleByWorktree[worktreeId] ?? s.previewFontScale;
+            return {
+              previewFontScaleByWorktree: {
+                ...s.previewFontScaleByWorktree,
+                [worktreeId]: Math.min(1.5, Math.max(0.75, Math.round((cur + delta) * 100) / 100)),
+              },
+            };
+          }),
+        setMasterDetailVertical: (worktreeId, vertical) =>
+          set((s) => {
+            const cur = s.layoutByWorktree[worktreeId] ?? DEFAULT_WORKTREE_LAYOUT;
+            return {
+              layoutByWorktree: {
+                ...s.layoutByWorktree,
+                [worktreeId]: { ...cur, masterDetailVertical: vertical },
+              },
+            };
+          }),
         toggleFileTree: () => set((s) => ({ fileTreeVisible: !s.fileTreeVisible })),
         bumpTerminalFont: (delta) =>
           set((s) => ({
@@ -1364,6 +1400,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
         diffScopeByWorktree: s.diffScopeByWorktree,
         treeScopeByWorktree: s.treeScopeByWorktree,
         previewFontScale: s.previewFontScale,
+        previewFontScaleByWorktree: s.previewFontScaleByWorktree,
         fileTreeVisible: s.fileTreeVisible,
         terminalFontScale: s.terminalFontScale,
         leftSidebarCollapsed: s.leftSidebarCollapsed,

--- a/web-ui/src/hooks/useWorkspaceKeyboardShortcuts.ts
+++ b/web-ui/src/hooks/useWorkspaceKeyboardShortcuts.ts
@@ -3,7 +3,7 @@ import { useWorkspaceStore } from "@/hooks/useStore";
 
 /**
  * ⌘/Ctrl+Shift+F/P → Files/Preview tool tab; ⌘/Ctrl+Shift+Z → terminal dock;
- * ⌘/Ctrl+P quick-open files; ⌘/Ctrl+\ → toggle tool pane;
+ * ⌘/Ctrl+P quick-open files; ⌘/Ctrl+\ or ⌘/Ctrl+B → toggle tool pane;
  * ⌘/Ctrl+Shift+G → new agent in current worktree;
  * ⌘/Ctrl+Shift+M → new worktree in the current project;
  * Alt+N → new agent in the current worktree;
@@ -81,6 +81,13 @@ export function useWorkspaceKeyboardShortcuts(
       // the backslash on US and similar layouts; Ctrl+Shift+\ produces
       // `e.key === "|"` so this never conflicts).
       if (!e.shiftKey && e.key === "\\") {
+        e.preventDefault();
+        toggleToolPanel();
+        return;
+      }
+
+      // ⌘/Ctrl+B — toggle tool pane (VS Code-style sidebar shortcut).
+      if (!e.shiftKey && e.key.toLowerCase() === "b") {
         e.preventDefault();
         toggleToolPanel();
         return;

--- a/web-ui/src/styles/chat.css
+++ b/web-ui/src/styles/chat.css
@@ -78,19 +78,84 @@
   cursor: not-allowed;
 }
 
+/* Chat pane top-right overlay — font buttons + ⇄ Terminal toggle. Same visual
+   treatment as the terminal-font-overlay but anchored to .chat-pane instead. */
+.chat-font-overlay {
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-2);
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+.chat-font-overlay .channel-toggle-button {
+  position: static;
+  top: auto;
+  right: auto;
+}
+.chat-font-overlay__btns {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+/* Font size + channel toggle overlay — groups −/+ buttons with the ⇄ toggle
+   in the top-right corner of the terminal pane. The channel-toggle-button's
+   own absolute positioning is neutralized here; the wrapper owns it instead. */
+.terminal-font-overlay {
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-2);
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+.terminal-font-overlay .channel-toggle-button {
+  position: static;
+  top: auto;
+  right: auto;
+}
+.terminal-font-overlay__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  background: var(--bg-elevated);
+  border: var(--border-width) solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--fg-secondary);
+  cursor: pointer;
+  opacity: 0.85;
+}
+.terminal-font-overlay__btn:hover {
+  color: var(--fg-primary);
+  border-color: var(--fg-secondary);
+  opacity: 1;
+}
+
 /* Exited terminal: the toggle drops out of the top-right overlay and sits in
    normal flow just below the "Session exited / Resume" banner. Neutralize the
-   shared button's absolute positioning so it lays out inline (right-aligned). */
+   wrapper's absolute positioning so it lays out inline (right-aligned). */
 .terminal-exited-toggle {
   flex-shrink: 0;
   display: flex;
   justify-content: flex-end;
   padding: var(--space-2);
 }
-.terminal-exited-toggle .channel-toggle-button {
+.terminal-exited-toggle .channel-toggle-button,
+.terminal-exited-toggle .terminal-font-overlay {
   position: static;
   top: auto;
   right: auto;
+}
+.terminal-exited-toggle .terminal-font-overlay {
+  display: flex;
+  align-items: center;
+  gap: 2px;
 }
 
 /* ── Terminal-mode file upload (item 3) — separate control from the channel

--- a/web-ui/src/styles/workspace.css
+++ b/web-ui/src/styles/workspace.css
@@ -1270,8 +1270,7 @@
  * navigation (useRovingListNav), distinct from `--selected` (the currently
  * open file, which can differ from where the cursor currently sits). */
 .changed-file-list-file--cursor {
-  outline: 2px solid var(--accent);
-  outline-offset: -2px;
+  background: var(--bg-active);
 }
 
 .changed-file-list-file-icon {
@@ -1439,19 +1438,18 @@
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  padding: var(--space-1) var(--space-3);
-  font-size: 11px;
-  color: var(--text-muted);
-  border-bottom: 1px solid var(--border);
+  padding: var(--space-1) var(--space-3) var(--space-2);
+  font-size: 10px;
+  color: var(--fg-muted);
+  border-bottom: var(--border-width) solid var(--border-default);
+  margin-bottom: var(--space-1);
   user-select: text;
   cursor: default;
 }
 
 .wt-menu__info-label {
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
   flex-shrink: 0;
+  opacity: 0.7;
 }
 
 .wt-menu__info-value {
@@ -1515,10 +1513,10 @@
   right: 0;
   z-index: 200;
   min-width: 200px;
-  background: var(--bg-overlay);
+  background: var(--bg-card);
   border: var(--border-width) solid var(--border-default);
   border-radius: var(--radius-md);
-  box-shadow: var(--shadow-lg, 0 4px 12px rgba(0,0,0,0.15));
+  box-shadow: var(--shadow-md);
   padding: var(--space-1) 0;
 }
 
@@ -1527,10 +1525,10 @@
   align-items: center;
   gap: var(--space-2);
   width: 100%;
-  padding: var(--space-1) var(--space-3);
+  padding: var(--space-2) var(--space-3);
   font-size: var(--font-size-sm);
   font-family: inherit;
-  color: var(--fg-secondary);
+  color: var(--fg-primary);
   background: transparent;
   border: none;
   cursor: pointer;
@@ -1541,7 +1539,6 @@
 
 .top-bar__overflow-item:hover {
   background: var(--bg-hover);
-  color: var(--fg-primary);
 }
 
 .top-bar__overflow-item--active {
@@ -1555,7 +1552,14 @@
 
 .top-bar__overflow-item:disabled:hover {
   background: transparent;
-  color: var(--fg-secondary);
+}
+
+.top-bar__overflow-kbd {
+  margin-left: auto;
+  font-size: var(--font-size-xs);
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  padding-left: var(--space-2);
 }
 
 /* Hover = a NEUTRAL, transient highlight (grey bg, mid opacity). Deliberately a
@@ -1716,8 +1720,7 @@
  * navigation (useRovingListNav), distinct from `data-active` (the currently
  * OPEN file, which can differ from where the cursor currently sits). */
 .tree-row--cursor {
-  outline: 2px solid var(--accent);
-  outline-offset: -2px;
+  background: var(--bg-active);
 }
 
 .tree-row[data-active="true"] .wt-row__label {
@@ -4537,9 +4540,8 @@ a.dashboard-card.dashboard-card--session {
   list-style: none;
   margin: 0;
   padding: 0;
-  width: 44%;
-  max-width: 280px;
-  min-width: 150px;
+  width: 100%;
+  height: 100%;
   overflow: auto;
   border-right: var(--border-width) solid var(--border-default);
 }
@@ -4842,6 +4844,36 @@ a.dashboard-card.dashboard-card--session {
   color: var(--fg-muted);
   padding: 0 var(--space-1) 0 var(--space-2);
   user-select: none;
+}
+
+/* Font size overlay — top-right corner of the file/diff preview pane. */
+.preview-font-overlay {
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-2);
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+.preview-font-overlay__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  background: var(--bg-elevated);
+  border: var(--border-width) solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--fg-secondary);
+  cursor: pointer;
+  opacity: 0.85;
+}
+.preview-font-overlay__btn:hover {
+  color: var(--fg-primary);
+  border-color: var(--fg-secondary);
+  opacity: 1;
 }
 
 /* Slim, content-scoped diff info strip at the top of the preview body. */


### PR DESCRIPTION
## Summary

- **Remove tool pane X button** — top-bar CMD/Ctrl+B toggle is sufficient; canvas tiles keep their own close via `onClose` prop (also fixes a crash: missing `X` import that broke canvas layout)
- **Relocate font controls** — agent pane −/+ moves to the terminal/rich-chat toggle overlay; Files/VCS pane −/+ moves to an absolute overlay on the file preview; Rich Chat JSON view gets the same controls left of the toggle
- **Split orientation toggle** — Files, VCS, and Artifacts tabs each get a vertical/horizontal split button; orientation + preview font scale are persisted per worktree (shared across all three tabs; agent chat font stays separate)
- **File tree arrow navigation** — ArrowUp/Down now auto-selects/previews files without pressing Enter (both Files and VCS tabs); clicking blank space in the tree then pressing arrow instantly previews a file
- **Selection indicator** — replace purple outline on cursor row with a background shade
- **Canvas fixes** — save button shows icon only; tool-panel toggle icon now reflects the effective orientation on mobile (was reading raw stored value); first press of split toggle on mobile now correctly flips from effective orientation (was a no-op)
- **Overflow menu** — appearance matches sidebar popup menus (`bg-card`, `shadow-md`, `space-2` padding); Terminal shortcut rendered as a dimmed monospace hint
- **Worktree id row** — fix broken CSS token refs, reduce font size, tone down label, add visible separator

## Review fixes applied (post Opus review)
- `MasterDetailShell` and `ArtifactsPanel` `autoSaveId` now encodes orientation (`-v`/`-h`) so split sizes don't bleed across layout modes
- `ArtifactsPanel` `autoSaveId` also encodes `worktreeId` so sizes are isolated per worktree

## Test plan
- [ ] CMD/Ctrl+B toggles tool panel; fullscreen button still present; X removed from tab bar
- [ ] Font −/+ works in terminal overlay, file preview overlay, and Rich Chat status bar
- [ ] Split toggle in Files/VCS/Artifacts persists per worktree across tab switches and refreshes
- [ ] Arrow keys in Files tree auto-preview; click blank space → arrow instantly previews
- [ ] Arrow keys in VCS Changed Files list auto-preview
- [ ] Cursor row shows background shade, not purple outline
- [ ] Canvas layout opens without crash; save icon-only button visible
- [ ] On mobile: tool-panel toggle icon matches actual layout; first press of split toggle in overflow menu works
- [ ] Overflow menu uses card background, items are spaced, Terminal shortcut is dimmed
- [ ] Worktree popup id row has visible separator and looks like metadata