### PR TITLE
fix: worktree create no longer auto-links parent; unlink button always reachable

### DIFF
--- a/cli/src/commands/worktree/create.ts
+++ b/cli/src/commands/worktree/create.ts
@@ -68,7 +68,7 @@ export function registerWorktreeCreate(worktree: Command): void {
         const explicitlyPassed = opts.parent !== undefined;
         const sourceAgentId = explicitlyPassed
           ? explicitParent || undefined
-          : process.env.VST_SESSION || undefined;
+          : undefined;
 
         try {
           const result = await daemonPost<WorktreeCreateResponse>(

--- a/web-ui/src/components/chat/SubagentRow.tsx
+++ b/web-ui/src/components/chat/SubagentRow.tsx
@@ -140,12 +140,19 @@ export function SubagentRow({ session, onOpen, api }: SubagentRowProps) {
             </button>
           </span>
         ) : (
-          <button
-            type="button"
+          <div
             className="chat-subagent-row__item chat-subagent-row__item--parent"
             onClick={() => parent.worktreeId === session.worktreeId && onOpen(parent)}
-            disabled={parent.worktreeId !== session.worktreeId}
-            title={parent.worktreeId === session.worktreeId ? undefined : "This parent is in a different worktree"}
+            style={
+              parent.worktreeId !== session.worktreeId
+                ? { opacity: 0.5, cursor: "default" }
+                : undefined
+            }
+            title={
+              parent.worktreeId === session.worktreeId
+                ? undefined
+                : "This parent is in a different worktree"
+            }
           >
             <span className="chat-subagent-row__arrow" aria-hidden="true">
               ↑
@@ -164,7 +171,7 @@ export function SubagentRow({ session, onOpen, api }: SubagentRowProps) {
                 <Unlink size={11} />
               </button>
             ) : null}
-          </button>
+          </div>
         )
       ) : null}
       {visibleChildren.length > 0 ? (
@@ -211,7 +218,7 @@ export function SubagentRow({ session, onOpen, api }: SubagentRowProps) {
           >
             <StatusDot status={sessionStateToStatus(statusFor(child))} pr={null} />
             <span className="chat-subagent-row__label">{sessionLabel(child)}</span>
-            {api && sameWorktree ? (
+            {api ? (
               <button
                 type="button"
                 className="chat-subagent-row__delink"


### PR DESCRIPTION
## Summary

- **Worktree create parent link** (`cli/src/commands/worktree/create.ts`): removed the `$VST_SESSION` fallback so `vst worktree create` never auto-links the new worktree's agent as a subagent of the caller. Parent is now only set when `--parent` is explicitly passed.
- **Unlink button** (`web-ui/src/components/chat/SubagentRow.tsx`): two fixes so the button always works:
  - Child-row: removed `sameWorktree` guard — the button now renders for cross-worktree children too (confirmation dialog already existed)
  - Parent-row: converted the outer `<button>` to a `<div>` so the nested unlink button is no longer trapped inside a disabled element for cross-worktree parents

## Test plan

- [ ] Spawn an agent that runs `vst worktree create` — the new worktree should appear standalone with no parent link
- [ ] Open a session that has a parent in a different worktree — Unlink button should render and open the confirmation dialog
- [ ] Open a session with a parent in the same worktree — Unlink button should still work as before