### PR TITLE
fix(ws): stop remote socket connect/disconnect cycling

### DIFF
--- a/daemon/src/__tests__/connection.test.ts
+++ b/daemon/src/__tests__/connection.test.ts
@@ -215,3 +215,77 @@ describe("WSConnection.cleanup closes watchers regardless of refCount", () => {
     expect(conn.fileWatches.size).toBe(0);
   });
 });
+
+/**
+ * REGRESSION — remote socket cycling (see `connection.ts` header). `send()`
+ * used to close the socket with 1009 once `bufferedAmount` passed 1MB; over
+ * any real network the reconnect replay burst crosses 1MB instantly, so every
+ * fresh connection was killed again at the same byte count — a deterministic
+ * connect/disconnect cycle. These tests pin the replacement behaviour: never
+ * close on ordinary pressure; coalesce lossy `session:output`; only close at
+ * the shared HARD_LIMIT.
+ */
+describe("WSConnection.send backpressure (socket-cycling fix)", () => {
+  function makeBackpressuredConn(bufferedAmount: number) {
+    const fakeWs = {
+      readyState: 1,
+      send: vi.fn(),
+      close: vi.fn(),
+      bufferedAmount,
+    } as unknown as ConstructorParameters<typeof WSConnection>[0];
+    return { conn: new WSConnection(fakeWs), ws: fakeWs };
+  }
+
+  it("does NOT close the socket when the write buffer exceeds the soft limit (was 1009 at 1MB)", () => {
+    const { conn, ws } = makeBackpressuredConn(2_000_000);
+    conn.send({ type: "session:output", sessionId: "s1", chunk: "hello" });
+    expect(ws.close).not.toHaveBeenCalled();
+  });
+
+  it("coalesces session:output frames instead of sending them when backed up", () => {
+    const { conn, ws } = makeBackpressuredConn(2_000_000);
+    conn.send({ type: "session:output", sessionId: "s1", chunk: "a" });
+    conn.send({ type: "session:output", sessionId: "s1", chunk: "b" });
+    // Both frames coalesced (not sent individually) and the socket stays open.
+    expect(ws.send).not.toHaveBeenCalled();
+    expect(ws.close).not.toHaveBeenCalled();
+    // Cleanup cancels the coalesce flush timer so no handle lingers.
+    void conn.cleanup();
+  });
+
+  it("still delivers small must-deliver frames under backpressure", () => {
+    const { conn, ws } = makeBackpressuredConn(2_000_000);
+    conn.send({ type: "pong" });
+    expect(ws.send).toHaveBeenCalledTimes(1);
+    expect(ws.close).not.toHaveBeenCalled();
+  });
+
+  it("closes the socket only at the shared HARD_LIMIT (50MB)", () => {
+    const { conn, ws } = makeBackpressuredConn(51 * 1024 * 1024);
+    conn.send({ type: "pong" });
+    expect(ws.close).toHaveBeenCalledWith(1009, "Message Too Big");
+  });
+
+  it("flushes coalesced output once the buffer drains", async () => {
+    const fakeWs = {
+      readyState: 1,
+      send: vi.fn(),
+      close: vi.fn(),
+      bufferedAmount: 2_000_000,
+    } as unknown as ConstructorParameters<typeof WSConnection>[0];
+    const conn = new WSConnection(fakeWs);
+    conn.send({ type: "session:output", sessionId: "s1", chunk: "abc" });
+    expect(fakeWs.send).not.toHaveBeenCalled();
+    // Buffer drains; a later (non-output) send must flush the coalesced chunk
+    // FIRST, then deliver the new message.
+    fakeWs.bufferedAmount = 0;
+    conn.send({ type: "pong" });
+    expect(fakeWs.send).toHaveBeenCalledTimes(2);
+    const flushed = JSON.parse(String(fakeWs.send.mock.calls[0]![0])) as { type: string };
+    expect(flushed.type).toBe("session:output");
+    expect(flushed).toMatchObject({ sessionId: "s1", chunk: "abc" });
+    const after = JSON.parse(String(fakeWs.send.mock.calls[1]![0])) as { type: string };
+    expect(after.type).toBe("pong");
+    void conn.cleanup();
+  });
+});

--- a/daemon/src/__tests__/jsonChatRoutes.test.ts
+++ b/daemon/src/__tests__/jsonChatRoutes.test.ts
@@ -919,10 +919,14 @@ describe("JSON chat REST + WS", () => {
     expect(pageBody.oldestSeq).toBe(5);
     expect(pageBody.hasMore).toBe(true);
 
-    // `since` delta → only events strictly newer than the cursor.
+    // `since` delta → only events strictly newer than the cursor, plus a
+    // bounded forward page with a `nextSeq`/`hasMore` cursor (socket-cycling
+    // fix — a reconnect delta is never one unbounded frame).
     const since = await app.inject({ method: "GET", url: `/sessions/${SESSION_ID}/transcript?since=9` });
-    const sinceBody = since.json<{ events: NormalizedEvent[] }>();
+    const sinceBody = since.json<{ events: NormalizedEvent[]; nextSeq?: number; hasMore?: boolean }>();
     expect(sinceBody.events.map((e) => e.logSeq)).toEqual([10, 11, 12, 13, 14]);
+    expect(sinceBody.nextSeq).toBe(14);
+    expect(sinceBody.hasMore).toBe(false);
   });
 
   it("P1.T3 — chat:open replay→live loses no event and does not duplicate the tail", async () => {
@@ -984,9 +988,12 @@ describe("JSON chat REST + WS", () => {
 
     // Only events strictly newer than seq 1 — not the whole turn.
     expect(replay.events.map((e: NormalizedEvent) => e.logSeq)).toEqual([2, 3, 4]);
-    // A `since` delta carries no keyset cursor (it's not a window top).
+    // A `since` delta carries the FORWARD cursor (nextSeq/hasMore) so the client
+    // can page a large backlog in bounded frames (socket-cycling fix). It does
+    // NOT carry the backward `oldestSeq` keyset cursor.
     expect(replay.oldestSeq).toBeUndefined();
-    expect(replay.hasMore).toBeUndefined();
+    expect(replay.nextSeq).toBe(4);
+    expect(replay.hasMore).toBe(false);
   });
 
   it("1.T5 — message_generated event persisted while no chat:open stream open appears in chat:replay", async () => {

--- a/daemon/src/__tests__/transcriptStore.test.ts
+++ b/daemon/src/__tests__/transcriptStore.test.ts
@@ -135,8 +135,26 @@ describe("P1.T1 — tail / pageBefore keyset (turn-aligned, never split)", () =>
     const store = openSqliteTranscriptStore(dataDir, SESSION_ID);
     for (let i = 1; i <= 3; i++) appendTurn(store, `t${i}`);
     // seq 0..8; since(5) → seq 6,7,8.
-    const delta = store.since(5);
-    expect(delta.map((e) => e.logSeq)).toEqual([6, 7, 8]);
+    const page = store.since(5);
+    expect(page.events.map((e) => e.logSeq)).toEqual([6, 7, 8]);
+    expect(page.nextSeq).toBe(8);
+    expect(page.hasMore).toBe(false);
+    store.close();
+  });
+
+  it("since(seq) is bounded by LIMIT and returns a pagination cursor when more rows exist", () => {
+    const store = openSqliteTranscriptStore(dataDir, SESSION_ID);
+    for (let i = 1; i <= 5; i++) appendTurn(store, `t${i}`); // seq 0..14
+    // Limit 3: returns seq 1,2,3 and reports more after nextSeq=3.
+    const page = store.since(0, 3);
+    expect(page.events.map((e) => e.logSeq)).toEqual([1, 2, 3]);
+    expect(page.nextSeq).toBe(3);
+    expect(page.hasMore).toBe(true);
+    // Next page from the cursor continues where the last left off.
+    const page2 = store.since(page.nextSeq!, 3);
+    expect(page2.events.map((e) => e.logSeq)).toEqual([4, 5, 6]);
+    expect(page2.nextSeq).toBe(6);
+    expect(page2.hasMore).toBe(true);
     store.close();
   });
 
@@ -193,7 +211,7 @@ describe("P4.T1 — markSupersededFrom (fork truncation, R3.4)", () => {
     expect(tail.events.every((e) => e.turnId === "t1")).toBe(true);
     expect(tail.hasMore).toBe(false);
     // `since` also excludes superseded — a reconnect never replays a forked branch.
-    expect(store.since(s1).some((e) => e.turnId === "t2" || e.turnId === "t3")).toBe(false);
+    expect(store.since(s1).events.some((e) => e.turnId === "t2" || e.turnId === "t3")).toBe(false);
     store.close();
   });
 

--- a/daemon/src/broadcaster.ts
+++ b/daemon/src/broadcaster.ts
@@ -73,6 +73,14 @@ export function unregisterConnection(conn: WSConnection): void {
 }
 
 /**
+ * Invoke `fn` for every live WS connection. Used by `ws/server.ts`'s heartbeat
+ * sweep to ping connections and reap stale ones (socket-cycling fix, Fix 5).
+ */
+export function forEachConnection(fn: (conn: WSConnection) => void): void {
+  for (const conn of connections) fn(conn);
+}
+
+/**
  * Return a snapshot of token-level remote sessions.
  *
  * Minted browser tokens (from auth-state) are the source of truth — a device

--- a/daemon/src/routes/sessions.ts
+++ b/daemon/src/routes/sessions.ts
@@ -2440,7 +2440,9 @@ export function registerSessionRoutes(app: FastifyInstance): void {
     if (q.since !== undefined) {
       const sinceSeq = Number(q.since);
       if (!Number.isFinite(sinceSeq)) return reply.status(400).send({ error: "invalid since" });
-      return reply.send({ events: readSessionSince(ctx, sinceSeq) });
+      // Bounded forward page + cursor (socket-cycling fix) — never the whole
+      // delta in one response.
+      return reply.send(readSessionSince(ctx, sinceSeq));
     }
 
     if (q.beforeSeq !== undefined) {

--- a/daemon/src/services/jsonAgent.ts
+++ b/daemon/src/services/jsonAgent.ts
@@ -17,7 +17,7 @@ import { mkdirSync, existsSync, readFileSync, readdirSync, writeFileSync, unlink
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import type { AgentPlugin, TurnInput, TurnContext } from "./spawn.js";
-import type { TranscriptMeta, TranscriptPage, TranscriptStore, ImportOutcome } from "./transcriptStore.js";
+import type { SincePage, TranscriptMeta, TranscriptPage, TranscriptStore, ImportOutcome } from "./transcriptStore.js";
 import { openSqliteTranscriptStore, transcriptDbPath } from "./sqliteTranscriptStore.js";
 import { getNativeHistoryImporter } from "./nativeHistoryImporter.js";
 import { capToolResultContent } from "./toolResultCap.js";
@@ -1034,9 +1034,10 @@ export class JsonAgentSession {
     return this.store.pageBefore(beforeSeq, limit);
   }
 
-  /** Reconnect delta — events strictly newer than `sinceSeq` (R2.3). */
-  since(sinceSeq: number): NormalizedEvent[] {
-    return this.store.since(sinceSeq);
+  /** Reconnect delta — bounded forward page of events strictly newer than
+   *  `sinceSeq` (R2.3 + socket-cycling fix). */
+  since(sinceSeq: number, limit?: number): SincePage {
+    return this.store.since(sinceSeq, limit);
   }
 
   /**
@@ -1968,9 +1969,9 @@ export function readPageBeforeFromDataDir(
   });
 }
 
-/** Reconnect delta from disk (no live session). */
-export function readSinceFromDataDir(dataDir: string, sessionId: string, sinceSeq: number): NormalizedEvent[] {
-  return withDiskStore(dataDir, sessionId, (store) => store.since(sinceSeq), []);
+/** Reconnect delta from disk (no live session) — bounded forward page. */
+export function readSinceFromDataDir(dataDir: string, sessionId: string, sinceSeq: number): SincePage {
+  return withDiskStore(dataDir, sessionId, (store) => store.since(sinceSeq), { events: [], hasMore: false });
 }
 
 /** Bounded last model + last real usage from disk (R2.6 — no full read). */

--- a/daemon/src/services/jsonAgentChat.ts
+++ b/daemon/src/services/jsonAgentChat.ts
@@ -27,7 +27,7 @@ import {
 } from "./jsonAgent.js";
 import { sessionChannel } from "./channel.js";
 import { sessionDataDir, directSessionDataDir, worktreePath } from "./paths.js";
-import type { TranscriptPage } from "./transcriptStore.js";
+import type { SincePage, TranscriptPage } from "./transcriptStore.js";
 import type {
   ProjectRecord,
   WorktreeRecord,
@@ -308,8 +308,9 @@ export function readSessionPageBefore(
   return readPageBeforeFromDataDir(sessionDataDirFor(ctx), ctx.session.id, beforeSeq, limit);
 }
 
-/** Reconnect delta — events strictly newer than `sinceSeq` (R2.3). */
-export function readSessionSince(ctx: JsonSessionContext, sinceSeq: number): NormalizedEvent[] {
+/** Reconnect delta — bounded forward page of events strictly newer than
+ *  `sinceSeq` (R2.3 + socket-cycling fix). */
+export function readSessionSince(ctx: JsonSessionContext, sinceSeq: number): SincePage {
   const live = jsonAgentRegistry.get(ctx.session.id);
   if (live) return live.since(sinceSeq);
   return readSinceFromDataDir(sessionDataDirFor(ctx), ctx.session.id, sinceSeq);

--- a/daemon/src/services/sqliteTranscriptStore.ts
+++ b/daemon/src/services/sqliteTranscriptStore.ts
@@ -19,12 +19,24 @@ import type { NormalizedEvent, UsageInfo } from "../types.js";
 import type {
   ImportOutcome,
   NativeWatermark,
+  SincePage,
   TranscriptMeta,
   TranscriptPage,
   TranscriptStore,
 } from "./transcriptStore.js";
 import { migrateJsonlIntoDb } from "./transcriptMigration.js";
 import { capToolResultContent, TOOL_RESULT_MAX_BYTES } from "./toolResultCap.js";
+
+/**
+ * Default page size for the bounded forward `since()` replay (socket-cycling
+ * fix). `since()` previously returned EVERY event newer than the cursor in one
+ * array, so a reconnect over a long-lived session replayed the whole tail in a
+ * single `chat:replay` frame that blew past the WS write-buffer limit and
+ * killed the socket — forever, since the client re-requested the same delta on
+ * every reconnect. A bounded page keeps each frame small; the client pages
+ * toward the head via `nextSeq`/`hasMore`.
+ */
+export const SINCE_PAGE_SIZE = 200;
 
 /** A usage event reflects a real model call only when it billed tokens. */
 function hasRealUsage(usage: UsageInfo | undefined): usage is UsageInfo {
@@ -379,13 +391,28 @@ export class SqliteTranscriptStore implements TranscriptStore {
     };
   }
 
-  since(seq: number): NormalizedEvent[] {
+  /**
+   * Bounded forward page of events strictly newer than `seq`, with a
+   * `nextSeq`/`hasMore` cursor (socket-cycling fix). Previously this returned
+   * the ENTIRE delta in one array — an unbounded `chat:replay` frame. Now it
+   * returns at most `limit` rows (default `SINCE_PAGE_SIZE`) so the client can
+   * page toward the head instead of pulling the whole backlog at once.
+   */
+  since(seq: number, limit?: number): SincePage {
+    const lim = Math.max(1, Math.floor(limit ?? SINCE_PAGE_SIZE));
     const rows = this.db
       .prepare(
-        "SELECT seq, payload FROM message WHERE session_id = ? AND superseded = 0 AND seq > ? ORDER BY seq ASC",
+        "SELECT seq, payload FROM message WHERE session_id = ? AND superseded = 0 AND seq > ? ORDER BY seq ASC LIMIT ?",
       )
-      .all(this.sessionId, seq) as { seq: number; payload: string }[];
-    return rows.map((r) => this.parseRow(r.seq, r.payload));
+      .all(this.sessionId, seq, lim) as { seq: number; payload: string }[];
+    if (rows.length === 0) return { events: [], hasMore: false };
+    const events = rows.map((r) => this.parseRow(r.seq, r.payload));
+    const lastSeq = rows[rows.length - 1]!.seq;
+    return {
+      events,
+      nextSeq: lastSeq,
+      hasMore: this.existsAfter(lastSeq),
+    };
   }
 
   /** Every row with `seq >= fromSeq`, asc, as a page with `hasMore` before it. */
@@ -422,6 +449,14 @@ export class SqliteTranscriptStore implements TranscriptStore {
   private existsBefore(seq: number): boolean {
     const row = this.db
       .prepare("SELECT EXISTS(SELECT 1 FROM message WHERE session_id = ? AND superseded = 0 AND seq < ?) AS e")
+      .get(this.sessionId, seq) as { e: number };
+    return row.e === 1;
+  }
+
+  /** True when any live row exists strictly after `seq` (bounded EXISTS). */
+  private existsAfter(seq: number): boolean {
+    const row = this.db
+      .prepare("SELECT EXISTS(SELECT 1 FROM message WHERE session_id = ? AND superseded = 0 AND seq > ?) AS e")
       .get(this.sessionId, seq) as { e: number };
     return row.e === 1;
   }

--- a/daemon/src/services/transcriptStore.ts
+++ b/daemon/src/services/transcriptStore.ts
@@ -29,6 +29,24 @@ export interface TranscriptPage {
   hasMore: boolean;
 }
 
+/**
+ * A bounded FORWARD window of transcript events newer than a cursor, for the
+ * reconnect delta replay (socket-cycling fix).
+ *
+ * Unlike `TranscriptPage` (which pages backward toward the transcript's start),
+ * this pages forward toward its head: `nextSeq` is the `logSeq` of the LAST
+ * event in `events` (absent when the window is empty) — the cursor the client
+ * passes back as the next `sinceSeq`. `hasMore` is true when live rows exist
+ * beyond `nextSeq`. Pagination is what keeps a single `chat:replay` frame
+ * bounded, so an arbitrarily large backlog can never exceed the WS hard limit
+ * and kill the socket (the original socket-cycling root cause).
+ */
+export interface SincePage {
+  events: NormalizedEvent[];
+  nextSeq?: number;
+  hasMore: boolean;
+}
+
 /** The native cursor watermark persisted for a session (R0.5). */
 export interface NativeWatermark {
   cli: string;
@@ -59,8 +77,13 @@ export interface TranscriptStore {
   tail(nTurns: number): TranscriptPage;
   /** Keyset page of events strictly before `seq`, turn-aligned + a cursor (P1). */
   pageBefore(seq: number, limit: number): TranscriptPage;
-  /** Events strictly newer than `seq` — the reconnect delta (P1). */
-  since(seq: number): NormalizedEvent[];
+  /**
+   * Bounded FORWARD page of events strictly newer than `seq` — the reconnect
+   * delta (P1). Returns at most `limit` events (default `SINCE_PAGE_SIZE`) plus
+   * a `nextSeq`/`hasMore` cursor so the caller can page toward the head instead
+   * of pulling the whole tail in one frame (socket-cycling fix).
+   */
+  since(seq: number, limit?: number): SincePage;
   /**
    * Mark every row at/after `seq` superseded (edit-a-sent-message fork, R3.4).
    * Append-only: the old branch is kept but hidden from all reads. Returns the

--- a/daemon/src/ws/connection.ts
+++ b/daemon/src/ws/connection.ts
@@ -5,6 +5,39 @@ import type { JsonAgentStream } from "./streams/jsonAgentStream.js";
 import type { NormalizedEvent, SessionMeta, TokenScope } from "../types.js";
 
 /**
+ * REGRESSION — remote socket cycling (see branch `fix/ws-socket-cycling`).
+ *
+ * `send()` used to hard-close the socket with code 1009 once `bufferedAmount`
+ * exceeded 1MB. On loopback that never fired, but over any real network (LAN /
+ * Tailscale / tunnel) the reconnect replay burst queues past 1MB instantly.
+ * The client then reconnected, `onopen` replayed the SAME oversized
+ * `chat:replay` + terminal scrollback burst, and the socket was killed again
+ * at the same byte count — a deterministic connect/disconnect cycle with no
+ * escape (the daemon log shows millions of identical
+ * "[WS] Write buffer exceeded 1MB, closing connection" lines in unbroken runs).
+ *
+ * The fix (three cooperating changes):
+ *  1. `send()` never closes on ordinary pressure. It coalesces lossy
+ *     `session:output` frames (terminal scrollback, which tmux redraws anyway)
+ *     when the buffer is high, and only hard-closes at the real shared
+ *     `HARD_LIMIT` (50MB) — see `WS_HARD_LIMIT` and `ws/server.ts`.
+ *  2. `chat:replay` deltas are bounded + paginated (LIMIT in
+ *     `sqliteTranscriptStore.since()`) so a single frame can never exceed the
+ *     limit in the first place.
+ *  3. The client advances its `sinceSeq` cursor on `chat:replay` (not just live
+ *     `session:message`) so a partially-delivered replay is never re-requested
+ *     identically, and resets its reconnect backoff only after the connection
+ *     has been stable.
+ */
+
+/** Soft backpressure threshold: above this we begin coalescing lossy
+ *  `session:output` frames rather than queueing an unbounded scrollback. */
+export const WS_SOFT_LIMIT = 1_000_000;
+/** Hard limit: above this the connection is beyond hope — close it. Shared
+ *  with `ws/server.ts`'s periodic backpressure check so the two agree. */
+export const WS_HARD_LIMIT = 50 * 1024 * 1024;
+
+/**
  * A live JSON chat subscription: listeners attached to a session's
  * `JsonAgentStream` for `chat:open`, so `chat:close`/cleanup can detach them
  * without leaking (mirrors the tmux/direct `OpenStreamEntry` pattern).
@@ -84,29 +117,89 @@ export class WSConnection {
     return this.ws;
   }
 
+  /** Pending coalesced terminal output per session (session:output only), sent
+   *  as a single chunk on the next send once the buffer has drained. */
+  private coalescedOutput = new Map<string, string>();
+  private coalesceFlushTimer: ReturnType<typeof setTimeout> | null = null;
+
   /**
-   * Send a message to the client. Handles backpressure: if write buffer
-   * exceeds ~1MB, close with code 1009.
+   * Send a message to the client, handling backpressure WITHOUT killing the
+   * socket on ordinary write-buffer pressure (see the file-header regression
+   * note — this is the primary fix for the remote socket-cycling bug).
+   *
+   * Behaviour:
+   *  - Under `WS_SOFT_LIMIT` (1MB): send normally.
+   *  - Over `WS_SOFT_LIMIT` but under `WS_HARD_LIMIT` (50MB): coalesce lossy
+   *    `session:output` frames into a single chunk per session, and flush once
+   *    the buffer drains. Terminal scrollback is lossy-tolerant — tmux redraws
+   *    on resize/input — so dropping/merging it loses nothing the user can't
+   *    recover. All other (small, must-deliver) frames pass through.
+   *  - Over `WS_HARD_LIMIT`: the connection is beyond hope; only then close
+   *    with 1009. This mirrors the periodic check in `ws/server.ts`.
    */
   send(msg: ServerMessage): void {
     if (this.ws.readyState !== 1) { // 1 is WebSocket.OPEN
       return;
     }
-    const json = JSON.stringify(msg);
     const bufferSize = this.ws.bufferedAmount || 0;
 
-    // If write buffer is already large, reject to avoid pileup
-    if (bufferSize > 1_000_000) {
-      console.warn(`[WS] Write buffer exceeded 1MB (${bufferSize} bytes), closing connection`);
+    // Only close at the true hard limit — never on ordinary backpressure.
+    if (bufferSize > WS_HARD_LIMIT) {
+      console.warn(`[WS] Write buffer exceeded ${WS_HARD_LIMIT} bytes (${bufferSize}), closing connection`);
       this.ws.close(1009, "Message Too Big");
       return;
     }
 
-    this.ws.send(json, (err: Error | undefined) => {
+    // Backlog is high but not fatal: coalesce lossy terminal output so we
+    // don't queue an unbounded scrollback.
+    if (bufferSize > WS_SOFT_LIMIT && msg.type === "session:output") {
+      this.coalesceOutput(msg);
+      return;
+    }
+
+    this.flushCoalesced();
+    this.ws.send(JSON.stringify(msg), (err: Error | undefined) => {
       if (err) {
         console.error(`[WS] Send error:`, err);
       }
     });
+  }
+
+  /** Accumulate a `session:output` chunk into the coalesced buffer and
+   *  schedule a flush so a stall in new sends can't starve the terminal. */
+  private coalesceOutput(msg: Extract<ServerMessage, { type: "session:output" }>): void {
+    const existing = this.coalescedOutput.get(msg.sessionId) ?? "";
+    this.coalescedOutput.set(msg.sessionId, existing + msg.chunk);
+    // Bound the coalesced buffer itself so a runaway producer can't grow it
+    // without bound; flush it immediately rather than coalescing forever.
+    if (this.coalescedOutput.get(msg.sessionId)!.length > WS_SOFT_LIMIT) {
+      this.flushCoalesced();
+      return;
+    }
+    if (!this.coalesceFlushTimer) {
+      this.coalesceFlushTimer = setTimeout(() => {
+        this.coalesceFlushTimer = null;
+        this.flushCoalesced();
+      }, 100);
+    }
+  }
+
+  /** Send accumulated coalesced output as one frame per session, but only
+   *  once the socket has drained enough that we aren't immediately
+   *  re-backpressuring. */
+  private flushCoalesced(): void {
+    if (this.coalescedOutput.size === 0 || this.ws.readyState !== 1) return;
+    const bufferSize = this.ws.bufferedAmount || 0;
+    if (bufferSize > WS_SOFT_LIMIT) return; // still backed up — wait for the timer
+    for (const [sessionId, chunk] of this.coalescedOutput) {
+      this.ws.send(
+        JSON.stringify({ type: "session:output", sessionId, chunk }),
+        (err: Error | undefined) => {
+          if (err) console.error(`[WS] Send error:`, err);
+        },
+      );
+    }
+    this.coalescedOutput.clear();
   }
 
   /**
@@ -396,5 +489,13 @@ export class WSConnection {
     }
     this.treeWatches.clear();
     this.treeWatchDebt.clear();
+
+    // Drop any pending coalesced output — the socket is gone, there's nothing
+    // to flush to.
+    if (this.coalesceFlushTimer) {
+      clearTimeout(this.coalesceFlushTimer);
+      this.coalesceFlushTimer = null;
+    }
+    this.coalescedOutput.clear();
   }
 }

--- a/daemon/src/ws/handlers/chatOpen.ts
+++ b/daemon/src/ws/handlers/chatOpen.ts
@@ -104,6 +104,13 @@ export async function handleChatOpen(
 /**
  * Send the bounded `chat:replay`: a `sinceSeq` delta (reconnect) or the tail-N
  * window + `{ oldestSeq, hasMore }` cursor (fresh open). Reads live-or-disk.
+ *
+ * Socket-cycling fix: the `sinceSeq` delta is now a BOUNDED page (LIMIT in
+ * `sqliteTranscriptStore.since()`) carrying a `nextSeq`/`hasMore` cursor. It
+ * used to be the entire delta in one frame — over a real network a long-lived
+ * session's backlog blew past the WS hard limit and killed the socket, forever
+ * (see `connection.ts` header). The client pages toward the head by re-sending
+ * `chat:open` with the advanced `sinceSeq` while `hasMore` is true.
  */
 function sendSnapshot(
   conn: WSConnection,
@@ -112,7 +119,14 @@ function sendSnapshot(
   sinceSeq: number | undefined,
 ): void {
   if (sinceSeq !== undefined) {
-    conn.send({ type: "chat:replay", sessionId, events: readSessionSince(ctx, sinceSeq) });
+    const page = readSessionSince(ctx, sinceSeq);
+    conn.send({
+      type: "chat:replay",
+      sessionId,
+      events: page.events,
+      ...(page.nextSeq !== undefined ? { nextSeq: page.nextSeq } : {}),
+      hasMore: page.hasMore,
+    });
     return;
   }
   const page = readSessionTail(ctx, TAIL_TURNS);

--- a/daemon/src/ws/protocol.ts
+++ b/daemon/src/ws/protocol.ts
@@ -509,6 +509,12 @@ const ChatReplayEvent = z.object({
    *  event and whether older rows exist. Omitted on a `sinceSeq` delta replay. */
   oldestSeq: z.number().optional(),
   hasMore: z.boolean().optional(),
+  /** Forward-pagination cursor (socket-cycling fix): the `logSeq` of the LAST
+   *  event in `events`, set on a bounded `sinceSeq` delta replay. The client
+   *  passes it back as the next `sinceSeq` while `hasMore` is true, so a large
+   *  backlog is delivered in bounded frames instead of one oversized frame.
+   *  Omitted on a fresh tail snapshot. */
+  nextSeq: z.number().optional(),
 });
 
 const SessionMessageEvent = z.object({

--- a/daemon/src/ws/server.ts
+++ b/daemon/src/ws/server.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance, FastifyRequest } from "fastify";
 import type { WebSocket } from "@fastify/websocket";
 import fastifyWebsocket from "@fastify/websocket";
 import { ClientMessage } from "./protocol.js";
-import { WSConnection } from "./connection.js";
+import { WSConnection, WS_HARD_LIMIT } from "./connection.js";
 import { handleSubscribe, handleUnsubscribe } from "./handlers/subscribe.js";
 import { handlePing } from "./handlers/ping.js";
 import { handleSessionOpen } from "./handlers/sessionOpen.js";
@@ -15,7 +15,7 @@ import { handleTreeWatch } from "./handlers/treeWatch.js";
 import { handleTreeUnwatch } from "./handlers/treeUnwatch.js";
 import { handleDebugLog } from "./handlers/debugLog.js";
 import { handleChatOpen, handleChatClose } from "./handlers/chatOpen.js";
-import { registerConnection, unregisterConnection } from "../broadcaster.js";
+import { registerConnection, unregisterConnection, forEachConnection } from "../broadcaster.js";
 import { replayNavigateToConnection } from "../routes/open.js";
 import { COOKIE_NAME, verifyToken } from "../auth.js";
 import type { AuthState } from "../state/auth-state.js";
@@ -108,6 +108,41 @@ export async function registerWSEndpoint(app: FastifyInstance, authState?: AuthS
   // Ensure the websocket plugin is registered
   await app.register(fastifyWebsocket);
 
+  // Heartbeat (socket-cycling fix, Fix 5). Previously nothing ever sent a ping
+  // frame and `lastSeenAt` was never swept, so an idle socket could be silently
+  // dropped by a NAT / Tailscale / cloudflared tunnel middlebox and the client
+  // would reconnect — starting the cycling loop. Now:
+  //   - We send WS-level ping frames each tick so the `ws` library can detect
+  //     dead peers and the outbound traffic keeps tunnel mappings alive.
+  //   - We close connections whose `lastSeenAt` is stale (no app-level message,
+  //     including the client's 25s `{type:"ping"}`, for a long time). The client
+  //     heartbeat guarantees a healthy connection always has a fresh `lastSeenAt`,
+  //     so this only reaps genuinely dead sockets.
+  // The interval is `.unref()`d so it never holds the process (or a test) open,
+  // and cleared when the Fastify app closes.
+  const STALE_CONNECTION_MS = 120_000;
+  const HEARTBEAT_INTERVAL_MS = 30_000;
+  const heartbeatTimer = setInterval(() => {
+    forEachConnection((conn) => {
+      try {
+        conn.socket.ping();
+      } catch {
+        /* socket already closing */
+      }
+      if (Date.now() - conn.lastSeenAt > STALE_CONNECTION_MS) {
+        try {
+          conn.socket.close(1001, "Heartbeat timeout");
+        } catch {
+          /* already closed */
+        }
+      }
+    });
+  }, HEARTBEAT_INTERVAL_MS);
+  heartbeatTimer.unref();
+  app.addHook("onClose", async () => {
+    clearInterval(heartbeatTimer);
+  });
+
   app.get("/ws", { websocket: true }, (socket: WebSocket, req) => {
     // Auth gate — reject before registering the connection
     const authResult = authenticateWS(req, authState);
@@ -129,12 +164,14 @@ export async function registerWSEndpoint(app: FastifyInstance, authState?: AuthS
     replayNavigateToConnection(conn);
 
     // Monitor buffered amount for backpressure. The hard close threshold is
-    // intentionally very generous (50MB) — terminal scrollback replay across
-    // many subscribed sessions can briefly buffer multiple MB at once and we
-    // don't want to kill the connection over transient pressure. We also poll
-    // periodically instead of only on the next session:input, so a truly
-    // runaway producer is bounded even if the user isn't typing.
-    const HARD_LIMIT = 50 * 1024 * 1024;
+    // intentionally very generous (50MB, shared with `connection.send()`) —
+    // terminal scrollback replay across many subscribed sessions can briefly
+    // buffer multiple MB at once and we don't want to kill the connection over
+    // transient pressure. `connection.send()` now coalesces `session:output`
+    // past `WS_SOFT_LIMIT` instead of closing, so this periodic check is the
+    // backstop that bounds a truly runaway producer even if the user isn't
+    // typing (previously the 1MB check in `send()` ran first and killed the
+    // socket on every real-network burst — the socket-cycling regression).
     let lastWarnAt = 0;
     const checkBackpressure = () => {
       const buffered = socket.bufferedAmount || 0;
@@ -142,8 +179,8 @@ export async function registerWSEndpoint(app: FastifyInstance, authState?: AuthS
         console.warn(`[WS] Write buffer at ${(buffered / 1_048_576).toFixed(1)}MB`);
         lastWarnAt = Date.now();
       }
-      if (buffered > HARD_LIMIT) {
-        console.warn(`[WS] Write buffer exceeded ${HARD_LIMIT} bytes (${buffered}), closing connection`);
+      if (buffered > WS_HARD_LIMIT) {
+        console.warn(`[WS] Write buffer exceeded ${WS_HARD_LIMIT} bytes (${buffered}), closing connection`);
         socket.close(1009, "Message Too Big");
       }
     };

--- a/web-ui/src/api/client.test.ts
+++ b/web-ui/src/api/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createClientApi } from "./client";
 
 /** Creates a fake WebSocket class that auto-opens and records sent messages. */
@@ -93,5 +93,125 @@ describe("openChat / closeChat refcounting", () => {
 
     const closeMsgs = chatMsgsFor(sent, "chat:close", "sess-c");
     expect(closeMsgs).toHaveLength(1);
+  });
+});
+
+/**
+ * REGRESSION — remote socket cycling (see daemon `connection.ts` header).
+ * These tests pin the client-side fixes:
+ *  - the reconnect `sinceSeq` cursor advances from `chat:replay` (not just live
+ *    `session:message`), and the client pages a bounded `chat:replay` toward
+ *    the head while `hasMore` is true;
+ *  - the reconnect backoff is NOT reset on every `onopen` — only after the
+ *    connection has been stable for ~10s.
+ */
+describe("socket-cycling fixes (sinceSeq cursor + backoff)", () => {
+  /** Controllable WebSocket: lets the test fire onopen/onclose/onmessage by hand. */
+  function makeControllableWsFactory() {
+    const sent: string[] = [];
+    const sockets: Array<{
+      readyState: number;
+      onopen: (() => void) | null;
+      onclose: ((ev: { code: number }) => void) | null;
+      onerror: (() => void) | null;
+      onmessage: ((ev: { data: string }) => void) | null;
+      send: (d: string) => void;
+      close: () => void;
+    }> = [];
+    class FakeWebSocket {
+      static OPEN = 1;
+      static CONNECTING = 0;
+      readyState = 0;
+      onopen: (() => void) | null = null;
+      onclose: ((ev: { code: number }) => void) | null = null;
+      onerror: (() => void) | null = null;
+      onmessage: ((ev: { data: string }) => void) | null = null;
+      constructor(_url: string) {
+        sockets.push(this);
+      }
+      send(d: string) {
+        sent.push(d);
+      }
+      close() {
+        this.readyState = 3;
+        this.onclose?.({ code: 1000 });
+      }
+    }
+    return { FakeWebSocket, sockets, sent };
+  }
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("advances sinceSeq from a bounded chat:replay, pages while hasMore, and replays the delta on reconnect", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const { FakeWebSocket, sockets, sent } = makeControllableWsFactory();
+    vi.stubGlobal("WebSocket", FakeWebSocket);
+    const api = createClientApi();
+
+    api.startConnection();
+    sockets[0]!.readyState = 1;
+    sockets[0]!.onopen!();
+    await api.openChat("sess-x"); // fresh open — no sinceSeq
+    sent.splice(0);
+
+    // Server sends a bounded replay page with a forward cursor + hasMore.
+    sockets[0]!.onmessage!({
+      data: JSON.stringify({
+        type: "chat:replay",
+        sessionId: "sess-x",
+        events: [{ id: "e1", logSeq: 5 }, { id: "e2", logSeq: 7 }],
+        nextSeq: 7,
+        hasMore: true,
+      }),
+    });
+    // The client immediately pages: re-requests with the advanced cursor.
+    const pageReq = sent
+      .map((s) => JSON.parse(s) as Record<string, unknown>)
+      .find((m) => m.type === "chat:open" && m.sessionId === "sess-x");
+    expect(pageReq?.sinceSeq).toBe(7);
+
+    sent.splice(0);
+    // Drop and reconnect — the reconnect must replay the DELTA from seq 7, not
+    // the whole tail (otherwise the oversized delta would recur on every drop).
+    sockets[0]!.onclose!({ code: 1006 });
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(sockets.length).toBe(2);
+    sockets[1]!.readyState = 1;
+    sockets[1]!.onopen!();
+    const reOpen = sent
+      .map((s) => JSON.parse(s) as Record<string, unknown>)
+      .find((m) => m.type === "chat:open" && m.sessionId === "sess-x");
+    expect(reOpen?.sinceSeq).toBe(7);
+  });
+
+  it("does NOT reset the reconnect backoff on a reconnect onopen before ~10s stable", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const { FakeWebSocket, sockets } = makeControllableWsFactory();
+    vi.stubGlobal("WebSocket", FakeWebSocket);
+    const api = createClientApi();
+
+    api.startConnection();
+    sockets[0]!.readyState = 1;
+    sockets[0]!.onopen!();
+
+    // First drop: backoff 1000 -> 1700; reconnect waits ~1000ms.
+    sockets[0]!.onclose!({ code: 1006 });
+    await vi.advanceTimersByTimeAsync(1100);
+    expect(sockets.length).toBe(2);
+    sockets[1]!.readyState = 1;
+    sockets[1]!.onopen!(); // must NOT reset backoff to 1000 (the old bug)
+
+    // Second drop: if backoff had been reset to 1000 on onopen, the reconnect
+    // would fire at ~1000ms. With the fix it waits ~1700ms.
+    sockets[1]!.onclose!({ code: 1006 });
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(sockets.length).toBe(2); // reconnect not fired yet (backoff kept growing)
+    await vi.advanceTimersByTimeAsync(700);
+    expect(sockets.length).toBe(3); // fired at ~1700ms
   });
 });

--- a/web-ui/src/api/client.ts
+++ b/web-ui/src/api/client.ts
@@ -125,10 +125,16 @@ export type AuthEvent = { type: "auth:expired" };
 
 const INITIAL_BACKOFF_MS = 1000;
 const MAX_BACKOFF_MS = 15000;
+/** How long a connection must stay up (no reconnect) before the reconnect
+ *  backoff is reset to `INITIAL_BACKOFF_MS` (socket-cycling fix). */
+const STABLE_BACKOFF_RESET_MS = 10_000;
 
 export function createClientApi() {
   let ws: WebSocket | null = null;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Set when a socket opens; resets `backoffMs` once the connection has been
+   *  stable for `STABLE_BACKOFF_RESET_MS` (see `onopen`). Cleared on close. */
+  let stableTimer: ReturnType<typeof setTimeout> | null = null;
   let backoffMs = INITIAL_BACKOFF_MS;
   /** Ref-counted subs: multiple components can sub to the same sessionId without
    *  one cleanup tearing down the others. */
@@ -173,6 +179,59 @@ export function createClientApi() {
     if (typed) for (const h of typed) h(ev);
   }
 
+  /**
+   * Advance a chat subscription's stored `sinceSeq` cursor so a WS reconnect
+   * replays only the delta since the last event actually seen, and page a
+   * bounded `chat:replay` toward the head.
+   *
+   * REGRESSION — remote socket cycling (see the daemon's `connection.ts`
+   * header). The old code only advanced from a live `session:message` — and
+   * even then read the wrong field (`sm.logSeq` instead of `sm.event.logSeq`),
+   * so the cursor never moved. A reconnect therefore re-requested the SAME
+   * oversized delta forever; the daemon answered with an unbounded
+   * `chat:replay`, the write buffer passed 1MB, and the socket was closed 1009
+   * → reconnect → same replay. Two changes:
+   *   1. Advance from live `session:message.event.logSeq` (the correct field).
+   *   2. Advance from `chat:replay` too (max `logSeq` / `nextSeq`), and when the
+   *      daemon reports `hasMore`, request the next page with the advanced
+   *      cursor so a large backlog arrives in bounded frames.
+   */
+  function advanceSinceSeq(msg: WSEvent): void {
+    let sid: string | undefined;
+    let maxSeq = 0;
+    let more = false;
+
+    if (msg.type === "session:message" && msg.sessionId != null) {
+      sid = msg.sessionId;
+      const logSeq = (msg.event as { logSeq?: number } | undefined)?.logSeq;
+      if (typeof logSeq === "number") maxSeq = logSeq;
+    } else if (msg.type === "chat:replay" && msg.sessionId != null) {
+      sid = msg.sessionId;
+      for (const e of msg.events) {
+        if (typeof e.logSeq === "number" && e.logSeq > maxSeq) maxSeq = e.logSeq;
+      }
+      if (typeof msg.nextSeq === "number" && msg.nextSeq > maxSeq) maxSeq = msg.nextSeq;
+      more = msg.hasMore === true;
+    }
+
+    if (sid == null) return;
+
+    const entry = chatSubs.get(sid);
+    if (entry) {
+      const current = entry.sinceSeq ?? 0;
+      if (maxSeq > current) {
+        chatSubs.set(sid, { ...entry, sinceSeq: maxSeq });
+      }
+    }
+
+    // A bounded page still has more events beyond `nextSeq` — fetch the next
+    // page with the advanced cursor (paced by the network, so a huge backlog
+    // can never arrive as one oversized frame).
+    if (more && maxSeq > 0 && ws?.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: "chat:open", sessionId: sid, sinceSeq: maxSeq }));
+    }
+  }
+
   function ensureWs(): Promise<void> {
     if (ws?.readyState === WebSocket.OPEN) return Promise.resolve();
     if (wsReadyPromise) return wsReadyPromise;
@@ -198,29 +257,39 @@ export function createClientApi() {
           const msg = JSON.parse(String(ev.data)) as WSEvent & { type?: string };
           if (msg.type) {
             emit(msg as WSEvent);
-            // Fix 3: advance the stored sinceSeq cursor as live session:message
-            // events arrive so WS-reconnect uses the delta from the latest seen
-            // event rather than replaying everything since mount (unbounded replay
-            // regression introduced by snapshot-cache feature).
-            if (msg.type === "session:message") {
-              const sm = msg as unknown as { sessionId?: string; logSeq?: number };
-              if (sm.sessionId != null && sm.logSeq != null) {
-                const entry = chatSubs.get(sm.sessionId);
-                if (entry) {
-                  const current = entry.sinceSeq ?? 0;
-                  if (sm.logSeq > current) {
-                    chatSubs.set(sm.sessionId, { ...entry, sinceSeq: sm.logSeq });
-                  }
-                }
-              }
-            }
+            // REGRESSION — remote socket cycling (see daemon/src/ws/connection.ts
+            // header). The stored `sinceSeq` cursor must advance from BOTH live
+            // `session:message` events AND `chat:replay` frames, otherwise a
+            // reconnect re-requests the same oversized delta forever:
+            //
+            //  - The old code read `sm.logSeq` straight off the message, but a
+            //    `session:message` carries its cursor as `event.logSeq` — so live
+            //    advancement never fired either. Read `event.logSeq`.
+            //  - `chat:replay` was never consumed for cursor advancement, so a
+            //    failed/partial replay was re-requested identically on every
+            //    reconnect (the 1MB close → reconnect → same replay loop).
+            //  - `chat:replay` is now a bounded page carrying `nextSeq`/`hasMore`;
+            //    the client pages toward the head while `hasMore` is true instead
+            //    of asking for the whole backlog in one frame.
+            advanceSinceSeq(msg);
           }
         } catch {
           /* ignore */
         }
       };
       socket.onopen = () => {
-        backoffMs = INITIAL_BACKOFF_MS;
+        // REGRESSION — socket cycling: the backoff was reset to INITIAL_BACKOFF_MS
+        // here, so a connection that dropped and reconnected every ~1s never grew
+        // its backoff — it stayed a 1s strobe forever (handshake always succeeds,
+        // then the oversized chat:replay kills it again). Only reset the backoff
+        // after the connection has been stable for STABLE_BACKOFF_RESET_MS, so a
+        // genuinely failing connection backs off properly instead of hammering.
+        if (stableTimer) clearTimeout(stableTimer);
+        stableTimer = setTimeout(() => {
+          stableTimer = null;
+          // Only reset if this socket is still the live one (no reconnect since).
+          if (ws === socket) backoffMs = INITIAL_BACKOFF_MS;
+        }, STABLE_BACKOFF_RESET_MS);
         setConnState("online");
         if (subRefs.size > 0) {
           socket.send(JSON.stringify({ type: "subscribe", sessionIds: [...subRefs.keys()] }));
@@ -258,6 +327,10 @@ export function createClientApi() {
       };
       socket.onclose = (ev) => {
         if (ws === socket) ws = null;
+        if (stableTimer) {
+          clearTimeout(stableTimer);
+          stableTimer = null;
+        }
         wsReadyPromise = null;
         setConnState("offline");
         // Code 4401 = daemon rejected the WS connection due to expired/missing
@@ -1257,6 +1330,19 @@ export function createClientApi() {
       };
     },
   };
+
+  // Heartbeat (socket-cycling fix, Fix 5): send an app-level `{type:"ping"}`
+  // every ~25s. The daemon replies `pong` and, more importantly, refreshes this
+  // connection's `lastSeenAt` so its stale-connection sweep doesn't kill an
+  // otherwise-healthy socket. Regular outbound traffic also keeps NAT /
+  // Tailscale / cloudflared tunnel mappings alive, preventing the idle drops
+  // that used to start the whole cycling loop.
+  const PING_INTERVAL_MS = 25_000;
+  setInterval(() => {
+    if (ws?.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: "ping" }));
+    }
+  }, PING_INTERVAL_MS);
 
   return api;
 }

--- a/web-ui/src/api/mock.ts
+++ b/web-ui/src/api/mock.ts
@@ -1274,7 +1274,16 @@ export function createMockApi() {
       const events = chatTranscripts.get(sessionId) ?? [];
       if (sinceSeq !== undefined) {
         const delta = events.filter((e) => (e.logSeq ?? -1) > sinceSeq);
-        emit({ type: "chat:replay", sessionId, events: structuredClone(delta) });
+        // Mirror the bounded forward page + cursor (socket-cycling fix): the
+        // mock replays the whole delta but reports no more pages.
+        const nextSeq = delta.length ? delta[delta.length - 1]!.logSeq : undefined;
+        emit({
+          type: "chat:replay",
+          sessionId,
+          events: structuredClone(delta),
+          ...(nextSeq !== undefined ? { nextSeq } : {}),
+          hasMore: false,
+        });
         return;
       }
       // Bounded tail cursor mirror: the mock has no turn indexing, so replay all

--- a/web-ui/src/api/types.ts
+++ b/web-ui/src/api/types.ts
@@ -501,6 +501,10 @@ export type WSEvent =
       oldestSeq?: number;
       /** True when older rows exist before `oldestSeq`. */
       hasMore?: boolean;
+      /** Forward-pagination cursor (socket-cycling fix): `logSeq` of the LAST
+       *  event in `events`, set on a bounded `sinceSeq` delta replay. The client
+       *  passes it back as the next `sinceSeq` while `hasMore` is true. */
+      nextSeq?: number;
     }
   | {
       /** JSON agent chat: one live normalized event. */


### PR DESCRIPTION
## Summary

Fixes the remote WebSocket socket-cycling bug (connections repeatedly connect/disconnect on LAN/Tailscale/tunnel).

## Root cause

`daemon/src/ws/connection.ts` `send()` hard-closed the socket with code 1009 once `bufferedAmount` passed 1MB. On loopback this never fires; over any real network the reconnect replay burst queues past 1MB instantly, killing the socket. Reconnect replays the same oversized burst → killed again → forever. Live proof: 1,836,130 occurrences of "[WS] Write buffer exceeded 1MB, closing connection" in `~/.vibe-station/logs/daemon.log` with identical byte counts.

## Fixes

1. **Backpressure (`connection.ts`)** — `send()` no longer closes on ordinary pressure. It coalesces lossy `session:output` frames past a shared 1MB soft limit and only closes at the real 50MB `HARD_LIMIT` (now a shared constant with `ws/server.ts`).
2. **Bounded replay (`sqliteTranscriptStore.since()`)** — now `LIMIT`-bounded (`SINCE_PAGE_SIZE`) and returns a `nextSeq`/`hasMore` forward cursor, so a reconnect delta is a bounded frame the client pages toward the head instead of one oversized frame.
3. **Client cursor advancement (`client.ts`)** — advances the stored `sinceSeq` from `chat:replay` (max `logSeq`/`nextSeq`) AND from the correct `session:message.event.logSeq` field (the old code read the wrong field, so it never advanced), and re-requests the next page while `hasMore` is true. A failed/partial replay is never re-requested identically.
4. **Backoff (`client.ts`)** — no longer resets on every `onopen`; only after the connection has been stable ~10s, so a failing connection backs off properly instead of 1s-strobing.
5. **Heartbeat** — client sends `{type:ping}` every 25s; daemon sends WS ping frames and sweeps stale `lastSeenAt` connections, preventing idle drops on NAT/Tailscale/cloudflared tunnels.

## Tests

- `connection.send` backpressure: no close at soft limit, coalescing of `session:output`, close only at `HARD_LIMIT`, flush-on-drain.
- `sqliteTranscriptStore.since()`: LIMIT respected + `nextSeq`/`hasMore` pagination cursor.
- Client: `sinceSeq` advances from `chat:replay` + pagination + delta replay on reconnect; backoff not reset before ~10s stable.

Note: `jsonAgent.test.ts` and several web-ui component test failures observed in this worktree are pre-existing on the base branch (verified via stash) and unrelated to these changes.