### PR TITLE
feat(ui): image rendering — zoomable images in file preview, markdown, and chat

### DIFF
--- a/.vibekit/feature-plans/done/image-rendering/.sdlc-state.yaml
+++ b/.vibekit/feature-plans/done/image-rendering/.sdlc-state.yaml
@@ -1,0 +1,19 @@
+feature: image-rendering
+worktree: /home/gb/.vibe-station/projects/vibe-station/worktrees/vs-119
+master:
+  prd: complete
+  plan: complete
+current_subfeature: root
+subfeatures:
+  - id: root
+    origin: planned
+    spawned_from: null
+    mode: done
+    last_completed: review
+    awaiting_phase: null
+    awaiting_artifact: null
+    phase_chain: [plan, implement, verify, review]
+    superseded_reason: null
+    parked_reason: null
+    handoff: {next_item: null, returned_at: null, verified_by: null}
+    commit: 64d7b31

--- a/.vibekit/feature-plans/done/image-rendering/plan-image-rendering.md
+++ b/.vibekit/feature-plans/done/image-rendering/plan-image-rendering.md
@@ -1,0 +1,348 @@
+<!--
+RULES — read before writing or implementing:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. REQUIREMENTS: One crisp line each — no verbose descriptions
+3. CHECKLIST: Mark items [x] as you complete them — this is your persistent todo list
+4. READING TIME: Optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+# Plan: Markdown image rendering + fullscreen image/mermaid zoom
+
+> Implements the 3 TODO items from the parent task: chat image resolution (TODO 1), image file preview (TODO 2), and fullscreen zoom/pan for markdown images + mermaid (TODO 3), sharing one zoom/pan/fullscreen component and one image-path resolver.
+
+**Issue:** image-rendering
+**Branch:** `feat/image-rendering`
+**Status:** Approved
+**PRD:** `.vibekit/feature-plans/wip/image-rendering/prd-image-rendering.md`
+**Parent task:** vs-119 (SDLC-driven)
+
+**Reference files:**
+- `web-ui/src/components/preview/MarkdownView.tsx:10-59` (`MarkdownImage` — remote vs repo-image resolution), `:61-95` (`MarkdownView` + `img` component)
+- `web-ui/src/components/chat/StreamingMarkdown.tsx:34-47` (routes markdown → `MarkdownView`, mermaid → `MermaidView`; no api/worktree today)
+- `web-ui/src/components/chat/TextMessage.tsx:19-56` (`<StreamingMarkdown source={text}/>` at `:55`)
+- `web-ui/src/components/chat/ThinkingBlock.tsx:80` (second `StreamingMarkdown` callsite)
+- `web-ui/src/components/chat/MessageList.tsx:434-500` (`MessageListProps` — already has `api`, `sessionId`), `:807-935` (`TextMessage` callsites at 817, 847, 860, 865, 934)
+- `web-ui/src/components/layout/ChatPane.tsx:29-37` (props: `api`, `session: Session`, `visible`), `:274-292` (`MessageList` render — passes `api`, `sessionId`)
+- `web-ui/src/api/types.ts:106-110` (`Session.worktreeId: string | null`), `:78` (`FileScope = "worktree" | "project"`)
+- `web-ui/src/api/client.ts:618-623` (`getFileBlob(worktreeId, filePath, scope)` — already works)
+- `web-ui/src/components/layout/FilePreviewPane.tsx:284-320` (decides md→Markdown, else→CodeView; image files hit `CodeView` at `:319`)
+- `web-ui/src/components/preview/MermaidView.tsx:19-64` (renders SVG into `hostRef` div)
+- `web-ui/src/styles/workspace.css:2682-2687` (`.markdown-img`), `:2184` (`.pane-viewport-fullscreen` pattern)
+- `web-ui/src/styles/chat.css:422` (`.mermaid-view svg`)
+
+---
+
+## Problem
+
+- `MarkdownImage` (markdown both contexts) resolves repo paths only when `api`/`worktreeId`/`scope` are passed — chat passes none, so relative/root-relative images render nothing (`MarkdownView.tsx:30-45`)
+- Image files open as raw binary text via `CodeView` (`FilePreviewPane.tsx:319`) — no image rendering, no zoom
+- No fullscreen zoom/pan for markdown images or mermaid diagrams anywhere
+
+## Out of Scope
+
+- Daemon changes — `getFileBlob` already serves repo files as blobs
+- Editing/cropping images
+- Inline (non-fullscreen) mermaid pan
+- Image thumbnails / virtualized lists
+
+---
+
+## Requirements
+
+| # | Requirement |
+|---|-------------|
+| 1 | Relative + root-relative repo image paths render inline in assistant markdown (chat) |
+| 2 | Remote URLs (`http(s)://`, `//`, `data:`) still render as plain `<img>` in chat |
+| 3 | Chat scope: worktree session → `worktree`; direct session (`worktreeId` null) → `project` |
+| 4 | Missing/unfetchable repo image renders nothing (no broken flash) |
+| 5 | Image-file types open as the actual image in the file preview |
+| 6 | Image preview + fullscreen support mouse and touch zoom/pan |
+| 7 | Markdown image click → fullscreen zoom/pan overlay |
+| 8 | Mermaid diagram click → same fullscreen zoom/pan overlay |
+| 9 | Esc / close button dismisses overlay; body scroll locked while open |
+| 10 | One shared zoom/pan/fullscreen component + one image-path resolver reused across contexts |
+
+---
+
+## Change Map
+
+```
+web-ui/src/components/preview/
+  MarkdownView.tsx        ~ MarkdownImage clickable + fullscreen; keep remote handling
+  MermaidView.tsx         ~ clickable → fullscreen
+  ZoomableMedia.tsx       + shared zoom/pan/fullscreen component
+  ImageZoomOverlay.tsx    + fullscreen overlay (portal) wrapping ZoomableMedia
+web-ui/src/components/chat/
+  StreamingMarkdown.tsx   ~ accept api/worktreeId/scope, forward to MarkdownView
+  TextMessage.tsx         ~ accept + forward context props
+  ThinkingBlock.tsx       ~ forward context props to StreamingMarkdown
+  MessageList.tsx         ~ accept context props, forward to TextMessage/ThinkingBlock
+web-ui/src/components/layout/
+  ChatPane.tsx            ~ derive worktreeId/scope from session, pass to MessageList
+  FilePreviewPane.tsx     ~ image-file branch → ZoomableMedia
+web-ui/src/lib/
+  imageFile.ts            + image detection (extension→isImage) + path resolver
+web-ui/src/styles/
+  workspace.css           ~ fullscreen overlay + zoom cursor + preview image styles
+```
+
+| Today | After this plan |
+|-------|-----------------|
+| Chat: relative/root-relative images render nothing | Chat: repo images render inline (worktree/project scope); remote unchanged |
+| File preview: `.png` opens as raw binary text via `CodeView` | File preview: image files render as zoomable images |
+| No fullscreen zoom anywhere | Markdown images + mermaid + preview images open a shared fullscreen zoom/pan overlay |
+
+---
+
+## Research
+
+### Image resolution — current behavior
+
+- `MarkdownImage` (`MarkdownView.tsx:20-59`): `isRemote` covers `http(s)://`, `//`, `data:`; else `getFileBlob(worktreeId, imagePath, scope)` where `imagePath` = root-relative stripped of `/`, or `fileDir/src` for relative (`:37-39`)
+- Root-relative `src="/x.png"` resolves from worktree root; relative `./x.png` joins against `fileDir` — logic already correct and reusable
+- File preview passes `api`/`worktreeId`/`scope`/`filePath` (`FilePreviewPane.tsx:311`); chat passes none (`StreamingMarkdown.tsx:41`)
+
+### Chat context plumbing
+
+- `ChatPane` has `session: Session` with `worktreeId` (`api/types.ts:109`) — the only place worktree context is reachable for chat
+- `MessageList` already receives `api` + `sessionId` (`ChatPane.tsx:286-287`); `TextMessage` (`MessageList.tsx:817,847,860,865,934`) and `ThinkingBlock` (`MessageList.tsx:892-898`) are the render sites
+
+### File preview branching
+
+- `FilePreviewPane.tsx:305-319`: `isMd` → markdown segments; else → `CodeView` — image files fall into the else branch
+- `getFileBody` is fetched as text (`:89,98,111`) — binary images are NOT text; need a separate blob fetch for image types
+
+### Fullscreen pattern
+
+- `.pane-viewport-fullscreen` (`workspace.css:2184`) shows the established escape-the-overflow pattern; a `createPortal` to `document.body` with `position: fixed` is the standard overlay approach (no React-tree constraint here — overlay is safe to remount, unlike TerminalPane)
+
+---
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    ChatPane -->|"api, worktreeId, scope"| MessageList
+    MessageList -->|"api, worktreeId, scope"| TextMessage
+    MessageList -->|"api, worktreeId, scope"| ThinkingBlock
+    TextMessage -->|"api, worktreeId, scope"| StreamingMarkdown
+    ThinkingBlock -->|"api, worktreeId, scope"| StreamingMarkdown
+    StreamingMarkdown -->|"api, worktreeId, scope"| MarkdownView
+    MarkdownView -->|"repo path → getFileBlob"| MarkdownImage
+    MarkdownImage -->|"blob URL"| ZoomableMedia
+    MermaidView -->|"SVG → blob URL"| ZoomableMedia
+    FilePreviewPane -->|"blob URL"| ZoomableMedia
+    ZoomableMedia --> ImageZoomOverlay
+```
+
+Single-module change within `web-ui`; no new service boundary.
+
+---
+
+## Design Details
+
+### Critical User Journeys (CUJs)
+
+#### CUJ 1 — Repo image in Rich Chat (TODO 1)
+
+```
+User reads assistant reply containing ![logo](./assets/logo.png)
+  → StreamingMarkdown passes api/worktreeId/scope to MarkdownView
+  → MarkdownImage resolves ./assets/logo.png against fileDir (null in chat → worktree-root relative)
+  → getFileBlob(worktreeId, "assets/logo.png", scope) → blob URL → <img>
+  → Image renders inline; click opens fullscreen
+```
+
+- **Edge:** root-relative `/assets/logo.png` in chat → resolved from worktree root (no fileDir in chat, `MarkdownView.tsx:37-39` handles via leading-`/` branch)
+- **Edge:** missing file → `getFileBlob` rejects → renders nothing (`MarkdownView.tsx:45` catch)
+- **Edge:** direct session (`worktreeId` null) → scope `project`, resolves against project files
+
+#### CUJ 2 — Image file in preview (TODO 2)
+
+```
+User opens docs/diagram.png in Files tab
+  → FilePreviewPane detects .png as image → fetches blob via getFileBlob
+  → Renders ZoomableMedia with blob URL (not CodeView)
+  → Mouse wheel zooms, drag pans, pinch zooms on touch
+  → Double-click / zoom button opens fullscreen overlay
+```
+
+- **Edge:** image too large → still renders scaled to fit (blob, no text-size limit)
+- **Edge:** non-image binary → unchanged `CodeView` path
+
+#### CUJ 3 — Fullscreen mermaid (TODO 3)
+
+```
+User clicks a mermaid diagram (chat or file preview)
+  → MermaidView wraps its SVG in ZoomableMedia
+  → Click opens ImageZoomOverlay portal with the SVG content
+  → Zoom/pan; Esc or ✕ closes; body scroll locked
+```
+
+- **Edge:** mermaid render failed → fallback `<pre>` not clickable (only successful SVG is)
+
+### Data Model
+
+- None persisted — blob URLs and overlay state are ephemeral component state (no migration)
+
+### Key Decisions
+
+#### Decision 1: New `ZoomableMedia` + `ImageZoomOverlay` shared components (new files in `preview/`)
+
+- **Decision:** one `ZoomableMedia` component that renders an image from a `src` (blob/remote URL) with zoom/pan interaction, and one `ImageZoomOverlay` (fullscreen portal wrapping `ZoomableMedia`). `MarkdownImage`, `MermaidView`, and `FilePreviewPane` all reuse them. `ZoomableMedia` takes only `{ src: string; alt?: string; className?: string; onOpenFullscreen?: () => void }` — no `contentRef` (see Decision 5a: mermaid passes a blob URL, so no DOM-node mode is needed).
+- **Rationale:** R10 — avoids duplicating wheel/pinch/drag transform logic in 3 places; one `src`-based contract keeps the component simple and unambiguous
+- **Where:** new `web-ui/src/components/preview/ZoomableMedia.tsx`, `web-ui/src/components/preview/ImageZoomOverlay.tsx`
+
+```tsx
+// ZoomableMedia — transform-based zoom/pan over an <img>. scale + translate state;
+// wheel/buttons scale, pointer drag translates, pinch scales. Reset on src change.
+<ZoomableMedia src={blobUrl} alt={alt} onOpenFullscreen={openFullscreen} />
+```
+
+#### Decision 2: Chat context plumbing — `api`/`worktreeId`/`scope` threaded `ChatPane → MessageList → TextMessage/ThinkingBlock → StreamingMarkdown → MarkdownView`
+
+- **Decision:** add optional `api`/`worktreeId`/`scope` props to `StreamingMarkdown`, `TextMessage`, `ThinkingBlock`, `MessageList`; `ChatPane` derives `worktreeId = session?.worktreeId ?? null` and `scope = worktreeId ? "worktree" : "project"` and passes all three down.
+- **Rationale:** R1/R3 — reuses the file-preview resolver unchanged; `Session.worktreeId` is already on the object `ChatPane` receives (`api/types.ts:109`)
+- **Where:** `ChatPane.tsx:274-292`, `MessageList.tsx:807-935`, `TextMessage.tsx:19-56`, `ThinkingBlock.tsx:80`, `StreamingMarkdown.tsx:34-47`
+
+#### Decision 3: File-preview image branch — detect by extension, fetch blob, render `ZoomableMedia`
+
+- **Decision:** in `FilePreviewPane`, compute `isImage = imageFile.isImagePath(path)`; when `isImage` and a worktree id exists, fetch the blob (not text) and render `ZoomableMedia`; non-image keeps the existing `CodeView` path.
+- **Rationale:** R5/R6 — clean branch, no daemon change; blob fetch is the correct endpoint for binary
+- **Where:** `FilePreviewPane.tsx:284-320`
+
+#### Decision 4: New `lib/imageFile.ts` — image detection + shared path resolver
+
+- **Decision:** a small pure module exporting `isImagePath(path)` (extension set) and a resolver `resolveImagePath(src, baseDir)`: strip any leading `/` (root-relative) or leading `./` (explicit-relative), then join against `baseDir` when present. `MarkdownImage`, `FilePreviewPane`, and `ZoomableMedia` all use it.
+- **Rationale:** single source of truth for "is this an image" and "how does a path resolve" (R10); stripping leading `./` is required because `getFileBlob` (`client.ts:619`) strips only leading `/`, so a literal `./x.png` would 404 in the chat path where `baseDir` is null
+- **Where:** new `web-ui/src/lib/imageFile.ts`; `MarkdownImage` refactors to use it
+
+#### Decision 5: Mermaid fullscreen — serialize SVG to a blob URL, pass as `src` to `ZoomableMedia`
+
+- **Decision:** `MermaidView` keeps rendering the SVG inline, but wraps the inline image in a clickable `ZoomableMedia`; on click it serializes the rendered SVG string to a blob URL and opens `ImageZoomOverlay` with that `src` (re-rendering the diagram fullscreen). Only successful renders are clickable (the failed `<pre>` fallback is not).
+- **Rationale:** R8/R9 — reuses the same `src`-based `ZoomableMedia` for mermaid with no DOM-node/clone ambiguity; the SVG string is already in scope at render time (`MermaidView.tsx:40`)
+- **Where:** `MermaidView.tsx:19-64`
+
+#### Decision 5a: No `contentRef` / DOM-node mode on `ZoomableMedia`
+
+- **Decision:** `ZoomableMedia` exposes only the `src`-based contract. Mermaid fullscreen goes through a blob URL (Decision 5), so the previously-considered `contentRef: RefObject<HTMLElement>` mode is dropped — it was the source of the implementation ambiguity (appendChild vs cloneNode vs move) and is now unused.
+- **Rationale:** reviewer finding (BLOCKING) — one unambiguous contract; the plan must not leave a fresh implementer to invent the mechanism
+- **Where:** `ZoomableMedia.tsx` props; `MermaidView.tsx` (Decision 5)
+
+#### Decision 6: Overlay — `createPortal` to `document.body`, fixed positioning, body scroll lock
+
+- **Decision:** `ImageZoomOverlay` renders via `createPortal(document.body)` with `position: fixed; inset: 0; z-index` above everything; `body { overflow: hidden }` while open; Esc + close button dismiss. Overlay remounting is safe (no daemon stream), unlike `TerminalPane`.
+- **Rationale:** R9/R10 — matches the established fixed-overlay pattern; portal avoids parent `overflow: hidden` traps (see `workspace.css:2184` rationale)
+- **Where:** new `ImageZoomOverlay.tsx`
+
+---
+
+## Risks / Open Questions
+
+| # | Question | Notes |
+|---|----------|-------|
+| 1 | SVG files: blob vs text fetch — `getFileBlob` returns the raw SVG, rendered via `<img src=blobUrl>` | SVG as `<img>` can't execute scripts (safe); acceptable |
+| 2 | Touch pinch inside the chat scroll container may conflict with page scroll | Zoom gesture handled with `touch-action: none` on the zoom surface only while zoomed |
+| 3 | Mermaid SVG click-to-select conflicts with drag | Click (no drag) opens overlay; drag threshold distinguishes pan from click |
+| 4 | Large images in chat memory | Blob URL revoked on unmount (`MarkdownView.tsx:47-51` pattern) |
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Shared zoom/pan/fullscreen infrastructure
+
+- [x] **1.1** `web-ui/src/lib/imageFile.ts`: `isImagePath(path)` (png/jpg/jpeg/gif/webp/svg/bmp/avif) + `resolveImagePath(src, baseDir)` (strip leading `/` and leading `./`; join against `baseDir` when present) — pure functions (Decision 4)
+- [x] **1.2** `web-ui/src/components/preview/ZoomableMedia.tsx`: transform-based zoom/pan — props `{ src: string; alt?: string; className?: string; onOpenFullscreen?: () => void }` (NO `contentRef`); wheel = zoom to cursor, pointer-drag = pan, touch pinch = zoom; `touch-action` handling; reset on `src` change; imperative handle to toggle fullscreen + `onOpenFullscreen` callback
+- [x] **1.3** `web-ui/src/components/preview/ImageZoomOverlay.tsx`: `createPortal(document.body)` fullscreen overlay wrapping `ZoomableMedia`; Esc + ✕ close; body scroll lock via `overflow:hidden` effect; dark backdrop
+- [x] **1.4** `web-ui/src/styles/workspace.css`: overlay + zoom cursor + preview-image styles (`.image-zoom-overlay`, `.image-zoom-overlay__close`, `.zoomable-media`, `.preview-image`)
+
+**Verify phase 1:**
+- [x] **1.T1** Unit — `imageFile.ts` (new `imageFile.test.ts`): `isImagePath("a.png")` true, `isImagePath("a.txt")` false, case-insensitive ext; `resolveImagePath("/x.png","docs")` → `x.png`, `resolveImagePath("./x.png","docs")` → `docs/x.png`, `resolveImagePath("x.png",null)` → `x.png`, `resolveImagePath("./x.png",null)` → `x.png` (strips `./` even with null baseDir — the chat failure path), `resolveImagePath("./sub/x.png","docs")` → `docs/sub/x.png`
+- [x] **1.T2** Component — `ZoomableMedia.test.tsx`: renders `img` with `src` when `src` given; wheel changes scale; drag changes translate; reset on `src` change
+- [x] **1.T3** Component — `ImageZoomOverlay.test.tsx`: renders children in a portal; Esc key calls `onClose`; ✕ button calls `onClose`
+- [x] **1.T4** `pnpm --filter @vibestation/web exec vitest run src/lib/imageFile.test.ts src/components/preview/ZoomableMedia.test.tsx src/components/preview/ImageZoomOverlay.test.tsx` passes
+- [x] **1.T5** `pnpm typecheck` clean
+
+### Phase 2 — TODO 1: Rich Chat image resolution
+
+- [x] **2.1** `StreamingMarkdown.tsx`: accept optional `api`/`worktreeId`/`scope` props; forward to `MarkdownView`
+- [x] **2.2** `TextMessage.tsx`: accept `api`/`worktreeId`/`scope`; forward to `StreamingMarkdown`
+- [x] **2.3** `ThinkingBlock.tsx`: accept + forward the same props to `StreamingMarkdown`
+- [x] **2.4** `MessageList.tsx`: accept `worktreeId`/`scope` props (api/sessionId already present); forward to every `TextMessage` + `ThinkingBlock` render
+- [x] **2.5** `ChatPane.tsx`: derive `worktreeId = session?.worktreeId ?? null`, `scope = worktreeId ? "worktree" : "project"`; pass `api`/`worktreeId`/`scope` to `MessageList`
+- [x] **2.6** `MarkdownView.tsx`: refactor `MarkdownImage` to use `resolveImagePath` (Decision 4); wrap the `<img>` in `ZoomableMedia` so clicking opens fullscreen (TODO 3 in chat); keep remote `src` path working
+
+**Verify phase 2:**
+- [x] **2.T1** Component — `StreamingMarkdown.test.tsx`: when `api`/`worktreeId`/`scope` passed and source has `![a](./x.png)`, `MarkdownImage` calls `getFileBlob` with resolved path; without props, no `getFileBlob` call (remote/`null` unchanged)
+- [x] **2.T2** Component — `MessageList.test.tsx`: passes `api`/`worktreeId`/`scope` through to `TextMessage` (assert prop forwarding)
+- [x] **2.T3** `pnpm --filter @vibestation/web exec vitest run src/components/chat/StreamingMarkdown.test.tsx src/components/chat/MessageList.test.tsx` passes (existing + new)
+- [x] **2.T4** `pnpm typecheck` clean
+
+### Phase 3 — TODO 2: Image file preview + TODO 3 (preview image fullscreen)
+
+- [x] **3.1** `FilePreviewPane.tsx`: compute `isImage = isImagePath(path)`; when image, fetch blob via `api.getFileBlob(worktreeId, path, fileScope)` (add `imageBlobUrl` state) and render `ZoomableMedia` in place of `CodeView`; revoke the prior blob URL in effect cleanup (mirror `MarkdownView.tsx:47-51` pattern); wrap in a click-to-fullscreen affordance (double-click / zoom button). Note: `worktreeId` is the context id — the project id when `fileScope === "project"` (`FilesPanel.tsx:85`, `FilePreviewPane.tsx:89-91`), so this one call covers worktree AND direct sessions (reviewer finding resolved by existing prop convention, no new `projectId` prop needed)
+- [x] **3.2** `FilePreviewPane.tsx`: integrate `ImageZoomOverlay` for the preview-image fullscreen (shared overlay from Phase 1)
+- [x] **3.3** `FilePreviewPane.tsx`: ensure the `scope === "commit"`/diff branches still skip image rendering (images only render in plain/none + local + branch file views where a blob is meaningful)
+
+**Verify phase 3:**
+- [x] **3.T1** Component — `FilePreviewPane.test.tsx`: `path="a.png"` with a mock `getFileBlob` renders `ZoomableMedia` (not `CodeView`); `path="a.ts"` still renders `CodeView`
+- [x] **3.T2** `pnpm --filter @vibestation/web exec vitest run src/components/layout/FilePreviewPane.test.tsx` passes
+- [x] **3.T3** `pnpm typecheck` clean
+
+### Phase 4 — TODO 3: Mermaid fullscreen
+
+- [x] **4.1** `MermaidView.tsx`: keep the inline SVG rendering (interactive) but wrap it in a clickable wrapper (`role="button"`, zoom-in cursor, Enter/Space opens); on click, serialize the rendered SVG string to a blob URL (`new Blob([svgString], {type:"image/svg+xml"})` + `URL.createObjectURL`) and open `ImageZoomOverlay` with that `src` (shared `ZoomableMedia` fullscreen — Decision 5). The blob URL is revoked on close/unmount (effect cleanup)
+- [x] **4.2** Ensure failed mermaid (`<pre>` fallback) is not clickable
+
+**Verify phase 4:**
+- [x] **4.T1** Component — `MermaidView.test.tsx`: successful render is wrapped in `ZoomableMedia`; click opens overlay; failed render (`<pre>`) is not clickable
+- [x] **4.T2** `pnpm --filter @vibestation/web exec vitest run src/components/preview/MermaidView.test.tsx` passes
+- [x] **4.T3** `pnpm typecheck` clean
+
+### Phase 5 — Verify + final review
+
+- [x] **5.1** Full `web-ui` vitest suite + repo-wide typecheck + lint
+- [x] **5.2** Boot docker dev sandbox (`scripts/dev-sandbox.sh up`) and manually verify: repo image renders in chat, image file opens in preview, markdown image + mermaid fullscreen zoom/pan (mouse + touch), remote URLs still work
+- [ ] **5.3** Opus reviewer subagent pass on the complete diff; address findings
+- [ ] **5.4** Commit on `feat/image-rendering`
+
+**Verify phase 5:**
+- [x] **5.T1** `pnpm --filter @vibestation/web exec vitest run` passes (full suite)
+- [x] **5.T2** `pnpm typecheck` + `pnpm lint` clean
+- [x] **5.T3** Docker sandbox manual verification recorded (screenshots/notes)
+
+---
+
+## Files & Phase Impact
+
+| File | Status | Phase | Description / Contract Change |
+|------|--------|-------|-------------------------------|
+| `web-ui/src/lib/imageFile.ts` | **New** | 1 | Contract: `isImagePath(path: string): boolean`, `resolveImagePath(src: string, baseDir: string\|null): string` — pure |
+| `web-ui/src/components/preview/ZoomableMedia.tsx` | **New** | 1 | Contract: `{ src: string; alt?: string; className?: string; onOpenFullscreen?: () => void }` — transform zoom/pan over `<img>`; Owns: zoom state |
+| `web-ui/src/components/preview/ImageZoomOverlay.tsx` | **New** | 1 | Contract: `{ open: boolean; onClose: () => void; children: ReactNode }` — portal overlay; Owns: body scroll lock |
+| `web-ui/src/components/preview/MarkdownView.tsx` | **Modified** | 2 | `MarkdownImage` uses `resolveImagePath`; `<img>` wrapped in `ZoomableMedia` (click → fullscreen) |
+| `web-ui/src/components/chat/StreamingMarkdown.tsx` | **Modified** | 2 | Contract: props gain `api?`/`worktreeId?`/`scope?` — forwarded to `MarkdownView` |
+| `web-ui/src/components/chat/TextMessage.tsx` | **Modified** | 2 | Contract: props gain `api?`/`worktreeId?`/`scope?` — forwarded to `StreamingMarkdown` |
+| `web-ui/src/components/chat/ThinkingBlock.tsx` | **Modified** | 2 | Contract: props gain `api?`/`worktreeId?`/`scope?` — forwarded to `StreamingMarkdown` |
+| `web-ui/src/components/chat/MessageList.tsx` | **Modified** | 2 | Contract: props gain `worktreeId?`/`scope?` — forwarded to `TextMessage`/`ThinkingBlock` |
+| `web-ui/src/components/layout/ChatPane.tsx` | **Modified** | 2 | Derives `worktreeId`/`scope` from `session`; passes `api`/`worktreeId`/`scope` to `MessageList` |
+| `web-ui/src/components/layout/FilePreviewPane.tsx` | **Modified** | 3 | Image-file branch → `ZoomableMedia` + `ImageZoomOverlay`; blob fetch for images |
+| `web-ui/src/components/preview/MermaidView.tsx` | **Modified** | 4 | Successful SVG → blob URL `src`, wrapped in `ZoomableMedia` (click → fullscreen) |
+| `web-ui/src/styles/workspace.css` | **Modified** | 1 | Overlay + zoom cursor + preview-image + markdown-img-fullscreen styles |
+| `web-ui/src/lib/imageFile.test.ts` | **New** | 1.T1 | Unit tests for `imageFile` |
+| `web-ui/src/components/preview/ZoomableMedia.test.tsx` | **New** | 1.T2 | Component tests for zoom/pan |
+| `web-ui/src/components/preview/ImageZoomOverlay.test.tsx` | **New** | 1.T3 | Component tests for overlay |
+| `web-ui/src/components/chat/StreamingMarkdown.test.tsx` | **Modified** | 2.T1 | Image-resolution coverage |
+| `web-ui/src/components/chat/MessageList.test.tsx` | **Modified** | 2.T2 | Prop-forwarding coverage |
+| `web-ui/src/components/layout/FilePreviewPane.test.tsx` | **Modified** | 3.T1 | Image-vs-code branching |
+| `web-ui/src/components/preview/MermaidView.test.tsx` | **Modified** | 4.T1 | Clickable/not-clickable coverage |
+
+---
+
+## Verification Method
+
+- Node/vitest: targeted component tests per phase + full `web-ui` suite in phase 5
+- `pnpm typecheck` repo-wide + `pnpm lint` at end of each phase and phase 5
+- Docker dev sandbox (`scripts/dev-sandbox.sh up`) manual verification in phase 5 — image in chat, image file in preview, fullscreen zoom/pan (mouse + touch), remote URLs
+- Reviewer: opus subagent pass on the complete diff (phase 5)

--- a/.vibekit/feature-plans/done/image-rendering/prd-image-rendering.md
+++ b/.vibekit/feature-plans/done/image-rendering/prd-image-rendering.md
@@ -1,0 +1,137 @@
+<!--
+RULES — read before writing or implementing:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. REQUIREMENTS: One crisp line each — no verbose descriptions
+3. CHECKLIST: Mark items [x] as you complete them — this is your persistent todo list
+4. READING TIME: Optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+# PRD: Markdown image rendering + fullscreen image/mermaid zoom
+
+> Render repo images in Rich Chat, show image files as images in the file preview, and add mouse/touch zoom-pan fullscreen for markdown images and mermaid diagrams.
+
+**Status:** Approved
+**Technical plan:** `.vibekit/feature-plans/wip/image-rendering/plan-image-rendering.md`
+
+---
+
+## Problem
+
+- Relative/root-relative repo image paths render broken (nothing) in Agent Rich Chat — `MarkdownView` gets no `api`/`worktreeId` there, so all non-remote `src` resolve to nothing (`MarkdownView.tsx:20-59`)
+- Opening an image file (e.g. `.png`) in the file preview shows raw binary garbage via `CodeView` (`FilePreviewPane.tsx:319`)
+- No way to zoom a markdown image or a mermaid diagram to inspect detail
+
+## Goals
+
+- Repo images render inline in both file-preview and Rich Chat, remote URLs keep working
+- Image files open as actual images in the file preview, zoomable/pannable via mouse + touch
+- Clicking a markdown image or a mermaid diagram opens a fullscreen zoom/pan overlay, shared across both contexts
+
+## Non-goals
+
+- Image editing, cropping, annotation
+- Mermaid diagram editing/pan inside the inline (non-fullscreen) view
+- Virtualized image lists, thumbnails
+- Daemon-side changes — image fetching already works via `api.getFileBlob`
+
+---
+
+## Requirements
+
+### 1. Rich Chat images
+
+| ID | Requirement |
+|----|-------------|
+| R1 | Relative (`./x.png` / `x.png`) and root-relative (`/x.png`) image paths in assistant markdown render the repo file inline |
+| R2 | Remote URLs (`http(s)://`, `//`, `data:`) still render as plain `<img>` in chat |
+| R3 | Worktree sessions resolve repo images against the worktree; direct sessions resolve against the project scope |
+| R4 | Missing/unfetchable image renders nothing (no broken-image flash) |
+
+### 2. File preview images
+
+| ID | Requirement |
+|----|-------------|
+| R5 | Opening a binary image file (png/jpg/gif/webp/svg) renders the actual image, not raw text |
+| R6 | Preview supports mouse and touch zoom-in / zoom-out / pan |
+| R7 | Double-click (or click affordance) opens the preview image in fullscreen zoom/pan |
+
+### 3. Fullscreen zoom
+
+| ID | Requirement |
+|----|-------------|
+| R8 | Clicking a markdown image opens a fullscreen overlay with mouse + touch zoom/pan |
+| R9 | Clicking a mermaid diagram opens the same fullscreen overlay with mouse + touch zoom/pan |
+| R10 | Escape / close button dismisses the overlay; body scroll is locked while open |
+| R11 | Shared zoom/pan/fullscreen component reused across file-preview and chat — no duplicated zoom logic |
+
+---
+
+## Options considered
+
+### Image-path resolution shared component
+
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| A — Thread `api`/`worktreeId`/`scope` through chat into `MarkdownImage` | Reuses existing `getFileBlob`; no daemon change | New props threaded `ChatPane→MessageList→TextMessage→StreamingMarkdown→MarkdownView` | ✅ chosen |
+| B — Global store lookup in chat | No prop threading | Hidden coupling; store may not have worktree for all chat instances | ❌ deferred |
+
+### Image preview in FilePreviewPane
+
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| A — Detect image by extension, fetch blob, render zoomable | Clean; reuses shared zoom component | Need extension→mime map | ✅ chosen |
+| B — Let `CodeView` handle it | No work | Shows binary garbage | ❌ rejected |
+
+---
+
+## Resolved design questions
+
+1. **Chat resolution scope?** — Worktree session → `worktree` scope; direct session (`worktreeId` null) → `project` scope. One prop pair `(worktreeId, scope)`.
+2. **Which file extensions are images?** — png, jpg, jpeg, gif, webp, svg, bmp, avif.
+3. **Fullscreen trigger for preview?** — a zoom button + the shared click-to-fullscreen affordance; double-click also opens.
+4. **Zoom model?** — transform-based (scale + translate), wheel = zoom, drag = pan, pinch = zoom; reset on close.
+
+---
+
+## Screen layouts
+
+### Fullscreen zoom overlay (shared, image + mermaid)
+
+```
+┌──────────────────────────────────────────────┐
+│  ✕  (close, top-right)                       │  ← always visible
+│                                              │
+│  ┌────────────────────────────────────────┐  │
+│  │                                        │  │
+│  │        [zoomable content —             │  │
+│  │         image or mermaid SVG]          │  │
+│  │   wheel / pinch = zoom                 │  │
+│  │   drag = pan                           │  │
+│  └────────────────────────────────────────┘  │
+│  dark backdrop, body scroll locked           │
+└──────────────────────────────────────────────┘
+```
+
+Notes:
+- Esc or ✕ closes
+- Double-click on image inside also toggles fullscreen (markdown + preview)
+- Mermaid click only opens fullscreen (not toggle-close) to avoid text-select conflicts
+
+---
+
+## Priority & sequencing
+
+| Order | Sub-feature | Depends on | Can ship independently? |
+|-------|-------------|------------|------------------------|
+| 1 | Shared `ZoomableMedia` + fullscreen overlay component | — | Yes |
+| 2 | Rich Chat images (TODO 1) | 1 | Yes |
+| 3 | File preview images (TODO 2) | 1 | Yes |
+| 4 | Mermaid fullscreen (TODO 3) | 1 | No (needs overlay) |
+
+---
+
+## Open questions
+
+| # | Question | Proposed answer / owner |
+|---|----------|------------------------|
+| 1 | Should inline markdown images also be click-to-fullscreen, or only preview images? | Both — R8 says markdown images open fullscreen on click |

--- a/scripts/demo-seed.sh
+++ b/scripts/demo-seed.sh
@@ -51,10 +51,12 @@ STUB
   init_repo northstar-api
   init_repo atlas-dashboard
   init_repo forge-cli
+  init_repo luminary-docs
 
   NAPI_SHA=$(git -C "$PROJECTS/northstar-api" rev-parse HEAD)
   ATLS_SHA=$(git -C "$PROJECTS/atlas-dashboard" rev-parse HEAD)
   FRGE_SHA=$(git -C "$PROJECTS/forge-cli" rev-parse HEAD)
+  LDOC_SHA=$(git -C "$PROJECTS/luminary-docs" rev-parse HEAD)
 
   # ─── 3. modes.json ──────────────────────────────────────────────────────────
   cat >"$VST/modes.json" <<'JSON'
@@ -882,6 +884,240 @@ TRANS
   ⎿  Running...
 TRANS
 
+  # luminary-docs ─────────────────────────────────────
+  read -r -d '' LDOC_MANIFEST <<JSON || true
+{
+  "id": "luminary-docs",
+  "absolutePath": "$PROJECTS/luminary-docs",
+  "prefix": "ldoc",
+  "defaultBranch": "main",
+  "createdAt": "2025-05-01T09:20:00.000Z",
+  "nextWorktreeNum": 2,
+  "worktrees": [
+    {
+      "id": "ldoc-1",
+      "branch": "feat/image-rendering-demo",
+      "baseBranch": "main",
+      "baseSha": "$LDOC_SHA",
+      "createdAt": "2025-05-06T09:00:00.000Z",
+      "sessions": [
+        { "id": "ldoc-1-m", "slot": "m", "type": "agent", "modeId": "mode-claude-001", "tmuxName": "vr-ldoc-1-m", "useTmux": true, "lifecycle": { "state": "idle", "lastTransitionAt": "2025-05-06T10:00:00.000Z" } }
+      ]
+    }
+  ]
+}
+JSON
+  write_manifest luminary-docs ldoc "$LDOC_SHA" "$LDOC_MANIFEST"
+
+  # ─── 6b. Populate ldoc-1 worktree checkout (image-rendering demo) ──────────
+  WT="$VST/projects/luminary-docs/worktrees/ldoc-1"
+  mkdir -p "$WT/docs/images" "$WT/screenshots" "$WT/assets"
+
+  cat >"$WT/README.md" <<'MD'
+# Luminary Docs
+
+Luminary Docs is a documentation platform for teams that care about clarity.
+It combines structured writing tools with a powerful search engine so your
+engineering knowledge stays discoverable as the team grows.
+
+## Features
+
+- Markdown-first authoring with live preview
+- Version-controlled docs alongside your code
+- Full-text search across all projects
+- Diagram-as-code via Mermaid
+
+## Hero
+
+![Hero Screenshot](./screenshots/hero.png)
+
+## Brand
+
+![Logo](./assets/logo.png)
+
+## Getting Started
+
+```bash
+npm install
+npm run dev
+```
+
+Browse to `http://localhost:4000` and sign in with your GitHub account.
+MD
+
+  mkdir -p "$WT/docs"
+  cat >"$WT/docs/ARCHITECTURE.md" <<'MD'
+# Architecture
+
+Luminary Docs is split into three tiers: a browser client, an API server, and
+a storage layer. All communication between tiers is JSON over HTTPS.
+
+## System overview
+
+![System overview](./images/overview.png)
+
+## Component flow
+
+```mermaid
+flowchart LR
+    Browser -->|HTTPS| APIGateway
+    APIGateway --> AuthService
+    APIGateway --> DocsService
+    DocsService --> PostgreSQL
+    DocsService --> SearchIndex[(Meilisearch)]
+    AuthService --> PostgreSQL
+```
+
+## Request lifecycle
+
+```mermaid
+sequenceDiagram
+    participant B as Browser
+    participant G as API Gateway
+    participant A as Auth Service
+    participant D as Docs Service
+    participant DB as PostgreSQL
+
+    B->>G: GET /docs/:id (Bearer token)
+    G->>A: verify token
+    A-->>G: { sub, roles }
+    G->>D: GET /docs/:id
+    D->>DB: SELECT * FROM docs WHERE id = ?
+    DB-->>D: doc row
+    D-->>G: { id, title, body, ... }
+    G-->>B: 200 OK
+```
+
+## Services
+
+### API Gateway
+
+The gateway is a thin Fastify proxy. It handles TLS termination, rate
+limiting, and JWT verification before forwarding requests downstream. No
+business logic lives here.
+
+### Auth Service
+
+Issues short-lived JWT access tokens (15 min) and long-lived refresh tokens
+(7 days). Tokens are signed with RS256; the public key is published at
+`/.well-known/jwks.json` so downstream services can verify without a network
+round-trip.
+
+### Docs Service
+
+Stores documents in PostgreSQL (structured metadata + full Markdown body) and
+keeps Meilisearch in sync via an outbox pattern. Every write to the `docs`
+table appends a row to `doc_events`; a background worker drains the outbox and
+updates the search index.
+
+## Data model
+
+| Table | Key columns |
+|---|---|
+| `users` | id, email, password_hash, roles |
+| `docs` | id, project_id, title, body, created_at, updated_at |
+| `doc_events` | id, doc_id, event_type, payload, processed_at |
+| `projects` | id, name, owner_id, created_at |
+MD
+
+  cat >"$WT/docs/DEPLOYMENT.md" <<'MD'
+# Deployment
+
+Luminary Docs ships as three Docker images: `luminary-gateway`,
+`luminary-auth`, and `luminary-docs`. They are orchestrated with
+Docker Compose for local development and Kubernetes in production.
+
+## CI pipeline
+
+![CI pipeline](/assets/ci-pipeline.png)
+
+## Deployment topology
+
+```mermaid
+graph TD
+    Internet -->|443| LoadBalancer
+    LoadBalancer --> GatewayA[Gateway replica A]
+    LoadBalancer --> GatewayB[Gateway replica B]
+    GatewayA --> AuthPod
+    GatewayB --> AuthPod
+    GatewayA --> DocsPodA[Docs replica A]
+    GatewayB --> DocsPodB[Docs replica B]
+    DocsPodA --> PrimaryDB[(PostgreSQL primary)]
+    DocsPodB --> PrimaryDB
+    DocsPodA --> Meilisearch
+    DocsPodB --> Meilisearch
+    PrimaryDB --> ReplicaDB[(PostgreSQL replica)]
+```
+
+## Environment variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `DATABASE_URL` | yes | Postgres connection string |
+| `JWT_SECRET` | yes | RS256 private key PEM |
+| `JWKS_URL` | yes | URL of the auth service's JWKS endpoint |
+| `SEARCH_URL` | yes | Meilisearch base URL |
+| `SEARCH_KEY` | yes | Meilisearch master key |
+| `PORT` | no | HTTP port, default 3000 |
+| `LOG_LEVEL` | no | Pino log level, default `info` |
+| `RATE_LIMIT_MAX` | no | Max requests/min per IP, default 200 |
+
+## Runbook
+
+### Rolling restart
+
+```bash
+kubectl rollout restart deployment/luminary-docs
+kubectl rollout status  deployment/luminary-docs
+```
+
+### Scale out
+
+```bash
+kubectl scale deployment/luminary-docs --replicas=4
+```
+
+### Database backup
+
+```bash
+pg_dump "$DATABASE_URL" | gzip > "backup-$(date +%Y%m%d).sql.gz"
+```
+MD
+
+  # Binary PNG files — generate solid-color placeholder images via Python so they
+  # are large enough to actually be visible in the file preview and markdown view.
+  python3 - "$WT" <<'PYEOF'
+import zlib, struct, sys, os
+
+def make_png(w, h, r, g, b):
+    def chunk(tag, data):
+        raw = tag + data
+        return struct.pack('>I', len(data)) + raw + struct.pack('>I', zlib.crc32(raw) & 0xffffffff)
+    ihdr = chunk(b'IHDR', struct.pack('>IIBBBBB', w, h, 8, 2, 0, 0, 0))
+    row = b'\x00' + bytes([r, g, b] * w)
+    idat = chunk(b'IDAT', zlib.compress(row * h, 9))
+    iend = chunk(b'IEND', b'')
+    return b'\x89PNG\r\n\x1a\n' + ihdr + idat + iend
+
+wt = sys.argv[1]
+images = {
+    'screenshots/hero.png':    (480, 280, 41, 128, 185),   # steel blue — hero banner
+    'assets/logo.png':         (200, 200, 80, 160, 100),   # green — brand logo
+    'assets/ci-pipeline.png':  (600, 160, 160, 80, 120),   # mauve — pipeline diagram
+    'docs/images/overview.png':(480, 300, 60, 90, 160),    # indigo — architecture diagram
+}
+for rel_path, (w, h, r, g, b) in images.items():
+    dest = os.path.join(wt, rel_path)
+    with open(dest, 'wb') as f:
+        f.write(make_png(w, h, r, g, b))
+PYEOF
+
+  git -C "$WT" init -q -b feat/image-rendering-demo
+  git -C "$WT" config user.email "demo@vibe-station.dev"
+  git -C "$WT" config user.name "Demo Agent"
+  git -C "$WT" add . >/dev/null
+  git -C "$WT" commit -q -m "docs: add architecture and deployment docs with diagrams"
+
   # ─── 7. Mark seeded ────────────────────────────────────────────────────────
   touch "$VST/.seeded"
   echo "[seed] data init complete"
@@ -898,6 +1134,7 @@ ALL_TMUX=(
   vr-napi-2-m vr-napi-3-m vr-napi-4-m
   vr-atls-1-m vr-atls-2-m vr-atls-3-m
   vr-frge-1-m vr-frge-2-m
+  vr-ldoc-1-m
 )
 for name in "${ALL_TMUX[@]}"; do
   tmux kill-session -t "$name" 2>/dev/null || true
@@ -962,6 +1199,9 @@ start_idle_session vr-atls-2-m
 start_done_session vr-napi-4-m
 start_done_session vr-atls-3-m
 start_done_session vr-frge-2-m
+
+# luminary-docs idle session
+start_idle_session vr-ldoc-1-m
 
 echo "[seed] tmux sessions ready: $(tmux ls 2>/dev/null | wc -l) running"
 echo "[seed] done."

--- a/web-ui/src/components/chat/MessageList.test.tsx
+++ b/web-ui/src/components/chat/MessageList.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { NormalizedEvent } from "@/api/types";
 import { createMockApi } from "@/api/mock";
@@ -1049,6 +1049,27 @@ describe("groupEvents message_generated (4.T1 / 4.T2)", () => {
     const userItems = items.filter((i) => i.type === "user");
     expect(userItems).toHaveLength(1);
     expect((userItems[0] as { text: string }).text).toBe("hi");
+  });
+});
+
+describe("MessageList repo-image prop forwarding (2.T2)", () => {
+  it("forwards api/worktreeId/scope so markdown images resolve via getFileBlob", async () => {
+    const getFileBlob = vi.fn().mockResolvedValue(new Blob(["x"], { type: "image/png" }));
+    const api = { getFileBlob } as never;
+    const events = [textEvent("a1", "t1", "![logo](./assets/logo.png)")];
+    const { container } = render(
+      <MessageList events={events} pending={[]} api={api} worktreeId="wt-1" scope="worktree" />,
+    );
+    await waitFor(() => expect(container.querySelector("img.markdown-img")).toBeTruthy());
+    expect(getFileBlob).toHaveBeenCalledWith("wt-1", "assets/logo.png", "worktree");
+  });
+
+  it("does not resolve repo images without context props", () => {
+    const getFileBlob = vi.fn();
+    const events = [textEvent("a1", "t1", "![logo](./assets/logo.png)")];
+    const { container } = render(<MessageList events={events} pending={[]} />);
+    expect(getFileBlob).not.toHaveBeenCalled();
+    expect(container.querySelector("img.markdown-img")).toBeNull();
   });
 });
 

--- a/web-ui/src/components/chat/MessageList.tsx
+++ b/web-ui/src/components/chat/MessageList.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { ApiInstance } from "@/api";
-import type { Attachment, Command, NormalizedEvent } from "@/api/types";
+import type { Attachment, Command, FileScope, NormalizedEvent } from "@/api/types";
 import type { PendingTurn } from "@/hooks/useChat";
 import { TextMessage } from "./TextMessage";
 import { QueuedTurnEditor } from "./QueuedTurnEditor";
@@ -464,6 +464,10 @@ interface MessageListProps {
   /** API + session for the inline fork editor (edit an answered message). */
   api?: ApiInstance;
   sessionId?: string;
+  /** Repo-image resolution context — forwarded to markdown in messages so
+   *  relative/root-relative image paths resolve via `getFileBlob`. */
+  worktreeId?: string | null;
+  scope?: FileScope;
   /** Edit an already-answered user turn → fork (R3.1). When provided, answered
    *  user bubbles show an Edit affordance; only enabled while the session is idle. */
   onForkTurn?: (turnId: string, message: string, attachmentIds: string[]) => Promise<void> | void;
@@ -493,6 +497,8 @@ export function MessageList({
   onRetry,
   api,
   sessionId,
+  worktreeId,
+  scope,
   onForkTurn,
   onAtBottomChange,
   cwd,
@@ -814,7 +820,7 @@ export function MessageList({
             if (item.cancelled) {
               node = (
                 <div key={key} className="chat-user-turn chat-user-turn--cancelled" data-role="user">
-                  <TextMessage role="user" text={item.text} attachments={item.attachments} />
+                  <TextMessage role="user" text={item.text} attachments={item.attachments} api={api} worktreeId={worktreeId} scope={scope} />
                   <span className="chat-user-turn__cancelled" title="This message was cancelled before the agent processed it.">
                     Canceled · not sent to agent
                   </span>
@@ -844,7 +850,7 @@ export function MessageList({
             } else if (forkable) {
               node = (
                 <div key={key} className="chat-user-turn">
-                  <TextMessage role="user" text={item.text} attachments={item.attachments} />
+                  <TextMessage role="user" text={item.text} attachments={item.attachments} api={api} worktreeId={worktreeId} scope={scope} />
                   <button
                     type="button"
                     className="chat-user-turn__edit"
@@ -857,12 +863,12 @@ export function MessageList({
                 </div>
               );
             } else {
-              node = <TextMessage key={key} role="user" text={item.text} attachments={item.attachments} />;
+              node = <TextMessage key={key} role="user" text={item.text} attachments={item.attachments} api={api} worktreeId={worktreeId} scope={scope} />;
             }
             break;
           }
           case "assistant":
-            node = <TextMessage key={key} role="assistant" text={item.text} />;
+            node = <TextMessage key={key} role="assistant" text={item.text} api={api} worktreeId={worktreeId} scope={scope} />;
             break;
           case "thinking":
             // A still-open thinking group renders NOTHING while the turn is
@@ -895,6 +901,9 @@ export function MessageList({
                 startedTs={item.startedTs}
                 endedTs={item.endedTs}
                 hadToolCall={item.hadToolCall}
+                api={api}
+                worktreeId={worktreeId}
+                scope={scope}
               />
             ) : null;
             break;
@@ -931,7 +940,7 @@ export function MessageList({
 
       {pending.map((p) => (
         <div key={p.turnId} className="chat-pending">
-          <TextMessage role="user" text={p.message} attachments={p.attachments} pending />
+          <TextMessage role="user" text={p.message} attachments={p.attachments} pending api={api} worktreeId={worktreeId} scope={scope} />
         </div>
       ))}
 

--- a/web-ui/src/components/chat/StreamingMarkdown.test.tsx
+++ b/web-ui/src/components/chat/StreamingMarkdown.test.tsx
@@ -75,4 +75,21 @@ describe("StreamingMarkdown (4.T3)", () => {
     expect(container.querySelector(".workspace-md-code-block")).toBeTruthy();
     expect(container.textContent).toContain("graph TD; A-->B");
   });
+
+  it("resolves a repo image via getFileBlob when context props are passed (2.T1)", async () => {
+    const getFileBlob = vi.fn().mockResolvedValue(new Blob(["x"], { type: "image/png" }));
+    const api = { getFileBlob } as never;
+    const { container } = render(
+      <StreamingMarkdown source="![logo](./assets/logo.png)" api={api} worktreeId="wt-1" scope="worktree" />,
+    );
+    await waitFor(() => expect(container.querySelector("img.markdown-img")).toBeTruthy());
+    expect(getFileBlob).toHaveBeenCalledWith("wt-1", "assets/logo.png", "worktree");
+  });
+
+  it("does not call getFileBlob without context props (no broken fetch) (2.T1)", () => {
+    const getFileBlob = vi.fn();
+    const { container } = render(<StreamingMarkdown source="![logo](./assets/logo.png)" />);
+    expect(getFileBlob).not.toHaveBeenCalled();
+    expect(container.querySelector("img.markdown-img")).toBeNull();
+  });
 });

--- a/web-ui/src/components/chat/StreamingMarkdown.tsx
+++ b/web-ui/src/components/chat/StreamingMarkdown.tsx
@@ -3,6 +3,8 @@ import { MarkdownView } from "@/components/preview/MarkdownView";
 import { MermaidView } from "@/components/preview/MermaidView";
 import { segmentMarkdownWithMermaid } from "@/preview/mdSegments";
 import { useTheme } from "@/hooks/useTheme";
+import type { ApiInstance } from "@/api";
+import type { FileScope } from "@/api/types";
 
 /**
  * Close an unterminated ``` fence so a mid-stream delta doesn't swallow the rest
@@ -31,14 +33,25 @@ export function closeUnterminatedFences(src: string): string {
  * segment and renders as a synthetic-closed code block until its real ``` lands,
  * at which point it flips to a diagram — no streaming flags needed.
  */
-export function StreamingMarkdown({ source }: { source: string }) {
+export function StreamingMarkdown({
+  source,
+  api = null,
+  worktreeId = null,
+  scope = "worktree",
+}: {
+  source: string;
+  /** When provided, repo-relative image paths resolve via `getFileBlob`. */
+  api?: ApiInstance | null;
+  worktreeId?: string | null;
+  scope?: FileScope;
+}) {
   const { theme } = useTheme();
   const segments = useMemo(() => segmentMarkdownWithMermaid(source), [source]);
   return (
     <div className="chat-md-segments">
       {segments.map((seg, i) =>
         seg.type === "markdown" ? (
-          <MarkdownView key={i} source={closeUnterminatedFences(seg.content)} />
+          <MarkdownView key={i} source={closeUnterminatedFences(seg.content)} api={api} worktreeId={worktreeId} scope={scope} />
         ) : (
           <MermaidView key={i} chart={seg.content} theme={theme} />
         ),

--- a/web-ui/src/components/chat/TextMessage.tsx
+++ b/web-ui/src/components/chat/TextMessage.tsx
@@ -1,4 +1,6 @@
 import type { Attachment } from "@/api/types";
+import type { ApiInstance } from "@/api";
+import type { FileScope } from "@/api/types";
 import { parseSkillSegments } from "@/lib/skillInvocation";
 import { StreamingMarkdown } from "./StreamingMarkdown";
 import { AttachmentChip } from "./AttachmentChip";
@@ -9,6 +11,10 @@ interface TextMessageProps {
   attachments?: Attachment[];
   /** Greyed-out pending (optimistic/queued) styling for user bubbles. */
   pending?: boolean;
+  /** Optional repo-image resolution context, forwarded to markdown. */
+  api?: ApiInstance | null;
+  worktreeId?: string | null;
+  scope?: FileScope;
 }
 
 /**
@@ -16,7 +22,7 @@ interface TextMessageProps {
  * plain-text bubble; assistant messages render GFM markdown (streaming-tolerant,
  * raw-HTML off — Decision 9).
  */
-export function TextMessage({ role, text, attachments, pending }: TextMessageProps) {
+export function TextMessage({ role, text, attachments, pending, api, worktreeId, scope }: TextMessageProps) {
   const isUser = role === "user";
   return (
     <div
@@ -52,7 +58,7 @@ export function TextMessage({ role, text, attachments, pending }: TextMessagePro
             )}
           </div>
         ) : (
-          <StreamingMarkdown source={text} />
+          <StreamingMarkdown source={text} api={api} worktreeId={worktreeId} scope={scope} />
         )}
         {attachments && attachments.length > 0 ? (
           <div className="chat-bubble__attachments">

--- a/web-ui/src/components/chat/ThinkingBlock.tsx
+++ b/web-ui/src/components/chat/ThinkingBlock.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import { StreamingMarkdown } from "./StreamingMarkdown";
+import type { ApiInstance } from "@/api";
+import type { FileScope } from "@/api/types";
 
 interface ThinkingBlockProps {
   text: string;
@@ -15,6 +17,10 @@ interface ThinkingBlockProps {
   /** True when a tool call ran while this thinking group was open — the
    *  completed label reads "Worked for Xs" instead of "Thought for Xs". */
   hadToolCall?: boolean;
+  /** Optional repo-image resolution context, forwarded to markdown. */
+  api?: ApiInstance | null;
+  worktreeId?: string | null;
+  scope?: FileScope;
 }
 
 /** "Thought for Xs" once `endedTs` is set, else the live "Thinking" label —
@@ -44,7 +50,7 @@ function thinkingLabel(startedTs: string, endedTs: string | undefined, hadToolCa
  *  extended by Decision 4). Signature-only / redacted thinking events carry no
  *  text — those render as a plain label with no chevron, since there's
  *  nothing to expand. */
-export function ThinkingBlock({ text, defaultOpen = false, startedTs, endedTs, hadToolCall }: ThinkingBlockProps) {
+export function ThinkingBlock({ text, defaultOpen = false, startedTs, endedTs, hadToolCall, api, worktreeId, scope }: ThinkingBlockProps) {
   const [open, setOpen] = useState(defaultOpen);
   const hasContent = text.trim().length > 0;
   const label = thinkingLabel(startedTs, endedTs, hadToolCall);
@@ -77,7 +83,7 @@ export function ThinkingBlock({ text, defaultOpen = false, startedTs, endedTs, h
        *  row is redundant, not additive. */}
       {open ? (
         <div className="chat-thinking__body">
-          <StreamingMarkdown source={text} />
+          <StreamingMarkdown source={text} api={api} worktreeId={worktreeId} scope={scope} />
         </div>
       ) : null}
     </div>

--- a/web-ui/src/components/layout/ChatPane.tsx
+++ b/web-ui/src/components/layout/ChatPane.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 import type { ApiInstance } from "@/api";
-import type { Attachment, Session } from "@/api/types";
+import type { Attachment, FileScope, Session } from "@/api/types";
 import { useChat } from "@/hooks/useChat";
 import { useWorkspaceStore } from "@/hooks/useStore";
 import { MessageList } from "@/components/chat/MessageList";
@@ -45,6 +45,11 @@ export function ChatPane({ api, session, visible }: ChatPaneProps) {
   const isJson = session?.channel === "json";
   const sessionId = session?.id ?? null;
   const enabled = visible && isJson && !!sessionId;
+  // Repo-image resolution context for markdown in chat: a worktree session
+  // resolves images against the worktree; a direct session (no worktreeId)
+  // against the project scope (its project id serves as the context id).
+  const contextId = session?.worktreeId ?? session?.projectId ?? null;
+  const scope: FileScope = session?.worktreeId ? "worktree" : "project";
 
   const terminalFontScale = useWorkspaceStore((s) => s.terminalFontScale);
   const layoutByWorktree = useWorkspaceStore((s) => s.layoutByWorktree);
@@ -284,6 +289,8 @@ export function ChatPane({ api, session, visible }: ChatPaneProps) {
               onLoadAll={() => void loadAll()}
               onRetry={handleRetry}
               api={api}
+              worktreeId={contextId}
+              scope={scope}
               {...(sessionId ? { sessionId } : {})}
               onForkTurn={(turnId, message, attachmentIds) => forkTurn(turnId, message, attachmentIds)}
               onAtBottomChange={setAtBottom}

--- a/web-ui/src/components/layout/FilePreviewPane.test.tsx
+++ b/web-ui/src/components/layout/FilePreviewPane.test.tsx
@@ -38,6 +38,31 @@ describe("FilePreviewPane — Phase 9 (diff-stat/scope-toggle in plain mode)", (
     expect(screen.getByText("Compared to fork base")).toBeInTheDocument();
   });
 
+  it("never renders the previous file's body under a new path while the new fetch is in flight", async () => {
+    // Regression: the old `fileBody` used to stay on screen after `path`
+    // changed, so `MarkdownView` resolved the OLD file's relative image srcs
+    // against the NEW file's directory (README's `./assets/logo.png` became
+    // `docs/assets/logo.png` → 404, blob revoked, image blinked out).
+    useWorkspaceStore.setState({
+      activeWorktreeId: "wt-1",
+      activeFilePath: "README.md",
+      diffScopeByWorktree: {},
+    });
+    render(<FilePreviewPane api={api} worktreeId="wt-1" />);
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Demo" })).toBeInTheDocument();
+    });
+
+    const getFileSpy = vi.spyOn(api, "getFile").mockImplementation(() => new Promise(() => {}));
+    act(() => {
+      useWorkspaceStore.setState({ activeFilePath: "docs/GUIDE.md" });
+    });
+    // Stale README body must be gone immediately — not lingering under docs/.
+    expect(screen.queryByRole("heading", { name: "Demo" })).not.toBeInTheDocument();
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
+    getFileSpy.mockRestore();
+  });
+
   it("no longer renders a DiffScopeSelector in the diffInfo strip (toggle moved to FileTreeSidebar's header, single control)", async () => {
     render(<FilePreviewPane api={api} worktreeId="wt-1" />);
     await waitFor(() => {
@@ -93,3 +118,35 @@ describe("FilePreviewPane — Phase 9 (diff-stat/scope-toggle in plain mode)", (
     expect(screen.queryByRole("button", { name: "branch" })).not.toBeInTheDocument();
   });
 });
+
+describe("FilePreviewPane image files (3.T1 / TODO 2)", () => {
+  it("renders a zoomable image for an image file via getFileBlob (not CodeView)", async () => {
+    const api = createMockApi();
+    const getFileBlobSpy = vi.spyOn(api, "getFileBlob");
+    useWorkspaceStore.setState({
+      activeWorktreeId: "wt-1",
+      activeFilePath: "assets/logo.png",
+      diffScopeByWorktree: {},
+    });
+    const { container } = render(<FilePreviewPane api={api} worktreeId="wt-1" />);
+    await waitFor(() => expect(container.querySelector(".zoomable-media")).toBeTruthy());
+    expect(getFileBlobSpy).toHaveBeenCalledWith("wt-1", "assets/logo.png", "worktree");
+    expect(container.querySelector(".workspace-code-viewer")).toBeNull();
+    getFileBlobSpy.mockRestore();
+  });
+
+  it("renders CodeView for a non-image file and never calls getFileBlob", async () => {
+    const api = createMockApi();
+    const getFileBlobSpy = vi.spyOn(api, "getFileBlob");
+    useWorkspaceStore.setState({
+      activeWorktreeId: "wt-1",
+      activeFilePath: "src/App.ts",
+      diffScopeByWorktree: {},
+    });
+    const { container } = render(<FilePreviewPane api={api} worktreeId="wt-1" />);
+    await waitFor(() => expect(container.querySelector(".workspace-code-viewer")).toBeTruthy());
+    expect(getFileBlobSpy).not.toHaveBeenCalled();
+    getFileBlobSpy.mockRestore();
+  });
+});
+

--- a/web-ui/src/components/layout/FilePreviewPane.tsx
+++ b/web-ui/src/components/layout/FilePreviewPane.tsx
@@ -9,7 +9,10 @@ import { useFileWatch, useTreeWatch } from "@/hooks/useSubscription";
 import { MarkdownView } from "@/components/preview/MarkdownView";
 import { MermaidView } from "@/components/preview/MermaidView";
 import { CodeView } from "@/components/preview/CodeView";
+import { ZoomableMedia } from "@/components/preview/ZoomableMedia";
+import { ImageZoomOverlay } from "@/components/preview/ImageZoomOverlay";
 import { DiffView } from "@/components/preview/DiffView";
+import { isImagePath } from "@/lib/imageFile";
 import { languageForFilePath } from "@/components/preview/codeHighlight";
 import { parseUnifiedDiff, summarizeDiffLines, syntheticUntrackedHunks } from "@/preview/diffParser";
 
@@ -51,7 +54,29 @@ export function FilePreviewPane({ api, worktreeId, scope: fileScope = "worktree"
   const { theme } = useTheme();
   const themeMode = theme;
 
-  const [fileBody, setFileBody] = useState<string | null>(null);
+  // Identity of the content this pane is currently asked to show. Fetched
+  // bodies are stored together with the key they were fetched for and only
+  // rendered while that key still matches — so the previous file's markdown
+  // is never rendered under the new `path` while the new fetch is in flight.
+  // (That mismatch made `MarkdownView` resolve the old file's relative image
+  // srcs against the new file's directory: blob URLs were revoked and
+  // refetched from paths that don't exist, so images blinked out or 404'd.)
+  // A watcher-triggered refetch keeps the same key, so the old body stays on
+  // screen until the fresh one lands — no "Loading…" flash on every save.
+  const bodyKey =
+    worktreeId && path ? `${fileScope}\0${worktreeId}\0${path}\0${scope}\0${commitSha ?? ""}` : null;
+  const [loaded, setLoaded] = useState<{ key: string; fileBody: string | null; diffBody: string | null } | null>(null);
+  const fileBody = loaded && loaded.key === bodyKey ? loaded.fileBody : null;
+  const diffBody = loaded && loaded.key === bodyKey ? loaded.diffBody : null;
+  // Blob URL for binary image files — fetched separately since images aren't
+  // text; rendered via ZoomableMedia instead of CodeView. Stored together with
+  // the key it was fetched for (mirrors `bodyKey` above) so a watcher-triggered
+  // refetch keeps the current blob on screen until the fresh one lands.
+  const imageKey =
+    worktreeId && path && isImagePath(path) ? `${fileScope}\0${worktreeId}\0${path}` : null;
+  const [imageBlob, setImageBlob] = useState<{ key: string; url: string } | null>(null);
+  const imageBlobUrl = imageBlob && imageBlob.key === imageKey ? imageBlob.url : null;
+  const [imageFullscreen, setImageFullscreen] = useState(false);
   const { lastChanged } = useFileWatch(api, worktreeId, path, fileScope);
   // Cheap insurance for directory-level rename-replace events (Phase 1's
   // watchFile() watches the parent dir): a tree-level change to this
@@ -60,14 +85,12 @@ export function FilePreviewPane({ api, worktreeId, scope: fileScope = "worktree"
   // contract (Phase 7, Requirement 5).
   const { lastChanged: treeLastChanged } = useTreeWatch(api, worktreeId, fileScope);
 
-  const [diffBody, setDiffBody] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [tooLarge, setTooLarge] = useState(false);
 
   useEffect(() => {
-    if (!worktreeId || !path) {
-      setFileBody(null);
-      setDiffBody(null);
+    if (!bodyKey || !worktreeId || !path || isImagePath(path)) {
+      setLoaded(null);
       setError(null);
       setTooLarge(false);
       return;
@@ -89,19 +112,13 @@ export function FilePreviewPane({ api, worktreeId, scope: fileScope = "worktree"
             api.getFile(worktreeId, path, fileScope),
             fileScope === "project" ? Promise.resolve(null) : api.getDiff(worktreeId, path, "local").catch(() => null),
           ]);
-          if (!cancelled) {
-            setFileBody(text);
-            setDiffBody(d);
-          }
+          if (!cancelled) setLoaded({ key: bodyKey, fileBody: text, diffBody: d });
         } else if (scope === "local") {
           const [text, d] = await Promise.all([
             api.getFile(worktreeId, path),
             api.getDiff(worktreeId, path, "local"),
           ]);
-          if (!cancelled) {
-            setFileBody(text);
-            setDiffBody(d);
-          }
+          if (!cancelled) setLoaded({ key: bodyKey, fileBody: text, diffBody: d });
         } else if (scope === "branch") {
           // Decision 7: `git diff <baseSha> -- <path>` already diffs the base
           // SHA against the working tree, i.e. the same content `getFile`
@@ -111,26 +128,19 @@ export function FilePreviewPane({ api, worktreeId, scope: fileScope = "worktree"
             api.getFile(worktreeId, path),
             api.getDiff(worktreeId, path, "branch"),
           ]);
-          if (!cancelled) {
-            setFileBody(text);
-            setDiffBody(d);
-          }
+          if (!cancelled) setLoaded({ key: bodyKey, fileBody: text, diffBody: d });
         } else {
           // scope === "commit" — a single commit's diff against its parent
           // (or the empty tree for a root commit). No plain file content:
           // the commit view is diff-only, same as branch scope used to be.
           const d = await api.getDiff(worktreeId, path, "commit", commitSha);
-          if (!cancelled) {
-            setFileBody(null);
-            setDiffBody(d);
-          }
+          if (!cancelled) setLoaded({ key: bodyKey, fileBody: null, diffBody: d });
         }
       } catch (e) {
         if (e instanceof ApiError && e.status === 422) {
           if (!cancelled) {
             setTooLarge(true);
-            setFileBody(null);
-            setDiffBody(null);
+            setLoaded(null);
           }
         } else if (!cancelled) {
           setError(e instanceof Error ? e.message : "Failed to load");
@@ -140,7 +150,44 @@ export function FilePreviewPane({ api, worktreeId, scope: fileScope = "worktree"
     return () => {
       cancelled = true;
     };
-  }, [api, worktreeId, path, scope, fileScope, lastChanged, treeLastChanged, commitSha]);
+  }, [api, bodyKey, worktreeId, path, scope, fileScope, lastChanged, treeLastChanged, commitSha]);
+
+  // Binary image files: fetch as a blob (not text) for ZoomableMedia. Gated on
+  // the path being an image + a context id existing. The blob is keyed by
+  // (fileScope, worktreeId, path); a watcher-triggered refetch keeps the same
+  // key, so the current blob stays on screen and any open fullscreen overlay
+  // stays open until the fresh blob lands (mirrors `bodyKey` for text).
+  const imageKeyRef = useRef<string | null>(imageKey);
+  useEffect(() => {
+    if (imageKeyRef.current === imageKey) return;
+    // Only when the image identity changes (switching files) do we revoke the
+    // old blob and close any open fullscreen overlay.
+    setImageFullscreen(false);
+    setImageBlob((prev) => {
+      if (prev) URL.revokeObjectURL(prev.url);
+      return null;
+    });
+    imageKeyRef.current = imageKey;
+  }, [imageKey]);
+
+  useEffect(() => {
+    if (!worktreeId || !path || !imageKey) return;
+    let cancelled = false;
+    api
+      .getFileBlob(worktreeId, path, fileScope)
+      .then((blob) => {
+        if (cancelled) return;
+        const url = URL.createObjectURL(blob);
+        setImageBlob((prev) => {
+          if (prev && prev.key === imageKey) URL.revokeObjectURL(prev.url);
+          return { key: imageKey, url };
+        });
+      })
+      .catch(() => { /* image not found — render the loading/empty state */ });
+    return () => {
+      cancelled = true;
+    };
+  }, [api, worktreeId, path, fileScope, imageKey, lastChanged, treeLastChanged]);
 
   // ── Scroll persistence ────────────────────────────────────────────────
   // Why a callback ref instead of useEffect: fullscreen toggling moves the
@@ -215,7 +262,7 @@ export function FilePreviewPane({ api, worktreeId, scope: fileScope = "worktree"
           : [];
     if (hunks.length === 0) return null;
     return summarizeDiffLines(hunks);
-  }, [scope, diffBody, fileBody]);
+  }, [diffBody, fileBody]);
 
   // No worktree context (e.g. nothing selected yet). The dashboard has its own
   // route now, so this is a plain empty state — never dashboard/kanban content.
@@ -282,8 +329,24 @@ export function FilePreviewPane({ api, worktreeId, scope: fileScope = "worktree"
   }
 
   const isMd = path.endsWith(".md");
+  const isImage = isImagePath(path);
 
   const body = (() => {
+    if (isImage) {
+      // Binary image — render the actual image (zoomable), not raw text.
+      // Images bypass the diff scope entirely: getDiff returns 422 for binary
+      // files, and there is no meaningful text diff to show for an image.
+      return imageBlobUrl ? (
+        <ZoomableMedia
+          src={imageBlobUrl}
+          alt={path}
+          className="preview-image"
+          onOpenFullscreen={() => setImageFullscreen(true)}
+        />
+      ) : (
+        <div className="empty-state">Loading image…</div>
+      );
+    }
     if (scope === "local" || scope === "branch" || scope === "commit") {
       const diffText = diffBody ?? "";
       const fallback = fileBody ?? undefined;
@@ -319,7 +382,7 @@ export function FilePreviewPane({ api, worktreeId, scope: fileScope = "worktree"
     return <CodeView code={fileBody} language={languageForFilePath(path)} filePath={path} themeMode={themeMode} />;
   })();
 
-  const useCodeChrome = scope === "local" || scope === "branch" || scope === "commit" || (!isMd && scope === "none");
+  const useCodeChrome = scope === "local" || scope === "branch" || scope === "commit" || (!isMd && !isImage && scope === "none");
 
   return (
     <div className="pane pane-stack">
@@ -332,6 +395,11 @@ export function FilePreviewPane({ api, worktreeId, scope: fileScope = "worktree"
       >
         {body}
       </div>
+      <ImageZoomOverlay
+        src={imageFullscreen ? imageBlobUrl : null}
+        alt={path}
+        onClose={() => setImageFullscreen(false)}
+      />
     </div>
   );
 }

--- a/web-ui/src/components/preview/ImageZoomOverlay.test.tsx
+++ b/web-ui/src/components/preview/ImageZoomOverlay.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ImageZoomOverlay } from "./ImageZoomOverlay";
+
+describe("ImageZoomOverlay", () => {
+  it("renders nothing when src is null", () => {
+    const { container } = render(<ImageZoomOverlay src={null} onClose={() => {}} />);
+    expect(container.querySelector(".image-zoom-overlay")).toBeNull();
+  });
+
+  it("renders the image in a portal when src is set", () => {
+    render(<ImageZoomOverlay src="blob:mock" alt="diagram" onClose={() => {}} />);
+    const img = document.body.querySelector("img");
+    expect(img).toHaveAttribute("src", "blob:mock");
+    expect(img).toHaveAttribute("alt", "diagram");
+  });
+
+  it("locks body scroll while open and restores on close", () => {
+    document.body.style.overflow = "scroll";
+    const { rerender } = render(<ImageZoomOverlay src="blob:mock" onClose={() => {}} />);
+    expect(document.body.style.overflow).toBe("hidden");
+    rerender(<ImageZoomOverlay src={null} onClose={() => {}} />);
+    expect(document.body.style.overflow).toBe("scroll");
+  });
+
+  it("closes on Escape keydown", () => {
+    const onClose = vi.fn();
+    render(<ImageZoomOverlay src="blob:mock" onClose={onClose} />);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("closes on the close button", () => {
+    const onClose = vi.fn();
+    render(<ImageZoomOverlay src="blob:mock" onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button", { name: "Close fullscreen" }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/web-ui/src/components/preview/ImageZoomOverlay.tsx
+++ b/web-ui/src/components/preview/ImageZoomOverlay.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { ZoomableMedia } from "./ZoomableMedia";
+
+interface ImageZoomOverlayProps {
+  /** Image URL to show fullscreen; when null the overlay is closed. */
+  src: string | null;
+  alt?: string;
+  onClose: () => void;
+}
+
+/**
+ * Fullscreen zoom/pan overlay. Renders via `createPortal` to `document.body`
+ * so it escapes any parent `overflow: hidden` container, locks body scroll
+ * while open, and dismisses on Esc or the close button.
+ *
+ * The overlay is safe to mount/unmount freely — it holds no daemon stream (unlike
+ * `TerminalPane`), so there is no React-tree-position invariant to preserve.
+ */
+export function ImageZoomOverlay({ src, alt, onClose }: ImageZoomOverlayProps) {
+  const open = src != null;
+  const [resetCount, setResetCount] = useState(0);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prev;
+    };
+  }, [open, onClose]);
+
+  if (!open || !src) return null;
+
+  return createPortal(
+    <div
+      className="image-zoom-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label={alt ?? "Image fullscreen"}
+    >
+      <div className="image-zoom-overlay__controls">
+        <button
+          type="button"
+          className="image-zoom-overlay__btn"
+          onClick={() => setResetCount((c) => c + 1)}
+          aria-label="Refit image"
+          title="Refit (reset zoom)"
+        >
+          ⤾
+        </button>
+        <button
+          type="button"
+          className="image-zoom-overlay__btn"
+          onClick={onClose}
+          aria-label="Close fullscreen"
+          title="Close (Esc)"
+        >
+          ✕
+        </button>
+      </div>
+      <ZoomableMedia src={src} alt={alt} fullscreen resetTrigger={resetCount} onTap={onClose} />
+    </div>,
+    document.body,
+  );
+}

--- a/web-ui/src/components/preview/MarkdownView.tsx
+++ b/web-ui/src/components/preview/MarkdownView.tsx
@@ -4,6 +4,8 @@ import rehypeHighlight from "rehype-highlight";
 import type { ComponentPropsWithoutRef, ReactNode } from "react";
 import { useEffect, useMemo, useState } from "react";
 import { CodeBlock } from "./CodeBlock";
+import { ImageZoomOverlay } from "./ImageZoomOverlay";
+import { resolveImagePath } from "@/lib/imageFile";
 import type { ApiInstance } from "@/api";
 import type { FileScope } from "@/api/types";
 
@@ -19,6 +21,7 @@ interface MarkdownImageProps {
 
 function MarkdownImage({ src, alt, api, worktreeId, scope, fileDir }: MarkdownImageProps) {
   const [blobUrl, setBlobUrl] = useState<string | null>(null);
+  const [fullscreen, setFullscreen] = useState(false);
 
   const isRemote =
     !src ||
@@ -32,11 +35,9 @@ function MarkdownImage({ src, alt, api, worktreeId, scope, fileDir }: MarkdownIm
     let cancelled = false;
     let objectUrl: string | null = null;
 
-    // Root-absolute paths (src="/images/foo.png") resolve from worktree root,
-    // not relative to fileDir — strip the leading slash and skip joining.
-    const imagePath = src.startsWith("/")
-      ? src.replace(/^\/+/, "")
-      : fileDir ? `${fileDir}/${src}` : src;
+    // Root-absolute paths (src="/images/foo.png") resolve from the context
+    // root; relative paths resolve against `fileDir` (null in chat → root).
+    const imagePath = resolveImagePath(src, fileDir);
 
     api.getFileBlob(worktreeId, imagePath, scope).then((blob) => {
       if (cancelled) return;
@@ -51,11 +52,20 @@ function MarkdownImage({ src, alt, api, worktreeId, scope, fileDir }: MarkdownIm
     };
   }, [src, api, worktreeId, scope, fileDir, isRemote]);
 
-  if (isRemote && src) {
-    return <img src={src} alt={alt ?? ""} className="markdown-img" />;
-  }
-  if (!blobUrl) return null;
-  return <img src={blobUrl} alt={alt ?? ""} className="markdown-img" />;
+  const imgSrc = isRemote ? src : blobUrl;
+  if (!imgSrc) return null;
+  return (
+    <>
+      <img
+        src={imgSrc}
+        alt={alt ?? ""}
+        className="markdown-img"
+        draggable={false}
+        onClick={() => setFullscreen(true)}
+      />
+      <ImageZoomOverlay src={fullscreen ? imgSrc : null} alt={alt} onClose={() => setFullscreen(false)} />
+    </>
+  );
 }
 
 interface MarkdownViewProps {

--- a/web-ui/src/components/preview/MermaidView.test.tsx
+++ b/web-ui/src/components/preview/MermaidView.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from "@testing-library/react";
+import { render, waitFor, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, type Mock } from "vitest";
 import mermaid from "mermaid";
 import { MermaidView } from "./MermaidView";
@@ -69,3 +69,31 @@ describe("MermaidView hardening (RA2)", () => {
     }
   });
 });
+
+describe("MermaidView fullscreen (4.T1)", () => {
+  it("wraps a successful render in a clickable wrapper (role=button)", async () => {
+    const { container } = render(<MermaidView chart="graph TD; A-->B" theme="dark" />);
+    await waitFor(() => expect(container.querySelector(".mermaid-view")?.innerHTML).toContain("svg"));
+    const clickable = container.querySelector(".mermaid-view--clickable");
+    expect(clickable).toBeTruthy();
+    expect(clickable?.getAttribute("role")).toBe("button");
+  });
+
+  it("opens the shared fullscreen overlay on click", async () => {
+    const { container } = render(<MermaidView chart="graph TD; A-->B" theme="dark" />);
+    await waitFor(() => expect(container.querySelector(".mermaid-view")?.innerHTML).toContain("svg"));
+    fireEvent.click(container.querySelector(".mermaid-view--clickable") as HTMLElement);
+    // Portal renders into document.body.
+    expect(document.body.querySelector(".image-zoom-overlay")).toBeTruthy();
+    expect(document.body.querySelector(".image-zoom-overlay img")).toBeTruthy();
+  });
+
+  it("does NOT open fullscreen from a failed render (<pre> fallback not clickable)", async () => {
+    mockedMermaid.render.mockRejectedValueOnce(new Error("boom"));
+    const { container } = render(<MermaidView chart="not a diagram" theme="dark" />);
+    await waitFor(() => expect(container.querySelector(".mermaid-fallback")).toBeTruthy());
+    expect(container.querySelector(".mermaid-view--clickable")).toBeNull();
+    expect(document.body.querySelector(".image-zoom-overlay")).toBeNull();
+  });
+});
+

--- a/web-ui/src/components/preview/MermaidView.tsx
+++ b/web-ui/src/components/preview/MermaidView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useId, useRef, useState } from "react";
 import mermaid from "mermaid";
+import { ImageZoomOverlay } from "./ImageZoomOverlay";
 
 interface MermaidViewProps {
   chart: string;
@@ -16,15 +17,27 @@ function sanitizeMermaidSource(src: string): string {
   );
 }
 
+/**
+ * Renders a mermaid diagram. The inline SVG stays interactive and is wrapped
+ * in a clickable wrapper; clicking opens the shared `ImageZoomOverlay`
+ * fullscreen from a blob URL of the SVG string — reusing `ZoomableMedia`
+ * (mouse + touch zoom/pan). The wrapper only presents as a button once the
+ * SVG has rendered, so a screen reader / cursor never advertises an action
+ * while the async render is still in flight. A failed render falls back to a
+ * raw `<pre>` that is NOT clickable.
+ */
 export function MermaidView({ chart, theme }: MermaidViewProps) {
   const hostRef = useRef<HTMLDivElement>(null);
   const uid = useId().replace(/:/g, "");
   const [failed, setFailed] = useState(false);
+  const [svgString, setSvgString] = useState<string | null>(null);
+  const [fullscreenSrc, setFullscreenSrc] = useState<string | null>(null);
 
   useEffect(() => {
     // Skip the mermaid.parse() pre-check — render() is the sole gate, already
     // wrapped in try/catch; fall back to the raw source block on failure.
     setFailed(false);
+    setSvgString(null);
     let cancelled = false;
     mermaid.initialize({
       startOnLoad: false,
@@ -40,6 +53,7 @@ export function MermaidView({ chart, theme }: MermaidViewProps) {
         const { svg } = await mermaid.render(`mmd-${uid}`, sanitized);
         if (cancelled) return;
         el.innerHTML = svg;
+        setSvgString(svg);
       } catch {
         if (cancelled) return;
         setFailed(true);
@@ -53,6 +67,20 @@ export function MermaidView({ chart, theme }: MermaidViewProps) {
     };
   }, [chart, theme, uid]);
 
+  // Revoke the fullscreen blob URL whenever it is replaced or the component
+  // unmounts while a diagram is open (close just sets it back to null).
+  useEffect(() => {
+    return () => {
+      if (fullscreenSrc) URL.revokeObjectURL(fullscreenSrc);
+    };
+  }, [fullscreenSrc]);
+
+  const openFullscreen = () => {
+    if (!svgString) return;
+    setFullscreenSrc(URL.createObjectURL(new Blob([svgString], { type: "image/svg+xml" })));
+  };
+  const closeFullscreen = () => setFullscreenSrc(null);
+
   if (failed) {
     return (
       <pre className="mermaid-fallback">
@@ -61,5 +89,32 @@ export function MermaidView({ chart, theme }: MermaidViewProps) {
     );
   }
 
-  return <div ref={hostRef} className="mermaid-view" />;
+  // Only interactive once the SVG has rendered (svgString != null); before
+  // that the async render is in flight and clicking is a no-op.
+  const interactive = svgString !== null;
+
+  return (
+    <>
+      <div
+        ref={hostRef}
+        className={`mermaid-view${interactive ? " mermaid-view--clickable" : ""}`}
+        role={interactive ? "button" : undefined}
+        tabIndex={interactive ? 0 : undefined}
+        aria-label={interactive ? "Open diagram fullscreen" : undefined}
+        title={interactive ? "Open fullscreen" : undefined}
+        onClick={interactive ? openFullscreen : undefined}
+        onKeyDown={
+          interactive
+            ? (e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  openFullscreen();
+                }
+              }
+            : undefined
+        }
+      />
+      <ImageZoomOverlay src={fullscreenSrc} alt="Mermaid diagram" onClose={closeFullscreen} />
+    </>
+  );
 }

--- a/web-ui/src/components/preview/ZoomableMedia.test.tsx
+++ b/web-ui/src/components/preview/ZoomableMedia.test.tsx
@@ -1,0 +1,94 @@
+import { render, fireEvent, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ZoomableMedia } from "./ZoomableMedia";
+
+function getImgTransform(container: HTMLElement): string {
+  const img = container.querySelector("img");
+  return (img as HTMLElement).style.transform;
+}
+
+describe("ZoomableMedia", () => {
+  it("renders an <img> with the given src", () => {
+    render(<ZoomableMedia src="blob:mock" alt="diagram" />);
+    const img = screen.getByRole("img") as HTMLImageElement;
+    expect(img).toHaveAttribute("src", "blob:mock");
+    expect(img).toHaveAttribute("alt", "diagram");
+  });
+
+  it("zooms in on wheel-up", () => {
+    const { container } = render(<ZoomableMedia src="blob:mock" />);
+    fireEvent.wheel(container.firstElementChild as HTMLElement, { deltaY: -100, clientX: 100, clientY: 100 });
+    // scale > 1 after zoom-in
+    expect(getImgTransform(container)).toContain("scale(1.15)");
+  });
+
+  it("zooms out on wheel-down", () => {
+    const { container } = render(<ZoomableMedia src="blob:mock" />);
+    fireEvent.wheel(container.firstElementChild as HTMLElement, { deltaY: 100, clientX: 100, clientY: 100 });
+    expect(getImgTransform(container)).toContain("scale(1)");
+  });
+
+  it("pans via pointer drag", () => {
+    const { container } = render(<ZoomableMedia src="blob:mock" />);
+    const el = container.firstElementChild as HTMLElement;
+    // Pan applies translate at any scale; no need to pre-zoom.
+    fireEvent.pointerDown(el, { pointerId: 1, clientX: 50, clientY: 50 });
+    fireEvent.pointerMove(el, { pointerId: 1, clientX: 80, clientY: 70 });
+    fireEvent.pointerUp(el, { pointerId: 1 });
+    expect(getImgTransform(container)).toContain("translate(30px, 20px)");
+  });
+
+  it("resets the transform when src changes", () => {
+    const { container, rerender } = render(<ZoomableMedia src="blob:one" />);
+    const el = container.firstElementChild as HTMLElement;
+    fireEvent.wheel(el, { deltaY: -100, clientX: 100, clientY: 100 });
+    expect(getImgTransform(container)).toContain("scale(1.15)");
+    rerender(<ZoomableMedia src="blob:two" />);
+    expect(getImgTransform(container)).toContain("scale(1)");
+  });
+
+  it("calls onOpenFullscreen on single tap (inline mode)", () => {
+    const spy = vi.fn();
+    const { container } = render(<ZoomableMedia src="blob:mock" onOpenFullscreen={spy} />);
+    const el = container.firstElementChild as HTMLElement;
+    fireEvent.pointerDown(el, { pointerId: 1, clientX: 50, clientY: 50 });
+    fireEvent.pointerUp(el, { pointerId: 1, clientX: 50, clientY: 50 });
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("does not call onOpenFullscreen when the pointer travels >5 px (inline mode)", () => {
+    const spy = vi.fn();
+    const { container } = render(<ZoomableMedia src="blob:mock" onOpenFullscreen={spy} />);
+    const el = container.firstElementChild as HTMLElement;
+    fireEvent.pointerDown(el, { pointerId: 1, clientX: 50, clientY: 50 });
+    fireEvent.pointerUp(el, { pointerId: 1, clientX: 100, clientY: 100 });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("calls onTap on single tap (fullscreen mode)", () => {
+    const spy = vi.fn();
+    const { container } = render(<ZoomableMedia src="blob:mock" fullscreen onTap={spy} />);
+    const el = container.firstElementChild as HTMLElement;
+    fireEvent.pointerDown(el, { pointerId: 1, clientX: 50, clientY: 50 });
+    fireEvent.pointerUp(el, { pointerId: 1, clientX: 50, clientY: 50 });
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("does not call onTap when the pointer travels >5 px (fullscreen mode)", () => {
+    const spy = vi.fn();
+    const { container } = render(<ZoomableMedia src="blob:mock" fullscreen onTap={spy} />);
+    const el = container.firstElementChild as HTMLElement;
+    fireEvent.pointerDown(el, { pointerId: 1, clientX: 50, clientY: 50 });
+    fireEvent.pointerUp(el, { pointerId: 1, clientX: 100, clientY: 100 });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("does not call onOpenFullscreen on tap in fullscreen mode", () => {
+    const spy = vi.fn();
+    const { container } = render(<ZoomableMedia src="blob:mock" fullscreen onOpenFullscreen={spy} />);
+    const el = container.firstElementChild as HTMLElement;
+    fireEvent.pointerDown(el, { pointerId: 1, clientX: 50, clientY: 50 });
+    fireEvent.pointerUp(el, { pointerId: 1, clientX: 50, clientY: 50 });
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/web-ui/src/components/preview/ZoomableMedia.tsx
+++ b/web-ui/src/components/preview/ZoomableMedia.tsx
@@ -1,0 +1,180 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const MIN_SCALE = 1;
+const MAX_SCALE = 12;
+
+interface ZoomableMediaProps {
+  /** Image URL (blob or remote) to render and zoom. */
+  src: string;
+  alt?: string;
+  className?: string;
+  /** When true, renders filling the viewport (used by `ImageZoomOverlay`). */
+  fullscreen?: boolean;
+  /** Called on single tap/click — fires on pointerUp when pointer travel < 5 px
+   *  (inline mode only). */
+  onOpenFullscreen?: () => void;
+  /** Called on single tap/click — fires on pointerUp when pointer travel < 5 px
+   *  (fullscreen mode only). Lets the overlay dismiss on a tap of the image. */
+  onTap?: () => void;
+  /** Increment to trigger a zoom/pan reset from outside (used by ImageZoomOverlay controls). */
+  resetTrigger?: number;
+}
+
+interface Transform {
+  scale: number;
+  tx: number;
+  ty: number;
+}
+
+const IDENTITY: Transform = { scale: 1, tx: 0, ty: 0 };
+
+/**
+ * Shared mouse + touch zoom/pan renderer for `<img>` — the single
+ * implementation reused by markdown images, the file preview, and the
+ * fullscreen overlay (wheel zooms to cursor, drag pans, pinch zooms about the
+ * midpoint, single tap opens fullscreen inline / closes fullscreen).
+ */
+export function ZoomableMedia({ src, alt, className, fullscreen = false, onOpenFullscreen, onTap, resetTrigger }: ZoomableMediaProps) {
+  const [t, setT] = useState<Transform>(IDENTITY);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const tRef = useRef(t);
+  tRef.current = t;
+  const dragRef = useRef<{ startX: number; startY: number; tx: number; ty: number } | null>(null);
+  const pointersRef = useRef<Map<number, { x: number; y: number }>>(new Map());
+  const pinchRef = useRef<{ startDist: number; startScale: number } | null>(null);
+
+  const reset = useCallback(() => setT(IDENTITY), []);
+  const apply = useCallback((next: Partial<Transform>) => {
+    setT((prev) => ({ ...prev, ...next }));
+  }, []);
+  const clamp = useCallback((scale: number) => Math.min(MAX_SCALE, Math.max(MIN_SCALE, scale)), []);
+
+  // Reset transform whenever the image source changes or the overlay fires a refit.
+  useEffect(() => {
+    reset();
+  }, [src, reset, resetTrigger]);
+
+  const onWheel = useCallback(
+    (e: WheelEvent) => {
+      e.preventDefault();
+      const rect = containerRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      const cur = tRef.current;
+      const newScale = clamp(cur.scale * (e.deltaY < 0 ? 1.15 : 1 / 1.15));
+      const ratio = newScale / cur.scale;
+      const cx = e.clientX - (rect.left ?? 0) - (rect.width ?? 0) / 2;
+      const cy = e.clientY - (rect.top ?? 0) - (rect.height ?? 0) / 2;
+      apply({ scale: newScale, tx: cx - (cx - cur.tx) * ratio, ty: cy - (cy - cur.ty) * ratio });
+    },
+    [apply, clamp],
+  );
+
+  // Wheel zoom must call preventDefault(), but React's synthetic onWheel is
+  // attached as a passive listener, so the page scrolls anyway. Attach a
+  // native non-passive listener directly instead.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    el.addEventListener("wheel", onWheel, { passive: false });
+    return () => el.removeEventListener("wheel", onWheel);
+  }, [onWheel]);
+
+  const onPointerDown = useCallback((e: React.PointerEvent) => {
+    pointersRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    if (pointersRef.current.size === 1) {
+      dragRef.current = { startX: e.clientX, startY: e.clientY, tx: tRef.current.tx, ty: tRef.current.ty };
+    } else if (pointersRef.current.size === 2) {
+      dragRef.current = null;
+      const pts = [...pointersRef.current.values()];
+      const dist = Math.hypot(pts[0]!.x - pts[1]!.x, pts[0]!.y - pts[1]!.y);
+      pinchRef.current = { startDist: dist || 1, startScale: tRef.current.scale };
+    }
+    // Optional — not implemented in jsdom; in browsers it keeps the drag
+    // gesture owned by this element even when the pointer leaves it.
+    e.currentTarget.setPointerCapture?.(e.pointerId);
+  }, []);
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!pointersRef.current.has(e.pointerId)) return;
+      pointersRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
+      const pts = [...pointersRef.current.values()];
+      if (pts.length === 2 && pinchRef.current) {
+        const dist = Math.hypot(pts[0]!.x - pts[1]!.x, pts[0]!.y - pts[1]!.y);
+        const cur = tRef.current;
+        const newScale = clamp(pinchRef.current.startScale * (dist / pinchRef.current.startDist));
+        const ratio = newScale / cur.scale;
+        const midX = (pts[0]!.x + pts[1]!.x) / 2;
+        const midY = (pts[0]!.y + pts[1]!.y) / 2;
+        const rect = containerRef.current?.getBoundingClientRect();
+        const cx = rect ? midX - (rect.left ?? 0) - (rect.width ?? 0) / 2 : 0;
+        const cy = rect ? midY - (rect.top ?? 0) - (rect.height ?? 0) / 2 : 0;
+        apply({ scale: newScale, tx: cx - (cx - cur.tx) * ratio, ty: cy - (cy - cur.ty) * ratio });
+      } else if (dragRef.current) {
+        const dx = e.clientX - dragRef.current.startX;
+        const dy = e.clientY - dragRef.current.startY;
+        apply({ tx: dragRef.current.tx + dx, ty: dragRef.current.ty + dy });
+      }
+    },
+    [apply, clamp],
+  );
+
+  const onPointerEnd = useCallback(
+    (e: React.PointerEvent) => {
+      const drag = dragRef.current;
+      pointersRef.current.delete(e.pointerId);
+      if (pointersRef.current.size < 2) pinchRef.current = null;
+      if (pointersRef.current.size === 0) dragRef.current = null;
+      // Single-tap/click fires only when the pointer didn't travel (i.e. it was
+      // a tap, not a pan). 5 px threshold covers natural jitter. Inline mode it
+      // opens the fullscreen overlay; in fullscreen mode it dismisses it.
+      const isTap =
+        pointersRef.current.size === 0 &&
+        drag &&
+        Math.hypot(e.clientX - drag.startX, e.clientY - drag.startY) < 5;
+      if (!isTap) return;
+      if (fullscreen) {
+        onTap?.();
+      } else {
+        onOpenFullscreen?.();
+      }
+    },
+    [fullscreen, onTap, onOpenFullscreen],
+  );
+
+  const zoomed = t.scale > 1;
+
+  return (
+    <div
+      ref={containerRef}
+      className={`zoomable-media${fullscreen ? " zoomable-media--fullscreen" : ""}${className ? ` ${className}` : ""}`}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerEnd}
+      onPointerCancel={onPointerEnd}
+
+      style={{ touchAction: zoomed ? "none" : "pan-x pan-y" }}
+    >
+      <img
+        src={src}
+        alt={alt ?? ""}
+        draggable={false}
+        className="zoomable-media__img"
+        style={{ transform: `translate(${t.tx}px, ${t.ty}px) scale(${t.scale})` }}
+      />
+      {zoomed && !fullscreen ? (
+        <button
+          type="button"
+          className="zoomable-media__reset"
+          onClick={reset}
+          onPointerDown={(e) => e.stopPropagation()}
+          onPointerUp={(e) => e.stopPropagation()}
+          aria-label="Reset zoom"
+          title="Reset zoom"
+        >
+          ⤾
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/web-ui/src/lib/imageFile.test.ts
+++ b/web-ui/src/lib/imageFile.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { isImagePath, resolveImagePath } from "./imageFile";
+
+describe("isImagePath", () => {
+  it("returns true for known image extensions (case-insensitive)", () => {
+    for (const p of ["a.png", "a.JPG", "b.jpeg", "c.gif", "d.webp", "e.svg", "f.bmp", "g.avif"]) {
+      expect(isImagePath(p)).toBe(true);
+    }
+  });
+
+  it("returns false for non-image extensions", () => {
+    for (const p of ["a.txt", "a.md", "a.ts", "noext", "a", "a.tar.gz"]) {
+      expect(isImagePath(p)).toBe(false);
+    }
+  });
+});
+
+describe("resolveImagePath", () => {
+  it("root-relative strips the leading slash", () => {
+    expect(resolveImagePath("/images/foo.png", "docs")).toBe("images/foo.png");
+  });
+
+  it("relative joins against baseDir", () => {
+    expect(resolveImagePath("./foo.png", "docs")).toBe("docs/foo.png");
+    expect(resolveImagePath("./sub/foo.png", "docs")).toBe("docs/sub/foo.png");
+    expect(resolveImagePath("./sub/dir/foo.png", "docs")).toBe("docs/sub/dir/foo.png");
+  });
+
+  it("relative with no baseDir passes through as-is", () => {
+    expect(resolveImagePath("foo.png", null)).toBe("foo.png");
+  });
+
+  it("explicit ./ relative with no baseDir strips the ./ (chat failure path)", () => {
+    expect(resolveImagePath("./foo.png", null)).toBe("foo.png");
+    expect(resolveImagePath("./assets/logo.png", null)).toBe("assets/logo.png");
+  });
+
+  it("collapses ../ against baseDir instead of emitting a literal 'docs/../' path", () => {
+    expect(resolveImagePath("../assets/ci-pipeline.png", "docs")).toBe("assets/ci-pipeline.png");
+    expect(resolveImagePath("../../img.png", "a/b/c")).toBe("a/img.png");
+    expect(resolveImagePath("./sub/../foo.png", "docs")).toBe("docs/foo.png");
+  });
+
+  it("never climbs above the context root", () => {
+    expect(resolveImagePath("../../../x.png", "docs")).toBe("x.png");
+    expect(resolveImagePath("../x.png", null)).toBe("x.png");
+    expect(resolveImagePath("/../x.png", "docs")).toBe("x.png");
+  });
+});

--- a/web-ui/src/lib/imageFile.ts
+++ b/web-ui/src/lib/imageFile.ts
@@ -1,0 +1,43 @@
+const IMAGE_EXTENSIONS = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+  "svg",
+  "bmp",
+  "avif",
+]);
+
+/** Whether `path` names a binary image file (by extension, case-insensitive). */
+export function isImagePath(path: string): boolean {
+  const dot = path.lastIndexOf(".");
+  if (dot < 0) return false;
+  const ext = path.slice(dot + 1).toLowerCase();
+  return IMAGE_EXTENSIONS.has(ext);
+}
+
+/**
+ * Resolve a markdown image `src` to a repo file path for `getFileBlob`.
+ *
+ * - Leading `/` (root-relative) → strip the slash; resolve from context root.
+ * - Leading `./` (explicit-relative) → strip it; `getFileBlob` only strips
+ *   leading `/`, so a literal `./x.png` would 404 — especially in chat where
+ *   `baseDir` is null.
+ * - Otherwise (relative) → join against `baseDir` when present.
+ * - `.` / `..` segments are collapsed (`docs` + `../assets/x.png` →
+ *   `assets/x.png`); `..` never climbs above the context root.
+ *
+ * Returns the path to pass to `api.getFileBlob`.
+ */
+export function resolveImagePath(src: string, baseDir: string | null): string {
+  // Root-relative: resolve from the context root (baseDir is NOT applied).
+  const joined = src.startsWith("/") ? src : baseDir ? `${baseDir}/${src}` : src;
+  const out: string[] = [];
+  for (const seg of joined.split("/")) {
+    if (seg === "" || seg === ".") continue;
+    if (seg === "..") out.pop();
+    else out.push(seg);
+  }
+  return out.join("/");
+}

--- a/web-ui/src/styles/chat.css
+++ b/web-ui/src/styles/chat.css
@@ -424,6 +424,11 @@
   height: auto;
 }
 
+/* Mermaid diagrams are click-to-fullscreen (TODO 3) — zoom-in affordance. */
+.mermaid-view--clickable {
+  cursor: zoom-in;
+}
+
 /* ── Thinking block ───────────────────────────────────────────────────────── */
 
 .chat-thinking {

--- a/web-ui/src/styles/workspace.css
+++ b/web-ui/src/styles/workspace.css
@@ -2687,6 +2687,117 @@
   margin: var(--space-2) 0;
 }
 
+/* Inline markdown image — static (no zoom/pan), click opens fullscreen overlay. */
+.markdown-img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: var(--space-2) 0;
+  cursor: zoom-in;
+  border-radius: var(--radius-sm);
+}
+
+/* ── Zoomable media (shared image zoom/pan — TODO 2/3) ──────────────────── */
+
+.zoomable-media {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  cursor: zoom-in;
+  user-select: none;
+}
+
+.zoomable-media--fullscreen {
+  width: 100%;
+  height: 100%;
+  cursor: grab;
+}
+
+.zoomable-media--fullscreen:active {
+  cursor: grabbing;
+}
+
+.zoomable-media__img {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  will-change: transform;
+  transform-origin: center;
+  border-radius: var(--radius-sm);
+}
+
+.zoomable-media--fullscreen .zoomable-media__img {
+  border-radius: 0;
+}
+
+.zoomable-media__reset {
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-2);
+  z-index: 1;
+  border: none;
+  background: color-mix(in srgb, var(--bg-elevated) 85%, transparent);
+  color: var(--fg-primary);
+  width: 2rem;
+  height: 2rem;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.image-zoom-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 300;
+  background: color-mix(in srgb, var(--bg-primary) 92%, transparent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.image-zoom-overlay__controls {
+  position: absolute;
+  top: var(--space-3);
+  right: var(--space-3);
+  z-index: 1;
+  display: flex;
+  gap: var(--space-1);
+}
+
+.image-zoom-overlay__btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border-default);
+  background: var(--bg-elevated);
+  color: var(--fg-primary);
+  width: 2rem;
+  height: 2rem;
+  border-radius: var(--radius-sm);
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.image-zoom-overlay__btn:hover {
+  background: var(--bg-input);
+}
+
+/* File-preview image — fills the pane; object-fit: contain letterboxes it. */
+.preview-image {
+  width: 100%;
+  height: 100%;
+}
+
+.preview-image .zoomable-media__img {
+  width: 100%;
+  height: 100%;
+}
+
 .workspace-markdown-preview strong {
   color: var(--fg-primary);
   font-weight: 700;

--- a/web-ui/src/test/setup.ts
+++ b/web-ui/src/test/setup.ts
@@ -33,6 +33,40 @@ if (!Element.prototype.scrollIntoView) {
   Element.prototype.scrollIntoView = function scrollIntoView() {};
 }
 
+// jsdom has no PointerEvent, so testing-library's fireEvent.pointer* falls back
+// to a bare event that drops clientX/clientY (and pointerId). Polyfill a minimal
+// PointerEvent over MouseEvent so pointer-based components (ZoomableMedia's
+// drag/pinch) are testable with real coordinates.
+if (typeof window.PointerEvent === "undefined") {
+  class PointerEventPolyfill extends MouseEvent {
+    pointerId: number;
+    pointerType: string;
+    constructor(type: string, params: MouseEventInit & { pointerId?: number; pointerType?: string } = {}) {
+      super(type, params);
+      this.pointerId = params.pointerId ?? 0;
+      this.pointerType = params.pointerType ?? "mouse";
+    }
+  }
+  Object.defineProperty(window, "PointerEvent", {
+    writable: true,
+    configurable: true,
+    value: PointerEventPolyfill,
+  });
+}
+
+// jsdom doesn't implement URL.createObjectURL/revokeObjectURL, which the image
+// renderers (MarkdownImage, FilePreviewPane, MermaidView) use to display blobs.
+// Polyfill with incrementing fake blob: URLs so image tests can assert rendering.
+if (typeof URL.createObjectURL === "undefined") {
+  let blobCounter = 0;
+  URL.createObjectURL = function createObjectURL() {
+    return `blob:mock-${blobCounter++}`;
+  };
+  URL.revokeObjectURL = function revokeObjectURL() {
+    /* no-op — fake blob URLs need no cleanup */
+  };
+}
+
 afterEach(() => {
   cleanup();
   localStorage.clear();


### PR DESCRIPTION
## Summary

- **ZoomableMedia** — new shared component for pointer-event zoom/pan/pinch on images and mermaid diagrams. Single-tap opens fullscreen (inline mode); single-tap on the image closes it (fullscreen mode). Native non-passive wheel listener so `preventDefault()` actually blocks page scroll. Reset button stops pointer-event propagation so a zoom-reset click can't accidentally open the overlay.
- **ImageZoomOverlay** — `createPortal` fullscreen overlay with always-visible refit + close buttons, Esc key dismiss, scrim-tap-to-close, body scroll lock.
- **imageFile.ts** — `isImagePath()` and `resolveImagePath()` utility with proper `../` segment collapsing.
- **FilePreviewPane** — binary image files bypass `getDiff` (which returns 422 for binary) and always render `ZoomableMedia` regardless of diff scope. `bodyKey` scheme prevents stale markdown being rendered under a new file path while a fetch is in-flight (was causing relative image srcs to resolve against the wrong directory). Blob URL keyed to fetch identity so file-watcher ticks no longer blank the image or slam the overlay shut.
- **Markdown / chat images** — `MarkdownImage` uses a plain `<img onClick>` (no `ZoomableMedia` inline, so images don't pan/drag in chat). Single-click opens `ImageZoomOverlay`. `resolveImagePath` handles relative + root-absolute `src` values. Project-scope (direct) chat sessions resolve `contextId` via `worktreeId ?? projectId` so images load there too.
- **Mermaid** — fullscreen zoom via `ImageZoomOverlay` on the rendered SVG blob.
- **Demo seed** — `luminary-docs` project with markdown files using relative + absolute image refs and mermaid diagrams; Python-generated solid-colour PNG fixtures for reliable visual testing.

## Test plan

- [ ] Open an image file in the Files tab — renders full-pane, pinch/scroll zooms, single-tap opens fullscreen overlay
- [ ] Overlay: refit button resets zoom, ✕ closes, Esc closes, tapping the image closes
- [ ] Switch diff scope to Local/Branch while an image is open — still shows the image (not a diff or error)
- [ ] Open a markdown file with inline images (luminary-docs README or ARCHITECTURE) — images render, single-click opens overlay
- [ ] Relative paths (`screenshots/hero.png`) and absolute paths (`/assets/logo.png`) both resolve correctly
- [ ] Switch between markdown files — images in the new file load correctly, old images don't ghost in
- [ ] File-watcher save tick — image stays visible, open overlay stays open
- [ ] Mermaid diagram block — single-click opens zoomable fullscreen overlay
- [ ] Scroll-wheel over a zoomed image — only the image zooms, surrounding pane does not scroll
- [ ] 17 pre-existing test failures on `main` are unchanged; no new failures introduced