### PR TITLE
fix(skills): follow symlinks when scanning skill directories

### DIFF
--- a/daemon/src/services/userSkillCatalog.ts
+++ b/daemon/src/services/userSkillCatalog.ts
@@ -16,7 +16,7 @@
  * (`~/.claude/skills`) avoids this, but the Skills settings UI does not block
  * the repo root either.
  */
-import { readdir, readFile } from "node:fs/promises";
+import { readdir, readFile, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { watch, type FSWatcher } from "chokidar";
 
@@ -130,8 +130,13 @@ export async function scanSkillDirectory(
   }
 
   for (const dirent of dirents) {
-    if (!dirent.isDirectory()) continue;
+    if (!dirent.isDirectory() && !dirent.isSymbolicLink()) continue;
     const skillDir = join(dir, dirent.name);
+    // stat() follows the symlink; skip entries that aren't actually directories.
+    if (dirent.isSymbolicLink()) {
+      const resolved = await stat(skillDir).catch(() => null);
+      if (!resolved?.isDirectory()) continue;
+    }
     const skillFile = join(skillDir, SKILL_FILE);
     let content: string;
     try {


### PR DESCRIPTION
## Summary

- `scanSkillDirectory` was skipping symlinked skill directories because `Dirent.isDirectory()` returns `false` for symlinks in Node.js, even when they point to directories
- Added a `stat()` follow for symlink entries to correctly pick them up
- This fixes `/vst` (and other symlinked skills: `android-coding`, `planning`, `prd`) not appearing in autocomplete for new agent dialogs and non-Claude rich-chat sessions (deepseek/opencode, cursor, agy)
- Claude sessions were unaffected because Claude's own ACP `available_commands_update` compensated for the missing dir-scan entry

## Root cause

`~/.claude/skills/vst` is a symlink (`lrwxrwxrwx`). The one-line guard `if (!dirent.isDirectory()) continue` silently skipped it. The fix adds `|| dirent.isSymbolicLink()` to the guard and a `stat()` call to confirm the target is a directory before processing it.

## Test plan

- [ ] `userSkillCatalog.test.ts` passes (13 tests, confirmed)
- [ ] `settingsRoutes.test.ts` passes (6 tests, confirmed)
- [ ] 2 pre-existing failures in `parent-flag.test.ts` and `jsonAgent.test.ts` are unrelated to this change (confirmed by running tests on main without this change)
- [ ] Verify `/vst` appears in new agent dialog autocomplete
- [ ] Verify `/vst` appears in deepseek/opencode rich-chat autocomplete