### PR TITLE
feat(ui): workspace UX polish — keyboard shortcuts, file tree focus, VCS improvements

### DIFF
--- a/.vibekit/feature-plans/pending/workspace-windows-button/plan-workspace-windows-button.md
+++ b/.vibekit/feature-plans/pending/workspace-windows-button/plan-workspace-windows-button.md
@@ -1,0 +1,295 @@
+<!--
+RULES — read before writing or implementing:
+1. FORMAT: Bullets, tables, code, diagrams ONLY — no prose paragraphs
+2. REQUIREMENTS: One crisp line each — no verbose descriptions
+3. CHECKLIST: Mark items [x] as you complete them — this is your persistent todo list
+4. READING TIME: Optimize for fast human scanning — if it's hard to skim, rewrite it
+-->
+
+# Plan: Workspace Windows Button — contextKey sessions + fragment search + canvas new-agent button
+
+> Fix the `+ Windows` picker missing sessions for the contextKey worktree in saved workspaces; ensure fragment-of-worktree-name search shows all windows; add a per-tile "New agent" button in canvas mode.
+
+**Issue:** vs-127
+**Branch:** `workspace-windows-button`
+**Status:** Implemented
+
+**Reference files:**
+- Route / props assembly: `web-ui/src/routes/Workspace.tsx`
+- Canvas + picker: `web-ui/src/components/layout/WorkspaceCanvas.tsx`
+- Dialog: `web-ui/src/components/dialogs/NewAgentTabDialog.tsx`
+- Button CSS: `web-ui/src/styles/workspace-canvas.css`
+
+---
+
+## Problem & Concept
+
+- Saved workspace "console home current" has "sounds" (ch-79) as its `contextKey` worktree (the worktree active when the workspace was saved)
+- `Workspace.tsx:472-473` always passes `agentSessions={[]}` and `terminalSessions={[]}` for the detached canvas — own-worktree picker section is always empty for detached view
+- `WorkspaceCanvas.tsx:510` also excludes the contextKey worktree from cross-context via `w.id !== worktreeId` — both picker paths are blind to it
+- Additionally, when search is active, `availableAgents`/`availableTerminals` only match session labels — typing the contextKey worktree's name doesn't surface its sessions
+
+## Out of Scope
+
+- Changing how `contextKey` is chosen when a workspace is saved
+- Done/exited worktree visibility in the picker
+- Archived session cleanup in the sessions filter
+
+## Requirements
+
+| # | Requirement |
+|---|-------------|
+| 1 | The contextKey worktree's sessions appear in the `+ Windows` picker for a saved/detached workspace |
+| 2 | Typing a fragment of the contextKey worktree's name shows all its sessions in the picker |
+| 3 | A `+` button appears on every agent canvas tile, to the left of the close button |
+| 4 | Clicking the `+` opens `NewAgentTabDialog` pre-seeded to that tile's worktree |
+| 5 | The created agent is added as a new tile to the current canvas |
+| 6 | The `+` button works in both detached saved-workspace view and per-worktree canvas |
+
+---
+
+## Change Map
+
+```
+web-ui/src/routes/
+  Workspace.tsx               ~ contextKey sessions passed to detached canvas (useMemo near line 308)
+web-ui/src/components/layout/
+  WorkspaceCanvas.tsx         ~ picker: contextKey name match for own-worktree search
+                              ~ tile chrome: add + button; dialog: lift out of isDetachedView guard
+web-ui/src/styles/
+  workspace-canvas.css        ~ append tile-newagent to existing button selector lists
+```
+
+| Today | After this plan |
+|-------|-----------------|
+| Detached canvas receives `agentSessions=[]`, `terminalSessions=[]` | Detached canvas receives real sessions for the contextKey worktree |
+| contextKey worktree's sessions invisible in `+ Windows` picker | contextKey worktree's sessions appear in the picker's own-worktree section |
+| Typing worktree name in search filters out sessions whose labels don't match | Typing contextKey worktree name shows all its sessions (mirrors cross-context `wtNameMatches` behavior) |
+| No per-tile affordance to spawn a sibling agent | `+` icon on each agent tile opens new-agent dialog for that tile's worktree |
+
+---
+
+## Research
+
+- `Workspace.tsx:301-308` — `worktreeAgentSessions` / `worktreeTerminalSessions` are `useMemo`s filtered by `worktreeId + type`; contextKey session memos must be placed alongside these (hooks can't follow conditional returns)
+- `Workspace.tsx:469-483` — detached canvas block; `agentSessions={[]}` line 472, `terminalSessions={[]}` line 473 — **root cause of issue 1**
+- `WorkspaceCanvas.tsx:455-461` — `matchesSearch` at 456; `availableAgents`/`availableTerminals` at 460-461 filter only `sessionLabel(s)` — no worktree-name match — **root cause of issue 2**
+- `WorkspaceCanvas.tsx:510` — `w.id !== worktreeId` excludes contextKey worktree from cross-context; `otherContextGroups` uses `wtNameMatches = matchesSearch(wtLabel)` at line 514 to surface all sessions when worktree name matches — the pattern to replicate in the own-worktree section
+- `WorkspaceCanvas.tsx:603` — `addTile(kind: TileKind, sessionId?: string, tileWorktreeId?: string)` — third arg already wired to `insertTileIntoCanvas`
+- `WorkspaceCanvas.tsx:919` — `session` is already in scope inside `renderTileChrome` via `sessionById.get(tile.sessionId)` — no need for `allSessions.find()`
+- `WorkspaceCanvas.tsx:1022-1039` — tile `...` menu button (guard: `tile.kind === "agent" && session`); insertion point for new `+` button is **line 1040** (before the 6-line comment block that precedes the close `<button>`)
+- `WorkspaceCanvas.tsx:1253` — picker's "New agent" item is itself guarded by `!isDetachedView`; `newAgentOpen` can never be `true` in detached view — moving dialog outside the guard is safe
+- `WorkspaceCanvas.tsx:1481-1489` — `NewAgentTabDialog` inside `{!isDetachedView ? ...}` today
+- `workspace-canvas.css:518-534` — `.workspace-canvas__tile-close` and `.workspace-canvas__tile-menu-trigger` share two existing rule blocks; append `.workspace-canvas__tile-newagent` to both selector lists rather than authoring a new block
+- **Pane mounting:** `detachedWorkspacePaneKeys` (Workspace.tsx:447-465) re-derives from `viewedWorkspace.tiles + live sessions`; per-worktree canvas includes foreign tiles (comment at 313-318) — no pane-host change needed for the new session tile
+
+---
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    subgraph "Workspace.tsx (detached branch)"
+        CKMemo["contextKeyAgentSessions\ncontextKeyTerminalSessions\n(new useMemos ~line 308)"]
+    end
+    subgraph "WorkspaceCanvas.tsx"
+        AvailAgents["availableAgents\n(+ contextKey name match)"]
+        Picker["+ Windows picker\nown-worktree section"]
+        TileChrome["renderTileChrome()"]
+        State["tileNewAgentWorktreeId\n(new state)"]
+        Dialog["NewAgentTabDialog\n(lifted out of !isDetachedView)"]
+    end
+
+    CKMemo -->|"agentSessions=\ncontextKeyAgentSessions"| AvailAgents
+    AvailAgents --> Picker
+    TileChrome -->|"+ button click\n(line 1040)"| State
+    State -->|"open=true\nworktreeId=tile's"| Dialog
+    Dialog -->|"onCreated(id)"| addTile["addTile('agent', id, tileWorktreeId)"]
+```
+
+---
+
+## Design Details
+
+### Critical User Journeys
+
+#### CUJ 1 — User finds contextKey worktree sessions in the picker
+
+```
+User opens saved workspace "console home current" (contextKey = ch-79 / "sounds")
+  → Clicks "+ Windows"
+  → Own-worktree section shows sounds' agent and terminal sessions
+  → User clicks a session → tile added to canvas
+```
+
+- **No sessions:** if sounds has no sessions the own-worktree section is empty — not a regression (same as per-worktree canvas today)
+
+#### CUJ 2 — Fragment search on contextKey worktree name
+
+```
+User opens "+ Windows"
+  → Types "sou" in search field
+  → contextKey worktree label "sounds" matches → ALL its agent + terminal sessions shown
+  → Other sessions whose labels don't match "sou" but whose worktree name does are still shown
+```
+
+#### CUJ 3 — Spawn sibling agent from a canvas tile
+
+```
+User in saved workspace, "sounds" tile visible in canvas
+  → Sees "+" button on tile header, left of the "X" close button
+  → Clicks "+"
+  → NewAgentTabDialog opens with sounds' worktreeId pre-set
+  → Chooses mode + prompt, submits
+  → New agent session created in sounds' worktree; new tile appears; dialog closes
+```
+
+- **Error path:** `api.createSession` fails → dialog shows error, tile NOT added
+
+### Key Decisions
+
+#### Decision 1: Place contextKey session `useMemo`s alongside `worktreeAgentSessions` in `Workspace.tsx`
+
+- **Decision:** Add two `useMemo`s after line 308, deps `[sessions, viewedWorkspace]`; compute sessions filtered by `s.worktreeId === viewedWorkspace?.contextKey`; pass to detached canvas
+- **Rationale:** Hooks must not follow conditional returns; `worktreeAgentSessions` at lines 301-308 is the established pattern; inline consts at line 469 would violate React's rules of hooks if placed after any early return — see Research § `Workspace.tsx:301-308`
+- **Where:** `web-ui/src/routes/Workspace.tsx:308` (insert after), `472-473` (replace `[]`)
+
+```tsx
+// After line 308 — same pattern as worktreeAgentSessions
+const contextKeyAgentSessions = useMemo(
+  () => sessions.filter((s) => s.worktreeId === viewedWorkspace?.contextKey && s.type === "agent"),
+  [sessions, viewedWorkspace],
+);
+const contextKeyTerminalSessions = useMemo(
+  () => sessions.filter((s) => s.worktreeId === viewedWorkspace?.contextKey && s.type === "terminal"),
+  [sessions, viewedWorkspace],
+);
+// Then at line 472: agentSessions={contextKeyAgentSessions}
+// At line 473: terminalSessions={contextKeyTerminalSessions}
+```
+
+#### Decision 2: Mirror `wtNameMatches` in `availableAgents`/`availableTerminals`
+
+- **Decision:** Look up the contextKey worktree's label from the `worktrees` prop; if the query matches the label, pass all `agentSessions`/`terminalSessions` instead of filtering by session label
+- **Rationale:** `otherContextGroups` does this at line 514 (`wtNameMatches`); the own-worktree section must match the same behavior — see Research § `WorkspaceCanvas.tsx:455-461`
+- **Where:** `web-ui/src/components/layout/WorkspaceCanvas.tsx:460-461`
+
+```tsx
+// Replace lines 460-461
+const contextKeyWorktree = worktrees.find((w) => w.id === worktreeId);
+const contextKeyLabel = contextKeyWorktree ? (contextKeyWorktree.name || contextKeyWorktree.branch) : "";
+const contextKeyNameMatches = matchesSearch(contextKeyLabel);
+const availableAgents = agentSessions.filter((s) => contextKeyNameMatches || matchesSearch(sessionLabel(s)));
+const availableTerminals = terminalSessions.filter((s) => contextKeyNameMatches || matchesSearch(sessionLabel(s)));
+```
+
+#### Decision 3: Single `NewAgentTabDialog` controlled by `tileNewAgentWorktreeId` state
+
+- **Decision:** Lift dialog outside `!isDetachedView`; add `tileNewAgentWorktreeId: string | null` state; pass `tileNewAgentWorktreeId ?? worktreeId` as `worktreeId`; `open = newAgentOpen || tileNewAgentWorktreeId != null`
+- **Rationale:** One dialog instance swapping `worktreeId` (same pattern as `tileMenu` portal); safe because `newAgentOpen` can never be `true` in detached view (picker's "New agent" item is itself behind `!isDetachedView` guard at line 1253) — see Research § `WorkspaceCanvas.tsx:1253`
+- **Where:** `WorkspaceCanvas.tsx:1481-1489`
+
+#### Decision 4: Use in-scope `session` in tile chrome; insert `+` at line 1040
+
+- **Decision:** `session` is already bound via `sessionById.get(tile.sessionId)` at line 919 — use `session?.worktreeId ?? worktreeId` directly; insert button at line 1040 (before the comment block, after the `}` closing the `...` menu at line 1039)
+- **Rationale:** `allSessions.find()` is redundant and slower; line 1040 is the correct gap — lines 1040-1045 are a comment belonging to the close button, not a separate element — see Research § `WorkspaceCanvas.tsx:919` and `1022-1039`
+- **Where:** `WorkspaceCanvas.tsx:1040` (insertion)
+
+#### Decision 5: Append `.workspace-canvas__tile-newagent` to existing CSS selector lists
+
+- **Decision:** Add selector to the two existing blocks at `workspace-canvas.css:518-519` and `532-534` rather than authoring a new rule block
+- **Rationale:** `.tile-close` and `.tile-menu-trigger` already share these blocks; adding a third selector is the minimal consistent change — see Research § `workspace-canvas.css:518-534`
+- **Where:** `web-ui/src/styles/workspace-canvas.css:518`, `532`
+
+---
+
+## Risks / Open Questions
+
+| # | Question | Notes |
+|---|----------|-------|
+| 1 | **contextKey worktree deleted?** | `sessions.filter(...)` returns `[]` safely; `worktrees.find(...)` returns undefined → `contextKeyLabel = ""` → `matchesSearch("")` only true when query is empty (always shows) — no crash |
+| 2 | **Draft key in dialog uses `worktreeId` — switching tiles clears draft?** | Acceptable; per-worktree draft by design (`draftKey = vst-newtab-draft-${worktreeId}`) |
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Fix contextKey sessions missing from detached canvas picker
+
+- [x] **1.1** In `Workspace.tsx` after line 308 (after `worktreeTerminalSessions` useMemo), add:
+  ```ts
+  const contextKeyAgentSessions = useMemo(
+    () => sessions.filter((s) => s.worktreeId === viewedWorkspace?.contextKey && s.type === "agent"),
+    [sessions, viewedWorkspace],
+  );
+  const contextKeyTerminalSessions = useMemo(
+    () => sessions.filter((s) => s.worktreeId === viewedWorkspace?.contextKey && s.type === "terminal"),
+    [sessions, viewedWorkspace],
+  );
+  ```
+- [x] **1.2** In `Workspace.tsx:472`, replace `agentSessions={[]}` with `agentSessions={contextKeyAgentSessions}`
+- [x] **1.3** In `Workspace.tsx:473`, replace `terminalSessions={[]}` with `terminalSessions={contextKeyTerminalSessions}`
+
+### Phase 2 — Fix fragment search for contextKey worktree name in own-worktree picker section
+
+- [x] **2.1** In `WorkspaceCanvas.tsx`, after the `matchesSearch` function definition (line 458), add:
+  ```ts
+  const contextKeyWorktree = worktrees.find((w) => w.id === worktreeId);
+  const contextKeyLabel = contextKeyWorktree ? (contextKeyWorktree.name || contextKeyWorktree.branch) : "";
+  const contextKeyNameMatches = matchesSearch(contextKeyLabel);
+  ```
+- [x] **2.2** Replace line 460 (`availableAgents`): `agentSessions.filter((s) => contextKeyNameMatches || matchesSearch(sessionLabel(s)))`
+- [x] **2.3** Replace line 461 (`availableTerminals`): `terminalSessions.filter((s) => contextKeyNameMatches || matchesSearch(sessionLabel(s)))`
+
+**Verify phases 1 + 2:**
+- [x] **1.T1** Manual — open dev sandbox, navigate to a saved workspace whose contextKey worktree has sessions; confirm those sessions appear in `+ Windows` own-worktree section
+- [x] **1.T2** Manual — type a fragment of the contextKey worktree's name; confirm all its sessions appear (not filtered to label matches only)
+- [x] **1.T3** Regression — per-worktree canvas (scratch, no `detachedWorkspaceId`) still shows own-worktree sessions correctly
+- [x] **1.T4** Regression — cross-context worktrees still appear in picker for saved workspaces
+- [x] **1.T5** Regression — typing a session label still filters correctly when no worktree name matches
+
+---
+
+### Phase 3 — Per-tile "New agent" button
+
+- [x] **3.1** Add `const [tileNewAgentWorktreeId, setTileNewAgentWorktreeId] = useState<string | null>(null)` to `WorkspaceCanvas`
+- [x] **3.2** At `WorkspaceCanvas.tsx:1040` (immediately after the closing `}` of the `...` menu button block at line 1039), insert for `tile.kind === "agent" && session` tiles:
+  ```tsx
+  {tile.kind === "agent" && session ? (
+    <button
+      type="button"
+      className="workspace-canvas__tile-newagent"
+      title="New agent in same worktree"
+      onPointerDown={(e) => e.stopPropagation()}
+      onClick={(e) => {
+        e.stopPropagation();
+        setTileNewAgentWorktreeId(session.worktreeId ?? worktreeId);
+      }}
+    >
+      <Plus size={13} />
+    </button>
+  ) : null}
+  ```
+- [x] **3.3** Move `NewAgentTabDialog` outside the `!isDetachedView` guard (currently line 1481); render it unconditionally
+- [x] **3.4** Change `open` prop to `newAgentOpen || tileNewAgentWorktreeId != null`
+- [x] **3.5** Change `worktreeId` prop to `tileNewAgentWorktreeId ?? worktreeId`
+- [x] **3.6** Update `onClose` to `() => { setNewAgentOpen(false); setTileNewAgentWorktreeId(null); }`
+- [x] **3.7** Update `onCreated` to `(sessionId) => { addTile("agent", sessionId, tileNewAgentWorktreeId ?? undefined); setTileNewAgentWorktreeId(null); }`
+- [x] **3.8** In `workspace-canvas.css:518`, change selector block opening from `.workspace-canvas__tile-close,\n.workspace-canvas__tile-menu-trigger {` to add `.workspace-canvas__tile-newagent` as a third selector
+- [x] **3.9** In `workspace-canvas.css:532-534`, add `.workspace-canvas__tile-newagent:hover` to the hover/expanded rule block
+
+**Verify phase 3:**
+- [x] **3.T1** Manual — in own-worktree canvas, `+` button appears on agent tiles to the left of `X`; absent on terminal and tools tiles
+- [x] **3.T2** Manual — click `+` on own-worktree tile; dialog opens; create agent; new tile appears in canvas
+- [x] **3.T3** Manual — in saved workspace, click `+` on a cross-worktree tile; new agent created in THAT worktree
+- [x] **3.T4** Regression — `X` (close) still removes tile; fullscreen toggle still works; `...` menu still opens agent actions
+
+---
+
+## Files & Phase Impact
+
+| File | Status | Phase | Description / Contract Change |
+|------|--------|-------|-------------------------------|
+| `web-ui/src/routes/Workspace.tsx` | **Modified** | 1.1–1.3 | Two new `useMemo`s after line 308 for contextKey agent/terminal sessions; replace `agentSessions={[]}` and `terminalSessions={[]}` at 472-473 |
+| `web-ui/src/components/layout/WorkspaceCanvas.tsx` | **Modified** | 2.1–2.3, 3.1–3.7 | Phase 2: `contextKeyWorktree` lookup + `contextKeyNameMatches` added to `availableAgents`/`availableTerminals` filter. Phase 3: `tileNewAgentWorktreeId` state; `+` button in tile chrome at line 1040; `NewAgentTabDialog` lifted out of `!isDetachedView`; `open`, `worktreeId`, `onClose`, `onCreated` updated |
+| `web-ui/src/styles/workspace-canvas.css` | **Modified** | 3.8–3.9 | `.workspace-canvas__tile-newagent` appended to existing selector lists at lines 518 and 532 |

--- a/web-ui/src/components/layout/ChangedFileList.tsx
+++ b/web-ui/src/components/layout/ChangedFileList.tsx
@@ -123,22 +123,23 @@ export function ChangedFileList({ entries, loading, error, controlled }: Changed
   const { cursorPath, setCursorPath, handleKeyDown, isTabbable } = useRovingListNav(rovingRows, {
     onOpen: selectFile,
     openOnArrow: true,
+    initialCursor: activePath,
   });
 
-  if (error) {
-    return <div className="changed-file-list-empty">Error: {error}</div>;
-  }
-
-  if (loading && flatFiles.length === 0) {
-    return <div className="changed-file-list-empty">Loading changes…</div>;
-  }
-
-  if (flatFiles.length === 0) {
-    return <div className="changed-file-list-empty">No changed files</div>;
-  }
-
   return (
-    <div className="changed-file-list" role="tree" aria-label="Changed files">
+    <div
+      className="changed-file-list"
+      role="tree"
+      aria-label="Changed files"
+      tabIndex={-1}
+    >
+      {error ? (
+        <div className="changed-file-list-empty">Error: {error}</div>
+      ) : loading && flatFiles.length === 0 ? (
+        <div className="changed-file-list-empty">Loading changes…</div>
+      ) : flatFiles.length === 0 ? (
+        <div className="changed-file-list-empty">No changed files</div>
+      ) : null}
       {groups.map((group) => {
         const isCollapsed = collapsedDirs.has(group.dir);
         const dirLabel = group.dir || "(root)";

--- a/web-ui/src/components/layout/FileTreeSidebar.tsx
+++ b/web-ui/src/components/layout/FileTreeSidebar.tsx
@@ -140,6 +140,7 @@ export function FileTreeSidebar({ api, contextId, scope: fileScope = "worktree" 
   const [branchError, setBranchError] = useState<string | null>(null);
   const { lastChanged } = useTreeWatch(api, activeWorktreeId, fileScope);
   const rowRefs = useRef(new Map<string, HTMLDivElement>());
+  const treeHasFocusRef = useRef(false);
 
   const diffMode = scope !== "none";
   // Which local/branch scope currently drives the PLAIN tree's per-file
@@ -398,8 +399,22 @@ export function FileTreeSidebar({ api, contextId, scope: fileScope = "worktree" 
   // Keep DOM focus following the roving cursor so subsequent key events land
   // on the cursored row without the caller needing to manage focus itself.
   useEffect(() => {
-    if (cursorPath) rowRefs.current.get(cursorPath)?.focus();
+    if (cursorPath && treeHasFocusRef.current) {
+      rowRefs.current.get(cursorPath)?.focus();
+    }
   }, [cursorPath]);
+
+  // Seed the roving cursor to the active file once the tree data loads,
+  // so arrow keys resume from the open file rather than row 0.
+  // Must not call .focus() here — focus stealing is handled conditionally
+  // in the effect above and in onFocusCapture.
+  useEffect(() => {
+    if (cursorPath !== null || !activeFilePath) return;
+    if (visibleRows.some((r) => r.path === activeFilePath)) {
+      setCursorPath(activeFilePath);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visibleRows, activeFilePath]);
 
   function setScope(next: DiffScope) {
     if (activeWorktreeId) setDiffScopeForWorktree(activeWorktreeId, next);
@@ -484,7 +499,24 @@ export function FileTreeSidebar({ api, contextId, scope: fileScope = "worktree" 
         }
         tabIndex={-1}
         onKeyDown={handleKeyDown}
-        onFocusCapture={() => setFocusedPane("file-tree")}
+        onFocusCapture={() => {
+          setFocusedPane("file-tree");
+          treeHasFocusRef.current = true;
+          // If the cursor was pre-seeded while the tree was out of focus
+          // (rows loaded after focus left), move DOM focus there now.
+          if (cursorPath) {
+            const el = rowRefs.current.get(cursorPath);
+            if (el && el !== document.activeElement) {
+              el.focus({ preventScroll: true });
+            }
+          }
+        }}
+        onBlurCapture={(e) => {
+          // Clear focus flag only when focus leaves the tree entirely.
+          if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+            treeHasFocusRef.current = false;
+          }
+        }}
       >
         <div style={{ minWidth: "max-content" }}>
           {!diffMode && (effectiveTreeScope === "branch" ? branchLoading : localLoading) ? (

--- a/web-ui/src/components/layout/KeyboardShortcutsDialog.tsx
+++ b/web-ui/src/components/layout/KeyboardShortcutsDialog.tsx
@@ -1,0 +1,106 @@
+import { Fragment } from "react";
+import { Dialog } from "@/components/dialogs/Dialog";
+import "@/styles/keyboard-shortcuts-dialog.css";
+
+interface KeyboardShortcutsDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+interface ShortcutDef {
+  keys: string[];
+  action: string;
+}
+
+interface ShortcutGroup {
+  title: string;
+  shortcuts: ShortcutDef[];
+}
+
+/** True on macOS so we can show ⌘/⌥ glyphs instead of Ctrl/Alt. */
+function isMac(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return /Mac|iPhone|iPod|iPad/i.test(navigator.platform ?? navigator.userAgent);
+}
+
+/** Render a shortcut as its platform-aware key combos. */
+function KeyCombo({ combo }: { combo: string }) {
+  const mac = isMac();
+  const modMap: Record<string, string> = mac
+    ? { Ctrl: "⌘", Shift: "⇧", Alt: "⌥" }
+    : { Cmd: "Ctrl" };
+  const parts = combo.split("+").map((part) => modMap[part] ?? part);
+  return (
+    <span className="shortcut-dialog__combo-parts">
+      {parts.map((part, i) => (
+        <span key={i} className="shortcut-dialog__combo-part">
+          {i > 0 && <span className="shortcut-dialog__combo-sep">+</span>}
+          <kbd className="shortcut-dialog__kbd">{part}</kbd>
+        </span>
+      ))}
+    </span>
+  );
+}
+
+const GROUPS: ShortcutGroup[] = [
+  {
+    title: "Navigation",
+    shortcuts: [
+      { keys: ["Ctrl+P"], action: "Quick-open files" },
+      { keys: ["Ctrl+Shift+F"], action: "Files tab" },
+    ],
+  },
+  {
+    title: "Layout",
+    shortcuts: [
+      { keys: ["Ctrl+B", "Ctrl+\\"], action: "Toggle tool panel" },
+      { keys: ["Ctrl+E"], action: "Toggle file tree" },
+      { keys: ["Ctrl+/"], action: "Toggle split orientation" },
+      { keys: ["Ctrl+Shift+Z"], action: "Toggle terminal dock" },
+    ],
+  },
+  {
+    title: "Agents & Worktrees",
+    shortcuts: [
+      { keys: ["Alt+N"], action: "New agent" },
+      { keys: ["Alt+Shift+N"], action: "New worktree" },
+      { keys: ["Ctrl+Shift+G"], action: "New agent" },
+      { keys: ["Ctrl+Shift+M"], action: "New worktree" },
+    ],
+  },
+];
+
+export function KeyboardShortcutsDialog({ open, onClose }: KeyboardShortcutsDialogProps) {
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title="Keyboard shortcuts"
+      cardClassName="dialog-card--shortcuts"
+    >
+      <div className="shortcut-dialog__groups">
+        {GROUPS.map((group) => (
+          <Fragment key={group.title}>
+            <div className="shortcut-dialog__group-title">{group.title}</div>
+            <table className="shortcut-dialog__table">
+              <tbody>
+                {group.shortcuts.map((sc, i) => (
+                  <tr key={i}>
+                    <td className="shortcut-dialog__action">{sc.action}</td>
+                    <td className="shortcut-dialog__keys">
+                      <span className="shortcut-dialog__combo-list">
+                        {sc.keys.map((k) => (
+                          <KeyCombo key={k} combo={k} />
+                        ))}
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </Fragment>
+        ))}
+      </div>
+    </Dialog>
+  );
+}

--- a/web-ui/src/components/layout/MasterDetailShell.tsx
+++ b/web-ui/src/components/layout/MasterDetailShell.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from "react";
+import { type ReactNode, useCallback, useEffect, useRef } from "react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { Columns2, FolderTree, Rows2 } from "lucide-react";
 import { DEFAULT_WORKTREE_LAYOUT, useWorkspaceStore } from "@/hooks/useStore";
@@ -19,6 +19,11 @@ interface MasterDetailShellProps {
    *  zoom controls for the Files tab; a "Commits › commit #x" breadcrumb for
    *  the VCS commit view). */
   topbarExtra?: ReactNode;
+  /** When true, focus the tree on mount (used by VcsCommitView so arrow keys
+   *  work immediately when a commit opens). Deliberately distinct from the
+   *  `treeVisible` effect, which skips the first render to avoid stealing
+   *  focus from the agent when the tool pane first opens. */
+  autoFocusTree?: boolean;
 }
 
 /**
@@ -33,7 +38,9 @@ interface MasterDetailShellProps {
  * preference, not per-content state, unlike the `controlled` overrides
  * `FilePreviewPane`/`ChangedFileList` need (Decision 6).
  */
-export function MasterDetailShell({ storageKey, worktreeId, treeToggle = true, leftPane, rightPane, topbarExtra }: MasterDetailShellProps) {
+export function MasterDetailShell({ storageKey, worktreeId, treeToggle = true, leftPane, rightPane, topbarExtra, autoFocusTree = false }: MasterDetailShellProps) {
+  const leftPaneRef = useRef<HTMLDivElement>(null);
+  const isFirstRender = useRef(true);
   const treeVisible = useWorkspaceStore((s) => s.fileTreeVisible);
   const toggleFileTree = useWorkspaceStore((s) => s.toggleFileTree);
   const layoutByWorktree = useWorkspaceStore((s) => s.layoutByWorktree);
@@ -41,6 +48,55 @@ export function MasterDetailShell({ storageKey, worktreeId, treeToggle = true, l
   const vertical = worktreeId
     ? !!(layoutByWorktree[worktreeId] ?? DEFAULT_WORKTREE_LAYOUT).masterDetailVertical
     : false;
+
+  const handleRightPanePointerDown = useCallback((e: React.PointerEvent) => {
+    // Walk the composed path — if any ancestor is interactive, let it be.
+    const interactiveTags = new Set(["BUTTON", "INPUT", "A", "TEXTAREA", "SELECT"]);
+    const path = e.nativeEvent.composedPath() as Element[];
+    if (path.some((el) => interactiveTags.has(el?.tagName) || (el as HTMLElement)?.isContentEditable)) return;
+    // Exempt preview bodies — clicking to select text in a rendered preview
+    // (code block, scroller, preview body) must not redirect arrow-key focus
+    // to the file tree, or ArrowDown would open a different file mid-select.
+    if ((e.target as Element).closest("pre, .cm-scroller, .preview-body, .workspace-markdown-preview, [data-no-tree-focus]")) return;
+    // Re-focus the file tree container after the browser settles focus.
+    requestAnimationFrame(() => {
+      // Prefer the roving-tabindex winner; fall back to any [tabindex] for the
+      // async case where no row is tabbable yet (the container div catches it).
+      const focusable =
+        leftPaneRef.current?.querySelector<HTMLElement>("[tabindex='0']") ??
+        leftPaneRef.current?.querySelector<HTMLElement>("[tabindex]");
+      focusable?.focus({ preventScroll: true });
+    });
+  }, []);
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    if (!treeVisible) return;
+    requestAnimationFrame(() => {
+      // Prefer the roving-tabindex winner; fall back to any [tabindex] for the
+      // async case where no row is tabbable yet (the container div catches it).
+      const focusable =
+        leftPaneRef.current?.querySelector<HTMLElement>("[tabindex='0']") ??
+        leftPaneRef.current?.querySelector<HTMLElement>("[tabindex]");
+      focusable?.focus({ preventScroll: true });
+    });
+  }, [treeVisible]);
+
+  useEffect(() => {
+    if (!autoFocusTree || !treeVisible) return;
+    requestAnimationFrame(() => {
+      // Prefer the roving-tabindex winner; fall back to any [tabindex] for the
+      // async case where no row is tabbable yet (the container div catches it).
+      const focusable =
+        leftPaneRef.current?.querySelector<HTMLElement>("[tabindex='0']") ??
+        leftPaneRef.current?.querySelector<HTMLElement>("[tabindex]");
+      focusable?.focus({ preventScroll: true });
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div className="files-panel">
@@ -79,15 +135,17 @@ export function MasterDetailShell({ storageKey, worktreeId, treeToggle = true, l
           style={{ width: "100%", flex: 1, minHeight: 0 }}
         >
           <Panel defaultSize={vertical ? 40 : 34} minSize={16} maxSize={60}>
-            <div className="pane-fill-host">{leftPane}</div>
+            <div className="pane-fill-host" ref={leftPaneRef}>{leftPane}</div>
           </Panel>
           <PanelResizeHandle className={vertical ? "resize-handle resize-handle--row" : "resize-handle resize-handle--col"} />
           <Panel defaultSize={vertical ? 60 : 66} minSize={30}>
-            {rightPane}
+            <div style={{ width: "100%", height: "100%" }} onPointerDownCapture={handleRightPanePointerDown}>
+              {rightPane}
+            </div>
           </Panel>
         </PanelGroup>
       ) : (
-        <div className="files-panel__preview-only">{rightPane}</div>
+        <div className="files-panel__preview-only" onPointerDownCapture={handleRightPanePointerDown}>{rightPane}</div>
       )}
     </div>
   );

--- a/web-ui/src/components/layout/TerminalPane.tsx
+++ b/web-ui/src/components/layout/TerminalPane.tsx
@@ -206,12 +206,17 @@ export function TerminalPane({ api, sessionId, session, channelToggle }: Termina
     term.focus();
     term.attachCustomKeyEventHandler((domEvent) => {
       const mod = domEvent.ctrlKey || domEvent.metaKey;
-      if (mod && !domEvent.shiftKey && domEvent.key.toLowerCase() === "p") {
-        return false;
+      if (mod && !domEvent.shiftKey) {
+        const k = domEvent.key.toLowerCase();
+        // Let app-level shortcuts (useWorkspaceKeyboardShortcuts) handle these
+        // instead of forwarding them to the PTY.
+        if (k === "p" || k === "b" || k === "e" || domEvent.key === "\\" || domEvent.key === "/") {
+          return false;
+        }
       }
       if (mod && domEvent.shiftKey) {
         const k = domEvent.key.length === 1 ? domEvent.key.toUpperCase() : domEvent.key;
-        if (k === "F" || k === "P" || k === "Z") {
+        if (k === "F" || k === "P" || k === "Z" || k === "G" || k === "M") {
           return false;
         }
       }

--- a/web-ui/src/components/layout/TopBar.tsx
+++ b/web-ui/src/components/layout/TopBar.tsx
@@ -3,6 +3,7 @@ import {
   ChevronDown,
   ChevronUp,
   Columns2,
+  Keyboard,
   LayoutGrid,
   MoreHorizontal,
   PanelLeft,
@@ -20,22 +21,35 @@ import type { Project, Session, Worktree } from "@/api/types";
 import { sessionLabel } from "@/lib/sessionLabel";
 import { ConnectionStatus } from "@/components/layout/ConnectionStatus";
 import { Logo } from "@/components/shared/Logo";
+import { KeyboardShortcutsDialog } from "@/components/layout/KeyboardShortcutsDialog";
 import { ToolbarOutlet, WORKSPACE_CANVAS_TOOLBAR_KEY } from "@/components/layout/paneOutlets";
 
 function shortcutHints() {
   if (typeof navigator === "undefined") {
-    return { fileTree: "⌘⇧F", preview: "⌘⇧P", terminal: "⌘⇧Z", quickOpen: "⌘P", toolPane: "⌘\\" };
+    return {
+      terminal: "⌘⇧Z",
+      quickOpen: "⌘P",
+      toolPane: "⌘\\",
+      fileTreeToggle: "⌘E",
+      splitToggle: "⌘/",
+    };
   }
   const mac = /Mac|iPhone|iPod|iPad/i.test(navigator.platform ?? navigator.userAgent);
   if (mac) {
-    return { fileTree: "⌘⇧F", preview: "⌘⇧P", terminal: "⌘⇧Z", quickOpen: "⌘P", toolPane: "⌘\\" };
+    return {
+      terminal: "⌘⇧Z",
+      quickOpen: "⌘P",
+      toolPane: "⌘\\",
+      fileTreeToggle: "⌘E",
+      splitToggle: "⌘/",
+    };
   }
   return {
-    fileTree: "Ctrl+Shift+F",
-    preview: "Ctrl+Shift+P",
     terminal: "Ctrl+Shift+Z",
     quickOpen: "Ctrl+P",
     toolPane: "Ctrl+\\",
+    fileTreeToggle: "Ctrl+E",
+    splitToggle: "Ctrl+/",
   };
 }
 
@@ -65,6 +79,10 @@ interface TopBarProps {
   settingsSectionLabel?: string;
   /** Mobile settings drill-in: back to section list */
   onSettingsBack?: () => void;
+  /** Keyboard-shortcuts reference dialog — controlled by the parent. */
+  shortcutsOpen?: boolean;
+  onOpenShortcuts?: () => void;
+  onCloseShortcuts?: () => void;
 }
 
 export function TopBar({
@@ -81,6 +99,9 @@ export function TopBar({
   onOpenQuickOpen,
   settingsSectionLabel,
   onSettingsBack,
+  shortcutsOpen = false,
+  onOpenShortcuts,
+  onCloseShortcuts,
 }: TopBarProps) {
   const {
     activeProjectId,
@@ -299,16 +320,29 @@ export function TopBar({
         ) : null}
         <ConnectionStatus />
         {layoutMode !== "workspace" && layoutMode !== "direct-session" ? (
-          <button
-            type="button"
-            className="icon-btn"
-            aria-label="Settings"
-            title="Settings"
-            aria-current={layoutMode === "settings" ? "page" : undefined}
-            onClick={() => navigate("/settings")}
-          >
-            <Settings size={18} />
-          </button>
+          <>
+            {onOpenShortcuts ? (
+              <button
+                type="button"
+                className="icon-btn"
+                aria-label="Keyboard shortcuts"
+                title="Keyboard shortcuts"
+                onClick={onOpenShortcuts}
+              >
+                <Keyboard size={18} />
+              </button>
+            ) : null}
+            <button
+              type="button"
+              className="icon-btn"
+              aria-label="Settings"
+              title="Settings"
+              aria-current={layoutMode === "settings" ? "page" : undefined}
+              onClick={() => navigate("/settings")}
+            >
+              <Settings size={18} />
+            </button>
+          </>
         ) : null}
         {layoutMode === "workspace" || layoutMode === "direct-session" ? (
           <>
@@ -411,6 +445,18 @@ export function TopBar({
                     role="menuitem"
                     onClick={() => {
                       setOverflowOpen(false);
+                      onOpenShortcuts?.();
+                    }}
+                  >
+                    <Keyboard size={14} />
+                    <span>Keyboard shortcuts</span>
+                  </button>
+                  <button
+                    type="button"
+                    className="top-bar__overflow-item"
+                    role="menuitem"
+                    onClick={() => {
+                      setOverflowOpen(false);
                       navigate("/settings");
                     }}
                   >
@@ -449,6 +495,10 @@ export function TopBar({
           </>
         ) : null}
       </div>
+      <KeyboardShortcutsDialog
+        open={shortcutsOpen}
+        onClose={() => onCloseShortcuts?.()}
+      />
       </div>
     </header>
   );

--- a/web-ui/src/components/layout/WorkspaceCanvas.tsx
+++ b/web-ui/src/components/layout/WorkspaceCanvas.tsx
@@ -190,6 +190,7 @@ export function WorkspaceCanvas({
    *  be seeded into any "expanded" set first. */
   const [collapsedPickerProjects, setCollapsedPickerProjects] = useState<Set<string>>(new Set());
   const [newAgentOpen, setNewAgentOpen] = useState(false);
+  const [tileNewAgentWorktreeId, setTileNewAgentWorktreeId] = useState<string | null>(null);
   // Agent tile "⋯" popup — same actions as the agent tab bar's right-click
   // menu (Reset / Reset with handoff) plus Terminate (mirrors the tab bar's
   // "×" close). Only one tile's menu can be open at a time, mirroring
@@ -457,8 +458,11 @@ export function WorkspaceCanvas({
     return !pickerQuery || label.toLowerCase().includes(pickerQuery);
   }
 
-  const availableAgents = agentSessions.filter((s) => matchesSearch(sessionLabel(s)));
-  const availableTerminals = terminalSessions.filter((s) => matchesSearch(sessionLabel(s)));
+  const contextKeyWorktree = worktrees.find((w) => w.id === worktreeId);
+  const contextKeyLabel = contextKeyWorktree ? (contextKeyWorktree.name || contextKeyWorktree.branch) : "";
+  const contextKeyNameMatches = matchesSearch(contextKeyLabel);
+  const availableAgents = agentSessions.filter((s) => contextKeyNameMatches || matchesSearch(sessionLabel(s)));
+  const availableTerminals = terminalSessions.filter((s) => contextKeyNameMatches || matchesSearch(sessionLabel(s)));
 
   /**
    * A worktree counts as "done" the same way the dashboard's "Finished"
@@ -1037,6 +1041,20 @@ export function WorkspaceCanvas({
               <MoreVertical size={13} />
             </button>
           ) : null}
+          {tile.kind === "agent" && session ? (
+            <button
+              type="button"
+              className="workspace-canvas__tile-newagent"
+              title="New agent in same worktree"
+              onPointerDown={(e) => e.stopPropagation()}
+              onClick={(e) => {
+                e.stopPropagation();
+                setTileNewAgentWorktreeId(session.worktreeId ?? worktreeId);
+              }}
+            >
+              <Plus size={13} />
+            </button>
+          ) : null}
           {/* Fullscreen: swap "remove tile" for "exit fullscreen" — clicking
               the header already exits fullscreen too (same toggle), this is
               just a second, more discoverable affordance for it. Removing a
@@ -1478,15 +1496,19 @@ export function WorkspaceCanvas({
           ? createPortal(toolbarNode, toolbarPortalEl)
           : toolbarNode
         : null}
-      {!isDetachedView ? (
-        <NewAgentTabDialog
-          open={newAgentOpen}
-          api={api}
-          worktreeId={worktreeId}
-          onClose={() => setNewAgentOpen(false)}
-          onCreated={(sessionId) => addTile("agent", sessionId)}
-        />
-      ) : null}
+      <NewAgentTabDialog
+        open={newAgentOpen || tileNewAgentWorktreeId != null}
+        api={api}
+        worktreeId={tileNewAgentWorktreeId ?? worktreeId}
+        onClose={() => {
+          setNewAgentOpen(false);
+          setTileNewAgentWorktreeId(null);
+        }}
+        onCreated={(sessionId) => {
+          addTile("agent", sessionId, tileNewAgentWorktreeId ?? undefined);
+          setTileNewAgentWorktreeId(null);
+        }}
+      />
       {tileMenu && tileMenuSession
         ? createPortal(
             <div

--- a/web-ui/src/components/tools/VcsCommitView.tsx
+++ b/web-ui/src/components/tools/VcsCommitView.tsx
@@ -45,6 +45,7 @@ export function VcsCommitView({ api, worktreeId, sha, onBack }: VcsCommitViewPro
         if (!cancelled) {
           setEntries(list);
           setLoading(false);
+          if (list.length > 0) setSelectedPath(list[0]!.path);
         }
       } catch (e) {
         if (!cancelled) {
@@ -68,6 +69,7 @@ export function VcsCommitView({ api, worktreeId, sha, onBack }: VcsCommitViewPro
     <MasterDetailShell
       storageKey={`commit-${worktreeId}`}
       worktreeId={worktreeId}
+      autoFocusTree
       topbarExtra={topbarExtra}
       leftPane={
         <ChangedFileList

--- a/web-ui/src/components/tools/VcsPanel.tsx
+++ b/web-ui/src/components/tools/VcsPanel.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChevronRight, ExternalLink, GitCommit, GitMerge, GitPullRequest, GitPullRequestClosed, GitPullRequestDraft, RefreshCw } from "lucide-react";
 import type { ApiInstance } from "@/api";
 import type { CommitLogEntry, PrInfo, SubmoduleInfo } from "@/api/types";
 import { VcsCommitView } from "@/components/tools/VcsCommitView";
+import { useWorkspaceStore } from "@/hooks/useStore";
 
 interface VcsPanelProps {
   api: ApiInstance;
@@ -261,9 +262,23 @@ export function VcsPanel({ api, worktreeId, baseBranch, branch }: VcsPanelProps)
   // ON by default — the branch's own commits are the point of this view;
   // flipping it OFF reveals the full unfiltered log inline (Requirement 1a-1c).
   const [diffFromMain, setDiffFromMain] = useState(true);
-  // Item 9 — set when a commit's diff-stat button is clicked; renders
-  // `VcsCommitView` in place of the commit graph until "Commits" is clicked.
-  const [selectedCommitSha, setSelectedCommitSha] = useState<string | null>(null);
+
+  // Item 9 — which commit's `VcsCommitView` is open, if any. Held in the
+  // Zustand store (non-persisted) rather than local state so it survives the
+  // tool panel unmounting when toggled off.
+  const vcsSelectedCommitByWorktree = useWorkspaceStore((s) => s.vcsSelectedCommitByWorktree);
+  const setVcsSelectedCommitStore = useWorkspaceStore((s) => s.setVcsSelectedCommit);
+  const selectedCommitSha = vcsSelectedCommitByWorktree[worktreeId] ?? null;
+  const setSelectedCommitSha = useCallback(
+    (sha: string | null) => setVcsSelectedCommitStore(worktreeId, sha),
+    [setVcsSelectedCommitStore, worktreeId],
+  );
+
+  useEffect(() => {
+    if (selectedCommitSha && !useWorkspaceStore.getState().fileTreeVisible) {
+      useWorkspaceStore.getState().toggleFileTree();
+    }
+  }, [selectedCommitSha]);
 
   const toggleExpanded = (sha: string) => {
     setExpanded((prev) => {

--- a/web-ui/src/hooks/useRovingListNav.ts
+++ b/web-ui/src/hooks/useRovingListNav.ts
@@ -1,4 +1,4 @@
-import { useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import { useEffect, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
 
 /** One flat, navigable row. Trees flatten to this shape too — `expandable`
  *  is what lets a single hook serve both a tree (FileTreeSidebar) and an
@@ -17,6 +17,10 @@ export interface UseRovingListNavOptions {
   /** When true, ArrowUp/ArrowDown also call `onOpen` for non-expandable rows,
    *  giving instant preview-as-you-navigate behaviour (like VSCode's explorer). */
   openOnArrow?: boolean;
+  /** Seeds the cursor on mount (when the path exists in `rows`), so the
+   *  tabbable row and the already-selected row are the same item instead of
+   *  rows[0] falling back to tabbable while something else is selected. */
+  initialCursor?: string | null;
 }
 
 export interface UseRovingListNavResult {
@@ -43,7 +47,38 @@ export function useRovingListNav(
   rows: RovingRow[],
   opts: UseRovingListNavOptions,
 ): UseRovingListNavResult {
-  const [cursorPath, setCursorPath] = useState<string | null>(null);
+  // Initializer runs once, at mount — later changes to `opts`/`rows` are
+  // intentionally ignored so the cursor stays user-controlled after that.
+  const [cursorPath, setCursorPath] = useState<string | null>(() => {
+    if (opts.initialCursor != null && rows.some((r) => r.path === opts.initialCursor)) {
+      return opts.initialCursor;
+    }
+    return null;
+  });
+
+  // Re-seed the cursor once `initialCursor` shows up in `rows` after an async
+  // load — the useState lazy initializer runs at mount when `rows` may still
+  // be empty (e.g. ChangedFileList mounts with entries=[]), so the seed there
+  // is always rejected. Only fire while `cursorPath === null` to stay
+  // user-controlled after the user has interacted.
+  useEffect(() => {
+    if (cursorPath !== null || opts.initialCursor == null) return;
+    if (rows.some((r) => r.path === opts.initialCursor)) {
+      setCursorPath(opts.initialCursor);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rows, opts.initialCursor]);
+
+  // Reset cursor when rows replace entirely (e.g. sha change in VcsCommitView)
+  // — the stale path would make isTabbable return false for every row.
+  // Guard on rows.length > 0 so loading flickers don't clear a valid cursor.
+  useEffect(() => {
+    if (cursorPath === null || rows.length === 0) return;
+    if (!rows.some((r) => r.path === cursorPath)) {
+      setCursorPath(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rows]);
 
   function handleKeyDown(e: ReactKeyboardEvent) {
     const idx = rows.findIndex((r) => r.path === cursorPath);

--- a/web-ui/src/hooks/useStore.ts
+++ b/web-ui/src/hooks/useStore.ts
@@ -172,6 +172,8 @@ export interface WorkspaceState {
    * keydown.
    */
   focusedPane: string | null;
+  /** Non-persisted: which commit is open in the VCS panel, keyed by worktreeId. */
+  vcsSelectedCommitByWorktree: Record<string, string | null>;
   /** Last opened file path per worktree (persisted). */
   lastFileByWorktree: Record<string, string>;
   /** Preview scroll position keyed by `${worktreeId}:${filePath}` (persisted). */
@@ -241,6 +243,8 @@ export interface WorkspaceState {
   setActiveFile: (path: string | null) => void;
   /** Set (or clear with null) which flat/tree list owns arrow-key focus. */
   setFocusedPane: (id: string | null) => void;
+  /** Set (or clear with null) which commit is open in the VCS panel for a worktree. */
+  setVcsSelectedCommit: (worktreeId: string, sha: string | null) => void;
   setFileScroll: (worktreeId: string, filePath: string, scrollTop: number) => void;
   setDiffScopeForWorktree: (worktreeId: string, scope: DiffScope) => void;
   setTreeScopeForWorktree: (worktreeId: string, scope: "local" | "branch") => void;
@@ -587,6 +591,7 @@ const initial = {
   activeTerminalSessionId: null as string | null,
   activeFilePath: null as string | null,
   focusedPane: null as string | null,
+  vcsSelectedCommitByWorktree: {} as Record<string, string | null>,
   lastFileByWorktree: {} as Record<string, string>,
   fileScrollByKey: {} as Record<string, number>,
   showDotFiles: true,
@@ -802,6 +807,10 @@ export const useWorkspaceStore = create<WorkspaceState>()(
             return { activeFilePath: path, lastFileByWorktree: nextLastFile };
           }),
         setFocusedPane: (id) => set({ focusedPane: id }),
+        setVcsSelectedCommit: (worktreeId, sha) =>
+          set((s) => ({
+            vcsSelectedCommitByWorktree: { ...s.vcsSelectedCommitByWorktree, [worktreeId]: sha },
+          })),
         setFileScroll: (worktreeId, filePath, scrollTop) =>
           set((s) => ({
             fileScrollByKey: { ...s.fileScrollByKey, [`${worktreeId}:${filePath}`]: scrollTop },

--- a/web-ui/src/hooks/useWorkspaceKeyboardShortcuts.ts
+++ b/web-ui/src/hooks/useWorkspaceKeyboardShortcuts.ts
@@ -2,12 +2,14 @@ import { useEffect } from "react";
 import { useWorkspaceStore } from "@/hooks/useStore";
 
 /**
- * ⌘/Ctrl+Shift+F/P → Files/Preview tool tab; ⌘/Ctrl+Shift+Z → terminal dock;
+ * ⌘/Ctrl+Shift+F → Files tool tab; ⌘/Ctrl+Shift+Z → terminal dock;
  * ⌘/Ctrl+P quick-open files; ⌘/Ctrl+\ or ⌘/Ctrl+B → toggle tool pane;
  * ⌘/Ctrl+Shift+G → new agent in current worktree;
  * ⌘/Ctrl+Shift+M → new worktree in the current project;
  * Alt+N → new agent in the current worktree;
- * Alt+Shift+N → new worktree in the current project.
+ * Alt+Shift+N → new worktree in the current project;
+ * ⌘/Ctrl+E → toggle file tree;
+ * ⌘/Ctrl+/ → toggle tool split orientation;
  *
  * The new-agent/new-worktree shortcuts deliberately use bare Alt (no ⌘/Ctrl)
  * combos, not Ctrl+N/Ctrl+Shift+N — those are reserved by the OS/browser
@@ -34,15 +36,24 @@ export function useWorkspaceKeyboardShortcuts(
     const setToolPanelTab = useWorkspaceStore.getState().setToolPanelTab;
     const toggleTerminalDock = useWorkspaceStore.getState().toggleTerminalDock;
     const toggleToolPanel = useWorkspaceStore.getState().toggleToolPanel;
+    const toggleFileTree = useWorkspaceStore.getState().toggleFileTree;
+    const toggleToolSplitOrientation = useWorkspaceStore.getState().toggleToolSplitOrientation;
 
     const onKey = (e: KeyboardEvent) => {
       const t = e.target as HTMLElement | null;
       const inEditable =
         t &&
         (t.tagName === "INPUT" ||
-          t.tagName === "TEXTAREA" ||
+          // Exclude xterm's hidden helper textarea — it is the keyboard target
+          // whenever the terminal has focus, but UI shortcuts (Ctrl+B, Ctrl+Shift+Z,
+          // etc.) must still fire from the terminal. The xterm customKeyEventHandler
+          // in TerminalPane.tsx handles which keys xterm forwards to the PTY vs.
+          // lets through; this guard must not re-block them at the app level.
+          (t.tagName === "TEXTAREA" && !t.classList.contains("xterm-helper-textarea")) ||
           t.tagName === "SELECT" ||
           t.isContentEditable);
+
+      const mod = e.metaKey || e.ctrlKey;
 
       // Alt+N / Alt+Shift+N — independent of ⌘/Ctrl, and of the `mod` gate
       // below. `e.code` (physical key), not `e.key`: Option+N is a dead key
@@ -66,7 +77,6 @@ export function useWorkspaceKeyboardShortcuts(
         return;
       }
 
-      const mod = e.metaKey || e.ctrlKey;
       if (!mod) return;
 
       if (!e.shiftKey && !e.altKey && e.key.toLowerCase() === "p") {
@@ -76,6 +86,15 @@ export function useWorkspaceKeyboardShortcuts(
       }
 
       if (inEditable) return;
+
+      // ⌘/Ctrl+E — toggle file tree (VS Code-style). Same placement as Ctrl+P:
+      // handled before the `inEditable` guard so it fires even from the terminal
+      // (the xterm passthrough in TerminalPane.tsx lets Ctrl+E through to us).
+      if (!e.shiftKey && !e.altKey && e.key.toLowerCase() === "e") {
+        e.preventDefault();
+        toggleFileTree();
+        return;
+      }
 
       // ⌘/Ctrl+\ — toggle tool pane (layout-agnostic: `e.key === "\\"` matches
       // the backslash on US and similar layouts; Ctrl+Shift+\ produces
@@ -93,12 +112,18 @@ export function useWorkspaceKeyboardShortcuts(
         return;
       }
 
+      // ⌘/Ctrl+/ — toggle tool split orientation (no args; falls back to the
+      // current `toolSplitOrientation` from state). Guarded against the Shift
+      // modifier so Ctrl+Shift+/ (i.e. `?` with Ctrl) is not misread here.
+      if (!e.shiftKey && !e.altKey && e.key === "/") {
+        e.preventDefault();
+        toggleToolSplitOrientation();
+        return;
+      }
+
       if (e.shiftKey) {
         const k = e.key.length === 1 ? e.key.toUpperCase() : e.key;
         if (k === "F") {
-          e.preventDefault();
-          setToolPanelTab("files");
-        } else if (k === "P") {
           e.preventDefault();
           setToolPanelTab("files");
         } else if (k === "Z") {

--- a/web-ui/src/routes/Workspace.tsx
+++ b/web-ui/src/routes/Workspace.tsx
@@ -81,6 +81,7 @@ export function Workspace() {
   // "current project"/"current worktree" are already resolved.
   const [shortcutNewWorktreeOpen, setShortcutNewWorktreeOpen] = useState(false);
   const [shortcutNewAgentOpen, setShortcutNewAgentOpen] = useState(false);
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
 
   const isMobile = useMediaQuery("(max-width: 768px)");
 
@@ -306,6 +307,14 @@ export function Workspace() {
     () => sessions.filter((s) => s.worktreeId === activeWorktreeId && s.type === "terminal"),
     [sessions, activeWorktreeId],
   );
+  const contextKeyAgentSessions = useMemo(
+    () => sessions.filter((s) => s.worktreeId === viewedWorkspace?.contextKey && s.type === "agent"),
+    [sessions, viewedWorkspace],
+  );
+  const contextKeyTerminalSessions = useMemo(
+    () => sessions.filter((s) => s.worktreeId === viewedWorkspace?.contextKey && s.type === "terminal"),
+    [sessions, viewedWorkspace],
+  );
   // A worktree's classic per-worktree canvas placement is ALWAYS its own
   // transient scratch canvas (it never binds to a saved WorkspaceDoc — see
   // WorkspaceCanvas.tsx's module doc), so the base of its pane-key set is its
@@ -469,8 +478,8 @@ export function Workspace() {
   const detachedWorkspaceCanvas = viewedWorkspace ? (
     <WorkspaceCanvas
       worktreeId={viewedWorkspace.contextKey}
-      agentSessions={[]}
-      terminalSessions={[]}
+      agentSessions={contextKeyAgentSessions}
+      terminalSessions={contextKeyTerminalSessions}
       hasTools
       toolPanelVisible
       terminalDockVisible
@@ -629,6 +638,9 @@ export function Workspace() {
             leftSidebarCollapsed={leftSidebarCollapsed}
             mobileSidebarOpen={mobileSidebarOpen}
             onOpenQuickOpen={() => setQuickOpen(true)}
+            shortcutsOpen={shortcutsOpen}
+            onOpenShortcuts={() => setShortcutsOpen(true)}
+            onCloseShortcuts={() => setShortcutsOpen(false)}
             settingsSectionLabel={isMobile ? settingsSectionLabel : undefined}
             // replace, not push: a plain push would leave the section entry in
             // history, so the phone's Back gesture right after tapping Back

--- a/web-ui/src/styles/keyboard-shortcuts-dialog.css
+++ b/web-ui/src/styles/keyboard-shortcuts-dialog.css
@@ -1,0 +1,95 @@
+/* Keyboard Shortcuts reference dialog — reuses the shared .dialog-card chrome
+   (workspace.css §dialog-overlay/.dialog-card) and layers a fixed-size, grouped
+   shortcut table on top. */
+
+.dialog-card--shortcuts {
+  width: min(90vw, 560px);
+  max-height: 80vh;
+  overflow: auto;
+}
+
+.dialog-card--shortcuts .dialog-card__body {
+  padding: var(--space-3) var(--space-4);
+}
+
+.shortcut-dialog__groups {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.shortcut-dialog__group-title {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-top: var(--space-1);
+}
+
+.shortcut-dialog__group-title:first-child {
+  margin-top: 0;
+}
+
+.shortcut-dialog__table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.shortcut-dialog__table td {
+  padding: var(--space-1) 0;
+  vertical-align: middle;
+}
+
+.shortcut-dialog__keys {
+  width: 1%;
+  white-space: nowrap;
+  padding-left: var(--space-3);
+}
+
+.shortcut-dialog__combo-list {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.shortcut-dialog__combo-parts {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.shortcut-dialog__combo-part {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.shortcut-dialog__combo-sep {
+  font-size: var(--font-size-xs, 0.7em);
+  color: var(--fg-muted);
+  padding: 0 1px;
+}
+
+.shortcut-dialog__kbd {
+  display: inline-block;
+  min-width: 1.6em;
+  padding: 0 0.4em;
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-sm);
+  line-height: 1.6;
+  text-align: center;
+  color: var(--fg-primary);
+  background: var(--bg-elevated, var(--bg-card));
+  border: var(--border-width) solid var(--border-default);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 1px 0 var(--border-default);
+}
+
+.shortcut-dialog__action {
+  color: var(--fg-primary);
+  max-width: 60%;
+  white-space: normal;
+  word-wrap: break-word;
+  padding-right: var(--space-3);
+}

--- a/web-ui/src/styles/tokens.css
+++ b/web-ui/src/styles/tokens.css
@@ -71,7 +71,7 @@
 }
 
 [data-theme="dark"] {
-  --accent: #6e78c7;
+  --accent: #e5e5e5;
   /* Quiet, chat-scoped accent (user bubble border, spinners, throttle badge).
      Contained here so the global purple --accent stays on primary buttons etc. */
   --chat-accent: #8a8a8a;
@@ -124,7 +124,7 @@
 }
 
 [data-theme="light"] {
-  --accent: #5c64b5;
+  --accent: #1a1a1a;
   --chat-accent: #737373;
   --bg-primary: #fafafa;
   --bg-secondary: #f5f5f5;

--- a/web-ui/src/styles/workspace-canvas.css
+++ b/web-ui/src/styles/workspace-canvas.css
@@ -516,7 +516,8 @@
 }
 
 .workspace-canvas__tile-close,
-.workspace-canvas__tile-menu-trigger {
+.workspace-canvas__tile-menu-trigger,
+.workspace-canvas__tile-newagent {
   appearance: none;
   border: none;
   background: transparent;
@@ -531,7 +532,8 @@
 
 .workspace-canvas__tile-close:hover,
 .workspace-canvas__tile-menu-trigger:hover,
-.workspace-canvas__tile-menu-trigger[aria-expanded="true"] {
+.workspace-canvas__tile-menu-trigger[aria-expanded="true"],
+.workspace-canvas__tile-newagent:hover {
   background: var(--bg-active);
   color: var(--fg-primary);
 }

--- a/web-ui/src/styles/workspace.css
+++ b/web-ui/src/styles/workspace.css
@@ -1691,6 +1691,10 @@
   border-radius: var(--radius-sm);
 }
 
+[role="tree"] .tree-row:focus {
+  outline: none;
+}
+
 /* Worktrees only: shorter row than default `.tree-row` (project font bumped below),
  * indented under the project row. Collapsed rail overrides this back to 0 so
  * the centered abbreviation chip stays centered. */
@@ -3354,13 +3358,13 @@
 }
 
 .btn--primary {
-  background: var(--accent, #6e78c7);
-  border-color: var(--accent, #6e78c7);
-  color: #ffffff;
+  background: var(--accent, #e5e5e5);
+  border-color: var(--accent, #e5e5e5);
+  color: var(--bg-primary);
 }
 
 .btn--primary:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--accent, #6e78c7) 88%, #ffffff);
+  background: color-mix(in srgb, var(--accent, #e5e5e5) 88%, var(--bg-primary));
 }
 
 .btn--secondary {


### PR DESCRIPTION
## Summary

- **Keyboard shortcuts**: Ctrl/Cmd+E toggles file tree, Ctrl/Cmd+/ toggles split orientation, new keyboard shortcuts reference dialog accessible from overflow menu and TopBar in all layout modes
- **File tree focus**: Arrow keys resume positionally from the currently open file; right-pane pointer-down routes focus to tree (exempting preview/markdown/code regions); roving cursor resets cleanly on content change (e.g. VCS sha change)
- **VCS commit view**: Auto-shows file tree on open, preserves selected commit across tool pane toggle, auto-selects first file, arrow keys work immediately
- **Visual**: Replace purple accent with neutral (dark `#e5e5e5` / light `#1a1a1a`); btn--primary text adapts via `var(--bg-primary)`

## Key technical decisions

- `useRovingListNav` gains `initialCursor` with two-phase seeding: lazy `useState` initializer for sync data + `useEffect` re-seed for async loads; stale-cursor reset when rows replace entirely
- `ChangedFileList` always renders its root container (with `tabIndex={-1}`) so `autoFocusTree` focus lookup has a target even during loading
- `vcsSelectedCommitByWorktree` store slice (non-persisted, keyed by worktree) preserves VCS commit state across tool pane unmounts
- `MasterDetailShell.autoFocusTree` prop for views that need tree focus on mount
- Neutral accent token replaces hardcoded purple in `tokens.css` only; design system default is untouched

## Test plan

- [ ] Ctrl/Cmd+E toggles file tree in Files / Artifacts / VCS tabs
- [ ] Ctrl/Cmd+/ toggles split orientation
- [ ] Keyboard shortcuts dialog opens from overflow menu and from TopBar button in dashboard/settings
- [ ] Open a file, toggle tree off/on with Ctrl+E, arrow keys resume from that file
- [ ] Click in a file preview (text selection) — arrow keys should NOT switch to a different file
- [ ] VCS: open a commit → file tree auto-shows, first file auto-selected, arrow keys work immediately
- [ ] VCS: toggle tool pane off/on → same commit stays open
- [ ] VCS: navigate to a different commit → cursor resets to first file (no stale highlight)
- [ ] Accent color is neutral white/dark in both light and dark mode