### PR TITLE
fix(ui): preserve chat history across tab switches (always-portal panes)

### DIFF
--- a/web-ui/src/components/layout/PaneHostLayer.tsx
+++ b/web-ui/src/components/layout/PaneHostLayer.tsx
@@ -1,5 +1,6 @@
 import { createPortal } from "react-dom";
 import type { ReactNode } from "react";
+import { useState } from "react";
 import { usePaneOutletElement } from "./paneOutlets";
 
 /**
@@ -52,14 +53,28 @@ export function PaneHostLayer({ paneKeys, renderPane }: PaneHostLayerProps) {
 
 function PaneHostSlot({ paneKey, children }: { paneKey: PaneKey; children: ReactNode }) {
   const outlet = usePaneOutletElement(paneKey);
+  // `holder` is null for the very first render; the callback ref fires during
+  // commit and React batches the state update, so children appear before paint.
+  const [holder, setHolder] = useState<HTMLDivElement | null>(null);
 
-  // This div's position as a child of PaneHostLayer never changes shape
-  // based on paneKey content — only whether `outlet` is null flips between
-  // the offscreen class and portaling. React never remounts `children`
-  // (the actual pane) because of this; only the portal target changes.
+  // ALWAYS portal children — never switch between portaled and inline rendering.
+  //
+  // The old pattern `{outlet ? createPortal(children, outlet) : children}` looks
+  // like it preserves the pane, but it doesn't: React reconciles position-0 and
+  // sees either a Portal node ($$typeof: REACT_PORTAL_TYPE) or an AgentPaneSlot
+  // element ($$typeof: REACT_ELEMENT_TYPE) — different types → unmount + remount
+  // on every tab switch. That remounts ChatPane/useChat and wipes in-memory chat
+  // history, forcing "load earlier messages" after every tab toggle.
+  //
+  // By always calling createPortal we only change the *target* DOM node, never
+  // the React element type. React moves the portal's DOM without touching the
+  // React subtree, so useChat state survives tab switches intact.
   return (
-    <div className={outlet ? undefined : "pane-holder--offscreen"}>
-      {outlet ? createPortal(children, outlet) : children}
-    </div>
+    <>
+      {/* Offscreen holder: portal target when no outlet claims this pane.
+          Always hidden (display:none via the CSS class) so it never affects layout. */}
+      <div className="pane-holder--offscreen" ref={setHolder} />
+      {holder && createPortal(children, outlet ?? holder)}
+    </>
   );
 }


### PR DESCRIPTION
## Problem

When toggling between two Rich Chat agents in the same worktree, chat history was wiped on every switch — requiring the user to click **\"load earlier messages\"** each time.

The LRU snapshot cache was working, but only as a band-aid: it saves/restores up to 200 events, so long sessions always restore with `hasMore=true` and the button appears.

## Root cause

`PaneHostSlot` in `PaneHostLayer.tsx` was switching between:

```tsx
// outlet present → Portal node ($$typeof: REACT_PORTAL_TYPE)
createPortal(children, outlet)

// outlet absent → AgentPaneSlot element ($$typeof: REACT_ELEMENT_TYPE)
children
```

React's reconciler compares element types at the same fiber position. Portal and component are **different types** — so React unmounted one and mounted the other on every tab switch. This remounted `ChatPane`/`useChat` on every toggle, triggering the snapshot save/restore cycle and losing the full in-memory event list.

The existing comment ("React never remounts children because of this") was incorrect.

## Fix

Always call `createPortal`. Use a callback ref to capture an offscreen holder div as the fallback portal target when no outlet claims the pane. Tab switches only change the portal's DOM **target** (which React handles by moving DOM nodes without touching the React fiber), so `useChat` state — including the full loaded event list — survives tab switches intact.

```tsx
const [holder, setHolder] = useState<HTMLDivElement | null>(null);
return (
  <>
    <div className="pane-holder--offscreen" ref={setHolder} />
    {holder && createPortal(children, outlet ?? holder)}
  </>
);
```

## Verified by Opus review

- Portal type stability → fiber never remounts ✓
- TerminalPane ghost-stream invariant preserved (same mechanism fixes terminal sessions too) ✓
- Callback ref → synchronous re-render before paint, no flash ✓
- Offscreen div always-hidden is harmless when empty ✓
- No CSS layout or event-bubbling dependencies on the removed wrapper div ✓
- Multiple outlet token system (workspace canvas) unaffected ✓